### PR TITLE
fix(flags): Node and browser detection

### DIFF
--- a/packages/cozy-flags/src/index.js
+++ b/packages/cozy-flags/src/index.js
@@ -1,6 +1,8 @@
 export { default as FlagSwitcher } from './browser/FlagSwitcher'
 
-const flag = global
+const isNode = global && global.process && global.process.title === 'node'
+
+const flag = isNode
   ? require('./node/flag').default
   : require('./browser/flag').default
 


### PR DESCRIPTION
Using `global` was not enough in all cases to detect if we are in a node process or not.