### PR TITLE
Add new options to Transaction::reconciliate

### DIFF
--- a/packages/cozy-doctypes/src/BankTransaction.js
+++ b/packages/cozy-doctypes/src/BankTransaction.js
@@ -157,7 +157,7 @@ class Transaction extends Document {
       )
 
       if (missedTransactions.length > 0) {
-        log('info', `Saving ${missedTransactions}.length`)
+        log('info', `Saving ${missedTransactions.length}`)
       } else {
         log('info', 'No missed transactions to catch-up')
       }

--- a/packages/cozy-doctypes/src/BankTransaction.js
+++ b/packages/cozy-doctypes/src/BankTransaction.js
@@ -81,7 +81,11 @@ class Transaction extends Document {
    * @param {array} stackTransactions
    * @returns {array}
    */
-  static getMissedTransactions(transactionsToCheck, stackTransactions) {
+  static getMissedTransactions(
+    transactionsToCheck,
+    stackTransactions,
+    options = {}
+  ) {
     const toCheckByIdentifier = groupBy(transactionsToCheck, t =>
       Transaction.prototype.getIdentifier.call(t)
     )
@@ -95,16 +99,16 @@ class Transaction extends Document {
     for (const [identifier, newTransactions] of Object.entries(
       toCheckByIdentifier
     )) {
-      const existingTransactions = existingByIdentifier[identifier]
+      const existingTransactions = existingByIdentifier[identifier] || []
 
-      if (!existingTransactions) {
-        missedTransactions.push(...newTransactions)
-        continue
+      if (typeof options.onMissedTransactionFound === 'function') {
+        options.onMissedTransactionFound(existingTransactions, newTransactions)
       }
 
       if (newTransactions.length > existingTransactions.length) {
         const difference = newTransactions.length - existingTransactions.length
         missedTransactions.push(...newTransactions.slice(0, difference))
+
         continue
       }
     }
@@ -153,7 +157,8 @@ class Transaction extends Document {
 
       const missedTransactions = Transaction.getMissedTransactions(
         transactionsBeforeSplit,
-        localTransactions
+        localTransactions,
+        options
       )
 
       if (missedTransactions.length > 0) {

--- a/packages/cozy-doctypes/src/BankTransaction.spec.js
+++ b/packages/cozy-doctypes/src/BankTransaction.spec.js
@@ -103,4 +103,24 @@ describe('getMissedTransactions', () => {
 
     expect(missedTransactions).toHaveLength(0)
   })
+
+  it('should call the given onMissedTransactionFound option', () => {
+    const newTransactions = [
+      {
+        amount: -15,
+        originalLabel: 'Test 04',
+        date: '2018-10-01'
+      }
+    ]
+
+    const onMissedTransactionFound = jest.fn()
+    BankTransaction.getMissedTransactions(
+      newTransactions,
+      existingTransactions,
+      { onMissedTransactionFound }
+    )
+
+    expect(onMissedTransactionFound).toHaveBeenCalledTimes(1)
+    expect(onMissedTransactionFound).toHaveBeenCalledWith([], newTransactions)
+  })
 })

--- a/packages/cozy-doctypes/src/utils/BankingReconciliator.js
+++ b/packages/cozy-doctypes/src/utils/BankingReconciliator.js
@@ -58,7 +58,7 @@ class BankingReconciliator {
     const transactions = BankTransaction.reconciliate(
       fetchedTransactions,
       stackTransactions,
-      options.transactionsReconciliationOptions
+      options
     )
 
     log('info', 'Saving transactions...')


### PR DESCRIPTION
Add `onCatchupNonExistentTransaction`, `onCatchupMoreNew` and `onCatchupLessNew` so we can track the following events in Piwik in the Linxo connector:

* We fetch a transaction that is before the date split, but it doesn't exist in the Cozy
* We fetch a transaction that is before the date split, but for the same `{ amount, date, label }` triplet we have less transactions in the cozy than we have fetched
* We fetch a transaction that is before the date split, but for the same `{ amount, date, label }` triplet we have more transactions in the cozy than we have fetched