### PR TITLE
Git pull before tagging beta or stable version

### DIFF
--- a/packages/cozy-release/scripts/cozy-release.sh
+++ b/packages/cozy-release/scripts/cozy-release.sh
@@ -348,6 +348,7 @@ beta () {
     warn_about_beta $remote
   fi
 
+  if ! git pull; then exit 1
   git push $remote HEAD
   tag_beta $remote
 }
@@ -366,6 +367,7 @@ stable () {
     warn_about_stable $remote
   fi
 
+  if ! git pull; then exit 1
   git push $remote HEAD
   tag_stable $remote
 }


### PR DESCRIPTION
Pulling avoids push errors and make sure everything is up to date before tagging a new beta or stable version.