### PR TITLE
Harvest: Handle legacy locales for field label

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -18,7 +18,7 @@
     "prebuild": "yarn tx",
     "prepublishOnly": "yarn build",
     "test": "jest --verbose --coverage",
-    "tx": "tx pull --all || true",
+    "tx": "tx pull --all",
     "watch": "babel src -d dist --copy-files --watch"
   },
   "dependencies": {

--- a/packages/cozy-harvest-lib/src/components/AccountForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm.jsx
@@ -43,7 +43,9 @@ export class AccountField extends PureComponent {
       className: 'u-m-0', // 0 margin
       disabled: !isEditable,
       fullwidth: true,
-      label: t(`fields.${localeKey}.label`, { _: name }),
+      label: t(`fields.${localeKey}.label`, {
+        _: t(`legacy.fields.${localeKey}.label`, { _: name })
+      }),
       placeholder: getFieldPlaceholder(
         this.props,
         t(`fields.${name}.placeholder`, { _: '' })

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -3,7 +3,7 @@
     "submit": {
       "label": "Submit"
     },
-    "fields":{
+    "fields": {
       "optional": "(optional)"
     },
     "password": {
@@ -29,7 +29,7 @@
       "label": "Date",
       "placeholder": "mm/dd/yyyy"
     },
-    "email" : {
+    "email": {
       "label": "Email address"
     },
     "firstname": {

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -52,5 +52,87 @@
     "connect": {
       "label": "Connect"
     }
+  },
+  "legacy": {
+    "fields": {
+      "access_token": {
+        "label": "Access token"
+      },
+      "accessTokenSecret": {
+        "label": "Access token secret"
+      },
+      "accountName": {
+        "label": "Account name"
+      },
+      "agreement": {
+        "label": "I agree"
+      },
+      "apikey": {
+        "label": "Api key"
+      },
+      "appKey": {
+        "label": "Application Key"
+      },
+      "appSecret": {
+        "label": "Application Secret"
+      },
+      "authCode": {
+        "label": "Auth code"
+      },
+      "bank_identifier": {
+        "label": "Bank identifier (optional)"
+      },
+      "branchName": {
+        "label": "Branch"
+      },
+      "cardNumber": {
+        "label": "Card Number"
+      },
+      "consumerKey": {
+        "label": "Consumer Key"
+      },
+      "consumerSecret": {
+        "label": "Consumer Secret"
+      },
+      "dob": {
+        "label": "Date of birth"
+      },
+      "folderPath": {
+        "label": "Folder path"
+      },
+      "identifier": {
+        "label": "Identifier"
+      },
+      "loginUrl": {
+        "label": "Login URL"
+      },
+      "namePath": {
+        "label": "Folder name"
+      },
+      "new_identifier": {
+        "label": "Identifier"
+      },
+      "phoneNumber": {
+        "label": "Phone number"
+      },
+      "profileName": {
+        "label": "Profile Name"
+      },
+      "refreshToken": {
+        "label": "Refresh Token"
+      },
+      "secret": {
+        "label": "Password"
+      },
+      "timeout": {
+        "label": "Delay (ms)"
+      },
+      "token": {
+        "label": "Token"
+      },
+      "tricountUrl": {
+        "label": "Tricount URL"
+      }
+    }
   }
 }

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
@@ -65,9 +65,15 @@ exports[`AccountForm AccountField render a dropdown field 1`] = `
       [MockFunction] {
         "calls": Array [
           Array [
-            "fields.multiple.label",
+            "legacy.fields.multiple.label",
             Object {
               "_": "multiple",
+            },
+          ],
+          Array [
+            "fields.multiple.label",
+            Object {
+              "_": "legacy.fields.multiple.label",
             },
           ],
           Array [
@@ -84,6 +90,10 @@ exports[`AccountForm AccountField render a dropdown field 1`] = `
           ],
         ],
         "results": Array [
+          Object {
+            "isThrow": false,
+            "value": "legacy.fields.multiple.label",
+          },
           Object {
             "isThrow": false,
             "value": "fields.multiple.label",


### PR DESCRIPTION
Some previous locales for field labels are now out of cozy-harvest-lib scope.

This PR got them back, identified as legacy, until the manifest of
concerned konnectors evolves.