### PR TITLE
Define missing cozy-release binary

### DIFF
--- a/packages/cozy-release/package.json
+++ b/packages/cozy-release/package.json
@@ -3,6 +3,9 @@
   "version": "1.2.0",
   "description": "A tool to manage Cozy application releases",
   "main": "cozy-release.js",
+  "bin": {
+    "cozy-release": "./cozy-release.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cozy/cozy-libs.git"


### PR DESCRIPTION
Without that the `cozy-release` command/binary won't be available for usage after installing the module