### PR TITLE
feat(flags): Handle flags enabled at build time

### DIFF
--- a/packages/cozy-flags/README.md
+++ b/packages/cozy-flags/README.md
@@ -43,3 +43,10 @@ const App = () => {
 }
 
 ```
+
+### Flags enabled at build time
+
+It is possible to handle flags enabled at build time. Your app should just
+provide a global `__ENABLED_FLAGS__` array with flag names that should be
+enabled. If such a global exists, `cozy-flags` will iterate on the array and
+enable all the flags it contains when it is imported.

--- a/packages/cozy-flags/src/index.js
+++ b/packages/cozy-flags/src/index.js
@@ -1,8 +1,14 @@
+/* global __ENABLED_FLAGS__ */
+
 import isNode from 'detect-node'
 export { default as FlagSwitcher } from './browser/FlagSwitcher'
 
 const flag = isNode
   ? require('./node/flag').default
   : require('./browser/flag').default
+
+if (__ENABLED_FLAGS__ && Array.isArray(__ENABLED_FLAGS__)) {
+  __ENABLED_FLAGS__.forEach(enabledFlag => flag(enabledFlag, true))
+}
 
 export default flag


### PR DESCRIPTION
If some flags were enabled at build time, enable them as soon as `cozy-flags` is imported.