### PR TITLE
Better options check

### DIFF
--- a/packages/cozy-app-publish/lib/prepublish.js
+++ b/packages/cozy-app-publish/lib/prepublish.js
@@ -30,23 +30,43 @@ const sanitize = options => {
   }
 }
 
+const isRequiredFromManifest = manifestAttribute => [
+  field => typeof field !== 'undefined',
+  () => `Property ${manifestAttribute} must be defined in manifest.`
+]
+
+const isRequired = [
+  field => typeof field !== 'undefined',
+  key => `Option ${key} is required.`
+]
+
+const isOneOf = values => [
+  field => values.includes(field),
+  key => `${key} should be one of the following values: ${values.join(', ')}`
+]
+
+const optionsTypes = {
+  appBuildUrl: [isRequired],
+  appSlug: [isRequiredFromManifest('slug')],
+  appType: [isRequiredFromManifest('type'), isOneOf(['webapp', 'konnector'])],
+  appVersion: [isRequired],
+  registryUrl: [isRequired],
+  registryEditor: [isRequired],
+  registryToken: [isRequired]
+}
+
 /**
  * Check if all expected options are defined
  */
 const check = options => {
-  ;[
-    'appBuildUrl',
-    'appSlug',
-    'appType',
-    'appVersion',
-    'registryUrl',
-    'registryEditor',
-    'registryToken'
-  ].forEach(option => {
-    if (typeof options[option] === 'undefined') {
-      throw new Error(`${option} cannot be undefined`)
-    }
-  })
+  for (const option in optionsTypes) {
+    const validators = optionsTypes[option]
+    validators.forEach(validator => {
+      if (!validator[0](options[option])) {
+        throw new Error(validator[1](option))
+      }
+    })
+  }
 
   return options
 }

--- a/packages/cozy-app-publish/test/__mocks__/prepublish-bad-value-options-hook.js
+++ b/packages/cozy-app-publish/test/__mocks__/prepublish-bad-value-options-hook.js
@@ -1,0 +1,11 @@
+module.exports = () => {
+  return {
+    appBuildUrl: 'http://example.mock',
+    appSlug: 'cozy-mock',
+    appType: 'webkonnectorwhichobviouslydoesntexist',
+    appVersion: '0.0.1',
+    registryUrl: 'http://registry.mock/',
+    registryEditor: 'Cozy',
+    registryToken: 'a5464f54e654c6546b54a56a'
+  }
+}

--- a/packages/cozy-app-publish/test/__mocks__/prepublish-missing-manifest-options-hook.js
+++ b/packages/cozy-app-publish/test/__mocks__/prepublish-missing-manifest-options-hook.js
@@ -1,0 +1,10 @@
+module.exports = () => {
+  return {
+    appBuildUrl: 'http://example.mock',
+    appSlug: 'cozy-mock',
+    appVersion: '0.0.1',
+    registryUrl: 'http://registry.mock/',
+    registryEditor: 'Cozy',
+    registryToken: 'a5464f54e654c6546b54a56a'
+  }
+}

--- a/packages/cozy-app-publish/test/__mocks__/prepublish-missing-options-hook.js
+++ b/packages/cozy-app-publish/test/__mocks__/prepublish-missing-options-hook.js
@@ -1,5 +1,7 @@
 module.exports = () => {
   return {
-    appBuildUrl: 'http://cozy.io'
+    appBuildUrl: 'http://cozy.io',
+    appSlug: 'cozy-mock',
+    appType: 'webapp'
   }
 }

--- a/packages/cozy-app-publish/test/__snapshots__/prepublish.spec.js.snap
+++ b/packages/cozy-app-publish/test/__snapshots__/prepublish.spec.js.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Prepublish script check for undefined mandatory options 1`] = `"appSlug cannot be undefined"`;
+exports[`Prepublish script check for bad values in options 1`] = `"appType should be one of the following values: webapp, konnector"`;
+
+exports[`Prepublish script check for undefined mandatory options 1`] = `"Option appVersion is required."`;
+
+exports[`Prepublish script check for undefined manifest mandatory options 1`] = `"Property type must be defined in manifest."`;
 
 exports[`Prepublish script generates sha256 1`] = `
 Object {

--- a/packages/cozy-app-publish/test/prepublish.spec.js
+++ b/packages/cozy-app-publish/test/prepublish.spec.js
@@ -39,6 +39,23 @@ describe('Prepublish script', () => {
     await expect(prepublishLib(options)).rejects.toThrowErrorMatchingSnapshot()
   })
 
+  it('check for undefined manifest mandatory options', async () => {
+    const options = {
+      ...optionsMock,
+      prepublishHook:
+        './test/__mocks__/prepublish-missing-manifest-options-hook'
+    }
+    await expect(prepublishLib(options)).rejects.toThrowErrorMatchingSnapshot()
+  })
+
+  it('check for bad values in options', async () => {
+    const options = {
+      ...optionsMock,
+      prepublishHook: './test/__mocks__/prepublish-bad-value-options-hook'
+    }
+    await expect(prepublishLib(options)).rejects.toThrowErrorMatchingSnapshot()
+  })
+
   it('runs without errors with built-in hook', async () => {
     const options = { ...optionsMock, prepublishHook: 'downcloud' }
     await expect(prepublishLib(options)).resolves.toMatchSnapshot()


### PR DESCRIPTION
The main idea is to be clearer when an options like `appType` or `appSlug` is missing.

This PR adds a dedicated error message for attributes retrieved from manifest file.

Also it checks that the appType has the correct value (`webapp` or `konnector`).