### PR TITLE
fix(doctypes): Identifier use originalBankLabel

### DIFF
--- a/packages/cozy-doctypes/src/BankTransaction.js
+++ b/packages/cozy-doctypes/src/BankTransaction.js
@@ -67,11 +67,11 @@ class Transaction extends Document {
 
   /**
    * Get the descriptive (and almost uniq) identifier of a transaction
-   * @param {object} transaction - The transaction (containing at least amount, originalLabel and date)
+   * @param {object} transaction - The transaction (containing at least amount, originalBankLabel and date)
    * @returns {object}
    */
   getIdentifier() {
-    return `${this.amount}-${this.originalLabel}-${this.date}`
+    return `${this.amount}-${this.originalBankLabel}-${this.date}`
   }
 
   /**

--- a/packages/cozy-doctypes/src/BankTransaction.spec.js
+++ b/packages/cozy-doctypes/src/BankTransaction.spec.js
@@ -13,7 +13,7 @@ describe('getIdentifier', () => {
   it('should return the identifier of a transaction', () => {
     const transaction = {
       amount: -10,
-      originalLabel: 'Test getIdentifier',
+      originalBankLabel: 'Test getIdentifier',
       date: '2018-10-02',
       currency: 'EUR'
     }
@@ -28,17 +28,17 @@ describe('getMissedTransactions', () => {
   const existingTransactions = [
     {
       amount: -10,
-      originalLabel: 'Test 01',
+      originalBankLabel: 'Test 01',
       date: '2018-10-02'
     },
     {
       amount: -20,
-      originalLabel: 'Test 02',
+      originalBankLabel: 'Test 02',
       date: '2018-10-02'
     },
     {
       amount: -30,
-      originalLabel: 'Test 03',
+      originalBankLabel: 'Test 03',
       date: '2018-10-02'
     }
   ]
@@ -47,12 +47,12 @@ describe('getMissedTransactions', () => {
     const newTransactions = [
       {
         amount: -10,
-        originalLabel: 'Test 01',
+        originalBankLabel: 'Test 01',
         date: '2018-10-02'
       },
       {
         amount: -15,
-        originalLabel: 'Test 04',
+        originalBankLabel: 'Test 04',
         date: '2018-10-01'
       }
     ]
@@ -69,12 +69,12 @@ describe('getMissedTransactions', () => {
     const newTransactions = [
       {
         amount: -10,
-        originalLabel: 'Test 01',
+        originalBankLabel: 'Test 01',
         date: '2018-10-02'
       },
       {
         amount: -10,
-        originalLabel: 'Test 01',
+        originalBankLabel: 'Test 01',
         date: '2018-10-02'
       }
     ]
@@ -91,7 +91,7 @@ describe('getMissedTransactions', () => {
     const newTransactions = [
       {
         amount: -10,
-        originalLabel: 'Test 01',
+        originalBankLabel: 'Test 01',
         date: '2018-10-02'
       }
     ]
@@ -108,7 +108,7 @@ describe('getMissedTransactions', () => {
     const newTransactions = [
       {
         amount: -15,
-        originalLabel: 'Test 04',
+        originalBankLabel: 'Test 04',
         date: '2018-10-01'
       }
     ]


### PR DESCRIPTION
The identifier was made using `originalLabel` which doesn't exist.