### PR TITLE
fix: No update all if no documents

### DIFF
--- a/packages/doctypes/src/Document.js
+++ b/packages/doctypes/src/Document.js
@@ -168,6 +168,9 @@ class Document {
   }
 
   static async updateAll(docs) {
+    if (!docs || !docs.length) {
+      return Promise.resolve([])
+    }
     try {
       const update = await cozyClient.fetchJSON(
         'POST',

--- a/packages/doctypes/src/Document.spec.js
+++ b/packages/doctypes/src/Document.spec.js
@@ -96,6 +96,15 @@ describe('Document', () => {
     })
   })
 
+  it('should not do anything if passed empty list', async () => {
+    jest.spyOn(cozyClient.data, 'create').mockReset()
+    jest.spyOn(cozyClient, 'fetchJSON').mockReset()
+    const res = await Simpson.updateAll([])
+    expect(cozyClient.data.create).not.toHaveBeenCalled()
+    expect(cozyClient.fetchJSON).not.toHaveBeenCalled()
+    expect(res).toEqual([])
+  })
+
   it('should create database when bulk updating', async () => {
     jest
       .spyOn(cozyClient.data, 'create')


### PR DESCRIPTION
Do not try to create an undefined document when updateAll is
called with an empty list.