### PR TITLE
Harvest: Handle I18n

### DIFF
--- a/packages/cozy-harvest-lib/.gitignore
+++ b/packages/cozy-harvest-lib/.gitignore
@@ -1,0 +1,3 @@
+# Locales
+**/locales/*
+!**/locales/en.json

--- a/packages/cozy-harvest-lib/.transifexrc.tpl
+++ b/packages/cozy-harvest-lib/.transifexrc.tpl
@@ -1,0 +1,4 @@
+[https://www.transifex.com]
+hostname = https://www.transifex.com
+username = gregorylegarec
+token =

--- a/packages/cozy-harvest-lib/.tx/config
+++ b/packages/cozy-harvest-lib/.tx/config
@@ -1,0 +1,8 @@
+[main]
+host = https://www.transifex.com
+
+[cozy-harvest-lib.client]
+file_filter = src/locales/<lang>.json
+source_file = src/locales/en.json
+source_lang = en
+type = KEYVALUEJSON

--- a/packages/cozy-harvest-lib/README.md
+++ b/packages/cozy-harvest-lib/README.md
@@ -42,6 +42,33 @@ Fields are declared by their name and can have several properties:
 }
 ```
 
+#### `locales`
+
+Object containing the local as specified in konnector's manifest.
+
+##### Example of `locales` object
+```js
+{
+  en: {
+    fields:
+      username: {
+        label: "Username"
+      }
+    }
+  },
+  fr: {
+    fields: {
+      username: {
+        label: "Nom d'utilisateur"
+      }
+    }
+  }
+}
+```
+Cozy-Harvest-Lib provides a defined range of field labels which do not need to be specified in the manifest. Those field labels are: `answer`, `birthdate`, `code`, `date`, `email`, `firstname`, `lastname`, `login`, `password`, `phone`.
+
+Any konnector can provide new locales for this field labels or add new ones. They will be loaded by the AccountForm component.
+
 ### AccountForm usage
 ```js
 <AccountForm fields={konnector.fields} locales={} />

