### PR TITLE
feat: Make it obvious that Document cannot be used concurrently

### DIFF
--- a/packages/cozy-doctypes/src/Document.js
+++ b/packages/cozy-doctypes/src/Document.js
@@ -118,7 +118,15 @@ const flagForDeletion = x => Object.assign({}, x, { _deleted: true })
 
 class Document {
   static registerClient(client) {
-    cozyClient = client
+    if (!cozyClient) {
+      cozyClient = client
+    } else {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Document already has been registered, this is not possible to re-register as the client is shared globally between all classes. This is to prevent concurrency bugs.'
+      )
+      throw new Error('Document cannot be re-registered to a client.')
+    }
   }
 
   static createOrUpdate(attributes) {

--- a/packages/cozy-doctypes/src/Document.spec.js
+++ b/packages/cozy-doctypes/src/Document.spec.js
@@ -20,6 +20,13 @@ describe('Document', () => {
     Document.registerClient(null)
   })
 
+  it('client cannot be registered twice', () => {
+    expect(() => {
+      const newClient = {}
+      Document.registerClient(newClient)
+    }).toThrow('Document cannot be re-registered to a client.')
+  })
+
   it('should do create or update', async () => {
     const marge = { name: 'Marge' }
     await Simpson.createOrUpdate(marge)


### PR DESCRIPTION
The fact that Document is using a global variable introduces subtle bugs when used concurrently (it can be re-registered behind your back). By not allowing it to be re-registered, we make it obvious that it is not possible to use it concurrently.