### PR TITLE
feat(babel): Update supported browsers list for Cozy platform

### DIFF
--- a/packages/babel-preset-cozy-app/index.js
+++ b/packages/babel-preset-cozy-app/index.js
@@ -3,13 +3,19 @@
 const { declare } = require('@babel/helper-plugin-utils')
 
 const browserEnv = {
-  targets: {
-    chrome: 42,
-    ie: 10,
-    firefox: 40,
-    browsers: ['last 2 versions']
-  },
-  // don't transform polyfills
+  targets: [
+    'last 2 Chrome major versions',
+    'last 2 ChromeAndroid major versions',
+    'last 2 Firefox major versions',
+    'last 2 FirefoxAndroid major versions',
+    'last 2 Safari major versions',
+    'last 2 iOS major versions',
+    'last 2 Edge major versions',
+    'Firefox ESR',
+    '> 1% in FR',
+    'not dead',
+    'not ie <= 11'
+  ],
   useBuiltIns: false
 }
 


### PR DESCRIPTION
Fix #215 

~~We wasn't previously transforming the polyfills with [`useBuiltIns`](https://babeljs.io/docs/en/babel-preset-env#usebuiltins) so we was required all the core-js I think, now it will be better handled by requiring only the ones needed for targeted browsers.~~

Edit: Only update the supported browsers list for now