--- a/packages/cozy-harvest-lib/jest.config.js
+++ b/packages/cozy-harvest-lib/jest.config.js
@@ -1,4 +1,9 @@
 module.exports = {
+  collectCoverageFrom: [
+    '**/*.{js,jsx}',
+    '!**/node_modules/**',
+    '!**/vendor/**'
+  ],
   testURL: 'http://localhost/',
   moduleFileExtensions: ['js', 'jsx', 'json', 'styl'],
   moduleDirectories: ['src', 'node_modules'],

--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -15,8 +15,10 @@
   },
   "scripts": {
     "build": "babel src -d dist --copy-files",
+    "prebuild": "yarn tx",
     "prepublishOnly": "yarn build",
     "test": "jest --verbose --coverage",
+    "tx": "tx pull --all || true",
     "watch": "babel src -d dist --copy-files --watch"
   },
   "dependencies": {

--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -14,10 +14,10 @@
     "url": "https://github.com/cozy/cozy-libs/issues"
   },
   "scripts": {
-    "test": "jest --verbose --coverage",
-    "build": "babel src -d dist",
+    "build": "babel src -d dist --copy-files",
     "prepublishOnly": "yarn build",
-    "watch": "yarn build --watch"
+    "test": "jest --verbose --coverage",
+    "watch": "babel src -d dist --copy-files --watch"
   },
   "dependencies": {
     "cozy-ui": "^17.8.0",

--- a/packages/cozy-harvest-lib/src/components/AccountForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm.jsx
@@ -2,29 +2,33 @@ import React, { PureComponent } from 'react'
 import { Form, Field as FinalFormField } from 'react-final-form'
 
 import Button from 'cozy-ui/react/Button'
+import { translate, extend } from 'cozy-ui/react/I18n'
 import Field from 'cozy-ui/react/Field'
 
 import Manifest from '../Manifest'
 
 export class AccountField extends PureComponent {
   render() {
-    const { type } = this.props
+    const { name, t, type } = this.props
+    const label = t(`fields.${name}.label`)
     const fieldProps = {
+      ...this.props,
       className: 'u-m-0', // 0 margin
+      label,
       size: 'medium'
     }
     switch (type) {
       case 'password':
-        return <Field {...this.props} {...fieldProps} />
+        return <Field {...fieldProps} />
       default:
-        return <Field {...this.props} {...fieldProps} type="text" />
+        return <Field {...fieldProps} type="text" />
     }
   }
 }
 
 export class AccountFields extends PureComponent {
   render() {
-    const { manifestFields } = this.props
+    const { manifestFields, t } = this.props
 
     // Ready to use named fields array
     const namedFields = Object.keys(manifestFields).map(fieldName => ({
@@ -37,7 +41,7 @@ export class AccountFields extends PureComponent {
         {namedFields.map((field, index) => (
           <FinalFormField key={index} name={field.name}>
             {({ input }) => (
-              <AccountField label={field.name} {...field} {...input} />
+              <AccountField label={field.name} {...field} {...input} t={t} />
             )}
           </FinalFormField>
         ))}
@@ -47,8 +51,16 @@ export class AccountFields extends PureComponent {
 }
 
 export class AccountForm extends PureComponent {
+  constructor(props, context) {
+    super(props, context)
+    const { lang, locales } = props
+    if (locales && lang) {
+      extend(locales[lang])
+    }
+  }
+
   render() {
-    const { fields } = this.props
+    const { fields, t } = this.props
     const sanitizedFields = Manifest.sanitizeFields(fields)
     return (
       <Form
@@ -56,14 +68,13 @@ export class AccountForm extends PureComponent {
         onSubmit={v => console.log(v)}
         render={({ values }) => (
           <div>
-            <AccountFields manifestFields={sanitizedFields} />
+            <AccountFields manifestFields={sanitizedFields} t={t} />
             <Button
               className="u-mt-2 u-mb-1-half"
-              onclick={() => alert(JSON.stringify(values, 0, 2))}
               extension="full"
-            >
-              Submit
-            </Button>
+              label={t('accountForm.submit.label')}
+              onclick={() => alert(JSON.stringify(values, 0, 2))}
+            />
           </div>
         )}
       />
@@ -71,4 +82,4 @@ export class AccountForm extends PureComponent {
   }
 }
 
-export default AccountForm
+export default translate()(AccountForm)

--- a/packages/cozy-harvest-lib/src/index.js
+++ b/packages/cozy-harvest-lib/src/index.js
@@ -1,4 +1,14 @@
+import React from 'react'
+import I18n from 'cozy-ui/react/I18n'
 import Harvest from './Harvest'
-export { AccountForm } from './components/AccountForm'
+import TranslatedAccountForm from './components/AccountForm'
+
+const dictRequire = lang => require(`./locales/${lang}.json`)
 
 export default Harvest
+
+export const AccountForm = (props, context) => (
+  <I18n dictRequire={dictRequire} lang={context.lang}>
+    <TranslatedAccountForm {...props} />
+  </I18n>
+)

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -1,0 +1,39 @@
+{
+  "accountForm": {
+    "submit": {
+      "label": "Submit"
+    }
+  },
+  "fields": {
+    "answer": {
+      "label": "Secret answer"
+    },
+    "birthdate": {
+      "label": "Birth date"
+    },
+    "code": {
+      "label": "Confidential code"
+    },
+    "date": {
+      "label": "Date"
+    },
+    "email" : {
+      "label": "Email address"
+    },
+    "firstname": {
+      "label": "First name"
+    },
+    "lastname": {
+      "label": "Last name"
+    },
+    "login": {
+      "label": "Login"
+    },
+    "password": {
+      "label": "Password"
+    },
+    "phone": {
+      "label": "Phone number"
+    }
+  }
+}

--- a/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
+++ b/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
@@ -34,9 +34,11 @@ const fixtures = {
   }
 }
 
+const t = jest.fn().mockImplementation(key => key)
+
 describe('AccountForm', () => {
   it('should render', () => {
-    const wrapper = shallow(<AccountForm fields={fixtures.fields} />)
+    const wrapper = shallow(<AccountForm fields={fixtures.fields} t={t} />)
     const component = wrapper.dive().getElement()
     expect(component).toMatchSnapshot()
   })
@@ -44,7 +46,7 @@ describe('AccountForm', () => {
   describe('AccountFields', () => {
     it('should render', () => {
       const component = shallow(
-        <AccountFields manifestFields={fixtures.fields} />
+        <AccountFields manifestFields={fixtures.fields} t={t} />
       ).getElement()
       expect(component).toMatchSnapshot()
     })
@@ -52,14 +54,20 @@ describe('AccountForm', () => {
 
   describe('AccountField', () => {
     it('should render', () => {
-      const wrapper = shallow(<AccountField {...fixtures.sanitized.username} />)
+      const wrapper = shallow(
+        <AccountField {...fixtures.sanitized.username} name="username" t={t} />
+      )
       const component = wrapper.dive().getElement()
       expect(component).toMatchSnapshot()
     })
 
     it('render password', () => {
       const wrapper = shallow(
-        <AccountField {...fixtures.sanitized.passphrase} />
+        <AccountField
+          {...fixtures.sanitized.passphrase}
+          name="passphrase"
+          t={t}
+        />
       )
       const component = wrapper.dive().getElement()
       expect(component).toMatchSnapshot()

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
@@ -9,7 +9,7 @@ exports[`AccountForm AccountField render password 1`] = `
     error={false}
     htmlFor=""
   >
-    
+    fields.passphrase.label
   </Label>
   <Input
     error={false}
@@ -31,7 +31,7 @@ exports[`AccountForm AccountField should render 1`] = `
     error={false}
     htmlFor=""
   >
-    
+    fields.username.label
   </Label>
   <Input
     error={false}
@@ -81,13 +81,27 @@ exports[`AccountForm should render 1`] = `
         },
       }
     }
+    t={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "accountForm.submit.label",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": "accountForm.submit.label",
+          },
+        ],
+      }
+    }
   />
   <DefaultButton
     className="u-mt-2 u-mb-1-half"
     extension="full"
+    label="accountForm.submit.label"
     onclick={[Function]}
-  >
-    Submit
-  </DefaultButton>
+  />
 </div>
 `;


### PR DESCRIPTION
This PR add I18n handling in cozy-harvest-lib.

It use the cozy I18N wrapper to create a local scope around the AccountForm.

I18n phrases are updated with konnector manifest locales object.

The main <I18n /> wrapper is set directly into `index.js` file, to not interfer with unit tests and keep the component like AccountForm as pure as dumb as possible.