### PR TITLE
feat: Create cozy-app renovate config

### DIFF
--- a/packages/renovate-config-cozy-app/package.json
+++ b/packages/renovate-config-cozy-app/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "renovate-config-cozy-app",
+  "version": "0.0.1",
+  "description": "Renovate config for Cozy Application (Cozy Cloud)",
+  "renovate-config": {
+    "default": {
+      "extends": ["config:base"],
+      "schedule": ["before 5am"],
+      "timezone": "Europe/Paris",
+      "updateNotScheduled": false
+    }
+  },
+  "license": "MIT"
+}


### PR DESCRIPTION
Once published to npm, this package should allow all our apps to use or at least extend the same renovate configuration.
[Here are the docs](https://renovatebot.com/docs/config-presets/) about how this works.

The configuration itself is very basic right now — it just prevents travis to be swamped during working hours. We'll be happy to consider more individual rules once the first version is published.