### PR TITLE
Harvest: Disable identifier with initial value

### DIFF
--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
@@ -13,6 +13,7 @@ exports[`AccountForm AccountField render dropdown 1`] = `
   </Label>
   <Aware
     className="u-m-0"
+    disabled={false}
     error={false}
     fieldProps={Object {}}
     fullwidth={true}
@@ -172,6 +173,7 @@ exports[`AccountForm should have disabled button if there is required field empt
 <div>
   <AccountFields
     fillEncrypted={false}
+    initialValues={Object {}}
     manifestFields={
       Object {
         "test": Object {
@@ -212,6 +214,7 @@ exports[`AccountForm should have enabled button if fields isn't required 1`] = `
 <div>
   <AccountFields
     fillEncrypted={false}
+    initialValues={Object {}}
     manifestFields={
       Object {
         "test": Object {
@@ -252,6 +255,11 @@ exports[`AccountForm should have enabled button if required field isn't empty 1`
 <div>
   <AccountFields
     fillEncrypted={false}
+    initialValues={
+      Object {
+        "test": "test",
+      }
+    }
     manifestFields={
       Object {
         "test": Object {
@@ -303,6 +311,7 @@ exports[`AccountForm should render 1`] = `
 <div>
   <AccountFields
     fillEncrypted={false}
+    initialValues={Object {}}
     manifestFields={
       Object {
         "passphrase": Object {


### PR DESCRIPTION
When a field having role set to `identifier` has an initial value, it cannot be editable.