### PR TITLE
Add Application

### DIFF
--- a/packages/cozy-doctypes/src/Application.js
+++ b/packages/cozy-doctypes/src/Application.js
@@ -1,0 +1,10 @@
+const Document = require('./Document')
+
+class Application extends Document {}
+
+Application.schema = {
+  doctype: 'io.cozy.apps',
+  attributes: {}
+}
+
+module.exports = Application

--- a/packages/cozy-doctypes/src/index.js
+++ b/packages/cozy-doctypes/src/index.js
@@ -1,3 +1,4 @@
+const Application = require('./Application')
 const Document = require('./Document')
 const BankAccount = require('./BankAccount')
 const BankTransaction = require('./BankTransaction')
@@ -5,6 +6,7 @@ const BalanceHistory = require('./BalanceHistory')
 const BankingReconciliator = require('./utils/BankingReconciliator')
 
 module.exports = {
+  Application,
   Document,
   BankTransaction,
   BankAccount,


### PR DESCRIPTION
The goal of this PR is to make the Application doctype's schema available
from anywhere. We need it to instanciate CozyClient at least in Home,
Store, and the Bar.

The idea is to just write :

```js
import Application from 'cozy-doctypes/Application'
// ...
const client = new CozyClient({
  schema: {
    app: Application.schema
  }
}
```