### PR TITLE
[eslint-config-cozy-app] Use latest react version

### DIFF
--- a/packages/eslint-config-cozy-app/react.js
+++ b/packages/eslint-config-cozy-app/react.js
@@ -8,6 +8,7 @@ module.exports = {
   parser: basics.parser,
   parserOptions: { ecmaFeatures: { jsx: true } },
   env: basics.env,
+  settings: { react: { version: 'latest' } },
   rules: Object.assign({}, basics.rules, {
     'react/prop-types': 0
   })


### PR DESCRIPTION
Get rid of the `Warning: React version not specified in eslint-plugin-react settings` message