### PR TITLE
chore: Remove eslint auto fix

### DIFF
--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "test": "jest --env node ./*.spec.js",
-    "lint": "eslint --fix ./*.js"
+    "lint": "eslint ./*.js"
   },
   "devDependencies": {
     "@commitlint/lint": "7.0.0",

--- a/packages/cozy-device-helper/package.json
+++ b/packages/cozy-device-helper/package.json
@@ -20,7 +20,7 @@
     "prepublishOnly": "yarn run build",
     "build": "babel src -d dist --ignore *.spec.js",
     "test": "jest src/**",
-    "lint": "eslint --fix src/**"
+    "lint": "eslint src/**"
   },
   "dependencies": {
     "lodash": "4.17.10"

--- a/packages/doctypes/package.json
+++ b/packages/doctypes/package.json
@@ -17,7 +17,7 @@
     "jest": "^23.5.0"
   },
   "scripts": {
-    "lint": "eslint --fix src/**",
+    "lint": "eslint src/**",
     "test": "jest src/"
   }
 }

--- a/packages/flags/package.json
+++ b/packages/flags/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/cozy/cozy-libs/issues"
   },
   "scripts": {
-    "lint": "eslint --fix src/**",
+    "lint": "eslint src/**",
     "build": "babel src -d dist",
     "test": "true",
     "prepublishOnly": "yarn build"

--- a/packages/interapp/package.json
+++ b/packages/interapp/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "test": "jest",
     "build": "babel src -d dist --ignore *.spec.js",
-    "lint": "eslint --fix src/**"
+    "lint": "eslint src/**"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "test": "true",
-    "lint": "eslint --fix src/**",
+    "lint": "eslint src/**",
     "build": "babel src -d dist",
     "prepublishOnly": "yarn build",
     "watch": "yarn build --watch"


### PR DESCRIPTION
The auto fix can send Travis + Lerna into a loop if some files are
commited to master with linting errors. Since the --fix does not warn
that there are linting errors, Travis will report green even in the
Pull request : linting errors can be integrated into
master without any warning.

Since --fix changes files, Lerna thinks something has changed and
publishes the application. The publishing of the application will
result in a commit, which will in turn launch a new Travis job
and the whole story starts again.
