### PR TITLE
[renovate] feat: Renovate schedule

### DIFF
--- a/packages/renovate-config-cozy-app/package.json
+++ b/packages/renovate-config-cozy-app/package.json
@@ -16,6 +16,7 @@
         }
       ],
       "timezone": "Europe/Paris",
+      "schedule": ["after 9pm and before 6am on every weekday", "every weekend"],
       "updateNotScheduled": false
     }
   },


### PR DESCRIPTION
[Here's the documentation for schedules](https://renovatebot.com/docs/configuration-options/#schedule) - basically, this PR tells renovate to do it's things outside of working hours. This keeps the travis pipelines free and avoids creating maintenance notifications during the day.

The downside is you only get notified about possible dependency upgrades the next day — which in most cases is perfectly fine.