### PR TITLE
fix: Use short commit for travis version

### DIFF
--- a/packages/cozy-app-publish/lib/travis.js
+++ b/packages/cozy-app-publish/lib/travis.js
@@ -15,7 +15,8 @@ const getAutoTravisVersion = async appManifestObj => {
   if (TRAVIS_TAG) {
     return TRAVIS_TAG
   } else {
-    return await getDevVersion(TRAVIS_COMMIT, appManifestObj.version)
+    const shortCommit = TRAVIS_COMMIT.slice(0, 7)
+    return await getDevVersion(shortCommit, appManifestObj.version)
   }
 }
 

--- a/packages/cozy-app-publish/test/__snapshots__/travis.spec.js.snap
+++ b/packages/cozy-app-publish/test/__snapshots__/travis.spec.js.snap
@@ -30,7 +30,7 @@ Object {
   "appBuildUrl": "https://github.com/mock-app/archive/f4a98378271c17e91faa9e70a2718c34c04cfc27.tar.gz",
   "appSlug": "mock-app",
   "appType": "webapp",
-  "appVersion": "2.1.8-dev.f4a98378271c17e91faa9e70a2718c34c04cfc271551298916519",
+  "appVersion": "2.1.8-dev.f4a98371551298916519",
   "prepublishHook": undefined,
   "registryEditor": "Cozy",
   "registryToken": "registryTokenForTest123",


### PR DESCRIPTION
We have to use the short commit otherwise the dev version is too long. 