### PR TITLE
fix: After publish don't execute ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_deploy:
 deploy:
   - provider: script
     skip-cleanup: true
-    script: git checkout master && git remote set-url origin https://cozy-bot:$GITHUB_TOKEN@github.com/cozy/cozy-libs.git && echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc && yarn lerna publish --yes
+    script: git checkout master && git remote set-url origin https://cozy-bot:$GITHUB_TOKEN@github.com/cozy/cozy-libs.git && echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc && yarn lerna publish --yes -m "[skip ci] Publish"
     on:
       branch: master
       repo: cozy/cozy-libs


### PR DESCRIPTION
When lerna publish Travis launch a new build so it can loop. This PR add `[skip ci]` to remove it.