### PR TITLE
cozy-release: Detect cozy remote

### DIFF
--- a/packages/cozy-release/scripts/cozy-release.sh
+++ b/packages/cozy-release/scripts/cozy-release.sh
@@ -719,11 +719,17 @@ if [[ ! -z "${UNKNOWN_OPTION// }" ]]; then
   exit 1
 fi
 
+cozy_remote=`git remote -v | grep "cozy/"  | tail -1 | awk '{print $1;}'`
+
+if [[ -z ${cozy_remote// } ]]; then
+  cozy_remote="origin"
+fi
+
 case "$command" in
-  start ) start ${remote:-origin} ;;
-  beta ) beta ${remote:-origin} ;;
-  stable ) stable ${remote:-origin} ;;
-  patch ) patch ${remote:-origin} $version;;
-  end ) end ${remote:-origin} ;;
+  start ) start ${remote:-$cozy_remote} ;;
+  beta ) beta ${remote:-$cozy_remote} ;;
+  stable ) stable ${remote:-$cozy_remote} ;;
+  patch ) patch ${remote:-$cozy_remote} $version;;
+  end ) end ${remote:-$cozy_remote} ;;
   *) show_help;;
 esac


### PR DESCRIPTION
If no remote is passed as argument, cozy-release now tries to detects wich remote is the cozy one.

If no cozy remote is found, cozy-release just use origin.

![capture d ecran 2018-09-19 a 18 48 41](https://user-images.githubusercontent.com/776764/45768253-aeb5a680-bc3c-11e8-9ff0-c614ac8a7599.png)
