### PR TITLE
Harvest: Use placeholders when editing encrypted value

### DIFF
--- a/packages/cozy-harvest-lib/src/Manifest.js
+++ b/packages/cozy-harvest-lib/src/Manifest.js
@@ -79,9 +79,12 @@ const legacyEncryptedFields = [
  */
 const sanitizeEncrypted = fields => {
   const sanitized = _cloneDeep(fields)
-  for (let fieldName in sanitized)
-    if (typeof sanitized[fieldName].encrypted !== 'boolean')
-      sanitized[fieldName].encrypted = legacyEncryptedFields.includes(fieldName)
+  for (let fieldName in sanitized) {
+    const field = sanitized[fieldName]
+    if (typeof field.encrypted !== 'boolean')
+      field.encrypted =
+        field.type === 'password' || legacyEncryptedFields.includes(fieldName)
+  }
   return sanitized
 }
 

--- a/packages/cozy-harvest-lib/src/Manifest.spec.js
+++ b/packages/cozy-harvest-lib/src/Manifest.spec.js
@@ -225,6 +225,18 @@ describe('Manifest', () => {
   })
 
   describe('sanitizeEncrypted', () => {
+    it('should et encrypted for type=password', () => {
+      const manifest = {
+        fields: {
+          username: { type: 'text' },
+          passphrase: { type: 'password' }
+        }
+      }
+
+      const result = Manifest.sanitize(manifest)
+      expect(result.fields.passphrase.encrypted).toBe(true)
+    })
+
     const legacyEncryptedFieldsTest = [
       'secret',
       'dob',
@@ -234,6 +246,7 @@ describe('Manifest', () => {
       'refresh_token',
       'appSecret'
     ]
+
     for (let name of legacyEncryptedFieldsTest) {
       let legacyManifest = {
         fields: {

--- a/packages/cozy-harvest-lib/src/components/AccountForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm.jsx
@@ -9,6 +9,8 @@ import Field from 'cozy-ui/react/Field'
 import Manifest from '../Manifest'
 import OAuthForm from './OAuthForm'
 
+const ENCRYPTED_PLACEHOLDER = '*************'
+
 const predefinedLabels = [
   'answer',
   'birthdate',
@@ -71,7 +73,7 @@ const parse = type => value => {
 
 export class AccountFields extends PureComponent {
   render() {
-    const { manifestFields, t } = this.props
+    const { fillEncrypted, manifestFields, t } = this.props
 
     // Ready to use named fields array
     const namedFields = Object.keys(manifestFields).map(fieldName => ({
@@ -87,7 +89,18 @@ export class AccountFields extends PureComponent {
             name={field.name}
             parse={parse(field.type)}
           >
-            {({ input }) => <AccountField {...field} {...input} t={t} />}
+            {({ input }) => (
+              <AccountField
+                {...field}
+                {...input}
+                placeholder={
+                  field.encrypted && fillEncrypted
+                    ? ENCRYPTED_PLACEHOLDER
+                    : field.placeholder
+                }
+                t={t}
+              />
+            )}
           </FinalFormField>
         ))}
       </div>
@@ -118,7 +131,11 @@ export class AccountForm extends PureComponent {
         onSubmit={v => console.log(v)}
         render={({ values }) => (
           <div>
-            <AccountFields manifestFields={sanitizedFields} t={t} />
+            <AccountFields
+              fillEncrypted={!!account}
+              manifestFields={sanitizedFields}
+              t={t}
+            />
             <Button
               className="u-mt-2 u-mb-1-half"
               extension="full"

--- a/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
+++ b/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
@@ -74,6 +74,13 @@ describe('AccountForm', () => {
       ).getElement()
       expect(component).toMatchSnapshot()
     })
+
+    it('should render encrypted fields with placeholder', () => {
+      const component = shallow(
+        <AccountFields manifestFields={fixtures.sanitized} t={t} />
+      ).getElement()
+      expect(component).toMatchSnapshot()
+    })
   })
 
   describe('AccountField', () => {

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
@@ -199,7 +199,7 @@ exports[`AccountForm should render 1`] = `
     manifestFields={
       Object {
         "passphrase": Object {
-          "encrypted": false,
+          "encrypted": true,
           "required": true,
           "type": "password",
         },

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
@@ -183,6 +183,25 @@ exports[`AccountForm AccountFields should render 1`] = `
 </div>
 `;
 
+exports[`AccountForm AccountFields should render encrypted fields with placeholder 1`] = `
+<div>
+  <Field
+    format={[Function]}
+    name="username"
+    parse={[Function]}
+  >
+    [Function]
+  </Field>
+  <Field
+    format={[Function]}
+    name="passphrase"
+    parse={[Function]}
+  >
+    [Function]
+  </Field>
+</div>
+`;
+
 exports[`AccountForm should redirect to OAuthForm 1`] = `
 <Wrapper
   oauth={
@@ -196,6 +215,7 @@ exports[`AccountForm should redirect to OAuthForm 1`] = `
 exports[`AccountForm should render 1`] = `
 <div>
   <AccountFields
+    fillEncrypted={false}
     manifestFields={
       Object {
         "passphrase": Object {


### PR DESCRIPTION
We cannot read encrypted value in apps so we display a dedicated
placeholder to show that the field has a value.