### PR TITLE
Bank{Reconciliator,Transaction} accept a trackEvent option

### DIFF
--- a/packages/cozy-doctypes/src/banking/BankTransaction.js
+++ b/packages/cozy-doctypes/src/banking/BankTransaction.js
@@ -82,7 +82,11 @@ class Transaction extends Document {
    * @param {array} stackTransactions
    * @returns {array}
    */
-  static getMissedTransactions(transactionsToCheck, stackTransactions) {
+  static getMissedTransactions(
+    transactionsToCheck,
+    stackTransactions,
+    options = {}
+  ) {
     const matchingResults = Array.from(
       matchTransactions(transactionsToCheck, stackTransactions)
     )
@@ -90,6 +94,26 @@ class Transaction extends Document {
     const missedTransactions = matchingResults
       .filter(result => !result.match)
       .map(result => result.transaction)
+
+    const trackEvent = options.trackEvent
+    if (typeof trackEvent === 'function') {
+      try {
+        const nbMissed = missedTransactions.length
+        const nbExisting = stackTransactions.length
+        trackEvent({
+          e_a: 'ReconciliateMissing',
+          e_n: 'MissedTransactionPct',
+          e_v: parseFloat((nbMissed / nbExisting).toFixed(2), 10)
+        })
+        trackEvent({
+          e_a: 'ReconciliateMissing',
+          e_n: 'MissedTransactionAbs',
+          e_v: nbMissed
+        })
+      } catch (e) {
+        log('warn', `Could not send MissedTransaction event: ${e.message}`)
+      }
+    }
 
     return missedTransactions
   }

--- a/packages/cozy-doctypes/src/banking/BankTransaction.js
+++ b/packages/cozy-doctypes/src/banking/BankTransaction.js
@@ -134,8 +134,10 @@ class Transaction extends Document {
     const splitDate = getSplitDate(localTransactions)
 
     if (splitDate) {
-      if (options.onSplitDate) {
-        options.onSplitDate()
+      if (typeof options.trackEvent === 'function') {
+        options.trackEvent({
+          e_a: 'ReconciliateSplitDate'
+        })
       }
 
       const isAfterSplit = x => Transaction.prototype.isAfter.call(x, splitDate)

--- a/packages/cozy-doctypes/src/banking/BankTransaction.spec.js
+++ b/packages/cozy-doctypes/src/banking/BankTransaction.spec.js
@@ -24,7 +24,7 @@ describe('getIdentifier', () => {
   })
 })
 
-describe('getMissedTransactions', () => {
+describe('reconciliation', () => {
   const existingTransactions = [
     {
       amount: -10,
@@ -65,28 +65,6 @@ describe('getMissedTransactions', () => {
     expect(missedTransactions).toEqual([newTransactions[1]])
   })
 
-  xit('should return transactions with an already existing identifier, if there are more new than existing', () => {
-    const newTransactions = [
-      {
-        amount: -10,
-        originalBankLabel: 'Test 01',
-        date: '2018-10-02'
-      },
-      {
-        amount: -10,
-        originalBankLabel: 'Test 01',
-        date: '2018-10-02'
-      }
-    ]
-
-    const missedTransactions = BankTransaction.getMissedTransactions(
-      newTransactions,
-      existingTransactions
-    )
-
-    expect(missedTransactions).toEqual([newTransactions[1]])
-  })
-
   it('should return an empty array when there is no missed transaction', () => {
     const newTransactions = [
       {
@@ -104,7 +82,7 @@ describe('getMissedTransactions', () => {
     expect(missedTransactions).toHaveLength(0)
   })
 
-  xit('should call the given onMissedTransactionsFound option', () => {
+  it('should send events if trackEvent option is set', () => {
     const newTransactions = [
       {
         amount: -15,
@@ -113,14 +91,22 @@ describe('getMissedTransactions', () => {
       }
     ]
 
-    const onMissedTransactionsFound = jest.fn()
+    const trackEvent = jest.fn()
     BankTransaction.getMissedTransactions(
       newTransactions,
       existingTransactions,
-      { onMissedTransactionsFound }
+      { trackEvent }
     )
-
-    expect(onMissedTransactionsFound).toHaveBeenCalledTimes(1)
-    expect(onMissedTransactionsFound).toHaveBeenCalledWith(1, 0)
+    expect(trackEvent).toHaveBeenCalledWith({
+      e_a: 'ReconciliateMissing',
+      e_n: 'MissedTransactionPct',
+      e_v: 0.33
+    })
+    expect(trackEvent).toHaveBeenCalledWith({
+      e_a: 'ReconciliateMissing',
+      e_n: 'MissedTransactionAbs',
+      e_v: 1
+    })
   })
+
 })

--- a/packages/cozy-doctypes/src/banking/BankTransaction.spec.js
+++ b/packages/cozy-doctypes/src/banking/BankTransaction.spec.js
@@ -109,4 +109,21 @@ describe('reconciliation', () => {
     })
   })
 
+  it('should send event for split date', () => {
+    const newTransactions = [
+      {
+        amount: -15,
+        originalBankLabel: 'Test 04',
+        date: '2018-10-01'
+      }
+    ]
+
+    const trackEvent = jest.fn()
+    BankTransaction.reconciliate(newTransactions, existingTransactions, {
+      trackEvent
+    })
+    expect(trackEvent).toHaveBeenCalledWith({
+      e_a: 'ReconciliateSplitDate'
+    })
+  })
 })


### PR DESCRIPTION
Previously, the reconciliation mechanism would send stats back to the konnector and the latter would send it to piwik. Here we change it so that the reconciliation process can directly send
the piwik events.

Sending directly the event from the reconciliation mechanism decouples the konnector from the reconciliation mechanism and allows for more flexibility should we want to send more/different
events.