### PR TITLE
Try/catch publish()

### DIFF
--- a/packages/cozy-app-publish/lib/travis.js
+++ b/packages/cozy-app-publish/lib/travis.js
@@ -99,7 +99,11 @@ async function travisPublish({
     )
   )
 
-  publish(publishOptions)
+  try {
+    await publish(publishOptions)
+  } catch (error) {
+    console.error(`↳ ❌  Publish failed: ${error.message}`)
+  }
 
   try {
     await postpublish({ ...publishOptions, postpublishHook })


### PR DESCRIPTION
The call to publish() was not encapsulated in a try/catch, generating warning about unhandled Promise rejections.