### PR TITLE
fix(doctypes): Format log properly

### DIFF
--- a/packages/cozy-doctypes/src/BankTransaction.js
+++ b/packages/cozy-doctypes/src/BankTransaction.js
@@ -93,7 +93,7 @@ class Transaction extends Document {
         sort: [{ date: 'desc' }]
       }
       const transactions = await Document.query(index, options)
-      log('info', transactions.length, 'last transactions length')
+      log('info', 'last transactions length: ' + transactions.length)
 
       return transactions
     } catch (e) {


### PR DESCRIPTION
This log used too many params, resulting in a `Could not parse stdout as JSON` error in the log files.