### PR TITLE
Harvest: Improve placeholder for encrypted fields mechanism

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm.jsx
@@ -6,11 +6,13 @@ import Button from 'cozy-ui/react/Button'
 import { translate, extend } from 'cozy-ui/react/I18n'
 import Field from 'cozy-ui/react/Field'
 
-import { sanitizeSelectProps } from '../helpers/fields'
+import {
+  getEncryptedFieldName,
+  getFieldPlaceholder,
+  sanitizeSelectProps
+} from '../helpers/fields'
 import Manifest from '../Manifest'
 import OAuthForm from './OAuthForm'
-
-const ENCRYPTED_PLACEHOLDER = '*************'
 
 const predefinedLabels = [
   'answer',
@@ -42,7 +44,10 @@ export class AccountField extends PureComponent {
       disabled: !isEditable,
       fullwidth: true,
       label: t(`fields.${localeKey}.label`, { _: name }),
-      placeholder: placeholder || t(`fields.${name}.placeholder`, { _: '' }),
+      placeholder: getFieldPlaceholder(
+        this.props,
+        t(`fields.${name}.placeholder`, { _: '' })
+      ),
       size: 'medium'
     }
     const passwordLabels = {
@@ -78,7 +83,7 @@ const parse = type => value => {
 
 export class AccountFields extends PureComponent {
   render() {
-    const { fillEncrypted, initialValues, manifestFields, t } = this.props
+    const { initialValues, manifestFields, t } = this.props
 
     // Ready to use named fields array
     const namedFields = Object.keys(manifestFields).map(fieldName => ({
@@ -98,9 +103,9 @@ export class AccountFields extends PureComponent {
               <AccountField
                 {...field}
                 {...input}
-                initialValue={initialValues[field.name]}
-                placeholder={
-                  field.encrypted && fillEncrypted && ENCRYPTED_PLACEHOLDER
+                initialValue={
+                  initialValues[field.name] ||
+                  initialValues[getEncryptedFieldName(field.name)]
                 }
                 t={t}
               />
@@ -155,7 +160,6 @@ export class AccountForm extends PureComponent {
           <div>
             <AccountFields
               initialValues={initialAndDefaultValues}
-              fillEncrypted={!!initialValues}
               manifestFields={sanitizedFields}
               t={t}
             />

--- a/packages/cozy-harvest-lib/src/helpers/fields.js
+++ b/packages/cozy-harvest-lib/src/helpers/fields.js
@@ -1,3 +1,38 @@
+const ENCRYPTED_PLACEHOLDER = '*************'
+
+/**
+ * Returns the encrypted fied name as it is computed by the cozy-stack.
+ * Cozy-stack encrypt both fields named `login` and `password` together into
+ * a property named `credentials_encrypted`.
+ * Any other named field is encrypted "alone" into a property named
+ * `${name}_encrypted`, ${name} being here the original name
+ *
+ * @param  {string} name Field name form manifest
+ * @return {string}      Encrypted property name
+ */
+export const getEncryptedFieldName = name => {
+  if (name === 'password') return 'credentials_encrypted'
+  return `${name}_encrypted`
+}
+
+/**
+ * If the field is encrypted and has an initial value, return a placeholder
+ * that indicate that the value exists.
+ *
+ * @param  {object} props AccountField component props
+ * @return {string}       The encrypted placeholder or en empty string if the
+ *                        field does not need encrypted placeholder
+ */
+export const getFieldPlaceholder = (props, fallback) => {
+  const { encrypted, initialValue, placeholder } = props
+  return (
+    (encrypted && initialValue && ENCRYPTED_PLACEHOLDER) ||
+    placeholder ||
+    fallback ||
+    ''
+  )
+}
+
 /**
  * Prepare props to pass to React-Select
  * Options must be consistent and value cannot be ''

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
@@ -172,7 +172,6 @@ exports[`AccountForm AccountFields should render encrypted fields with placehold
 exports[`AccountForm should have disabled button if there is required field empty 1`] = `
 <div>
   <AccountFields
-    fillEncrypted={false}
     initialValues={Object {}}
     manifestFields={
       Object {
@@ -213,7 +212,6 @@ exports[`AccountForm should have disabled button if there is required field empt
 exports[`AccountForm should have enabled button if fields isn't required 1`] = `
 <div>
   <AccountFields
-    fillEncrypted={false}
     initialValues={Object {}}
     manifestFields={
       Object {
@@ -254,7 +252,6 @@ exports[`AccountForm should have enabled button if fields isn't required 1`] = `
 exports[`AccountForm should have enabled button if required field isn't empty 1`] = `
 <div>
   <AccountFields
-    fillEncrypted={false}
     initialValues={
       Object {
         "test": "test",
@@ -310,7 +307,6 @@ exports[`AccountForm should redirect to OAuthForm 1`] = `
 exports[`AccountForm should render 1`] = `
 <div>
   <AccountFields
-    fillEncrypted={false}
     initialValues={Object {}}
     manifestFields={
       Object {

--- a/packages/cozy-harvest-lib/test/helpers/fields.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/fields.spec.js
@@ -1,7 +1,70 @@
 /* eslint-env jest */
-import { sanitizeSelectProps } from 'helpers/fields'
+import {
+  getEncryptedFieldName,
+  getFieldPlaceholder,
+  sanitizeSelectProps
+} from 'helpers/fields'
 
 describe('Fields Helper', () => {
+  describe('getEncryptedFieldName', () => {
+    it('should return encrypted password property', () => {
+      expect(getEncryptedFieldName('password')).toBe('credentials_encrypted')
+    })
+
+    it('should return encrypted field property', () => {
+      expect(getEncryptedFieldName('foo')).toBe('foo_encrypted')
+    })
+  })
+
+  describe('getFieldPlaceholder', () => {
+    it('shoud return empty string', () => {
+      expect(
+        getFieldPlaceholder({
+          name: 'password',
+          encrypted: true
+        })
+      ).toBe('Fallback placeholder')
+    })
+
+    it('shoud return fallback value', () => {
+      expect(
+        getFieldPlaceholder(
+          {
+            name: 'password',
+            encrypted: true
+          },
+          'Fallback placeholder'
+        )
+      ).toBe('Fallback placeholder')
+    })
+
+    it('shoud return prop `placeholder`', () => {
+      expect(
+        getFieldPlaceholder(
+          {
+            name: 'password',
+            encrypted: true,
+            placeholder: 'Random placeholder'
+          },
+          'Fallback placeholder'
+        )
+      ).toBe('Random placeholder')
+    })
+
+    it('should return placeholder for encrypted fields', () => {
+      expect(
+        getFieldPlaceholder(
+          {
+            encrypted: true,
+            initialValue: 'ezfZEZE435345DSFfd',
+            placeholder: 'Random placeholder'
+          },
+          'Fallback placeholder'
+        )
+      ).toBe('*************')
+    })
+  })
+
   describe('sanitizeSelectProps', () => {
     it('should sanitize legacy options', () => {
       const fieldWithLegacyOptions = {


### PR DESCRIPTION
Previous pattern was too ambiguous and was working almost by chance.

With this PR, every AccountField is now aware of its own encryption and if it
has an initial value.

Mapping field name with its encrypted name is done one level above, into AccountFields.