### PR TITLE
Harvest: Do not show OAuth button in edit form

### DIFF
--- a/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
@@ -5,8 +5,8 @@ import { translate } from 'cozy-ui/react/I18n'
 
 export class OAuthForm extends PureComponent {
   render() {
-    const { t } = this.props
-    return (
+    const { oauth, t } = this.props
+    return oauth ? null : (
       <Button
         className="u-mt-1"
         extension="full"

--- a/packages/cozy-harvest-lib/test/components/OAuthForm.spec.js
+++ b/packages/cozy-harvest-lib/test/components/OAuthForm.spec.js
@@ -14,4 +14,11 @@ describe('OAuthForm', () => {
     const component = shallow(<OAuthForm t={t} />).getElement()
     expect(component).toMatchSnapshot()
   })
+
+  it('should not render button when update', () => {
+    const component = shallow(
+      <OAuthForm t={t} oauth={{ token: '1234abcd' }} />
+    ).getElement()
+    expect(component).toBeNull()
+  })
 })


### PR DESCRIPTION
We should not show the Connect button for an existing OAuth account.