### PR TITLE
fix: Defensive programming

### DIFF
--- a/packages/cozy-doctypes/src/banking/matching-transactions.js
+++ b/packages/cozy-doctypes/src/banking/matching-transactions.js
@@ -24,9 +24,9 @@ const squash = (str, char) => {
 const redactedNumber = /\b[0-9X]+\b/gi
 const dateRx = /\b\d{2}\/\d{2}\/\d{4}\b/g
 
-const cleanLabel = label => label.replace(redactedNumber, '')
-const withoutDate = str => str.replace(dateRx, '')
-const compacted = str => str.replace(/\s/g, '').replace(/-/g, '')
+const cleanLabel = label => label && label.replace(redactedNumber, '')
+const withoutDate = str => str && str.replace(dateRx, '')
+const compacted = str => str && str.replace(/\s/g, '').replace(/-/g, '')
 
 const scoreLabel = (newTr, existingTr) => {
   if (
@@ -36,7 +36,7 @@ const scoreLabel = (newTr, existingTr) => {
     return [200, 'originalBankLabel']
   } else if (
     compacted(existingTr.originalBankLabel) ===
-    compacted(existingTr.originalBankLabel)
+    compacted(newTr.originalBankLabel)
   ) {
     return [120, 'originalBankLabelCompacted']
   } else if (

--- a/packages/cozy-doctypes/src/banking/matching-transactions.spec.js
+++ b/packages/cozy-doctypes/src/banking/matching-transactions.spec.js
@@ -73,3 +73,21 @@ it('should score', () => {
   // transactions are very similar and when scored within the same day, they should be matched
   expect(scoreResult.points).toBeGreaterThan(0)
 })
+
+it('should work without original bank label', () => {
+  const newTr = {
+    amount: -85,
+    date: '2018-09-22T12:00:00.000Z',
+    label: 'Web Sylvain Miserenne G',
+    originalBankLabel:
+      'Virement Web Sylvain Miserenne Courses G Courses Gard 24/09/2018'
+  }
+  const existingTr = {
+    amount: -85,
+    date: '2018-09-22T00:00:00+02:00',
+    label: 'Web Sylvain Miserenne G',
+    linxoId: '1209279242'
+  }
+  const scoreResult = scoreMatching(newTr, existingTr)
+  expect(scoreResult.points).toBeGreaterThan(0)
+})


### PR DESCRIPTION
Scoring should work even if there is not originalBankLabel.