### PR TITLE
[cozy-doctypes] Add updatedAt metadata on Document

### DIFF
--- a/packages/cozy-doctypes/src/Document.js
+++ b/packages/cozy-doctypes/src/Document.js
@@ -79,7 +79,7 @@ async function createOrUpdate(
   }
 
   if (results.length === 0) {
-    return cozyClient.data.create(doctype, attributes)
+    return cozyClient.data.create(doctype, Document.addCozyMetadata(attributes))
   } else if (results.length === 1) {
     const id = results[0]._id
     const update = omit(attributes, userAttributes)
@@ -95,7 +95,11 @@ async function createOrUpdate(
       // do not emit a mail for those attribute updates
       delete update.dateImport
 
-      return cozyClient.data.updateAttributes(doctype, id, update)
+      return cozyClient.data.updateAttributes(
+        doctype,
+        id,
+        Document.addCozyMetadata(update)
+      )
     } else {
       log(
         'debug',
@@ -128,6 +132,16 @@ class Document {
       )
       throw new Error('Document cannot be re-registered to a client.')
     }
+  }
+
+  static addCozyMetadata(attributes) {
+    if (!attributes.cozyMetadata) {
+      attributes.cozyMetadata = {}
+    }
+
+    attributes.cozyMetadata.updatedAt = new Date()
+
+    return attributes
   }
 
   static createOrUpdate(attributes) {

--- a/packages/cozy-doctypes/src/Document.js
+++ b/packages/cozy-doctypes/src/Document.js
@@ -107,7 +107,7 @@ async function createOrUpdate(
     }
   } else {
     throw new Error(
-      'Linxo cozy: Create or update with selectors that returns more than 1 result\n' +
+      'Create or update with selectors that returns more than 1 result\n' +
         JSON.stringify(selector) +
         '\n' +
         JSON.stringify(results)

--- a/packages/cozy-doctypes/src/Document.spec.js
+++ b/packages/cozy-doctypes/src/Document.spec.js
@@ -43,6 +43,14 @@ describe('Document', () => {
     expect(cozyClient.data.updateAttributes).toHaveBeenCalledTimes(1)
   })
 
+  it('should add cozy metadatas on create or update', async () => {
+    const marge = { name: 'Marge' }
+    const margeWithCozyMetas = Simpson.addCozyMetadata(marge)
+
+    expect(margeWithCozyMetas.cozyMetadata).toBeDefined()
+    expect(margeWithCozyMetas.cozyMetadata.updatedAt).toEqual(expect.any(Date))
+  })
+
   it('should do bulk fetch', async () => {
     await Simpson.fetchAll()
     expect(cozyClient.fetchJSON).toHaveBeenCalledWith(


### PR DESCRIPTION
Automatically add `cozyMetadata.updatedAt` when `createOrUpdate`ing a `Document`.