### PR TITLE
Harvest: Sanitize select props

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm.jsx
@@ -6,6 +6,7 @@ import Button from 'cozy-ui/react/Button'
 import { translate, extend } from 'cozy-ui/react/I18n'
 import Field from 'cozy-ui/react/Field'
 
+import { sanitizeSelectProps } from '../helpers/fields'
 import Manifest from '../Manifest'
 import OAuthForm from './OAuthForm'
 
@@ -44,18 +45,7 @@ export class AccountField extends PureComponent {
     }
     switch (type) {
       case 'dropdown':
-        return (
-          <Field
-            {...fieldProps}
-            options={fieldProps.options.map(option => ({
-              ...option,
-              // legacy
-              label: option.name
-            }))}
-            value={fieldProps.options.find(o => o.value === fieldProps.value)}
-            type="select"
-          />
-        )
+        return <Field {...sanitizeSelectProps(fieldProps)} />
       case 'password':
         return <Field {...fieldProps} secondaryLabels={passwordLabels} />
       default:

--- a/packages/cozy-harvest-lib/src/helpers/fields.js
+++ b/packages/cozy-harvest-lib/src/helpers/fields.js
@@ -1,0 +1,32 @@
+/**
+ * Prepare props to pass to React-Select
+ * Options must be consistent and value cannot be ''
+ * @param  {props} props Props passed to Cozy-UI <Field /> component
+ * @return {[type]}       Sanitized props, ready to be passed to
+ */
+export const sanitizeSelectProps = props => {
+  const { options, value } = props
+  const sanitized = { ...props }
+
+  sanitized.options = options
+    ? options.map(option => ({
+        ...option,
+        // legacy
+        label: option.label || option.name
+      }))
+    : []
+
+  // We cannot pass an empty string as value to React-Select, or no value is
+  // never displayed in the select.
+  // `false` is an accepted value.
+  if (typeof value !== 'undefined') {
+    sanitized.value = sanitized.options.find(o => o.value === value)
+  }
+
+  sanitized.type = 'select'
+  return sanitized
+}
+
+export default {
+  sanitizeSelectProps
+}

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
@@ -22,11 +22,11 @@ exports[`AccountForm AccountField render dropdown 1`] = `
     options={
       Array [
         Object {
-          "label": undefined,
+          "label": "Option 1",
           "value": "option1",
         },
         Object {
-          "label": undefined,
+          "label": "Option 2",
           "value": "option2",
         },
       ]

--- a/packages/cozy-harvest-lib/test/helpers/fields.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/fields.spec.js
@@ -1,0 +1,74 @@
+/* eslint-env jest */
+import { sanitizeSelectProps } from 'helpers/fields'
+
+describe('Fields Helper', () => {
+  describe('sanitizeSelectProps', () => {
+    it('should sanitize legacy options', () => {
+      const fieldWithLegacyOptions = {
+        options: [
+          { name: 'Option 1', value: '1' },
+          { name: 'Option 2', value: '2' },
+          { name: 'Option 3', value: '3' }
+        ],
+        type: 'select'
+      }
+      expect(sanitizeSelectProps(fieldWithLegacyOptions)).toEqual({
+        options: [
+          { name: 'Option 1', value: '1', label: 'Option 1' },
+          { name: 'Option 2', value: '2', label: 'Option 2' },
+          { name: 'Option 3', value: '3', label: 'Option 3' }
+        ],
+        type: 'select'
+      })
+    })
+
+    it('should keep labels with legacy options', () => {
+      const fieldWithLegacyOptions = {
+        options: [
+          { label: 'Label 1', name: 'Option 1', value: '1' },
+          { label: 'Label 2', name: 'Option 2', value: '2' },
+          { label: 'Label 3', name: 'Option 3', value: '3' }
+        ],
+        type: 'select'
+      }
+      expect(sanitizeSelectProps(fieldWithLegacyOptions)).toEqual({
+        options: [
+          { name: 'Option 1', value: '1', label: 'Label 1' },
+          { name: 'Option 2', value: '2', label: 'Label 2' },
+          { name: 'Option 3', value: '3', label: 'Label 3' }
+        ],
+        type: 'select'
+      })
+    })
+
+    it('should map existing value to option', () => {
+      const field = {
+        options: [
+          { label: 'Option 1', value: '1' },
+          { label: 'Option 2', value: '2' },
+          { label: 'Option 3', value: '3' }
+        ],
+        value: '2'
+      }
+
+      expect(sanitizeSelectProps(field).value).toEqual({
+        label: 'Option 2',
+        value: '2'
+      })
+    })
+
+    it('should not allow empty string for value', () => {
+      const field = {
+        value: ''
+      }
+      expect(sanitizeSelectProps(field).value).toBeUndefined()
+    })
+
+    it('should set type to select', () => {
+      const field = {
+        type: 'dropdown'
+      }
+      expect(sanitizeSelectProps(field).type).toBe('select')
+    })
+  })
+})


### PR DESCRIPTION
The goal is to avoid passing an empty string as value, as it make React-Select show no value selected.