### PR TITLE
fix: Add Android 5 and iOS 10

### DIFF
--- a/packages/babel-preset-cozy-app/index.js
+++ b/packages/babel-preset-cozy-app/index.js
@@ -1,17 +1,25 @@
 'use strict'
 
 const { declare } = require('@babel/helper-plugin-utils')
-
+/***
+ * We need to target Android 5 and at least iOS 10 for our mobile apps.
+ * We have to target Android 4.4 since Android 5 doesn't exist because Webview and OS
+ * version are different since Android 5.
+ * We didn't find any query targeting Android 5 with a very old browser (ie no updated),
+ * we can consider targeting Samsung browser since it should follow Android Browser
+ * but I'm not sure this is the right way to do.
+ * Changed to 3 last majors version of iOS because I think 2 is pretty dangerous specially when a new iOS version is released.
+ */
 const browserEnv = {
   targets: [
     'last 2 Chrome major versions',
-    'last 2 ChromeAndroid major versions',
     'last 2 Firefox major versions',
     'last 2 FirefoxAndroid major versions',
     'last 2 Safari major versions',
-    'last 2 iOS major versions',
+    'last 3 iOS major versions',
     'last 2 Edge major versions',
     'Firefox ESR',
+    'Android 4.4',
     '> 1% in FR',
     'not dead',
     'not ie <= 11'


### PR DESCRIPTION
We need to target Android 5 and iOS 10 for our mobile apps. 

- I have to target Android 4.4 since Android 5 doesn't exist because Webview and OS version are different since Android 5.
- I didn't find any query targeting Android 5 with a very old browser (ie no updated), we can consider targeting Samsung browser since it should follow Android Browser but I'm not sure this is the right way to do.

- I changed to `3 last majors version of iOS` because I think `2` is pretty dangerous specially when a new iOS version is released. 