### PR TITLE
Update shebang to use bash

### DIFF
--- a/packages/cozy-release/scripts/cozy-release.sh
+++ b/packages/cozy-release/scripts/cozy-release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+!#/bin/bash
 command=$1
 
 # https://superuser.com/questions/897148/shell-cant-shift-that-many-error


### PR DESCRIPTION
Without that, Travis CI will use the `dash` shell from ubuntu. 
So we can force using `bash` with this shebang