### PR TITLE
docs: Add docs about Document class

### DIFF
--- a/packages/cozy-doctypes/README.md
+++ b/packages/cozy-doctypes/README.md
@@ -16,7 +16,7 @@ directly the `cozy-client` APIs.
 
 ### How to use it
 
-Let's say we have a `io.cozy.simpsons` doctype, because we are developing a konnector that retrieves some Simpsons data. We create a class `Simpson` that inherits from `Document` :
+In the following section, we will see how to deal with a fictitious `io.cozy.simpsons` doctype (we are developing a konnector to retrieve al the Simpson characters). First, let's create a class `Simpson` that inherits from `Document` :
 
 ```js
 const { Document } = require('cozy-doctypes')

--- a/packages/cozy-doctypes/README.md
+++ b/packages/cozy-doctypes/README.md
@@ -24,7 +24,7 @@ const { Document } = require('cozy-doctypes')
 class Simpson extends Document {}
 ```
 
-The first thing we are going to do is specify the doctype:
+First, let's specify the doctype:
 
 ```js
 const { Document } = require('cozy-doctypes')

--- a/packages/cozy-doctypes/README.md
+++ b/packages/cozy-doctypes/README.md
@@ -105,7 +105,7 @@ Then it will not be updated, even if we specified a new `children` attribute.
 
 #### `createdByApp`
 
-`createdByApp` is the slug of an application / konnector that creates the document. This information is used for cozy metadatas (see the [metadatas documentation](https://github.com/cozy/cozy-doctypes#document-metadata) to learn more). If we provide this, then the metadata can be automatically added to any created or updated document:
+`createdByApp` is the slug of an application / konnector that creates the document. This information is used for cozy metadatas (see the [metadatas documentation](https://github.com/cozy/cozy-doctypes#document-metadata) to learn more). If we provide this, the metadata is automatically added to any created or updated document:
 
 ```js
 Simpson.createdByApp = 'my-awesome-simpsons-konnector'

--- a/packages/cozy-doctypes/README.md
+++ b/packages/cozy-doctypes/README.md
@@ -105,7 +105,7 @@ Then it will not be updated, even if we specified a new `children` attribute.
 
 #### `createdByApp`
 
