### PR TITLE
fix: Remove 72 chars limit on body description 🔥

### DIFF
--- a/packages/commitlint-config/index.js
+++ b/packages/commitlint-config/index.js
@@ -29,7 +29,6 @@ module.exports = {
         'style',
         'test'
       ]
-    ],
-    'body-max-length': [2, 'always', 72]
+    ]
   }
 }

--- a/packages/commitlint-config/index.spec.js
+++ b/packages/commitlint-config/index.spec.js
@@ -2,8 +2,8 @@ import lint from '@commitlint/lint'
 import cozyConfig from '.'
 
 const rules = cozyConfig.rules
-const TOO_LONG =
-  'This is an invalid sentence since it has too much character !!!!!!!!!!!!!'
+// const TOO_LONG =
+//  'This is an invalid sentence since it has too much character !!!!!!!!!!!!!'
 
 describe('Commitlint Config Cozy', () => {
   describe('Header', () => {
@@ -56,6 +56,7 @@ describe('Commitlint Config Cozy', () => {
     })
   })
 
+  /*
   describe('Body', () => {
     it('respect max length', async () => {
       const validBody = [`fix: Bar\n\nWith a small body`]
@@ -69,4 +70,5 @@ describe('Commitlint Config Cozy', () => {
       }
     })
   })
+  */
 })


### PR DESCRIPTION
We would like limit max length of each line, not all body part
We have to wait  to be introduced to commitlint

[See this PR](https://github.com/marionebl/commitlint/pull/400)