### PR TITLE
Harvest: Force folder_to_save for trigger

### DIFF
--- a/packages/cozy-harvest-lib/src/Manifest.js
+++ b/packages/cozy-harvest-lib/src/Manifest.js
@@ -3,6 +3,8 @@ import _cloneDeep from 'lodash/cloneDeep'
 import _mapValues from 'lodash/mapValues'
 import _pickBy from 'lodash/pickBy'
 
+const IDENTIFIER = 'identifier'
+
 /**
  * Returns a key/value object with field as key and default, if it exists in
  * fields parameter.
@@ -58,7 +60,7 @@ const sanitizeIdentifier = fields => {
   const sanitized = _cloneDeep(fields)
   let hasIdentifier = false
   for (let fieldName in sanitized)
-    if (sanitized[fieldName].role === 'identifier') {
+    if (sanitized[fieldName].role === IDENTIFIER) {
       if (hasIdentifier) delete sanitized[fieldName].role
       else hasIdentifier = true
     }
@@ -66,13 +68,13 @@ const sanitizeIdentifier = fields => {
 
   for (let name of legacyLoginFields)
     if (sanitized[name]) {
-      sanitized[name].role = 'identifier'
+      sanitized[name].role = IDENTIFIER
       return sanitized
     }
 
   for (let fieldName in sanitized)
     if (sanitized[fieldName].type !== 'password') {
-      sanitized[fieldName].role = 'identifier'
+      sanitized[fieldName].role = IDENTIFIER
       return sanitized
     }
 

--- a/packages/cozy-harvest-lib/src/Manifest.js
+++ b/packages/cozy-harvest-lib/src/Manifest.js
@@ -1,5 +1,6 @@
 import _flow from 'lodash/flow'
 import _cloneDeep from 'lodash/cloneDeep'
+import findKey from 'lodash/findKey'
 import _mapValues from 'lodash/mapValues'
 import _pickBy from 'lodash/pickBy'
 
@@ -37,6 +38,14 @@ const defaultFieldsValues = fields => {
     value => value.default
   )
 }
+
+/**
+ * Returns the key for the field having the role=identifier attribute
+ * @param  {Object} fields Konnector fields
+ * @return {[type]}        The key for the identifier field, example 'login'
+ */
+const getIdentifier = (fields = {}) =>
+  findKey(sanitizeIdentifier(fields), field => field.role === IDENTIFIER)
 
 /**
  * Ensures old fields are removed
@@ -146,6 +155,7 @@ export const sanitize = (manifest = {}) =>
 
 export default {
   defaultFieldsValues,
+  getIdentifier,
   sanitize,
   sanitizeFields
 }

--- a/packages/cozy-harvest-lib/src/Manifest.spec.js
+++ b/packages/cozy-harvest-lib/src/Manifest.spec.js
@@ -20,6 +20,34 @@ describe('Manifest', () => {
     })
   })
 
+  describe('getIdentifier', () => {
+    it('should return field having role=identifier', () => {
+      const fields = {
+        username: {
+          type: 'text'
+        },
+        id: {
+          type: 'text',
+          role: 'identifier'
+        }
+      }
+      expect(Manifest.getIdentifier(fields)).toBe('id')
+    })
+
+    it('should return the first field', () => {
+      const fields = {
+        username: {
+          type: 'text'
+        },
+        id: {
+          type: 'text'
+        }
+      }
+
+      expect(Manifest.getIdentifier(fields)).toBe('username')
+    })
+  })
+
   describe('sanitize', () => {
     it('should remove "fields" if fields is null', () => {
       const manifest = {

--- a/packages/cozy-harvest-lib/src/components/AccountCreator.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountCreator.jsx
@@ -5,7 +5,7 @@ import { withMutations } from 'cozy-client'
 
 import AccountForm from './AccountForm'
 import { accountsMutations } from '../connections/accounts'
-import { mergeAuth, prepareAccountData } from '../helpers/accounts'
+import accounts from '../helpers/accounts'
 
 /**
  * Encapsulates an AccountForm and create an account with resulting data.
@@ -26,10 +26,10 @@ export class AccountCreator extends PureComponent {
     onBeforeCreate()
     const account = await createAccount(
       konnector,
-      prepareAccountData(konnector, data)
+      accounts.build(konnector, data)
     )
     // Merge auth to keep original values for encrypted fields during creation
-    onCreateSuccess(mergeAuth(account, data))
+    onCreateSuccess(accounts.mergeAuth(account, data))
   }
 
   render() {

--- a/packages/cozy-harvest-lib/src/components/AccountEditor.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountEditor.jsx
@@ -5,7 +5,7 @@ import { withMutations } from 'cozy-client'
 
 import AccountForm from './AccountForm'
 import { accountsMutations } from '../connections/accounts'
-import { mergeAuth } from '../helpers/accounts'
+import accounts from '../helpers/accounts'
 
 /**
  * Encapsulates an AccountForm of an existing account, and allows to update it.
@@ -24,7 +24,9 @@ export class AccountEditor extends PureComponent {
       updateAccount
     } = this.props
     onBeforeUpdate(account)
-    const updatedAccount = await updateAccount(mergeAuth(account, data))
+    const updatedAccount = await updateAccount(
+      accounts.mergeAuth(account, data)
+    )
     onUpdateSuccess(updatedAccount)
   }
 

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -7,10 +7,7 @@ import AccountCreator from './AccountCreator'
 import AccountEditor from './AccountEditor'
 import TriggerSuccessMessage from './TriggerSuccessMessage'
 import { triggersMutations } from '../connections/triggers'
-import {
-  buildKonnectorCron,
-  buildKonnectorTriggerAttributes
-} from '../helpers/triggers'
+import triggers from '../helpers/triggers'
 
 const IDLE = 'IDLE'
 const RUNNING = 'RUNNING'
@@ -61,10 +58,10 @@ export class TriggerManager extends Component {
     })
 
     const trigger = await createTrigger(
-      buildKonnectorTriggerAttributes({
+      triggers.buildAttributes({
         konnector,
         account,
-        cron: buildKonnectorCron(konnector)
+        cron: triggers.buildCron(konnector)
       })
     )
 

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -11,6 +11,7 @@ import { triggersMutations } from '../connections/triggers'
 import filesMutations from '../connections/files'
 import permissionsMutations from '../connections/permissions'
 import accounts from '../helpers/accounts'
+import cron from '../helpers/cron'
 import konnectors from '../helpers/konnectors'
 import { slugify } from '../helpers/slug'
 import triggers from '../helpers/triggers'
@@ -87,7 +88,7 @@ export class TriggerManager extends Component {
     const trigger = await createTrigger(
       triggers.buildAttributes({
         account,
-        cron: triggers.buildCron(konnector),
+        cron: cron.fromKonnector(konnector),
         folder,
         konnector
       })

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -59,6 +59,7 @@ export class TriggerManager extends Component {
   async handleAccountCreationSuccess(account) {
     const {
       addPermission,
+      addReferencesTo,
       createDirectoryByPath,
       createTrigger,
       statDirectoryByPath,
@@ -80,6 +81,7 @@ export class TriggerManager extends Component {
         (await statDirectoryByPath(path)) || (await createDirectoryByPath(path))
 
       await addPermission(konnector, konnectors.buildFolderPermission(folder))
+      await addReferencesTo(konnector, [folder])
     }
 
     const trigger = await createTrigger(
@@ -165,6 +167,7 @@ TriggerManager.propTypes = {
   running: PropTypes.bool,
   // mutations
   addPermission: PropTypes.func,
+  addReferencesTo: PropTypes.func,
   createTrigger: PropTypes.func.isRequired,
   createDirectoryByPath: PropTypes.func,
   statDirectoryByPath: PropTypes.func,

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -9,6 +9,7 @@ import AccountEditor from './AccountEditor'
 import TriggerSuccessMessage from './TriggerSuccessMessage'
 import { triggersMutations } from '../connections/triggers'
 import filesMutations from '../connections/files'
+import permissionsMutations from '../connections/permissions'
 import accounts from '../helpers/accounts'
 import konnectors from '../helpers/konnectors'
 import { slugify } from '../helpers/slug'
@@ -57,6 +58,7 @@ export class TriggerManager extends Component {
    */
   async handleAccountCreationSuccess(account) {
     const {
+      addPermission,
       createDirectoryByPath,
       createTrigger,
       statDirectoryByPath,
@@ -76,6 +78,8 @@ export class TriggerManager extends Component {
 
       folder =
         (await statDirectoryByPath(path)) || (await createDirectoryByPath(path))
+
+      await addPermission(konnector, konnectors.buildFolderPermission(folder))
     }
 
     const trigger = await createTrigger(
@@ -160,6 +164,7 @@ TriggerManager.propTypes = {
   trigger: PropTypes.object,
   running: PropTypes.bool,
   // mutations
+  addPermission: PropTypes.func,
   createTrigger: PropTypes.func.isRequired,
   createDirectoryByPath: PropTypes.func,
   statDirectoryByPath: PropTypes.func,
@@ -171,5 +176,7 @@ TriggerManager.propTypes = {
 }
 
 export default translate()(
-  withMutations(filesMutations, triggersMutations)(TriggerManager)
+  withMutations(filesMutations, permissionsMutations, triggersMutations)(
+    TriggerManager
+  )
 )

--- a/packages/cozy-harvest-lib/src/connections/files.js
+++ b/packages/cozy-harvest-lib/src/connections/files.js
@@ -1,6 +1,20 @@
 const FILES_DOCTYPE = 'io.cozy.files'
 
 /**
+ * Add references to given files into given documents
+ * @param  {Object}  client    CozyClient
+ * @param  {Object}  document  Target document
+ * @param  {[type]}  files     Files to reference
+ * @return {Object}           Updated document
+ */
+export const addReferencesTo = async (client, document, files) => {
+  const { data } = await client
+    .collection(FILES_DOCTYPE)
+    .addReferencesTo(document, files)
+  return data
+}
+
+/**
  * Creates a directory from a given path
  * @param  {Object}  client CozyClient
  * @param  {string}  path   Directory path
@@ -32,6 +46,7 @@ export const statDirectoryByPath = async (client, path) => {
 }
 
 export const filesMutations = client => ({
+  addReferencesTo: addReferencesTo.bind(null, client),
   createDirectoryByPath: createDirectoryByPath.bind(null, client),
   statDirectoryByPath: statDirectoryByPath.bind(null, client)
 })

--- a/packages/cozy-harvest-lib/src/connections/files.js
+++ b/packages/cozy-harvest-lib/src/connections/files.js
@@ -1,0 +1,39 @@
+const FILES_DOCTYPE = 'io.cozy.files'
+
+/**
+ * Creates a directory from a given path
+ * @param  {Object}  client CozyClient
+ * @param  {string}  path   Directory path
+ * @return {Object}         Directory attributes
+ */
+export const createDirectoryByPath = async (client, path) => {
+  const { data } = await client
+    .collection(FILES_DOCTYPE)
+    .createDirectoryByPath(path)
+  return data
+}
+
+/**
+ * Retrieves a directory from its path
+ * @param  {Object}  client CozyClient
+ * @param  {string}  path   Directory path
+ * @return {Object}        Created io.cozy.files document
+ */
+export const statDirectoryByPath = async (client, path) => {
+  let response
+  try {
+    response = await client.collection(FILES_DOCTYPE).statByPath(path)
+  } catch (error) {
+    if (error && error.status === 404) return null
+    throw new Error(error.message)
+  }
+
+  return response.data
+}
+
+export const filesMutations = client => ({
+  createDirectoryByPath: createDirectoryByPath.bind(null, client),
+  statDirectoryByPath: statDirectoryByPath.bind(null, client)
+})
+
+export default filesMutations

--- a/packages/cozy-harvest-lib/src/connections/permissions.js
+++ b/packages/cozy-harvest-lib/src/connections/permissions.js
@@ -1,0 +1,21 @@
+const PERMISSIONS_DOCTYPE = 'io.cozy.permissions'
+
+/**
+ * Add the given permisison to the given subject
+ * @param {Object} client     CozyClient
+ * @param {Object} target     Target document, could have doctype io.cozy.apps,
+ * io.cozy.konnectors or io.cozy.permissions
+ * @param {{ type, values, verbs}} A permission objects
+ */
+const addPermission = async (client, target, permission) => {
+  const { data } = await client
+    .collection(PERMISSIONS_DOCTYPE)
+    .add(target, permission)
+  return data
+}
+
+export const permissionsMutations = client => ({
+  addPermission: addPermission.bind(null, client)
+})
+
+export default permissionsMutations

--- a/packages/cozy-harvest-lib/src/helpers/accounts.js
+++ b/packages/cozy-harvest-lib/src/helpers/accounts.js
@@ -1,5 +1,7 @@
 import merge from 'lodash/merge'
 
+import Manifest from '../Manifest'
+
 /**
  * Transforms AccountForm data to io.cozy.accounts attributes
  * @param  {object} konnector Konnector related to account
@@ -11,7 +13,8 @@ export const prepareAccountData = (konnector, data) => {
   // For now we are just ensuring legacy
   return {
     auth: data,
-    account_type: konnector.slug
+    account_type: konnector.slug,
+    identifier: Manifest.getIdentifier(konnector.fields)
   }
 }
 

--- a/packages/cozy-harvest-lib/src/helpers/accounts.js
+++ b/packages/cozy-harvest-lib/src/helpers/accounts.js
@@ -15,16 +15,16 @@ export const getLabel = account =>
   get(account, `auth.${account.identifier}`) || account._id
 
 /**
- * Transforms AccountForm data to io.cozy.accounts attributes
+ * Transforms AccountForm data to io.cozy.accounts document
  * @param  {object} konnector Konnector related to account
  * @param  {object} data      Data from AccountForm
  * @return {object}           io.cozy.accounts attributes
  */
-export const prepareAccountData = (konnector, data) => {
+export const build = (konnector, authData) => {
   // We are not at the final target for io.cozy.accounts.
   // For now we are just ensuring legacy
   return {
-    auth: data,
+    auth: authData,
     account_type: konnector.slug,
     identifier: Manifest.getIdentifier(konnector.fields)
   }
@@ -42,7 +42,7 @@ export const mergeAuth = (account, authData) => ({
 })
 
 export default {
+  build,
   getLabel,
-  prepareAccountData,
   mergeAuth
 }

--- a/packages/cozy-harvest-lib/src/helpers/accounts.js
+++ b/packages/cozy-harvest-lib/src/helpers/accounts.js
@@ -1,6 +1,18 @@
+import get from 'lodash/get'
 import merge from 'lodash/merge'
 
 import Manifest from '../Manifest'
+
+/**
+ * Returns the label for the given account.
+ * This label is by default the value for the identifier field.
+ * If there is no value for this field, the label is the io.cozy.accounts
+ * document id.
+ * @param  {Object} account io.cozy.accounts documents
+ * @return {string}         The label associated to this account.
+ */
+export const getLabel = account =>
+  get(account, `auth.${account.identifier}`) || account._id
 
 /**
  * Transforms AccountForm data to io.cozy.accounts attributes
@@ -28,3 +40,9 @@ export const mergeAuth = (account, authData) => ({
   ...account,
   auth: merge(account.auth, authData)
 })
+
+export default {
+  getLabel,
+  prepareAccountData,
+  mergeAuth
+}

--- a/packages/cozy-harvest-lib/src/helpers/cron.js
+++ b/packages/cozy-harvest-lib/src/helpers/cron.js
@@ -1,0 +1,61 @@
+import { randomDayTime } from './daytime'
+
+const DAILY = 'daily'
+const HOURLY = 'hourly'
+const MONTHLY = 'monthly'
+const WEEKLY = 'weekly'
+const VALID_FREQUENCIES = [DAILY, HOURLY, MONTHLY, WEEKLY]
+
+const DEFAULT_FREQUENCY = WEEKLY
+// By default konnectors are run at random hour between 12:00PM and 05:00AM.
+const DEFAULT_TIME_INTERVAL = [0, 5]
+
+/**
+ * Build a cron string for given konnector with given options
+ * See https://docs.cozy.io/en/cozy-stack/jobs/#cron-syntax
+ * @param  {string} frequency Frequency from `hourly`, `daily`, `weekly` or
+ * `monthly`.
+ * @param  {object} options   Object which may contain `dayOfMonth`,
+ * `dayOfWeek`, hours`, `minutes`.
+ * @return {string}           The cron definition for trigger
+ */
+export const fromFrequency = (frequency, options = {}) => {
+  const sanitizedFrequency = VALID_FREQUENCIES.includes(frequency)
+    ? frequency
+    : DEFAULT_FREQUENCY
+
+  const { dayOfMonth = 1, dayOfWeek = 1, hours = 0, minutes = 0 } = options
+
+  switch (sanitizedFrequency) {
+    case DAILY:
+      return `0 ${minutes} ${hours} * * *`
+    case HOURLY:
+      return `0 ${minutes} * * * *`
+    case MONTHLY:
+      return `0 ${minutes} ${hours} ${dayOfMonth} * *`
+    default:
+      // also WEEKLY
+      return `0 ${minutes} ${hours} * * ${dayOfWeek}`
+  }
+}
+
+export const fromKonnector = (
+  konnector,
+  startDate = new Date(),
+  randomDayTimeFn = randomDayTime
+) =>
+  cron.fromFrequency(konnector.frequency, {
+    ...randomDayTimeFn.apply(
+      null,
+      konnector.time_interval || DEFAULT_TIME_INTERVAL
+    ),
+    dayOfWeek: startDate.getDay(),
+    dayOfMonth: startDate.getDate()
+  })
+
+const cron = {
+  fromFrequency,
+  fromKonnector
+}
+
+export default cron

--- a/packages/cozy-harvest-lib/src/helpers/konnectors.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectors.js
@@ -1,0 +1,14 @@
+import has from 'lodash/has'
+
+/**
+ * Indicates if the given konnector requires a folder to work properly.
+ * This directly relies on the `fields.advancedFields.folderPath` from manifest.
+ * @param  {Object} konnector
+ * @return {bool}   `true` if the konnector needs a folder
+ */
+export const needsFolder = konnector =>
+  has(konnector, 'fields.advancedFields.folderPath')
+
+export default {
+  needsFolder
+}

--- a/packages/cozy-harvest-lib/src/helpers/konnectors.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectors.js
@@ -9,6 +9,25 @@ import has from 'lodash/has'
 export const needsFolder = konnector =>
   has(konnector, 'fields.advancedFields.folderPath')
 
+/**
+ * Returns a permission ready to be passed to
+ * client.collection('io.cozy.permissions').add().
+ * @param  {Object} konnector The konnector to add permission to
+ * @param  {Object} folder    The folder which the konnector should have access
+ * @return {Object}           Permission object
+ */
+export const buildFolderPermission = folder => {
+  return {
+    // Legacy name
+    saveFolder: {
+      type: 'io.cozy.files',
+      values: [folder._id],
+      verbs: ['GET', 'PUT']
+    }
+  }
+}
+
 export default {
-  needsFolder
+  needsFolder,
+  buildFolderPermission
 }

--- a/packages/cozy-harvest-lib/src/helpers/slug.js
+++ b/packages/cozy-harvest-lib/src/helpers/slug.js
@@ -1,0 +1,19 @@
+/**
+ * Generate slug from text.
+ * @param  {string} text The text to slugify
+ * @return {string}      The resulting slug
+ */
+export const slugify = (text, char = '_') =>
+  text
+    .toString()
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, char) // Replace spaces with -
+    .replace(/[^\w-]+/g, char) // Remove all non-word chars
+    .replace(/--+/g, '-') // Replace multiple - with single -
+    .replace(/^-+/, '') // Trim - from start of text
+    .replace(/-+$/, '') // Trim - from end of text
+
+export default {
+  slugify
+}

--- a/packages/cozy-harvest-lib/src/helpers/triggers.js
+++ b/packages/cozy-harvest-lib/src/helpers/triggers.js
@@ -20,7 +20,7 @@ const DEFAULT_TIME_INTERVAL = [0, 5]
  * `dayOfWeek`, hours`, `minutes`.
  * @return {string}           The cron definition for trigger
  */
-export const buildCron = (frequency, options = {}) => {
+export const buildCronFromFrequency = (frequency, options = {}) => {
   const sanitizedFrequency = VALID_FREQUENCIES.includes(frequency)
     ? frequency
     : DEFAULT_FREQUENCY
@@ -45,7 +45,7 @@ export const buildKonnectorCron = (
   startDate = new Date(),
   randomDayTimeFn = randomDayTime
 ) =>
-  buildCron(konnector.frequency, {
+  buildCronFromFrequency(konnector.frequency, {
     ...randomDayTimeFn.apply(
       null,
       konnector.time_interval || DEFAULT_TIME_INTERVAL

--- a/packages/cozy-harvest-lib/src/helpers/triggers.js
+++ b/packages/cozy-harvest-lib/src/helpers/triggers.js
@@ -40,12 +40,12 @@ export const buildCronFromFrequency = (frequency, options = {}) => {
   }
 }
 
-export const buildKonnectorCron = (
+export const buildCron = (
   konnector,
   startDate = new Date(),
   randomDayTimeFn = randomDayTime
 ) =>
-  buildCronFromFrequency(konnector.frequency, {
+  helpers.buildCronFromFrequency(konnector.frequency, {
     ...randomDayTimeFn.apply(
       null,
       konnector.time_interval || DEFAULT_TIME_INTERVAL
@@ -60,7 +60,7 @@ export const buildKonnectorCron = (
  * @param  {object} account
  * @return {object} created trigger
  */
-export const buildKonnectorTriggerAttributes = ({
+export const buildAttributes = ({
   konnector,
   account,
   cron = DEFAULT_CRON
@@ -73,3 +73,11 @@ export const buildKonnectorTriggerAttributes = ({
     account: account._id
   }
 })
+
+const helpers = {
+  buildAttributes,
+  buildCron,
+  buildCronFromFrequency
+}
+
+export default helpers

--- a/packages/cozy-harvest-lib/src/helpers/triggers.js
+++ b/packages/cozy-harvest-lib/src/helpers/triggers.js
@@ -1,58 +1,4 @@
-import { randomDayTime } from './daytime'
-
-const DAILY = 'daily'
-const HOURLY = 'hourly'
-const MONTHLY = 'monthly'
-const WEEKLY = 'weekly'
-const VALID_FREQUENCIES = [DAILY, HOURLY, MONTHLY, WEEKLY]
-
-const DEFAULT_FREQUENCY = WEEKLY
 const DEFAULT_CRON = '0 0 0 * * 0' // Once a week, sunday at midnight
-// By default konnectors are run at random hour between 12:00PM and 05:00AM.
-const DEFAULT_TIME_INTERVAL = [0, 5]
-
-/**
- * Build a cron string for given konnector with given options
- * See https://docs.cozy.io/en/cozy-stack/jobs/#cron-syntax
- * @param  {string} frequency Frequency from `hourly`, `daily`, `weekly` or
- * `monthly`.
- * @param  {object} options   Object which may contain `dayOfMonth`,
- * `dayOfWeek`, hours`, `minutes`.
- * @return {string}           The cron definition for trigger
- */
-export const buildCronFromFrequency = (frequency, options = {}) => {
-  const sanitizedFrequency = VALID_FREQUENCIES.includes(frequency)
-    ? frequency
-    : DEFAULT_FREQUENCY
-
-  const { dayOfMonth = 1, dayOfWeek = 1, hours = 0, minutes = 0 } = options
-
-  switch (sanitizedFrequency) {
-    case DAILY:
-      return `0 ${minutes} ${hours} * * *`
-    case HOURLY:
-      return `0 ${minutes} * * * *`
-    case MONTHLY:
-      return `0 ${minutes} ${hours} ${dayOfMonth} * *`
-    default:
-      // also WEEKLY
-      return `0 ${minutes} ${hours} * * ${dayOfWeek}`
-  }
-}
-
-export const buildCron = (
-  konnector,
-  startDate = new Date(),
-  randomDayTimeFn = randomDayTime
-) =>
-  helpers.buildCronFromFrequency(konnector.frequency, {
-    ...randomDayTimeFn.apply(
-      null,
-      konnector.time_interval || DEFAULT_TIME_INTERVAL
-    ),
-    dayOfWeek: startDate.getDay(),
-    dayOfMonth: startDate.getDate()
-  })
 
 /**
  * Build trigger attributes given konnector and account
@@ -84,9 +30,7 @@ export const buildAttributes = ({
 }
 
 const helpers = {
-  buildAttributes,
-  buildCron,
-  buildCronFromFrequency
+  buildAttributes
 }
 
 export default helpers

--- a/packages/cozy-harvest-lib/src/helpers/triggers.js
+++ b/packages/cozy-harvest-lib/src/helpers/triggers.js
@@ -61,18 +61,27 @@ export const buildCron = (
  * @return {object} created trigger
  */
 export const buildAttributes = ({
-  konnector,
   account,
-  cron = DEFAULT_CRON
-}) => ({
-  type: '@cron',
-  arguments: cron,
-  worker: 'konnector',
-  message: {
-    konnector: konnector.slug,
-    account: account._id
+  cron = DEFAULT_CRON,
+  folder,
+  konnector
+}) => {
+  const message = {
+    account: account._id,
+    konnector: konnector.slug
   }
-})
+
+  if (folder) {
+    message['folder_to_save'] = folder._id
+  }
+
+  return {
+    type: '@cron',
+    arguments: cron,
+    worker: 'konnector',
+    message
+  }
+}
 
 const helpers = {
   buildAttributes,

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -21,8 +21,9 @@
       "hide": "Hide"
     }
   },
-  "defaults": {
-    "dateFormat": "MM/DD/YYYY"
+  "default": {
+    "dateFormat": "MM/DD/YYYY",
+    "baseDir": "/Administrative"
   },
   "fields": {
     "answer": {

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -4,7 +4,7 @@ import { configure, shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 
 import { TriggerManager } from 'components/TriggerManager'
-import triggersHelpers from 'helpers/triggers'
+import cronHelpers from 'helpers/cron'
 
 configure({ adapter: new Adapter() })
 
@@ -197,9 +197,7 @@ describe('TriggerManager', () => {
 
   describe('handleAccountCreationSuccess', () => {
     beforeAll(() => {
-      jest
-        .spyOn(triggersHelpers, 'buildCronFromFrequency')
-        .mockReturnValue('0 0 0 * * 0')
+      jest.spyOn(cronHelpers, 'fromFrequency').mockReturnValue('0 0 0 * * 0')
     })
 
     afterEach(() => {

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -119,6 +119,7 @@ const fixtures = {
 }
 
 const addPermissionMock = jest.fn()
+const addReferencesToMock = jest.fn()
 const createTriggerMock = jest.fn().mockResolvedValue(fixtures.createdTrigger)
 const createDirectoryByPathMock = jest.fn()
 const statDirectoryByPathMock = jest.fn()
@@ -134,6 +135,7 @@ const shallowAccountCreator = konnector =>
   shallow(
     <TriggerManager
       addPermission={addPermissionMock}
+      addReferencesTo={addReferencesToMock}
       konnector={konnector || fixtures.konnector}
       createTrigger={createTriggerMock}
       createDirectoryByPath={createDirectoryByPathMock}
@@ -247,6 +249,11 @@ describe('TriggerManager', () => {
           fixtures.konnectorWithFolder,
           fixtures.folderPermission
         )
+        expect(addReferencesToMock).toHaveBeenCalledTimes(1)
+        expect(addReferencesToMock).toHaveBeenCalledWith(
+          fixtures.konnectorWithFolder,
+          [fixtures.folder]
+        )
       })
 
       it('should not create folder if it exists', async () => {
@@ -262,6 +269,11 @@ describe('TriggerManager', () => {
         expect(addPermissionMock).toHaveBeenCalledWith(
           fixtures.konnectorWithFolder,
           fixtures.folderPermission
+        )
+        expect(addReferencesToMock).toHaveBeenCalledTimes(1)
+        expect(addReferencesToMock).toHaveBeenCalledWith(
+          fixtures.konnectorWithFolder,
+          [fixtures.folder]
         )
       })
     })

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -31,6 +31,13 @@ const fixtures = {
     _id: '3f5b288af36041f189ec22063adab706'
   },
   folderPath: '/Administrative/myBills/foo',
+  folderPermission: {
+    saveFolder: {
+      type: 'io.cozy.files',
+      values: ['3f5b288af36041f189ec22063adab706'],
+      verbs: ['GET', 'PUT']
+    }
+  },
   triggerAttributes: {
     arguments: '0 0 0 * * 0',
     type: '@cron',
@@ -111,6 +118,7 @@ const fixtures = {
   }
 }
 
+const addPermissionMock = jest.fn()
 const createTriggerMock = jest.fn().mockResolvedValue(fixtures.createdTrigger)
 const createDirectoryByPathMock = jest.fn()
 const statDirectoryByPathMock = jest.fn()
@@ -125,6 +133,7 @@ const tMock = jest.fn().mockReturnValue('/Administrative')
 const shallowAccountCreator = konnector =>
   shallow(
     <TriggerManager
+      addPermission={addPermissionMock}
       konnector={konnector || fixtures.konnector}
       createTrigger={createTriggerMock}
       createDirectoryByPath={createDirectoryByPathMock}
@@ -223,6 +232,7 @@ describe('TriggerManager', () => {
     describe('when konnector needs folder', () => {
       it('should create folder if it does not exist', async () => {
         statDirectoryByPathMock.mockResolvedValue(null)
+        createDirectoryByPathMock.mockReturnValue(fixtures.folder)
 
         const wrapper = shallowAccountCreator(fixtures.konnectorWithFolder)
         await wrapper.instance().handleAccountCreationSuccess(fixtures.account)
@@ -231,6 +241,11 @@ describe('TriggerManager', () => {
         expect(createDirectoryByPathMock).toHaveBeenCalledTimes(1)
         expect(createDirectoryByPathMock).toHaveBeenCalledWith(
           fixtures.folderPath
+        )
+        expect(addPermissionMock).toHaveBeenCalledTimes(1)
+        expect(addPermissionMock).toHaveBeenCalledWith(
+          fixtures.konnectorWithFolder,
+          fixtures.folderPermission
         )
       })
 
@@ -242,6 +257,12 @@ describe('TriggerManager', () => {
 
         expect(statDirectoryByPathMock).toHaveBeenCalledTimes(1)
         expect(createDirectoryByPathMock).toHaveBeenCalledTimes(0)
+
+        expect(addPermissionMock).toHaveBeenCalledTimes(1)
+        expect(addPermissionMock).toHaveBeenCalledWith(
+          fixtures.konnectorWithFolder,
+          fixtures.folderPermission
+        )
       })
     })
   })

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -4,10 +4,9 @@ import { configure, shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 
 import { TriggerManager } from 'components/TriggerManager'
+import triggersHelpers from 'helpers/triggers'
 
 configure({ adapter: new Adapter() })
-
-const triggersHelper = require('helpers/triggers')
 
 const fixtures = {
   data: {
@@ -165,7 +164,7 @@ describe('TriggerManager', () => {
   describe('handleAccountCreationSuccess', () => {
     beforeAll(() => {
       jest
-        .spyOn(triggersHelper, 'buildKonnectorCron')
+        .spyOn(triggersHelpers, 'buildCronFromFrequency')
         .mockReturnValue('0 0 0 * * 0')
     })
 

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
@@ -29,6 +29,7 @@ exports[`TriggerManager should render AccountEditor 1`] = `
         "passphrase": "bar",
         "username": "foo",
       },
+      "identifier": "username",
     }
   }
   konnector={

--- a/packages/cozy-harvest-lib/test/connections/files.spec.js
+++ b/packages/cozy-harvest-lib/test/connections/files.spec.js
@@ -6,6 +6,7 @@ import { filesMutations } from 'connections/files'
 
 jest.mock('cozy-client', () => ({
   collection: jest.fn().mockReturnValue({
+    addReferencesTo: jest.fn(),
     createDirectoryByPath: jest.fn(),
     statByPath: jest.fn()
   })
@@ -23,13 +24,29 @@ const fixtures = {
     updated_at: '2018-12-18T11:22:41.065070118+01:00',
     tags: [],
     path: '/Administrative/KonnectTest/84595fcbc15242f2a69ac483b37ae999'
+  },
+  references: {
+    data: [
+      {
+        type: 'io.cozy.files',
+        id: '326267e55ff0511c7f7b9ba56e04b334'
+      }
+    ]
   }
 }
 
-const { createDirectoryByPath, statDirectoryByPath } = filesMutations(client)
+const {
+  addReferencesTo,
+  createDirectoryByPath,
+  statDirectoryByPath
+} = filesMutations(client)
 
 describe('Files mutations', () => {
   beforeAll(() => {
+    client
+      .collection()
+      .addReferencesTo.mockResolvedValue({ data: fixtures.references })
+
     client
       .collection()
       .createDirectoryByPath.mockResolvedValue({ data: fixtures.directory })
@@ -45,6 +62,17 @@ describe('Files mutations', () => {
 
   afterAll(() => {
     jest.restoreAllMocks()
+  })
+
+  describe('addReferencesTo', () => {
+    it('calls Cozy Client and return io.cozy.files', async () => {
+      await addReferencesTo(fixtures.konnector, [fixtures.directory])
+
+      expect(client.collection().addReferencesTo).toHaveBeenCalledWith(
+        fixtures.konnector,
+        [fixtures.directory]
+      )
+    })
   })
 
   describe('createDirectoryByPath', () => {

--- a/packages/cozy-harvest-lib/test/connections/files.spec.js
+++ b/packages/cozy-harvest-lib/test/connections/files.spec.js
@@ -1,0 +1,83 @@
+/* eslint-env jest */
+
+import client from 'cozy-client'
+
+import { filesMutations } from 'connections/files'
+
+jest.mock('cozy-client', () => ({
+  collection: jest.fn().mockReturnValue({
+    createDirectoryByPath: jest.fn(),
+    statByPath: jest.fn()
+  })
+}))
+
+const fixtures = {
+  path: '/Administrative/KonnectTest/84595fcbc15242f2a69ac483b37ae999',
+  directory: {
+    _id: '326267e55ff0511c7f7b9ba56e04b334',
+    _rev: '2-510e5a2b3c84aba208c480a91fd39abf',
+    type: 'directory',
+    name: '84595fcbc15242f2a69ac483b37ae999',
+    dir_id: '326267e55ff0511c7f7b9ba56e00ca07',
+    created_at: '2018-12-18T11:22:41.065070118+01:00',
+    updated_at: '2018-12-18T11:22:41.065070118+01:00',
+    tags: [],
+    path: '/Administrative/KonnectTest/84595fcbc15242f2a69ac483b37ae999'
+  }
+}
+
+const { createDirectoryByPath, statDirectoryByPath } = filesMutations(client)
+
+describe('Files mutations', () => {
+  beforeAll(() => {
+    client
+      .collection()
+      .createDirectoryByPath.mockResolvedValue({ data: fixtures.directory })
+
+    client
+      .collection()
+      .statByPath.mockResolvedValue({ data: fixtures.directory })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('createDirectoryByPath', () => {
+    it('calls Cozy Client and return io.cozy.files document', async () => {
+      const directory = await createDirectoryByPath(fixtures.path)
+
+      expect(client.collection().createDirectoryByPath).toHaveBeenCalledWith(
+        fixtures.path
+      )
+      expect(directory).toEqual(fixtures.directory)
+    })
+  })
+
+  describe('statDirectoryByPath', () => {
+    it('calls Cozy Client and return io.cozy.files data', async () => {
+      expect(await statDirectoryByPath(fixtures.path)).toEqual(
+        fixtures.directory
+      )
+    })
+
+    it('returns null if Cozy Client returns a 404 error', async () => {
+      client.collection().statByPath.mockRejectedValue({ status: 404 })
+      expect(await statDirectoryByPath(fixtures.path)).toBeNull()
+    })
+
+    it('throw error if Cozy Client returns any other error', async () => {
+      client
+        .collection()
+        .statByPath.mockRejectedValue({ status: 403, message: 'Test error' })
+
+      await expect(statDirectoryByPath(fixtures.path)).rejects.toThrow(
+        'Test error'
+      )
+    })
+  })
+})

--- a/packages/cozy-harvest-lib/test/connections/permission.spec.js
+++ b/packages/cozy-harvest-lib/test/connections/permission.spec.js
@@ -1,0 +1,68 @@
+/* eslint-env jest */
+
+import client from 'cozy-client'
+
+import { permissionsMutations } from 'connections/permissions'
+
+jest.mock('cozy-client', () => ({
+  collection: jest.fn().mockReturnValue({
+    add: jest.fn()
+  })
+}))
+
+const fixtures = {
+  konnector: {
+    _id: 'konnectest',
+    slug: 'konnectest'
+  },
+  addedPermission: {
+    data: {
+      type: 'io.cozy.permissions',
+      attributes: {
+        source_id: 'io.cozy.konnectors/konnectest',
+        permissions: {
+          saveFolder: {
+            type: 'io.cozy.files',
+            verbs: ['GET', 'PUT'],
+            values: ['0ab48d4150ca4cc9bf581b4b8ecc20dd']
+          }
+        }
+      }
+    }
+  },
+  permission: {
+    saveFolder: {
+      type: 'io.cozy.files',
+      verbs: ['GET', 'PUT'],
+      values: ['0ab48d4150ca4cc9bf581b4b8ecc20dd']
+    }
+  }
+}
+
+const { addPermission } = permissionsMutations(client)
+
+describe('Permissions mutations', () => {
+  beforeAll(() => {
+    client
+      .collection()
+      .add.mockResolvedValue({ data: fixtures.addedPermission })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('addPermission', () => {
+    it('calls Cozy Client and return io.cozy.permissions document', async () => {
+      await addPermission(fixtures.konnector, fixtures.permission)
+      expect(client.collection().add).toHaveBeenCalledWith(
+        fixtures.konnector,
+        fixtures.permission
+      )
+    })
+  })
+})

--- a/packages/cozy-harvest-lib/test/helpers/accounts.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/accounts.spec.js
@@ -1,4 +1,4 @@
-import { getLabel, mergeAuth, prepareAccountData } from 'helpers/accounts'
+import { build, getLabel, mergeAuth } from 'helpers/accounts'
 
 const fixtures = {
   konnector: {
@@ -44,9 +44,9 @@ describe('Accounts Helper', () => {
     })
   })
 
-  describe('prepareAccountData', () => {
+  describe('build', () => {
     it('should prepare account data', () => {
-      expect(prepareAccountData(fixtures.konnector, fixtures.data)).toEqual({
+      expect(build(fixtures.konnector, fixtures.data)).toEqual({
         account_type: 'konnectest',
         auth: {
           username: 'foo',

--- a/packages/cozy-harvest-lib/test/helpers/accounts.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/accounts.spec.js
@@ -1,4 +1,4 @@
-import { mergeAuth, prepareAccountData } from 'helpers/accounts'
+import { getLabel, mergeAuth, prepareAccountData } from 'helpers/accounts'
 
 const fixtures = {
   konnector: {
@@ -17,6 +17,7 @@ const fixtures = {
     passphrase: 'bar'
   },
   account: {
+    _id: '9dc83bc5b7dc44e19faa4d4c06d40524',
     account_type: 'konnectest',
     auth: {
       username: 'foo',
@@ -29,6 +30,20 @@ const fixtures = {
 }
 
 describe('Accounts Helper', () => {
+  describe('getLabel', () => {
+    it('should return identifier value', () => {
+      expect(getLabel({ ...fixtures.account, identifier: 'username' })).toBe(
+        'foo'
+      )
+    })
+
+    it('should return id', () => {
+      expect(getLabel(fixtures.account)).toBe(
+        '9dc83bc5b7dc44e19faa4d4c06d40524'
+      )
+    })
+  })
+
   describe('prepareAccountData', () => {
     it('should prepare account data', () => {
       expect(prepareAccountData(fixtures.konnector, fixtures.data)).toEqual({
@@ -45,6 +60,7 @@ describe('Accounts Helper', () => {
   describe('mergeAuth', () => {
     it('should hydrate account', () => {
       expect(mergeAuth(fixtures.account, fixtures.data)).toEqual({
+        _id: '9dc83bc5b7dc44e19faa4d4c06d40524',
         account_type: 'konnectest',
         auth: {
           username: 'foo',

--- a/packages/cozy-harvest-lib/test/helpers/accounts.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/accounts.spec.js
@@ -2,7 +2,15 @@ import { mergeAuth, prepareAccountData } from 'helpers/accounts'
 
 const fixtures = {
   konnector: {
-    slug: 'konnectest'
+    slug: 'konnectest',
+    fields: {
+      username: {
+        type: 'text'
+      },
+      passphrase: {
+        type: 'password'
+      }
+    }
   },
   data: {
     username: 'foo',
@@ -28,7 +36,8 @@ describe('Accounts Helper', () => {
         auth: {
           username: 'foo',
           passphrase: 'bar'
-        }
+        },
+        identifier: 'username'
       })
     })
   })

--- a/packages/cozy-harvest-lib/test/helpers/cron.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/cron.spec.js
@@ -1,0 +1,75 @@
+import { fromFrequency, fromKonnector } from 'helpers/cron'
+
+describe('Cron helpers', () => {
+  describe('fromFrequency', () => {
+    const options = {
+      dayOfMonth: 25,
+      dayOfWeek: 4,
+      hours: 14,
+      minutes: 15
+    }
+
+    it('creates default cron (weekly)', () => {
+      expect(fromFrequency()).toEqual('0 0 0 * * 1')
+    })
+
+    it('creates weekly cron', () => {
+      expect(fromFrequency('weekly', options)).toEqual('0 15 14 * * 4')
+    })
+
+    it('creates monthly cron', () => {
+      expect(fromFrequency('monthly', options)).toEqual('0 15 14 25 * *')
+    })
+
+    it('creates daily cron', () => {
+      expect(fromFrequency('daily', options)).toEqual('0 15 14 * * *')
+    })
+
+    it('creates hourly cron', () => {
+      expect(fromFrequency('hourly', options)).toEqual('0 15 * * * *')
+    })
+  })
+
+  describe('fromKonnector', () => {
+    const randomDayTimeMock = jest.fn()
+
+    beforeEach(() => {
+      randomDayTimeMock.mockImplementation((min, max) => ({
+        hours: max - 1,
+        minutes: 59
+      }))
+    })
+
+    afterEach(() => {
+      randomDayTimeMock.mockReset()
+    })
+
+    it('returns expected default cron', () => {
+      const konnector = {}
+      const date = new Date('2019-02-07T14:12:00')
+      expect(fromKonnector(konnector, date, randomDayTimeMock)).toEqual(
+        `0 59 4 * * 4`
+      )
+    })
+
+    it('returns expected monthly cron', () => {
+      const konnector = {
+        frequency: 'monthly'
+      }
+      const date = new Date('2019-02-07T14:12:00')
+      expect(fromKonnector(konnector, date, randomDayTimeMock)).toEqual(
+        `0 59 4 7 * *`
+      )
+    })
+
+    it('returns expected cron with time interval', () => {
+      const konnector = {
+        time_interval: [0, 12]
+      }
+      const date = new Date('2019-02-07T14:12:00')
+      expect(fromKonnector(konnector, date, randomDayTimeMock)).toEqual(
+        `0 59 11 * * 4`
+      )
+    })
+  })
+})

--- a/packages/cozy-harvest-lib/test/helpers/konnectors.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/konnectors.spec.js
@@ -1,0 +1,24 @@
+import { needsFolder } from 'helpers/konnectors'
+
+describe('Konnectors Helpers', () => {
+  describe('needsFolder', () => {
+    it('should return true', () => {
+      expect(
+        needsFolder({
+          fields: {
+            advancedFields: {
+              folderPath: {
+                advanced: true,
+                isRequired: false
+              }
+            }
+          }
+        })
+      ).toBe(true)
+    })
+
+    it('should return false', () => {
+      expect(needsFolder({})).toBe(false)
+    })
+  })
+})

--- a/packages/cozy-harvest-lib/test/helpers/konnectors.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/konnectors.spec.js
@@ -1,4 +1,10 @@
-import { needsFolder } from 'helpers/konnectors'
+import { buildFolderPermission, needsFolder } from 'helpers/konnectors'
+
+const fixtures = {
+  folder: {
+    _id: '006704d25afb417b9a279a758a08a964'
+  }
+}
 
 describe('Konnectors Helpers', () => {
   describe('needsFolder', () => {
@@ -19,6 +25,18 @@ describe('Konnectors Helpers', () => {
 
     it('should return false', () => {
       expect(needsFolder({})).toBe(false)
+    })
+  })
+
+  describe('buildFolderPermission', () => {
+    it('should return permission', () => {
+      expect(buildFolderPermission(fixtures.folder)).toEqual({
+        saveFolder: {
+          type: 'io.cozy.files',
+          values: [fixtures.folder._id],
+          verbs: ['GET', 'PUT']
+        }
+      })
     })
   })
 })

--- a/packages/cozy-harvest-lib/test/helpers/slug.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/slug.spec.js
@@ -1,0 +1,26 @@
+/* eslint-env jest */
+import { slugify } from 'helpers/slug'
+
+describe('Slug', () => {
+  describe('slugify', () => {
+    it('replaces spaces', () => {
+      expect(slugify('Foo bar')).toBe('foo_bar')
+    })
+
+    it('replaces non words characters', () => {
+      expect(slugify('Foo@bar,')).toBe('foo_bar_')
+    })
+
+    it('replaces multiple dashes', () => {
+      expect(slugify('Foo----bar')).toBe('foo-bar')
+    })
+
+    it('trims dashes', () => {
+      expect(slugify('--Foo bar-----')).toBe('foo_bar')
+    })
+
+    it('trims spaces', () => {
+      expect(slugify('   Foo bar  ')).toBe('foo_bar')
+    })
+  })
+})

--- a/packages/cozy-harvest-lib/test/helpers/triggers.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/triggers.spec.js
@@ -1,10 +1,6 @@
 /* eslint-env jest */
 
-import {
-  buildCronFromFrequency,
-  buildCron,
-  buildAttributes
-} from 'helpers/triggers'
+import { buildAttributes } from 'helpers/triggers'
 
 describe('Triggers Helper', () => {
   describe('buildAttributes', () => {
@@ -48,80 +44,6 @@ describe('Triggers Helper', () => {
           konnector: 'konnectest'
         }
       })
-    })
-  })
-
-  describe('buildCronFromFrequency', () => {
-    const options = {
-      dayOfMonth: 25,
-      dayOfWeek: 4,
-      hours: 14,
-      minutes: 15
-    }
-
-    it('creates default cron (weekly)', () => {
-      expect(buildCronFromFrequency()).toEqual('0 0 0 * * 1')
-    })
-
-    it('creates weekly cron', () => {
-      expect(buildCronFromFrequency('weekly', options)).toEqual('0 15 14 * * 4')
-    })
-
-    it('creates monthly cron', () => {
-      expect(buildCronFromFrequency('monthly', options)).toEqual(
-        '0 15 14 25 * *'
-      )
-    })
-
-    it('creates daily cron', () => {
-      expect(buildCronFromFrequency('daily', options)).toEqual('0 15 14 * * *')
-    })
-
-    it('creates hourly cron', () => {
-      expect(buildCronFromFrequency('hourly', options)).toEqual('0 15 * * * *')
-    })
-  })
-
-  describe('buildCron', () => {
-    const randomDayTimeMock = jest.fn()
-
-    beforeEach(() => {
-      randomDayTimeMock.mockImplementation((min, max) => ({
-        hours: max - 1,
-        minutes: 59
-      }))
-    })
-
-    afterEach(() => {
-      randomDayTimeMock.mockReset()
-    })
-
-    it('returns expected default cron', () => {
-      const konnector = {}
-      const date = new Date('2019-02-07T14:12:00')
-      expect(buildCron(konnector, date, randomDayTimeMock)).toEqual(
-        `0 59 4 * * 4`
-      )
-    })
-
-    it('returns expected monthly cron', () => {
-      const konnector = {
-        frequency: 'monthly'
-      }
-      const date = new Date('2019-02-07T14:12:00')
-      expect(buildCron(konnector, date, randomDayTimeMock)).toEqual(
-        `0 59 4 7 * *`
-      )
-    })
-
-    it('returns expected cron with time interval', () => {
-      const konnector = {
-        time_interval: [0, 12]
-      }
-      const date = new Date('2019-02-07T14:12:00')
-      expect(buildCron(konnector, date, randomDayTimeMock)).toEqual(
-        `0 59 11 * * 4`
-      )
     })
   })
 })

--- a/packages/cozy-harvest-lib/test/helpers/triggers.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/triggers.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 import {
-  buildCron,
+  buildCronFromFrequency,
   buildKonnectorCron,
   buildKonnectorTriggerAttributes
 } from 'helpers/triggers'
@@ -39,7 +39,7 @@ describe('Triggers Helper', () => {
     })
   })
 
-  describe('buildCron', () => {
+  describe('buildCronFromFrequency', () => {
     const options = {
       dayOfMonth: 25,
       dayOfWeek: 4,
@@ -48,23 +48,23 @@ describe('Triggers Helper', () => {
     }
 
     it('creates default cron (weekly)', () => {
-      expect(buildCron()).toEqual('0 0 0 * * 1')
+      expect(buildCronFromFrequency()).toEqual('0 0 0 * * 1')
     })
 
     it('creates weekly cron', () => {
-      expect(buildCron('weekly', options)).toEqual('0 15 14 * * 4')
+      expect(buildCronFromFrequency('weekly', options)).toEqual('0 15 14 * * 4')
     })
 
     it('creates monthly cron', () => {
-      expect(buildCron('monthly', options)).toEqual('0 15 14 25 * *')
+      expect(buildCronFromFrequency('monthly', options)).toEqual('0 15 14 25 * *')
     })
 
     it('creates daily cron', () => {
-      expect(buildCron('daily', options)).toEqual('0 15 14 * * *')
+      expect(buildCronFromFrequency('daily', options)).toEqual('0 15 14 * * *')
     })
 
     it('creates hourly cron', () => {
-      expect(buildCron('hourly', options)).toEqual('0 15 * * * *')
+      expect(buildCronFromFrequency('hourly', options)).toEqual('0 15 * * * *')
     })
   })
 

--- a/packages/cozy-harvest-lib/test/helpers/triggers.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/triggers.spec.js
@@ -25,14 +25,26 @@ describe('Triggers Helper', () => {
 
     it('build attributes with cron', () => {
       const cron = '0 0 0 * * 2'
-      expect(
-        buildAttributes({ konnector, account, cron })
-      ).toEqual({
+      expect(buildAttributes({ konnector, account, cron })).toEqual({
         arguments: '0 0 0 * * 2',
         type: '@cron',
         worker: 'konnector',
         message: {
           account: '963a51f6cdd34401b0904de32cc5578d',
+          konnector: 'konnectest'
+        }
+      })
+    })
+
+    it('build attributes with folder', () => {
+      const folder = { _id: '4c43f8e88e5f4a608667da6b5bae8fa4' }
+      expect(buildAttributes({ konnector, account, folder })).toEqual({
+        arguments: '0 0 0 * * 0',
+        type: '@cron',
+        worker: 'konnector',
+        message: {
+          account: '963a51f6cdd34401b0904de32cc5578d',
+          folder_to_save: '4c43f8e88e5f4a608667da6b5bae8fa4',
           konnector: 'konnectest'
         }
       })
@@ -56,7 +68,9 @@ describe('Triggers Helper', () => {
     })
 
     it('creates monthly cron', () => {
-      expect(buildCronFromFrequency('monthly', options)).toEqual('0 15 14 25 * *')
+      expect(buildCronFromFrequency('monthly', options)).toEqual(
+        '0 15 14 25 * *'
+      )
     })
 
     it('creates daily cron', () => {

--- a/packages/cozy-harvest-lib/test/helpers/triggers.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/triggers.spec.js
@@ -2,17 +2,17 @@
 
 import {
   buildCronFromFrequency,
-  buildKonnectorCron,
-  buildKonnectorTriggerAttributes
+  buildCron,
+  buildAttributes
 } from 'helpers/triggers'
 
 describe('Triggers Helper', () => {
-  describe('buildKonnectorTriggerAttributes', () => {
+  describe('buildAttributes', () => {
     const konnector = { slug: 'konnectest' }
     const account = { _id: '963a51f6cdd34401b0904de32cc5578d' }
 
     it('build attributes', () => {
-      expect(buildKonnectorTriggerAttributes({ konnector, account })).toEqual({
+      expect(buildAttributes({ konnector, account })).toEqual({
         arguments: '0 0 0 * * 0',
         type: '@cron',
         worker: 'konnector',
@@ -26,7 +26,7 @@ describe('Triggers Helper', () => {
     it('build attributes with cron', () => {
       const cron = '0 0 0 * * 2'
       expect(
-        buildKonnectorTriggerAttributes({ konnector, account, cron })
+        buildAttributes({ konnector, account, cron })
       ).toEqual({
         arguments: '0 0 0 * * 2',
         type: '@cron',
@@ -68,7 +68,7 @@ describe('Triggers Helper', () => {
     })
   })
 
-  describe('buildKonnectorCron', () => {
+  describe('buildCron', () => {
     const randomDayTimeMock = jest.fn()
 
     beforeEach(() => {
@@ -85,7 +85,7 @@ describe('Triggers Helper', () => {
     it('returns expected default cron', () => {
       const konnector = {}
       const date = new Date('2019-02-07T14:12:00')
-      expect(buildKonnectorCron(konnector, date, randomDayTimeMock)).toEqual(
+      expect(buildCron(konnector, date, randomDayTimeMock)).toEqual(
         `0 59 4 * * 4`
       )
     })
@@ -95,7 +95,7 @@ describe('Triggers Helper', () => {
         frequency: 'monthly'
       }
       const date = new Date('2019-02-07T14:12:00')
-      expect(buildKonnectorCron(konnector, date, randomDayTimeMock)).toEqual(
+      expect(buildCron(konnector, date, randomDayTimeMock)).toEqual(
         `0 59 4 7 * *`
       )
     })
@@ -105,7 +105,7 @@ describe('Triggers Helper', () => {
         time_interval: [0, 12]
       }
       const date = new Date('2019-02-07T14:12:00')
-      expect(buildKonnectorCron(konnector, date, randomDayTimeMock)).toEqual(
+      expect(buildCron(konnector, date, randomDayTimeMock)).toEqual(
         `0 59 11 * * 4`
       )
     })


### PR DESCRIPTION
It appeared that trigger still need a `message.folder_to_save` property.

This PR fixes this, but it comes with the full package:

* Folder fetching and/or creation
* Permission on folder for konnector
* Reference to files in konnector

The goal is to be iso with Cozy-Home, and it actually fixes
the issue we encountered.

I tried to make atomic commits, I did not start developing
with the idea to make so much commits. But good news they
are all pretty tiny and contains a lot of tests.