### PR TITLE
Harvest: Predefined labels

### DIFF
--- a/packages/cozy-harvest-lib/README.md
+++ b/packages/cozy-harvest-lib/README.md
@@ -27,7 +27,7 @@ Fields are declared by their name and can have several properties:
 |Property|Role|
 |-|-|
 |`encrypted` | Specify if field should be encrypted by stack (default: `true` if `type=password`, `false` otherwise). |
-|`required` | Specify if field is required (default: `true`). |
+|`label` | Predefined label can be used and specified in manifest. They are a common way to provide existing locales. List of predefined labels are `answer`, `birthdate`, `code`, `date`, `email`, `firstname`, `lastname`, `login`, `password`, `phone`. | |`required` | Specify if field is required (default: `true`). |
 |`type` | Can be `date`, `dropdown`, `email`, `text` or `password` (default: `text`). |
 
 ##### Example of `fields` object

--- a/packages/cozy-harvest-lib/src/components/AccountForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm.jsx
@@ -8,15 +8,31 @@ import Field from 'cozy-ui/react/Field'
 
 import Manifest from '../Manifest'
 
+const predefinedLabels = [
+  'answer',
+  'birthdate',
+  'code',
+  'date',
+  'email',
+  'firstname',
+  'lastname',
+  'login',
+  'password',
+  'phone'
+]
+
 export class AccountField extends PureComponent {
   render() {
-    const { name, t, type } = this.props
-    const label = t(`fields.${name}.label`)
+    const { label, name, t, type } = this.props
+
+    // Allow manifest to specify predefined label
+    const localeKey = predefinedLabels.includes(label) ? label : name
+
     const fieldProps = {
       ...this.props,
       className: 'u-m-0', // 0 margin
       fullwidth: true,
-      label,
+      label: t(`fields.${localeKey}.label`),
       size: 'medium'
     }
     const passwordLabels = {
@@ -46,9 +62,7 @@ export class AccountFields extends PureComponent {
       <div>
         {namedFields.map((field, index) => (
           <FinalFormField key={index} name={field.name}>
-            {({ input }) => (
-              <AccountField label={field.name} {...field} {...input} t={t} />
-            )}
+            {({ input }) => <AccountField {...field} {...input} t={t} />}
           </FinalFormField>
         ))}
       </div>

--- a/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
+++ b/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
@@ -86,5 +86,31 @@ describe('AccountForm', () => {
       const component = wrapper.dive().getElement()
       expect(component).toMatchSnapshot()
     })
+
+    it('uses predefined label', () => {
+      const wrapper = shallow(
+        <AccountField
+          label="login"
+          name="username"
+          required={true}
+          type="text"
+          t={t}
+        />
+      )
+      expect(wrapper.props().label).toBe('fields.login.label')
+    })
+
+    it('ignores invalid predefined label', () => {
+      const wrapper = shallow(
+        <AccountField
+          label="foo"
+          name="username"
+          required={true}
+          type="text"
+          t={t}
+        />
+      )
+      expect(wrapper.props().label).toBe('fields.username.label')
+    })
   })
 })


### PR DESCRIPTION
This PR adds predefined labels for manifest fields.

A field may declare a `label` value, which refers to one of the predefined labels provided by Cozy-Harvest-Lib. It is then this label which is used for i18n.