### PR TITLE
fix: incorrect plugin reference and exports

### DIFF
--- a/packages/cozy-device-helper/package.json
+++ b/packages/cozy-device-helper/package.json
@@ -15,8 +15,8 @@
   },
   "scripts": {
     "prepublishOnly": "yarn run build",
-    "build": "babel src -d dist",
-    "test": "jest",
+    "build": "babel src -d dist --ignore *.spec.js",
+    "test": "jest src/**",
     "lint": "eslint --fix src/**"
   },
   "dependencies": {

--- a/packages/cozy-device-helper/src/apps.js
+++ b/packages/cozy-device-helper/src/apps.js
@@ -23,6 +23,7 @@ const exported = {}
  * @returns Promise - False if the application was not able to be started
  */
 const startApp = (exported.startApp = async function(appInfo) {
+  const startAppPlugin = window.startApp
   const isAppInstalled = await exported.checkApp(appInfo)
   if (isAppInstalled) {
     const params = getParams(appInfo)
@@ -34,7 +35,7 @@ const startApp = (exported.startApp = async function(appInfo) {
         return
       }
 
-      global.startApp.set(params).start(resolve, reject)
+      startAppPlugin.set(params).start(resolve, reject)
     })
   } else {
     return false
@@ -55,6 +56,7 @@ const startApp = (exported.startApp = async function(appInfo) {
  * })
  */
 const checkApp = (exported.checkApp = async function(appInfo) {
+  const startAppPlugin = window.startApp
   const params = getParams(appInfo)
   return new Promise((resolve, reject) => {
     if (!cordovaPluginIsInstalled()) {
@@ -62,7 +64,7 @@ const checkApp = (exported.checkApp = async function(appInfo) {
       return
     }
 
-    startApp.set(params).check(
+    startAppPlugin.set(params).check(
       infos => {
         resolve(infos === 'OK' ? true : infos)
       },

--- a/packages/cozy-device-helper/src/apps.js
+++ b/packages/cozy-device-helper/src/apps.js
@@ -1,4 +1,3 @@
-/* global startApp */
 import { isAndroidApp } from './platform'
 
 const cordovaPluginIsInstalled = () => global.startApp

--- a/packages/cozy-device-helper/src/apps.js
+++ b/packages/cozy-device-helper/src/apps.js
@@ -1,6 +1,6 @@
 import { isAndroidApp } from './platform'
 
-const cordovaPluginIsInstalled = () => global.startApp
+const cordovaPluginIsInstalled = () => window.startApp
 
 /**
  * Normalize startApp params for Android and iOS

--- a/packages/cozy-device-helper/src/apps.js
+++ b/packages/cozy-device-helper/src/apps.js
@@ -22,7 +22,7 @@ const exported = {}
  * Start an application if it is installed on the phone
  * @returns Promise - False if the application was not able to be started
  */
-exported.startApp = async appInfo => {
+const startApp = (exported.startApp = async function(appInfo) {
   const isAppInstalled = await exported.checkApp(appInfo)
   if (isAppInstalled) {
     const params = getParams(appInfo)
@@ -39,7 +39,7 @@ exported.startApp = async appInfo => {
   } else {
     return false
   }
-}
+})
 
 /**
  * Check that an application is installed on the phone
@@ -54,7 +54,7 @@ exported.startApp = async appInfo => {
  *  applicationInfo: "ApplicationInfo{70aa0ef io.cozy.drive.mobile}"
  * })
  */
-exported.checkApp = async appInfo => {
+const checkApp = (exported.checkApp = async function(appInfo) {
   const params = getParams(appInfo)
   return new Promise((resolve, reject) => {
     if (!cordovaPluginIsInstalled()) {
@@ -78,6 +78,7 @@ exported.checkApp = async appInfo => {
       }
     )
   })
-}
+})
 
+export { checkApp, startApp }
 export default exported

--- a/packages/cozy-device-helper/src/apps.spec.js
+++ b/packages/cozy-device-helper/src/apps.spec.js
@@ -6,8 +6,8 @@ describe('apps helpers', () => {
     const mockStart = jest.fn().mockImplementation(successCb => {
       successCb(ok)
     })
-    global.startApp = {
-      set: () => global.startApp,
+    window.startApp = {
+      set: () => window.startApp,
       start: mockStart
     }
     appHelpers.checkApp = jest.fn().mockImplementation(async () => {


### PR DESCRIPTION
### Incorrect plugin reference

The plugin having the same name as the function, it was
incorrectly referenced.

### Incorrect export/import

```
const exported = { checkApp, startApp }
export default exported
```

is incorrect with this form of importing

```
import { checkApp, startApp } from 'cozy-device-helper'
```