### PR TITLE
feat(Document): Automatically add cozyMetadata.createdByApp

### DIFF
--- a/packages/cozy-doctypes/src/Document.js
+++ b/packages/cozy-doctypes/src/Document.js
@@ -141,6 +141,10 @@ class Document {
 
     attributes.cozyMetadata.updatedAt = new Date()
 
+    if (!attributes.cozyMetadata.createdByApp && this.createdByApp) {
+      attributes.cozyMetadata.createdByApp = this.createdByApp
+    }
+
     return attributes
   }
 

--- a/packages/cozy-doctypes/src/Document.spec.js
+++ b/packages/cozy-doctypes/src/Document.spec.js
@@ -43,12 +43,29 @@ describe('Document', () => {
     expect(cozyClient.data.updateAttributes).toHaveBeenCalledTimes(1)
   })
 
-  it('should add cozy metadatas on create or update', async () => {
+  it('should update updatedAt cozyMetadata on create or update', async () => {
     const marge = { name: 'Marge' }
     const margeWithCozyMetas = Simpson.addCozyMetadata(marge)
 
     expect(margeWithCozyMetas.cozyMetadata).toBeDefined()
     expect(margeWithCozyMetas.cozyMetadata.updatedAt).toEqual(expect.any(Date))
+  })
+
+  it('should add createdByApp cozyMetadata on create or update if needed and possible', async () => {
+    const marge = { name: 'Marge' }
+    const margeWithCozyMetas = Simpson.addCozyMetadata(marge)
+
+    expect(margeWithCozyMetas.cozyMetadata).toBeDefined()
+    expect(margeWithCozyMetas.cozyMetadata.createdByApp).not.toBeDefined()
+
+    Simpson.createdByApp = 'simpsoncreator'
+    const bart = { name: 'Bart' }
+    const bartWithCozyMetas = Simpson.addCozyMetadata(bart)
+
+    expect(bartWithCozyMetas.cozyMetadata).toBeDefined()
+    expect(bartWithCozyMetas.cozyMetadata.createdByApp).toEqual(
+      'simpsoncreator'
+    )
   })
 
   it('should do bulk fetch', async () => {


### PR DESCRIPTION
Automatically add `cozyMetadata.createdByApp` when `createOrUpdate`ing a `Document`. The property is added if it doesn't exist and if the `Document` has a static property `createdByApp`.

I had to relocate the `createOrUpdate` function as a method of `Document` otherwise we would lose the reference to static properties like `createdByApp` between the call to `createOrUpdate` and the call to `Document::addCozyMetadata`.