### PR TITLE
fix(flags): Add default property to require

### DIFF
--- a/packages/cozy-flags/src/index.js
+++ b/packages/cozy-flags/src/index.js
@@ -1,5 +1,7 @@
 export { default as FlagSwitcher } from './browser/FlagSwitcher'
 
-const flag = global ? require('./node/flag') : require('./browser/flag')
+const flag = global
+  ? require('./node/flag').default
+  : require('./browser/flag').default
 
 export default flag


### PR DESCRIPTION
Since we use `require`, we need to get the `default` property of the module.