### PR TITLE
[commitlint] Raise max commit message length

### DIFF
--- a/packages/commitlint-config-cozy/index.js
+++ b/packages/commitlint-config-cozy/index.js
@@ -3,7 +3,7 @@ module.exports = {
     'body-leading-blank': [1, 'always'],
     'body-max-line-length': [2, 'always', 72],
     'footer-leading-blank': [1, 'always'],
-    'header-max-length': [2, 'always', 50],
+    'header-max-length': [2, 'always', 72],
     'scope-case': [0, 'always', 'lower-case'],
     'subject-case': [
       2,

--- a/packages/commitlint-config-cozy/index.spec.js
+++ b/packages/commitlint-config-cozy/index.spec.js
@@ -32,11 +32,12 @@ describe('Commitlint Config Cozy', () => {
     })
 
     it('respect max length', async () => {
-      const valideLength = 'fix: This is a 50 characters lines !!!!!!!!!!!!!!!'
+      const valideLength =
+        'fix: This line contains exactly 72 characters meaning it passes the test'
       expect((await lint(valideLength, rules)).valid).toBeTruthy()
 
       const invalidLength =
-        'refactor: This is a 51 characters lines !!!!!!!!!!!'
+        'refactor: This one contains more than 72 so it really should not pass the test because no one can read the end'
       expect((await lint(invalidLength, rules)).valid).toBeFalsy()
     })
 


### PR DESCRIPTION
This issue brought up in a meeting recently, but I'm formally proposing we raise the limit for commit message titles to 72 chars instead of 50.

From what I can see (in [this article](https://chris.beams.io/posts/git-commit/#limit-50) and in various git tools):

- 50 character is the desired length
- 72 is the hard limit after which things gets truncated

Since `commitlint` is rejecting commits that don't match the configuration it's enforcing a *hard* limit, and should be 72 and not 50. But we as humans should still try to shoot for 50.

Does that sound ok? Especially pinging people who mentioned this issue @CPatchane @kosssi @enguerran 


edit: Don't mind Travis, I'll update the tests if/when we get consensus on this.

