### PR TITLE
Harvest: Better tests with a fix

### DIFF
--- a/packages/cozy-harvest-lib/src/connections/triggers.js
+++ b/packages/cozy-harvest-lib/src/connections/triggers.js
@@ -57,10 +57,10 @@ const waitForLoginSuccess = async (
   )
 
   return new Promise(resolve => {
-    const resolveJob = () => resolve(job)
-    setTimeout(resolveJob, expectedSuccessDelay)
+    setTimeout(() => resolve(job), expectedSuccessDelay)
     jobSubscription.onUpdate(
-      job => JOB_END_STATES.includes(job.state) && resolveJob(job)
+      realtimeJob =>
+        JOB_END_STATES.includes(realtimeJob.state) && resolve(realtimeJob)
     )
   })
 }


### PR DESCRIPTION
The first goal of this PR was to improve tests relying on timeout
and execution time.

But (new Date()).getTime() was not accurate enough and was sometimes
causing errored elapsed time (99ms instead of 100ms), and was
making the whole test fail.

After a try with `process.hrtime()`, I eventually realized that
dealing with timeout and elapsed time was absolutely not the
right solution, as often when there is a `setTimeout` implied.

So I just rewrote the tests with expected returned job and
it now works much better. It also lead me to detect a flaw
in the implementation : only the job passed as argument was
returned, never the one updated from realtime.