### PR TITLE
Add domain an secure config parameters

### DIFF
--- a/packages/cozy-realtime/README.md
+++ b/packages/cozy-realtime/README.md
@@ -44,9 +44,10 @@ or
 
 This method allow you to subscribe to realtime for all documents of a provided doctype. Here are the parameters:
 
-- `config`: a config object with two key :
-  - `url`: the cozy url (ex: https://recette.cozy.works)
+- `config`: a config object with the following keys :
+  - `domain`: the instance domain (ex: `cozy.works`, `cozy.tools:8080`), must be provided if `url` is not set
   - `token`: the cozy token (ex: the global `cozy.client._token.token`)
+  - `url`: the cozy url (ex: https://recette.cozy.works), must be provided if `domain` is not set
 - `doctype`: the doctype to subscribe (ex: `io.cozy.accounts`)
 - `parse`: a custom function to be use as parser for your resulting documents (default: `doc => doc`)
 
@@ -72,9 +73,10 @@ subscription.unsubscribe()
 
 This method is exactly the same working as the previous `subscribeAll()` function but to listen only one document. Here are the parameters:
 
-- `config`: a config object with two key :
-  - `url`: the cozy url (ex: https://recette.cozy.works)
+- `config`: a config object with the following keys :
+  - `domain`: the instance domain (ex: `cozy.works`, `cozy.tools:8080`), must be provided if `url` is not set
   - `token`: the cozy token (ex: the global `cozy.client._token.token`)
+  - `url`: the cozy url (ex: https://recette.cozy.works)
 - `doctype`: the doctype to subscribe (ex: `io.cozy.accounts`)
 - `doc`: the document to listen, it must be at least a JS object with the `_id` attribute of the wanted document (only the `_id` will be checked to know if this is the wanted document or not).
 - `parse`: a custom function to be use as parser for your resulting documents (default: `doc => doc`)

--- a/packages/cozy-realtime/README.md
+++ b/packages/cozy-realtime/README.md
@@ -48,6 +48,7 @@ This method allow you to subscribe to realtime for all documents of a provided d
   - `domain`: the instance domain (ex: `cozy.works`, `cozy.tools:8080`), must be provided if `url` is not set
   - `token`: the cozy token (ex: the global `cozy.client._token.token`)
   - `url`: the cozy url (ex: https://recette.cozy.works), must be provided if `domain` is not set
+  - `secure`: a boolean indicating if a secure protocol must be used (default `true`). Should not be provided along `url`.
 - `doctype`: the doctype to subscribe (ex: `io.cozy.accounts`)
 - `parse`: a custom function to be use as parser for your resulting documents (default: `doc => doc`)
 
@@ -77,6 +78,7 @@ This method is exactly the same working as the previous `subscribeAll()` functio
   - `domain`: the instance domain (ex: `cozy.works`, `cozy.tools:8080`), must be provided if `url` is not set
   - `token`: the cozy token (ex: the global `cozy.client._token.token`)
   - `url`: the cozy url (ex: https://recette.cozy.works)
+  - `secure`: a boolean indicating if a secure protocol must be used (default `true`). Should not be provided along `url`.
 - `doctype`: the doctype to subscribe (ex: `io.cozy.accounts`)
 - `doc`: the document to listen, it must be at least a JS object with the `_id` attribute of the wanted document (only the `_id` will be checked to know if this is the wanted document or not).
 - `parse`: a custom function to be use as parser for your resulting documents (default: `doc => doc`)

--- a/packages/cozy-realtime/src/index.js
+++ b/packages/cozy-realtime/src/index.js
@@ -72,6 +72,19 @@ function keepAlive(socket, interval, message) {
 
 const isRequired = [attr => !!attr, 'is required']
 const isString = [str => typeof str === 'string', 'should be a string']
+const isURL = [
+  url => {
+    if (typeof url === 'undefined') return true
+    try {
+      new URL(url)
+    } catch (error) {
+      return false
+    }
+
+    return true
+  },
+  'should be an URL'
+]
 
 const validate = types => obj => {
   for (const [attr, rules] of Object.entries(types)) {
@@ -85,7 +98,7 @@ const validate = types => obj => {
 
 const configTypes = {
   token: [isRequired, isString],
-  url: [isRequired, isString]
+  url: [isRequired, isURL]
 }
 
 const validateConfig = validate(configTypes)

--- a/packages/cozy-realtime/src/index.js
+++ b/packages/cozy-realtime/src/index.js
@@ -71,7 +71,10 @@ function keepAlive(socket, interval, message) {
 }
 
 const isRequired = [attr => !!attr, 'is required']
-const isString = [str => typeof str === 'string', 'should be a string']
+const isString = [
+  str => typeof str === 'undefined' || typeof str === 'string',
+  'should be a string'
+]
 const isURL = [
   url => {
     if (typeof url === 'undefined') return true

--- a/packages/cozy-realtime/src/index.js
+++ b/packages/cozy-realtime/src/index.js
@@ -101,6 +101,11 @@ async function connectWebSocket(
   return new Promise((resolve, reject) => {
     const protocol = getWebsocketProtocol(config.url)
     const domain = getDomainFromUrl(config.url)
+
+    if (!domain) {
+      throw new Error('Unable to detect domain')
+    }
+
     const socket = new WebSocket(
       `${protocol}://${domain}/realtime/`,
       'io.cozy.websocket'

--- a/packages/cozy-realtime/src/index.js
+++ b/packages/cozy-realtime/src/index.js
@@ -70,7 +70,15 @@ function keepAlive(socket, interval, message) {
   return socket
 }
 
+const isBoolean = [
+  bool => typeof bool === 'undefined' || typeof bool === 'boolean',
+  'should be a boolean'
+]
 const isRequired = [attr => !!attr, 'is required']
+const isRequiredIfNo = keys => [
+  (attr, obj) => keys.find(key => !!obj[key]) || !!attr,
+  `is required if no attribute ${keys.join(' or ')} are provider.`
+]
 const isString = [
   str => typeof str === 'undefined' || typeof str === 'string',
   'should be a string'
@@ -92,7 +100,7 @@ const isURL = [
 const validate = types => obj => {
   for (const [attr, rules] of Object.entries(types)) {
     for (const [validator, message] of rules) {
-      if (!validator(obj[attr])) {
+      if (!validator(obj[attr], obj)) {
         throw new Error(`${attr} ${message}.`)
       }
     }

--- a/packages/cozy-realtime/src/index.js
+++ b/packages/cozy-realtime/src/index.js
@@ -108,8 +108,9 @@ const validate = types => obj => {
 }
 
 const configTypes = {
+  domain: [isRequiredIfNo(['url']), isString],
   token: [isRequired, isString],
-  url: [isRequired, isURL]
+  url: [isRequiredIfNo(['domain']), isURL]
 }
 
 const validateConfig = validate(configTypes)
@@ -124,7 +125,7 @@ async function connectWebSocket(
   validateConfig(config)
   return new Promise((resolve, reject) => {
     const protocol = getWebsocketProtocol(config.url)
-    const domain = getDomainFromUrl(config.url)
+    const domain = config.domain || getDomainFromUrl(config.url)
 
     if (!domain) {
       throw new Error('Unable to detect domain')


### PR DESCRIPTION
Following #21

We have been dealing with [an unpleasant case in the cozy-bar where we had to build a fake URL to pass it as a config parameter](https://github.com/cozy/cozy-bar/commit/eba3eb2420ee87c8eaa54102a0452f851f6d2d46#diff-73642d587163f2eb4d72f0fa6ebfba02R179).

In this PR, we allow two new config parameters : `domain` and `secure`.

`domain` can be directly extracted from the data set of the `[role=application]` element in every app.

`secure` is set to `true` by default, but can be overriden at realtime initialization with something like
```js
realtime.subcribeAll({
    domain: data.cozyDomain,
    secure: __SSL__,
    token: data.cozyToken
  },
// [...]
)
```