### PR TITLE
Add missing push in `end` command

### DIFF
--- a/packages/cozy-release/scripts/cozy-release.sh
+++ b/packages/cozy-release/scripts/cozy-release.sh
@@ -523,6 +523,7 @@ end_release() {
   git branch -D $branch
 
   if [[ ! $NO_PUSH ]]; then
+    git push $remote HEAD
     git push $remote :$branch
   fi
 


### PR DESCRIPTION
A push for master was missing in the end release process.