### PR TITLE
Avoid `undefined` in archive folder

### DIFF
--- a/packages/cozy-app-publish/lib/hooks/pre/downcloud.js
+++ b/packages/cozy-app-publish/lib/hooks/pre/downcloud.js
@@ -36,7 +36,8 @@ const deleteArchive = async filename => {
 const pushArchive = async (archiveFileName, options) => {
   const { appSlug, appVersion, buildCommit } = options
   console.log(`↳ ℹ️  Sending archive to downcloud`)
-  const folder = `www-upload/${appSlug}/${appVersion}-${buildCommit}/`
+  const folder = `www-upload/${appSlug}/${appVersion}${buildCommit &&
+    `-${buildCommit}`}/`
   try {
     await launchCmd('ssh', [
       '-o',


### PR DESCRIPTION
For stable and beta version, buildCommit is not defined and the folder name was something like `x.x.x-undefined`.