### PR TITLE
fix: Shasum was not following redirects

### DIFF
--- a/packages/cozy-app-publish/lib/prepublish.js
+++ b/packages/cozy-app-publish/lib/prepublish.js
@@ -74,9 +74,11 @@ const check = options => {
 const shasum256FromURL = url =>
   new Promise((resolve, reject) => {
     const hasher = crypto.createHash('sha256').setEncoding('hex')
-    const req = request(url).pipe(hasher).on('finish', res => {
-      resolve(hasher.read())
-    })
+    const req = request(url)
+      .pipe(hasher)
+      .on('finish', () => {
+        resolve(hasher.read())
+      })
 
     req.on('error', e => {
       reject(e)

--- a/packages/cozy-app-publish/lib/prepublish.js
+++ b/packages/cozy-app-publish/lib/prepublish.js
@@ -1,6 +1,5 @@
 const runHooks = require('../utils/runhooks')
-const http = require('http')
-const https = require('https')
+const request = require('request')
 const crypto = require('crypto')
 /**
  * Returns only expected value, avoid data injection by hook
@@ -74,16 +73,9 @@ const check = options => {
 
 const shasum256FromURL = url =>
   new Promise((resolve, reject) => {
-    const hash = crypto.createHash('sha256')
-    const httpLib = url.indexOf('https://') === 0 ? https : http
-    const req = httpLib.get(url, res => {
-      res.on('data', d => {
-        hash.update(d)
-      })
-
-      res.on('end', () => {
-        resolve(hash.digest('hex'))
-      })
+    const hasher = crypto.createHash('sha256').setEncoding('hex')
+    const req = request(url).pipe(hasher).on('finish', res => {
+      resolve(hasher.read())
     })
 
     req.on('error', e => {

--- a/packages/cozy-app-publish/package.json
+++ b/packages/cozy-app-publish/package.json
@@ -6,9 +6,7 @@
   "license": "MIT",
   "scripts": {
     "test": "jest --verbose --coverage",
-    "test:manual": "jest test/manual.spec.js",
-    "test:publish": "jest test/publish.spec.js",
-    "test:travis": "jest test/travis.spec.js"
+    "test:integration": "env TEST_INTEGRATION=1 jest"
   },
   "bin": {
     "cozy-app-publish": "./cozy-app-publish.js"
@@ -20,6 +18,7 @@
     "fs-extra": "7.0.1",
     "node-fetch": "2.2.0",
     "prompt": "1.0.0",
+    "request": "^2.88.0",
     "tar": "4.4.8"
   },
   "files": [

--- a/packages/cozy-app-publish/test/prepublish.spec.js
+++ b/packages/cozy-app-publish/test/prepublish.spec.js
@@ -7,11 +7,14 @@ jest.doMock('../lib/hooks/pre/downcloud', () => downcloudSpy)
 describe('Prepublish script', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    prepublishLib.shasum256FromURL = jest
-      .fn()
+    jest.spyOn(prepublishLib, 'shasum256FromURL')
       .mockResolvedValue(
         'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
       )
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
   })
 
   const optionsMock = {
@@ -67,3 +70,13 @@ describe('Prepublish script', () => {
     expect(downcloudSpy).toHaveBeenCalled()
   })
 })
+
+if (process.env.TEST_INTEGRATION) {
+  describe('shasum', () => {
+    it('should do a correct shasum, following redirections', async () => {
+      const url = 'https://github.com/konnectors/rtm/archive/b1e77ca0d9d76b682b87ae4114669b11953083d0.tar.gz'
+      const sha = await prepublishLib.shasum256FromURL(url)
+      expect(sha).toBe('7d9b75938613af486f27a58f5423e52eab566e32de2a77a863facc84c63f41ae')
+    })
+  })
+}

--- a/packages/cozy-app-publish/test/prepublish.spec.js
+++ b/packages/cozy-app-publish/test/prepublish.spec.js
@@ -7,7 +7,8 @@ jest.doMock('../lib/hooks/pre/downcloud', () => downcloudSpy)
 describe('Prepublish script', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    jest.spyOn(prepublishLib, 'shasum256FromURL')
+    jest
+      .spyOn(prepublishLib, 'shasum256FromURL')
       .mockResolvedValue(
         'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
       )
@@ -74,9 +75,12 @@ describe('Prepublish script', () => {
 if (process.env.TEST_INTEGRATION) {
   describe('shasum', () => {
     it('should do a correct shasum, following redirections', async () => {
-      const url = 'https://github.com/konnectors/rtm/archive/b1e77ca0d9d76b682b87ae4114669b11953083d0.tar.gz'
+      const url =
+        'https://github.com/konnectors/rtm/archive/b1e77ca0d9d76b682b87ae4114669b11953083d0.tar.gz'
       const sha = await prepublishLib.shasum256FromURL(url)
-      expect(sha).toBe('7d9b75938613af486f27a58f5423e52eab566e32de2a77a863facc84c63f41ae')
+      expect(sha).toBe(
+        '7d9b75938613af486f27a58f5423e52eab566e32de2a77a863facc84c63f41ae'
+      )
     })
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7186,7 +7186,7 @@ request@2.83.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
-request@^2.87.0:
+request@^2.87.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==


### PR DESCRIPTION
NodeJS standard `http` and `https` do not follow redirects. GitHub archive urls are redirections. We were shasumming the redirection page and not the archive. I changed to use `request` which automatically follow redirects (like a good boy 🐶 ).

For info `curl` does not follow redirects by default, it needs the `-L` option.