### PR TITLE
Handle 404 from registry

### DIFF
--- a/packages/cozy-app-publish/lib/manual.js
+++ b/packages/cozy-app-publish/lib/manual.js
@@ -113,7 +113,14 @@ async function manualPublish(
     console.log()
     if (err) throw new Error(colorize.red(`prompt: ${err}`))
     if (received.confirm.match(/^y(es)?$/i)) {
-      await publish(publishOptions)
+      try {
+        await publish(publishOptions)
+      } catch (e) {
+        const errorMessage =
+          '↳ ❌  Publishing failed. Publishing aborted.'
+        console.error(e)
+        console.error(errorMessage)
+      }
     } else {
       const errorMessage =
         '↳ ❌  Publishing manually cancelled. Publishing aborted.'

--- a/packages/cozy-app-publish/lib/manual.js
+++ b/packages/cozy-app-publish/lib/manual.js
@@ -116,8 +116,7 @@ async function manualPublish(
       try {
         await publish(publishOptions)
       } catch (e) {
-        const errorMessage =
-          '↳ ❌  Publishing failed. Publishing aborted.'
+        const errorMessage = '↳ ❌  Publishing failed. Publishing aborted.'
         console.error(e)
         console.error(errorMessage)
       }

--- a/packages/cozy-app-publish/lib/prepublish.js
+++ b/packages/cozy-app-publish/lib/prepublish.js
@@ -1,6 +1,7 @@
 const runHooks = require('../utils/runhooks')
-const spawn = require('cross-spawn')
-
+const http = require('http')
+const https = require('https')
+const crypto = require('crypto')
 /**
  * Returns only expected value, avoid data injection by hook
  */
@@ -71,30 +72,36 @@ const check = options => {
   return options
 }
 
-const shasum = options => {
-  const { appBuildUrl, verbose } = options
-  // get the sha256 hash from the archive from the url
-  const shaSumProcess = spawn.sync(
-    'sh',
-    ['-c', `curl -sSL --fail "${appBuildUrl}" | shasum -a 256 | cut -d" " -f1`],
-    {
-      stdio: verbose ? 'inherit' : 'pipe'
-    }
-  )
-  // Note: if the Url don't return an archive or if 404 Not found,
-  // the shasum will be the one of the error message from the curl command
-  // so no error throwed here whatever the url is
-  if (shaSumProcess.status !== 0) {
-    throw new Error(
-      `Error from archive shasum computing (${appBuildUrl}). Publishing failed.`
-    )
-  }
-  // remove also the ending line break
-  options.sha256Sum = shaSumProcess.stdout.toString().replace(/\r?\n|\r/g, '')
+const shasum256FromURL = url =>
+  new Promise((resolve, reject) => {
+    const hash = crypto.createHash('sha256')
+    const httpLib = url.indexOf('https://') === 0 ? https : http
+    const req = httpLib.get(url, res => {
+      res.on('data', d => {
+        hash.update(d)
+      })
+
+      res.on('end', () => {
+        resolve(hash.digest('hex'))
+      })
+    })
+
+    req.on('error', e => {
+      reject(e)
+    })
+  })
+
+const shasum = async options => {
+  const { appBuildUrl } = options
+  const shasum = await prepublish.shasum256FromURL(appBuildUrl)
+  options.sha256Sum = shasum
   return options
 }
 
-module.exports = async options =>
+const prepublish = async options =>
   shasum(
     check(sanitize(await runHooks(options.prepublishHook, 'pre', options)))
   )
+
+module.exports = prepublish
+prepublish.shasum256FromURL = shasum256FromURL

--- a/packages/cozy-app-publish/lib/publish.js
+++ b/packages/cozy-app-publish/lib/publish.js
@@ -11,32 +11,33 @@ module.exports = async ({
   sha256Sum,
   appType
 }) => {
-  let response
-  try {
-    response = await fetch(
-      `${registryUrl}/${spaceName ? spaceName + '/' : ''}registry/${appSlug}`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Token ${registryToken}`
-        },
-        body: JSON.stringify({
-          editor: registryEditor,
-          version: appVersion,
-          url: appBuildUrl,
-          sha256: sha256Sum,
-          type: appType
-        })
-      }
-    )
-  } catch (error) {
-    throw error
-  }
+  const url = `${registryUrl}/${spaceName ? spaceName + '/' : ''}registry/${appSlug}`
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Token ${registryToken}`
+    },
+    body: JSON.stringify({
+      editor: registryEditor,
+      version: appVersion,
+      url: appBuildUrl,
+      sha256: sha256Sum,
+      type: appType
+    })
+  })
 
-  if (response.status !== 201) {
-    const body = await response.json()
-    throw new Error(`${response.status} ${response.statusText}: ${body.error}`)
+  if (response.status === 404) {
+    const text = await response.text()
+    throw new Error(text)
+  } else if (response.status !== 201) {
+    try {
+      const body = await response.json()
+      throw new Error(`${response.status} ${response.statusText}: ${body.error}`)
+    } catch (e) {
+      const text = await response.text()
+      throw new Error(`${response.status} ${response.statusText}: ${text}`)
+    }
   }
 
   return response

--- a/packages/cozy-app-publish/lib/publish.js
+++ b/packages/cozy-app-publish/lib/publish.js
@@ -11,7 +11,9 @@ module.exports = async ({
   sha256Sum,
   appType
 }) => {
-  const url = `${registryUrl}/${spaceName ? spaceName + '/' : ''}registry/${appSlug}`
+  const url = `${registryUrl}/${
+    spaceName ? spaceName + '/' : ''
+  }registry/${appSlug}`
   const response = await fetch(url, {
     method: 'POST',
     headers: {
@@ -33,7 +35,9 @@ module.exports = async ({
   } else if (response.status !== 201) {
     try {
       const body = await response.json()
-      throw new Error(`${response.status} ${response.statusText}: ${body.error}`)
+      throw new Error(
+        `${response.status} ${response.statusText}: ${body.error}`
+      )
     } catch (e) {
       const text = await response.text()
       throw new Error(`${response.status} ${response.statusText}: ${text}`)

--- a/packages/cozy-app-publish/test/__snapshots__/publish.spec.js.snap
+++ b/packages/cozy-app-publish/test/__snapshots__/publish.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Publish script (helper) should handle error message if the publishing failed with 404 1`] = `"404 (TEST) Not Found: Application slug not found"`;
+exports[`Publish script (helper) should handle error message if the publishing failed with 404 1`] = `"{\\"error\\":\\"Application slug not found\\"}"`;
 
 exports[`Publish script (helper) should handle error message if the publishing failed with an unexpected fetch error 1`] = `"(TEST) Unexpected error"`;
 

--- a/packages/cozy-app-publish/test/prepublish.spec.js
+++ b/packages/cozy-app-publish/test/prepublish.spec.js
@@ -7,6 +7,11 @@ jest.doMock('../lib/hooks/pre/downcloud', () => downcloudSpy)
 describe('Prepublish script', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    prepublishLib.shasum256FromURL = jest
+      .fn()
+      .mockResolvedValue(
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+      )
   })
 
   const optionsMock = {


### PR DESCRIPTION
When publishing on a non-existent space, the error was not handled.

Also, do sha sum handling in NodeJS.

I find the code in manual a bit hard to understand since it deals with prompt and also with the fetch logic and error handling.