### PR TITLE
feat: Support _changes query params

### DIFF
--- a/packages/cozy-doctypes/src/Document.js
+++ b/packages/cozy-doctypes/src/Document.js
@@ -11,6 +11,7 @@ const sortBy = require('lodash/sortBy')
 const get = require('lodash/get')
 const { parallelMap } = require('./utils')
 const log = require('cozy-logger').namespace('Document')
+const querystring = require('querystring')
 
 let cozyClient
 
@@ -266,9 +267,16 @@ class Document {
    * @param  {[type]} options   { includeDesign: false, includeDeleted: false }
    */
   static async fetchChanges(since, options = {}) {
+    const queryParams = {
+      since,
+      include_docs: 'true'
+    }
+    if (options.params) {
+      Object.assign(queryParams, options.params)
+    }
     const result = await cozyClient.fetchJSON(
       'GET',
-      `/data/${this.doctype}/_changes?include_docs=true&since=${since}`
+      `/data/${this.doctype}/_changes?${querystring.stringify(queryParams)}`
     )
 
     const newLastSeq = result.last_seq


### PR DESCRIPTION
Add support to add query parameters to the _changes route. It is useful for example to set the `limit` and `descending` parameters to only fetch the last changes.