### PR TITLE
Use initialValues prop instead of account

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm.jsx
@@ -118,12 +118,11 @@ export class AccountForm extends PureComponent {
   }
 
   render() {
-    const { account, fields, oauth, t } = this.props
+    const { fields, initialValues, oauth, t } = this.props
 
     if (oauth) return <OAuthForm oauth={oauth} />
 
     const sanitizedFields = Manifest.sanitizeFields(fields)
-    const initialValues = account ? account.auth : {}
     return (
       <Form
         initialValues={initialValues}
@@ -132,7 +131,7 @@ export class AccountForm extends PureComponent {
         render={({ values }) => (
           <div>
             <AccountFields
-              fillEncrypted={!!account}
+              fillEncrypted={!!initialValues}
               manifestFields={sanitizedFields}
               t={t}
             />

--- a/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
+++ b/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
@@ -55,7 +55,11 @@ describe('AccountForm', () => {
 
   it('should inject initial values from account', () => {
     const wrapper = shallow(
-      <AccountForm account={fixtures.account} fields={fixtures.fields} t={t} />
+      <AccountForm
+        initialValues={fixtures.account.auth}
+        fields={fixtures.fields}
+        t={t}
+      />
     )
     expect(wrapper.props().initialValues).toEqual(fixtures.account.auth)
   })


### PR DESCRIPTION
We aim to limit the logic related to account into accountForm, and deal only with values.