-`createdByApp` is the slug of an application / konnector that created the document. This information is used for cozy metadatas (see the [metadatas documentation](https://github.com/cozy/cozy-doctypes#document-metadata) to learn more). If we provide this, then the metadata can be automatically added to any created or updated document:
+`createdByApp` is the slug of an application / konnector that creates the document. This information is used for cozy metadatas (see the [metadatas documentation](https://github.com/cozy/cozy-doctypes#document-metadata) to learn more). If we provide this, then the metadata can be automatically added to any created or updated document:
 
 ```js
 Simpson.createdByApp = 'my-awesome-simpsons-konnector'

--- a/packages/cozy-doctypes/README.md
+++ b/packages/cozy-doctypes/README.md
@@ -24,7 +24,7 @@ const { Document } = require('cozy-doctypes')
 class Simpson extends Document {}
 ```
 
-First, let's specify the doctype:
+Second, let's specify the doctype:
 
 ```js
 const { Document } = require('cozy-doctypes')

--- a/packages/cozy-doctypes/README.md
+++ b/packages/cozy-doctypes/README.md
@@ -6,7 +6,121 @@ This repository is meant to bring together methods and functions for doctypes th
 - [Bank accounts](./src/banking/BankAccount.js)
 - [Balance histories](./src/banking/BalanceHistory.js)
 
+## `Document`
+
 The [Document](./src/Document.js) API is useful in NodeJS contexts where you need to have global models, available across files.
+It can be used as a base for other document types (see [BankTransaction](https://github.com/cozy/cozy-libs/blob/master/packages/cozy-doctypes/src/banking/BankTransaction.js) for example.
 
 ⚠️ The Document API does not work well in contexts where you need to change the client in flight. For this, prefer to use
 directly the `cozy-client` APIs.
+
+### How to use it
+
+Let's say we have a `io.cozy.simpsons` doctype, because we are developing a konnector that retrieves some Simpsons data. We create a class `Simpson` that inherits from `Document` :
+
+```js
+const { Document } = require('cozy-doctypes')
+
+class Simpson extends Document {}
+```
+
+The first thing we are going to do is specify the doctype:
+
+```js
+const { Document } = require('cozy-doctypes')
+
+class Simpson extends Document {}
+Simpson.doctype = 'io.cozy.simpsons'
+```
+
+Then we attach a `cozy-client-js` instance to it. We are going to use [cozy-konnector-libs](https://github.com/konnectors/libs/tree/master/packages/cozy-konnector-libs) to get this instance. Take a look at the [konnectors documentation](https://docs.cozy.io/en/tutorials/konnector/) to learn more about that.
+
+```
+const { Document } = require('cozy-doctypes')
+const { cozyClient } = require('cozy-konnector-libs')
+
+class Simpson extends Document {}
+Simpson.doctype = 'io.cozy.simpsons'
+
+Simpson.registerClient(cozyClient)
+```
+
+With this, we can already use our class. For example, we can create a new document:
+
+```js
+Simpson.create({
+  name: 'Homer'
+})
+```
+
+Or get some documents given their ids:
+
+```js
+const documents = await Simpson.getAll(['id1', 'id2', 'id3']
+```
+
+Take a look at [the Document class](https://github.com/cozy/cozy-libs/blob/master/packages/cozy-doctypes/src/Document.js) to see all the methods it implements.
+
+### Special class properties
+
+There are some properties that can be given to `Document` that have a special meaning.
+
+#### `idAttributes`
+
+`idAttributes` is an array of attributes that are seen as ids. When `Document` knows that, it becomes able to determine if a given document must be created or updated. This is used in the `¢reateOrUpdate` method. Let's say that we want the `name` of our `Simpson`s to be an id:
+
+```js
+Simpson.idAttributes = ['name']
+```
+
+Now, if we do the following:
+
+```js
+Simpson.createOrUpdate({ name: 'Homer', description: 'Likes donuts' })
+```
+
+Since we said that `name` is an id attribute, the document we previously created with the name « Homer » will be updated. But if we do:
+
+```js
+Simpson.createOrUpdate({ name: 'Marge', description: "Homer's wife" })
+```
+
+This document will be created, because no document exists with this `name`.
+
+#### `checkedAttributes`
+
+`checkedAttributes` is also an array of attributes. But it is used to determine if a document should be updated or not. Let's say that we want a document to be updated only if its `description` changed:
+
+```js
+Simpson.checkedAttributes = ['description']
+```
+
+Now, if I try to update a document, without changing its `description`:
+
+```js
+Simpson.createOrUpdate({ name: 'Marge', children: ['Bart', 'Lisa', 'Maggie'] })
+```
+
+Then it will not be updated, even if we specified a new `children` attribute.
+
+#### `createdByApp`
+
+`createdByApp` is the slug of an application / konnector that created the document. This information is used for cozy metadatas (see the [metadatas documentation](https://github.com/cozy/cozy-doctypes#document-metadata) to learn more). If we provide this, then the metadata can be automatically added to any created or updated document:
+
+```js
+Simpson.createdByApp = 'my-awesome-simpsons-konnector'
+
+Simpson.createOrUpdate({ name: 'Bart' })
+```
+
+The created document will have a `cozyMetadata` property like this:
+
+```js
+{
+  "_id": "the_id_generated_by_couchdb",
+  "name": "Bart",
+  "cozyMetadata": {
+    "createdByApp": "my-awesome-simpsons-konnector"
+  }
+}
+```

--- a/packages/cozy-doctypes/README.md
+++ b/packages/cozy-doctypes/README.md
@@ -33,7 +33,7 @@ class Simpson extends Document {}
 Simpson.doctype = 'io.cozy.simpsons'
 ```
 
-Then we attach a `cozy-client-js` instance to it. We are going to use [cozy-konnector-libs](https://github.com/konnectors/libs/tree/master/packages/cozy-konnector-libs) to get this instance. Take a look at the [konnectors documentation](https://docs.cozy.io/en/tutorials/konnector/) to learn more about that.
+Then we provide a `cozy-client-js` instance to our class. We are going to use [cozy-konnector-libs](https://github.com/konnectors/libs/tree/master/packages/cozy-konnector-libs) to get this instance. Take a look at the [konnectors documentation](https://docs.cozy.io/en/tutorials/konnector/) to learn more about that.
 
 ```
 const { Document } = require('cozy-doctypes')
@@ -45,7 +45,7 @@ Simpson.doctype = 'io.cozy.simpsons'
 Simpson.registerClient(cozyClient)
 ```
 
-With this, we can already use our class. For example, we can create a new document:
+With this, the class is already usable. For example, we can create a new document:
 
 ```js
 Simpson.create({
@@ -89,7 +89,7 @@ This document will be created, because no document exists with this `name`.
 
 #### `checkedAttributes`
 
-`checkedAttributes` is also an array of attributes. But it is used to determine if a document should be updated or not. Let's say that we want a document to be updated only if its `description` changed:
+`checkedAttributes` is an array of attributes. But it is used to determine if a document should be updated or not. Let's say that we want a document to be updated only if its `description` changed:
 
 ```js
 Simpson.checkedAttributes = ['description']

--- a/packages/cozy-doctypes/README.md
+++ b/packages/cozy-doctypes/README.md
@@ -9,7 +9,7 @@ This repository is meant to bring together methods and functions for doctypes th
 ## `Document`
 
 The [Document](./src/Document.js) API is useful in NodeJS contexts where you need to have global models, available across files.
-It can be used as a base for other document types (see [BankTransaction](https://github.com/cozy/cozy-libs/blob/master/packages/cozy-doctypes/src/banking/BankTransaction.js) for example.
+It can be used as a base for other document types (see [BankTransaction](https://github.com/cozy/cozy-libs/blob/master/packages/cozy-doctypes/src/banking/BankTransaction.js) for example).
 
 ⚠️ The Document API does not work well in contexts where you need to change the client in flight. For this, prefer to use
 directly the `cozy-client` APIs.
@@ -67,7 +67,7 @@ There are some properties that can be given to `Document` that have a special me
 
 #### `idAttributes`
 
-`idAttributes` is an array of attributes that are seen as ids. When `Document` knows that, it becomes able to determine if a given document must be created or updated. This is used in the `¢reateOrUpdate` method. Let's say that we want the `name` of our `Simpson`s to be an id:
+`idAttributes` is an array of attributes that are seen as ids. When `Document` knows that, it becomes able to determine if a given document must be created or updated. This is used in the `createOrUpdate` method. Let's say that we want the `name` of our `Simpson`s to be an id:
 
 ```js
 Simpson.idAttributes = ['name']
@@ -95,7 +95,7 @@ This document will be created, because no document exists with this `name`.
 Simpson.checkedAttributes = ['description']
 ```
 
-Now, if I try to update a document, without changing its `description`:
+Now, if we try to update a document, without changing its `description`:
 
 ```js
 Simpson.createOrUpdate({ name: 'Marge', children: ['Bart', 'Lisa', 'Maggie'] })


### PR DESCRIPTION
A contributor wanted to use this class, but was a bit lost because no documentation existed. This intends to fix this situation.