### PR TITLE
Harvest: Fix job promise fullfilment

### DIFF
--- a/packages/cozy-harvest-lib/src/connections/triggers.js
+++ b/packages/cozy-harvest-lib/src/connections/triggers.js
@@ -3,6 +3,8 @@ import { subscribe } from 'cozy-realtime'
 const JOBS_DOCTYPE = 'io.cozy.jobs'
 const TRIGGERS_DOCTYPE = 'io.cozy.triggers'
 
+const JOB_END_STATES = ['done', 'errored']
+
 /**
  * Creates a trigger with given attributes
  * @param  {Object} client CozyClient
@@ -57,7 +59,9 @@ const waitForLoginSuccess = async (
   return new Promise(resolve => {
     const resolveJob = () => resolve(job)
     setTimeout(resolveJob, expectedSuccessDelay)
-    jobSubscription.onUpdate(resolveJob)
+    jobSubscription.onUpdate(
+      job => JOB_END_STATES.includes(job.state) && resolveJob(job)
+    )
   })
 }
 

--- a/packages/cozy-harvest-lib/test/connections/triggers.spec.js
+++ b/packages/cozy-harvest-lib/test/connections/triggers.spec.js
@@ -88,10 +88,14 @@ describe('Trigger mutations', () => {
     const longLoginResponseTime = 150
     const jobSuccessResponseTime = 100
 
+    const updatedJob = {
+      state: 'done'
+    }
+
     beforeAll(() => {
       // Mock realtime to respond at 100ms
       realtime.subscribe.mockImplementation(() => ({
-        onUpdate: fn => setTimeout(() => fn(), jobSuccessResponseTime)
+        onUpdate: fn => setTimeout(() => fn(updatedJob), jobSuccessResponseTime)
       }))
     })
 
@@ -113,6 +117,19 @@ describe('Trigger mutations', () => {
       const endTime = new Date().getTime()
       expect(endTime - startTime).toBeGreaterThanOrEqual(jobSuccessResponseTime)
       expect(endTime - startTime).toBeLessThan(longLoginResponseTime)
+    })
+
+    it('ignore unfinished job', async () => {
+      // Mock realtime to respond at 100ms
+      realtime.subscribe.mockImplementation(() => ({
+        onUpdate: fn =>
+          setTimeout(() => fn({ state: 'queued' }), jobSuccessResponseTime)
+      }))
+      const startTime = new Date().getTime()
+      await waitForLoginSuccess({}, shortLoginResponseTime)
+      const endTime = new Date().getTime()
+      expect(endTime - startTime).toBeGreaterThanOrEqual(shortLoginResponseTime)
+      expect(endTime - startTime).toBeLessThan(jobSuccessResponseTime)
     })
   })
 })


### PR DESCRIPTION
Promise was resolved on first job update, even if job
state was not done or errored. Handlers were triggered too early.