### PR TITLE
feat: Add optional chaining to the babel preset

### DIFF
--- a/packages/babel-preset-cozy-app/package.json
+++ b/packages/babel-preset-cozy-app/package.json
@@ -20,6 +20,7 @@
     "@babel/helper-plugin-utils": "7.0.0",
     "@babel/plugin-proposal-class-properties": "7.2.3",
     "@babel/plugin-proposal-object-rest-spread": "7.2.0",
+    "@babel/plugin-proposal-optional-chaining": "^7.2.0",
     "@babel/plugin-transform-runtime": "7.2.0",
     "@babel/preset-env": "7.2.3",
     "@babel/preset-react": "7.0.0",

--- a/packages/eslint-config-cozy-app/basics.js
+++ b/packages/eslint-config-cozy-app/basics.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  plugins: ['prettier'],
+  plugins: ['prettier', '@babel/plugin-proposal-optional-chaining'],
   extends: ['eslint:recommended', 'eslint-config-prettier'],
   parser: 'babel-eslint',
   env: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -392,6 +392,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
 
+"@babel/plugin-proposal-optional-chaining@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.2.0.tgz#ae454f4c21c6c2ce8cb2397dc332ae8b420c5441"
+  integrity sha512-ea3Q6edZC/55wEBVZAEz42v528VulyO0eir+7uky/sT4XRcdkWJcFi1aPtitTlwUzGnECWJNExWww1SStt+yWw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-optional-chaining" "^7.2.0"
+
 "@babel/plugin-proposal-unicode-property-regex@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.2.0.tgz#abe7281fe46c95ddc143a65e5358647792039520"
@@ -433,6 +441,13 @@
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz#a94013d6eda8908dfe6a477e7f9eda85656ecf5c"
   integrity sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-optional-chaining@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.2.0.tgz#a59d6ae8c167e7608eaa443fda9fa8fa6bf21dff"
+  integrity sha512-HtGCtvp5Uq/jH/WNUPkK6b7rufnCPLLlDAFN7cmACoIjaOOiXxUt3SswU5loHqrhtqTsa/WoLQ1OQ1AGuZqaWA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 


### PR DESCRIPTION
[Optional chaining](https://github.com/tc39/proposal-optional-chaining)
allows to chain potentially null components.

Instead of doing
```
if (window && window.location && window.location.protocol) {
  ssl = window.location.protocol
}
```
we could do
```
ssl = window?.location?.protocol
```

The spec is stage 1 only but [they seem to have reach consensus](https://github.com/tc39/proposal-optional-chaining/pull/75#issue-234782431)
and [the formal stage 2 decision should be in March](https://github.com/tc39/proposal-optional-chaining/issues/76#issuecomment-443435613)

There should not be any compatibility break