### PR TITLE
feat: Add an nativeLinkOpen helper

### DIFF
--- a/packages/cozy-device-helper/src/index.js
+++ b/packages/cozy-device-helper/src/index.js
@@ -12,3 +12,5 @@ export {
   hasInAppBrowserPlugin,
   hasSafariPlugin
 } from './plugins'
+
+export { nativeLinkOpen } from './link'

--- a/packages/cozy-device-helper/src/link.js
+++ b/packages/cozy-device-helper/src/link.js
@@ -1,0 +1,26 @@
+import { hasSafariPlugin, hasInAppBrowserPlugin } from './plugins'
+
+export const nativeLinkOpen = async ({ url }) => {
+  if ((await hasSafariPlugin()) && window.SafariViewController) {
+    window.SafariViewController.show(
+      {
+        url: url,
+        transition: 'curl'
+      },
+      result => {
+        if (result.event === 'closed') {
+          window.SafariViewController.hide()
+        }
+      },
+      () => {
+        window.SafariViewController.hide()
+      }
+    )
+  } else if (hasInAppBrowserPlugin()) {
+    const target = '_blank'
+    const options = 'clearcache=yes,zoom=no'
+    window.cordova.InAppBrowser.open(url, target, options)
+  } else {
+    window.location = url
+  }
+}


### PR DESCRIPTION
L'idée c'est de pouvoir assez facilement ouvrir des liens, depuis nos applications mobiles, dans safariViewController, ou dans le inAppBrowser (Android) ou dans le browser si rien n'est dispo (standalone). 

On va utiliser ça sur l'onboarding pour avoir une certaines cohérences car certains liens ouvrent actuellement Safari, d'autre SafariView etc. 

```
<Button 
onClick={() => {
    nativeLinkOpen({ url })
  }}
/>
```