### PR TITLE
Make Travis fail on publish, prepublish or postpublish error

### DIFF
--- a/packages/cozy-app-publish/cozy-app-publish.js
+++ b/packages/cozy-app-publish/cozy-app-publish.js
@@ -99,23 +99,28 @@ function _getPublishMode() {
   }
 }
 
-function publishApp(cliOptions) {
+async function publishApp(cliOptions) {
   const publishMode = _getPublishMode()
   if (publishMode === MODES.TRAVIS) {
     console.log()
     console.log(`${colorize.bold('Travis')} ${colorize.blue('publish mode')}`)
     console.log()
-    scripts.travis({
-      registryToken: cliOptions.token,
-      buildDir: cliOptions.buildDir,
-      buildCommit: cliOptions.buildCommit,
-      buildUrl: cliOptions.buildUrl,
-      prepublishHook: cliOptions.prepublishHook,
-      postpublishHook: cliOptions.postpublishHook,
-      registryUrl: cliOptions.registryUrl,
-      spaceName: cliOptions.space,
-      verbose: cliOptions.verbose
-    })
+    try {
+      await scripts.travis({
+        registryToken: cliOptions.token,
+        buildDir: cliOptions.buildDir,
+        buildCommit: cliOptions.buildCommit,
+        buildUrl: cliOptions.buildUrl,
+        prepublishHook: cliOptions.prepublishHook,
+        postpublishHook: cliOptions.postpublishHook,
+        registryUrl: cliOptions.registryUrl,
+        spaceName: cliOptions.space,
+        verbose: cliOptions.verbose
+      })
+    } catch (error) {
+      console.error(`↳ ❌  ${error.message}`)
+      process.exit(1)
+    }
   } else if (publishMode === MODES.MANUAL) {
     console.log()
     console.log(`${colorize.bold('Manual')} ${colorize.blue('publish mode')}`)

--- a/packages/cozy-app-publish/lib/publish.js
+++ b/packages/cozy-app-publish/lib/publish.js
@@ -11,28 +11,33 @@ module.exports = async ({
   sha256Sum,
   appType
 }) => {
-  const response = await fetch(
-    `${registryUrl}/${spaceName ? spaceName + '/' : ''}registry/${appSlug}`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Token ${registryToken}`
-      },
-      body: JSON.stringify({
-        editor: registryEditor,
-        version: appVersion,
-        url: appBuildUrl,
-        sha256: sha256Sum,
-        type: appType
-      })
-    }
-  )
+  let response
+  try {
+    response = await fetch(
+      `${registryUrl}/${spaceName ? spaceName + '/' : ''}registry/${appSlug}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Token ${registryToken}`
+        },
+        body: JSON.stringify({
+          editor: registryEditor,
+          version: appVersion,
+          url: appBuildUrl,
+          sha256: sha256Sum,
+          type: appType
+        })
+      }
+    )
+  } catch (error) {
+    throw error
+  }
 
   if (response.status !== 201) {
     const body = await response.json()
     throw new Error(`${response.status} ${response.statusText}: ${body.error}`)
   }
 
-  return true
+  return response
 }

--- a/packages/cozy-app-publish/lib/travis.js
+++ b/packages/cozy-app-publish/lib/travis.js
@@ -90,8 +90,7 @@ async function travisPublish({
       appType
     })
   } catch (error) {
-    console.error(`↳ ❌  Prepublish failed: ${error.message}`)
-    return
+    throw new Error(`Prepublish failed: ${error.message}`)
   }
 
   // publish the application on the registry
@@ -105,12 +104,16 @@ async function travisPublish({
     )
   )
 
-  publish(publishOptions)
+  try {
+    await publish(publishOptions)
+  } catch (error) {
+    throw new Error(`Publish failed: ${error.message}`)
+  }
 
   try {
     await postpublish({ ...publishOptions, postpublishHook })
   } catch (error) {
-    console.error(`↳ ❌  Postpublish hooks failed: ${error.message}`)
+    throw new Error(`Postpublish hooks failed: ${error.message}`)
   }
 }
 

--- a/packages/cozy-app-publish/test/__snapshots__/travis.spec.js.snap
+++ b/packages/cozy-app-publish/test/__snapshots__/travis.spec.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Travis publishing script should fail on postPublish error 1`] = `[Error: Postpublish hooks failed: Postpublish test error]`;
+
+exports[`Travis publishing script should fail on prePublish error 1`] = `[Error: Prepublish failed: Prepublish test error]`;
+
+exports[`Travis publishing script should fail on publish error 1`] = `[Error: Publish failed: Publish test error]`;
+
 exports[`Travis publishing script should throw an error if the editor is missing 1`] = `"Registry editor is missing in the manifest. Publishing failed."`;
 
 exports[`Travis publishing script should throw an error if the token is missing 1`] = `"Registry token is missing. Publishing failed."`;

--- a/packages/cozy-app-publish/test/travis.spec.js
+++ b/packages/cozy-app-publish/test/travis.spec.js
@@ -126,11 +126,30 @@ describe('Travis publishing script', () => {
     expect(postpublish).toHaveBeenCalledTimes(0)
   })
 
-  it('should handle correctly errored postpublish', async () => {
+  it('should fail on prePublish error', async () => {
     const options = getOptions()
-    postpublish.mockRejectedValueOnce(new Error('(TEST) Postpublish error'))
-    await expect(travisScript(options)).resolves
+    prepublish.mockRejectedValueOnce(new Error('Prepublish test error'))
+    await expect(travisScript(options)).rejects.toMatchSnapshot()
     expect(prepublish).toHaveBeenCalledTimes(1)
+    expect(publishLib).toHaveBeenCalledTimes(0)
+    expect(postpublish).toHaveBeenCalledTimes(0)
+  })
+
+  it('should fail on publish error', async () => {
+    const options = getOptions()
+    publishLib.mockRejectedValueOnce(new Error('Publish test error'))
+    await expect(travisScript(options)).rejects.toMatchSnapshot()
+    expect(prepublish).toHaveBeenCalledTimes(1)
+    expect(publishLib).toHaveBeenCalledTimes(1)
+    expect(postpublish).toHaveBeenCalledTimes(0)
+  })
+
+  it('should fail on postPublish error', async () => {
+    const options = getOptions()
+    postpublish.mockRejectedValueOnce(new Error('Postpublish test error'))
+    await expect(travisScript(options)).rejects.toMatchSnapshot()
+    expect(prepublish).toHaveBeenCalledTimes(1)
+    expect(publishLib).toHaveBeenCalledTimes(1)
     expect(postpublish).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/cozy-app-publish/test/travis.spec.js
+++ b/packages/cozy-app-publish/test/travis.spec.js
@@ -50,6 +50,7 @@ function getOptions(buildUrl = null) {
 describe('Travis publishing script', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    global.console.log = jest.fn()
   })
 
   it('should work correctly if Travis environment variable provided (no TRAVIS_TAG)', async () => {


### PR DESCRIPTION
Travis is not failing when an error occurs during prepublish, publish, or postpublish. It causes "false positive" build, where the registry publication can fail but Travis is still green and a message is sent to Mattermost.

This PR prevents this behaviour.