### PR TITLE
feat(doctypes): Add account to Transaction checkedAttributes

### DIFF
--- a/packages/cozy-doctypes/src/BankTransaction.js
+++ b/packages/cozy-doctypes/src/BankTransaction.js
@@ -272,7 +272,8 @@ Transaction.idAttributes = ['vendorId']
 Transaction.checkedAttributes = [
   'label',
   'originalBankLabel',
-  'automaticCategoryId'
+  'automaticCategoryId',
+  'account'
 ]
 
 module.exports = Transaction


### PR DESCRIPTION
This way transactions are effectively updated by `createOrUpdate` when their account is updated.