### PR TITLE
fix(flags): Return null if flag doesn't exist

### DIFF
--- a/packages/flags/src/flag.js
+++ b/packages/flags/src/flag.js
@@ -14,7 +14,7 @@ const getFlag = name => {
   } else {
     // set the key so that it can be listed
     setFlag(name, null)
-    return JSON.stringify(null)
+    return null
   }
 }
 


### PR DESCRIPTION
We were returning `JSON.stringify(null)`, which returns a string. So if the flag didn't exist, we get a truthy value instead of a falsy one.

Now we return `null` :+1: