### PR TITLE
Update BankTransaction::reconciliate algorithm

### DIFF
--- a/packages/cozy-doctypes/src/BankTransaction.js
+++ b/packages/cozy-doctypes/src/BankTransaction.js
@@ -67,11 +67,11 @@ class Transaction extends Document {
 
   /**
    * Get the descriptive (and almost uniq) identifier of a transaction
-   * @param {object} transaction - The transaction (containing at least amount, label and date)
+   * @param {object} transaction - The transaction (containing at least amount, originalLabel and date)
    * @returns {object}
    */
   getIdentifier() {
-    return `${this.amount}-${this.label}-${this.date}`
+    return `${this.amount}-${this.originalLabel}-${this.date}`
   }
 
   /**

--- a/packages/cozy-doctypes/src/BankTransaction.js
+++ b/packages/cozy-doctypes/src/BankTransaction.js
@@ -47,11 +47,16 @@ class Transaction extends Document {
     }
   }
 
-  static reconciliate(remoteTransactions, localTransactions, options) {
+  static reconciliate(remoteTransactions, localTransactions) {
+    const alreadyExists = transaction =>
+      localTransactions.find(t => t.vendorId === transaction.vendorId)
+
     const groups = groupBy(
       remoteTransactions,
-      tr => (options.isNew(tr) ? 'newTransactions' : 'updatedTransactions')
+      transaction =>
+        alreadyExists(transaction) ? 'updatedTransactions' : 'newTransactions'
     )
+
     let newTransactions = groups.newTransactions || []
     const updatedTransactions = groups.updatedTransactions || []
 

--- a/packages/cozy-doctypes/src/BankTransaction.js
+++ b/packages/cozy-doctypes/src/BankTransaction.js
@@ -75,25 +75,15 @@ class Transaction extends Document {
   }
 
   /**
-   * Tell if a transaction exists in a given array of transactions
+   * Tell if a transaction exists in a given array of transactions identifiers
    * @param {object} transactionToCheck
-   * @param {array} existingTransactions
+   * @param {array} existingIdentifiers - The identifiers of transactions that already exist
    * @returns {boolean} whether the searched transaction was found or not
    */
-  alreadyExists(existingTransactions) {
+  alreadyExists(existingIdentifiers) {
     const identifier = Transaction.prototype.getIdentifier.call(this)
 
-    for (const existingTransaction of existingTransactions) {
-      const existingIdentifier = Transaction.prototype.getIdentifier.call(
-        existingTransaction
-      )
-
-      if (identifier === existingIdentifier) {
-        return true
-      }
-    }
-
-    return false
+    return existingIdentifiers.includes(identifier)
   }
 
   /**
@@ -104,12 +94,16 @@ class Transaction extends Document {
    * @returns {array}
    */
   static getMissedTransactions(transactionsToCheck, stackTransactions) {
+    const existingIdentifiers = stackTransactions.map(transaction =>
+      Transaction.prototype.getIdentifier.call(transaction)
+    )
+
     const missedTransactions = transactionsToCheck
       .map(
         transaction =>
           !Transaction.prototype.alreadyExists.call(
             transaction,
-            stackTransactions
+            existingIdentifiers
           ) && transaction
       )
       .filter(Boolean)

--- a/packages/cozy-doctypes/src/BankTransaction.js
+++ b/packages/cozy-doctypes/src/BankTransaction.js
@@ -55,21 +55,15 @@ class Transaction extends Document {
     let newTransactions = groups.newTransactions || []
     const updatedTransactions = groups.updatedTransactions || []
 
-    // If saving from a new banking vendor, transactions will not have the same vendor ids as the ones in the
-    // database, we have to filter all transactions that are before our last save transactions
     const splitDate = getSplitDate(localTransactions)
-    const onlyMostRecent = options.onlyMostRecent
-    if (onlyMostRecent && splitDate) {
-      log('info', 'Saving transactions from a new vendor')
+
+    if (splitDate) {
       log('info', `Not saving new transactions before: ${splitDate}`)
       const isAfterSplit = x => Transaction.prototype.isAfter.call(x, splitDate)
       newTransactions = newTransactions.filter(isAfterSplit)
       log('info', `After split ${newTransactions.length}`)
     } else {
-      log(
-        'info',
-        `onlyMostRecent: ${onlyMostRecent}, saving all new transactions`
-      )
+      log('info', "Can't find a split date, saving all new transactions")
     }
 
     log(

--- a/packages/cozy-doctypes/src/BankTransaction.js
+++ b/packages/cozy-doctypes/src/BankTransaction.js
@@ -1,7 +1,6 @@
 const keyBy = require('lodash/keyBy')
 const groupBy = require('lodash/groupBy')
 const max = require('lodash/max')
-const isEqual = require('lodash/isEqual')
 const Document = require('./Document')
 const BankAccount = require('./BankAccount')
 const log = require('./log')

--- a/packages/cozy-doctypes/src/BankTransaction.js
+++ b/packages/cozy-doctypes/src/BankTransaction.js
@@ -7,9 +7,12 @@ const log = require('./log')
 
 const getDate = transaction => transaction.date.slice(0, 10)
 
-const getSplitDate = (linxoTransactions, stackTransactions) => {
-  // Find the first date for which we have new linxo transactions
-  // We'll delete transactions after this date and add new ones
+/**
+ * Get the date of the latest transaction in an array
+ * @param {array} stackTransactions
+ * @returns {string} The date of the latest transaction (YYYY-MM-DD)
+ */
+const getSplitDate = stackTransactions => {
   return max(stackTransactions.map(transaction => getDate(transaction)))
 }
 
@@ -54,7 +57,7 @@ class Transaction extends Document {
 
     // If saving from a new banking vendor, transactions will not have the same vendor ids as the ones in the
     // database, we have to filter all transactions that are before our last save transactions
-    const splitDate = getSplitDate(remoteTransactions, localTransactions)
+    const splitDate = getSplitDate(localTransactions)
     const onlyMostRecent = options.onlyMostRecent
     if (onlyMostRecent && splitDate) {
       log('info', 'Saving transactions from a new vendor')

--- a/packages/cozy-doctypes/src/BankTransaction.js
+++ b/packages/cozy-doctypes/src/BankTransaction.js
@@ -127,12 +127,23 @@ class Transaction extends Document {
     const splitDate = getSplitDate(localTransactions)
 
     if (splitDate) {
-      log('info', `Not saving new transactions before: ${splitDate}`)
       const isAfterSplit = x => Transaction.prototype.isAfter.call(x, splitDate)
       const isBeforeSplit = x =>
         Transaction.prototype.isBeforeOrSame.call(x, splitDate)
 
       const transactionsAfterSplit = newTransactions.filter(isAfterSplit)
+
+      if (transactionsAfterSplit.length > 0) {
+        log(
+          'info',
+          `Saving ${
+            transactionsAfterSplit.length
+          } transaction after ${splitDate}`
+        )
+      } else {
+        log('info', `No transaction after ${splitDate}`)
+      }
+
       const transactionsBeforeSplit = newTransactions.filter(isBeforeSplit)
 
       const missedTransactions = Transaction.getMissedTransactions(
@@ -140,9 +151,13 @@ class Transaction extends Document {
         localTransactions
       )
 
-      newTransactions = [...transactionsAfterSplit, ...missedTransactions]
+      if (missedTransactions.length > 0) {
+        log('info', `Saving ${missedTransactions}.length`)
+      } else {
+        log('info', 'No missed transactions to catch-up')
+      }
 
-      log('info', `After split ${newTransactions.length}`)
+      newTransactions = [...transactionsAfterSplit, ...missedTransactions]
     } else {
       log('info', "Can't find a split date, saving all new transactions")
     }

--- a/packages/cozy-doctypes/src/BankTransaction.spec.js
+++ b/packages/cozy-doctypes/src/BankTransaction.spec.js
@@ -13,7 +13,7 @@ describe('getIdentifier', () => {
   it('should return the identifier of a transaction', () => {
     const transaction = {
       amount: -10,
-      label: 'Test getIdentifier',
+      originalLabel: 'Test getIdentifier',
       date: '2018-10-02',
       currency: 'EUR'
     }
@@ -28,17 +28,17 @@ describe('alreadyExists', () => {
   const existingTransactions = [
     {
       amount: -10,
-      label: 'Test 01',
+      originalLabel: 'Test 01',
       date: '2018-10-02'
     },
     {
       amount: -20,
-      label: 'Test 02',
+      originalLabel: 'Test 02',
       date: '2018-10-02'
     },
     {
       amount: -30,
-      label: 'Test 03',
+      originalLabel: 'Test 03',
       date: '2018-10-02'
     }
   ]
@@ -46,7 +46,7 @@ describe('alreadyExists', () => {
   it('should return true if the transaction exists', () => {
     const transaction = {
       amount: -10,
-      label: 'Test 01',
+      originalLabel: 'Test 01',
       date: '2018-10-02'
     }
 
@@ -61,7 +61,7 @@ describe('alreadyExists', () => {
   it('should return false if the transaction does not exist', () => {
     const transaction = {
       amount: -50,
-      label: 'Not existing',
+      originalLabel: 'Not existing',
       date: '2018-10-02'
     }
 
@@ -78,17 +78,17 @@ describe('getMissedTransactions', () => {
   const existingTransactions = [
     {
       amount: -10,
-      label: 'Test 01',
+      originalLabel: 'Test 01',
       date: '2018-10-02'
     },
     {
       amount: -20,
-      label: 'Test 02',
+      originalLabel: 'Test 02',
       date: '2018-10-02'
     },
     {
       amount: -30,
-      label: 'Test 03',
+      originalLabel: 'Test 03',
       date: '2018-10-02'
     }
   ]
@@ -97,12 +97,12 @@ describe('getMissedTransactions', () => {
     const newTransactions = [
       {
         amount: -10,
-        label: 'Test 01',
+        originalLabel: 'Test 01',
         date: '2018-10-02'
       },
       {
         amount: -15,
-        label: 'Test 04',
+        originalLabel: 'Test 04',
         date: '2018-10-01'
       }
     ]
@@ -119,7 +119,7 @@ describe('getMissedTransactions', () => {
     const newTransactions = [
       {
         amount: -10,
-        label: 'Test 01',
+        originalLabel: 'Test 01',
         date: '2018-10-02'
       }
     ]

--- a/packages/cozy-doctypes/src/BankTransaction.spec.js
+++ b/packages/cozy-doctypes/src/BankTransaction.spec.js
@@ -8,3 +8,127 @@ describe('transaction reconciliation', () => {
     expect(filter({ date: new Date('2018-10-05').toISOString() })).toBe(true) // day after
   })
 })
+
+describe('getIdentifier', () => {
+  it('should return the identifier of a transaction', () => {
+    const transaction = {
+      amount: -10,
+      label: 'Test getIdentifier',
+      date: '2018-10-02',
+      currency: 'EUR'
+    }
+
+    const identifier = BankTransaction.prototype.getIdentifier.call(transaction)
+
+    expect(identifier).toBe('-10-Test getIdentifier-2018-10-02')
+  })
+})
+
+describe('alreadyExists', () => {
+  const existingTransactions = [
+    {
+      amount: -10,
+      label: 'Test 01',
+      date: '2018-10-02'
+    },
+    {
+      amount: -20,
+      label: 'Test 02',
+      date: '2018-10-02'
+    },
+    {
+      amount: -30,
+      label: 'Test 03',
+      date: '2018-10-02'
+    }
+  ]
+
+  it('should return true if the transaction exists', () => {
+    const transaction = {
+      amount: -10,
+      label: 'Test 01',
+      date: '2018-10-02'
+    }
+
+    const exists = BankTransaction.prototype.alreadyExists.call(
+      transaction,
+      existingTransactions
+    )
+
+    expect(exists).toBe(true)
+  })
+
+  it('should return false if the transaction does not exist', () => {
+    const transaction = {
+      amount: -50,
+      label: 'Not existing',
+      date: '2018-10-02'
+    }
+
+    const exists = BankTransaction.prototype.alreadyExists.call(
+      transaction,
+      existingTransactions
+    )
+
+    expect(exists).toBe(false)
+  })
+})
+
+describe('getMissedTransactions', () => {
+  const existingTransactions = [
+    {
+      amount: -10,
+      label: 'Test 01',
+      date: '2018-10-02'
+    },
+    {
+      amount: -20,
+      label: 'Test 02',
+      date: '2018-10-02'
+    },
+    {
+      amount: -30,
+      label: 'Test 03',
+      date: '2018-10-02'
+    }
+  ]
+
+  it('should return the missed transactions when there are some', () => {
+    const newTransactions = [
+      {
+        amount: -10,
+        label: 'Test 01',
+        date: '2018-10-02'
+      },
+      {
+        amount: -15,
+        label: 'Test 04',
+        date: '2018-10-01'
+      }
+    ]
+
+    const missedTransactions = BankTransaction.getMissedTransactions(
+      newTransactions,
+      existingTransactions
+    )
+
+    expect(missedTransactions).toEqual([newTransactions[1]])
+  })
+
+  it('should return an empty array when there is no missed transaction', () => {
+    const newTransactions = [
+      {
+        amount: -10,
+        label: 'Test 01',
+        date: '2018-10-02'
+      }
+    ]
+
+    const missedTransactions = BankTransaction.getMissedTransactions(
+      newTransactions,
+      existingTransactions
+    )
+
+    expect(missedTransactions).toHaveLength(0)
+  })
+})

--- a/packages/cozy-doctypes/src/BankTransaction.spec.js
+++ b/packages/cozy-doctypes/src/BankTransaction.spec.js
@@ -24,44 +24,6 @@ describe('getIdentifier', () => {
   })
 })
 
-describe('alreadyExists', () => {
-  const existingIdentifiers = [
-    '-10-Test 01-2018-10-02',
-    '-20-Test 02-2018-10-02',
-    '-30-Test 03-2018-10-02'
-  ]
-
-  it('should return true if the transaction exists', () => {
-    const transaction = {
-      amount: -10,
-      originalLabel: 'Test 01',
-      date: '2018-10-02'
-    }
-
-    const exists = BankTransaction.prototype.alreadyExists.call(
-      transaction,
-      existingIdentifiers
-    )
-
-    expect(exists).toBe(true)
-  })
-
-  it('should return false if the transaction does not exist', () => {
-    const transaction = {
-      amount: -50,
-      originalLabel: 'Not existing',
-      date: '2018-10-02'
-    }
-
-    const exists = BankTransaction.prototype.alreadyExists.call(
-      transaction,
-      existingIdentifiers
-    )
-
-    expect(exists).toBe(false)
-  })
-})
-
 describe('getMissedTransactions', () => {
   const existingTransactions = [
     {
@@ -92,6 +54,28 @@ describe('getMissedTransactions', () => {
         amount: -15,
         originalLabel: 'Test 04',
         date: '2018-10-01'
+      }
+    ]
+
+    const missedTransactions = BankTransaction.getMissedTransactions(
+      newTransactions,
+      existingTransactions
+    )
+
+    expect(missedTransactions).toEqual([newTransactions[1]])
+  })
+
+  it('should return transactions with an already existing identifier, if there are more new than existing', () => {
+    const newTransactions = [
+      {
+        amount: -10,
+        originalLabel: 'Test 01',
+        date: '2018-10-02'
+      },
+      {
+        amount: -10,
+        originalLabel: 'Test 01',
+        date: '2018-10-02'
       }
     ]
 

--- a/packages/cozy-doctypes/src/BankTransaction.spec.js
+++ b/packages/cozy-doctypes/src/BankTransaction.spec.js
@@ -25,22 +25,10 @@ describe('getIdentifier', () => {
 })
 
 describe('alreadyExists', () => {
-  const existingTransactions = [
-    {
-      amount: -10,
-      originalLabel: 'Test 01',
-      date: '2018-10-02'
-    },
-    {
-      amount: -20,
-      originalLabel: 'Test 02',
-      date: '2018-10-02'
-    },
-    {
-      amount: -30,
-      originalLabel: 'Test 03',
-      date: '2018-10-02'
-    }
+  const existingIdentifiers = [
+    '-10-Test 01-2018-10-02',
+    '-20-Test 02-2018-10-02',
+    '-30-Test 03-2018-10-02'
   ]
 
   it('should return true if the transaction exists', () => {
@@ -52,7 +40,7 @@ describe('alreadyExists', () => {
 
     const exists = BankTransaction.prototype.alreadyExists.call(
       transaction,
-      existingTransactions
+      existingIdentifiers
     )
 
     expect(exists).toBe(true)
@@ -67,7 +55,7 @@ describe('alreadyExists', () => {
 
     const exists = BankTransaction.prototype.alreadyExists.call(
       transaction,
-      existingTransactions
+      existingIdentifiers
     )
 
     expect(exists).toBe(false)

--- a/packages/cozy-doctypes/src/utils/BankingReconciliator.js
+++ b/packages/cozy-doctypes/src/utils/BankingReconciliator.js
@@ -60,10 +60,6 @@ class BankingReconciliator {
       stackTransactions,
       BankTransaction.vendorIdAttr
     )
-    const fromNewKonnectorAccount = BankAccount.isFromNewKonnector(
-      fetchedAccounts,
-      stackAccounts
-    )
     const transactions = BankTransaction.reconciliate(
       fetchedTransactions,
       stackTransactions,
@@ -71,8 +67,7 @@ class BankingReconciliator {
         isNew: transaction => {
           let vendorId = transaction[BankTransaction.vendorIdAttr]
           return !vendorId || !stackTransactionsByVendorId[vendorId]
-        },
-        onlyMostRecent: fromNewKonnectorAccount
+        }
       }
     )
 

--- a/packages/cozy-doctypes/src/utils/BankingReconciliator.js
+++ b/packages/cozy-doctypes/src/utils/BankingReconciliator.js
@@ -1,4 +1,3 @@
-const keyBy = require('lodash/keyBy')
 const fromPairs = require('lodash/fromPairs')
 const log = require('cozy-logger').namespace('BankingReconciliator')
 

--- a/packages/cozy-doctypes/src/utils/BankingReconciliator.js
+++ b/packages/cozy-doctypes/src/utils/BankingReconciliator.js
@@ -56,19 +56,9 @@ class BankingReconciliator {
       stackAccounts.map(x => x._id)
     )
 
-    const stackTransactionsByVendorId = keyBy(
-      stackTransactions,
-      BankTransaction.vendorIdAttr
-    )
     const transactions = BankTransaction.reconciliate(
       fetchedTransactions,
-      stackTransactions,
-      {
-        isNew: transaction => {
-          let vendorId = transaction[BankTransaction.vendorIdAttr]
-          return !vendorId || !stackTransactionsByVendorId[vendorId]
-        }
-      }
+      stackTransactions
     )
 
     log('info', 'Saving transactions...')

--- a/packages/cozy-doctypes/src/utils/BankingReconciliator.spec.js
+++ b/packages/cozy-doctypes/src/utils/BankingReconciliator.spec.js
@@ -43,7 +43,7 @@ describe('banking reconciliator', () => {
     expect(Document.createOrUpdate).toHaveBeenCalledTimes(2)
   })
 
-  it('should correctly reconciliate when accounts do not exist', async () => {
+  it('should correctly reconciliate when accounts exist', async () => {
     existingAccounts = [
       {
         vendorId: 1,
@@ -76,7 +76,7 @@ describe('banking reconciliator', () => {
           amount: -200,
           label: 'Debit 200',
           vendorAccountId: 2,
-          date: '2018-06-24T00:00' // prior to split date, not saved
+          date: '2018-06-24T00:00' // prior to split date and doesn't exist, saved
         },
         {
           amount: -100,
@@ -86,7 +86,7 @@ describe('banking reconciliator', () => {
         }
       ]
     )
-    expect(Document.createOrUpdate).toHaveBeenCalledTimes(2)
+    expect(Document.createOrUpdate).toHaveBeenCalledTimes(3)
     expect(Document.createOrUpdate.mock.calls).toMatchSnapshot()
   })
 })

--- a/packages/cozy-doctypes/src/utils/__snapshots__/BankingReconciliator.spec.js.snap
+++ b/packages/cozy-doctypes/src/utils/__snapshots__/BankingReconciliator.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`banking reconciliator should correctly reconciliate when accounts do not exist 1`] = `
+exports[`banking reconciliator should correctly reconciliate when accounts exist 1`] = `
 Array [
   Array [
     Object {
@@ -17,6 +17,15 @@ Array [
       "amount": -100,
       "date": "2018-06-27T00:00",
       "label": "Debit 100",
+      "vendorAccountId": 2,
+    },
+  ],
+  Array [
+    Object {
+      "account": 1,
+      "amount": -200,
+      "date": "2018-06-24T00:00",
+      "label": "Debit 200",
       "vendorAccountId": 2,
     },
   ],


### PR DESCRIPTION
We had a duplicates bug in some specific cases. We decided to use the same algorithm whichever the transactions are fetched by a « old » connector, or a newly configured one.

So now we use the algorithm based on the date everytime:

* We get the date of the most recent transaction already saved
* We create all the newly fetched transactions that are after this date
* For each newly fetched transaction that is before this date, we check if some of them don't exist in the DB yet (by comparing their `{ amount, originalLabel, date }` triplet)

This way, we don't need to know if the connector is a new one or not, we always do the same work.

Before merging this PR, I think we must try it on a real world case, even if I added some unit test to add more confidence.