### PR TITLE
Fix some bugs

### DIFF
--- a/packages/interapp/src/intents.js
+++ b/packages/interapp/src/intents.js
@@ -4,8 +4,8 @@ import Request from './request'
 import { pickService, buildRedirectionURL, removeQueryString } from './helpers'
 
 class Intents {
-  constructor({ client, fetchJSON } = {}) {
-    this.request = new Request(fetchJSON || client.client.fetchJSON)
+  constructor({ client } = {}) {
+    this.request = new Request(client)
   }
 
   create(action, type, data = {}, permissions = []) {

--- a/packages/interapp/src/intents.spec.js
+++ b/packages/interapp/src/intents.spec.js
@@ -4,6 +4,6 @@ describe('Interapp', () => {
   it('should initialise with cozy client', () => {
     const client = { client: { fetchJSON: jest.fn() } }
     const intents = new Intents({ client })
-    expect(intents.request.cozyFetchJSON).toEqual(client.client.fetchJSON)
+    expect(intents.request.client).toEqual(client.client)
   })
 })

--- a/packages/interapp/src/request.js
+++ b/packages/interapp/src/request.js
@@ -1,14 +1,14 @@
 class Request {
-  constructor(cozyFetchJSON) {
-    this.cozyFetchJSON = cozyFetchJSON
+  constructor(cozyClient) {
+    this.client = cozyClient.client
   }
 
   get(id) {
-    return this.cozyFetchJSON('GET', `/intents/${id}`)
+    return this.client.fetchJSON('GET', `/intents/${id}`)
   }
 
   post(action, type, data, permissions) {
-    return this.cozyFetchJSON('POST', '/intents', {
+    return this.client.fetchJSON('POST', '/intents', {
       data: {
         type: 'io.cozy.intents',
         attributes: {

--- a/packages/interapp/src/request.js
+++ b/packages/interapp/src/request.js
@@ -4,21 +4,25 @@ class Request {
   }
 
   get(id) {
-    return this.client.fetchJSON('GET', `/intents/${id}`)
+    return this.client
+      .fetchJSON('GET', `/intents/${id}`)
+      .then(resp => resp.data)
   }
 
   post(action, type, data, permissions) {
-    return this.client.fetchJSON('POST', '/intents', {
-      data: {
-        type: 'io.cozy.intents',
-        attributes: {
-          action: action,
-          type: type,
-          data: data,
-          permissions: permissions
+    return this.client
+      .fetchJSON('POST', '/intents', {
+        data: {
+          type: 'io.cozy.intents',
+          attributes: {
+            action: action,
+            type: type,
+            data: data,
+            permissions: permissions
+          }
         }
-      }
-    })
+      })
+      .then(resp => resp.data)
   }
 }
 

--- a/packages/interapp/src/request.spec.js
+++ b/packages/interapp/src/request.spec.js
@@ -1,24 +1,28 @@
 import Request from './request'
 
 describe('[Interapp] Request', () => {
-  let request, cozyFetchJSON
+  let request, cozyClient
 
   beforeEach(() => {
-    cozyFetchJSON = jest.fn()
-    request = new Request(cozyFetchJSON)
+    cozyClient = {
+      client: {
+        fetchJSON: jest.fn().mockReturnValue(Promise.resolve({ data: [] }))
+      }
+    }
+    request = new Request(cozyClient)
   })
 
   it('should initialise with cozyFetchJSON function', () => {
-    expect(request.cozyFetchJSON).toEqual(cozyFetchJSON)
+    expect(request.client).toEqual(cozyClient.client)
   })
 
   it('should get an intent', () => {
     request.get()
-    expect(cozyFetchJSON).toHaveBeenCalledTimes(1)
+    expect(cozyClient.client.fetchJSON).toHaveBeenCalledTimes(1)
   })
 
   it('should post an intent', () => {
     request.post()
-    expect(cozyFetchJSON).toHaveBeenCalledTimes(1)
+    expect(cozyClient.client.fetchJSON).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Cette PR permet de retourner directement les documents lorsque l'on fetch avec cozy client.

Au lieu de faire `request.get(13).then(resp => resp.data).then(intent => intent....)`, il est possible de faire `request.get(13).then(intent => intent....)`