### PR TITLE
[doctypes] BankTransaction logs enhancements

### DIFF
--- a/packages/cozy-doctypes/src/BankTransaction.js
+++ b/packages/cozy-doctypes/src/BankTransaction.js
@@ -107,8 +107,13 @@ class Transaction extends Document {
       const existingTransactions = existingByIdentifier[identifier] || []
 
       if (newTransactions.length > existingTransactions.length) {
+        const level =
+          newTransactions.length === 1 && existingTransactions.length === 0
+            ? 'debug'
+            : 'warn'
+
         log(
-          'warn',
+          level,
           `Linxo have ${
             newTransactions.length
           } transactions for identifier ${identifier}, but we have only ${

--- a/packages/cozy-doctypes/src/BankTransaction.js
+++ b/packages/cozy-doctypes/src/BankTransaction.js
@@ -116,8 +116,10 @@ class Transaction extends Document {
           level,
           `Linxo have ${
             newTransactions.length
-          } transactions for identifier ${identifier}, but we have only ${
+          } transactions, but we have only ${
             existingTransactions.length
+          } with the same identifier as ${this.vendorIdAttr} ${
+            newTransactions[0][this.vendorIdAttr]
           }`
         )
 
@@ -132,8 +134,10 @@ class Transaction extends Document {
           'warn',
           `Linxo have ${
             newTransactions.length
-          } transactions for identifier ${identifier}, but we already have ${
+          } transactions, but we already have ${
             existingTransactions.length
+          } with the same identifier as ${this.vendorIdAttr} ${
+            existingTransactions[0][this.vendorIdAttr]
           }`
         )
 


### PR DESCRIPTION
There was two problems with these logs:

* The normal case (Linxo has 1 transaction and have 0) was logged as a warning. It caused a lot of unnecessary warning lines in the logs. It is now logged as debug.
* Sensitive data was logged. Now we only log the vendor ID of a transaction.