### PR TITLE
feat: Add updatedByApps

### DIFF
--- a/packages/cozy-doctypes/src/Document.js
+++ b/packages/cozy-doctypes/src/Document.js
@@ -44,6 +44,20 @@ function sanitizeKey(key) {
   return key
 }
 
+function updateCreatedByApp(cozyMetadata, appSlug) {
+  if (!cozyMetadata.updatedByApps) {
+    cozyMetadata.updatedByApps = []
+  }
+  const now = new Date()
+  for (const appInfo of cozyMetadata.updatedByApps) {
+    if (appInfo.slug === appSlug) {
+      appInfo.date = now
+      return
+    }
+  }
+  cozyMetadata.updatedByApps.push({ slug: appSlug, date: now })
+}
+
 const withoutUndefined = x => omitBy(x, isUndefined)
 
 const flagForDeletion = x => Object.assign({}, x, { _deleted: true })
@@ -84,6 +98,10 @@ class Document {
 
     if (!attributes.cozyMetadata.createdByApp && this.createdByApp) {
       attributes.cozyMetadata.createdByApp = this.createdByApp
+    }
+
+    if (this.createdByApp) {
+      updateCreatedByApp(attributes.cozyMetadata, this.createdByApp)
     }
 
     return attributes

--- a/packages/cozy-doctypes/src/Document.spec.js
+++ b/packages/cozy-doctypes/src/Document.spec.js
@@ -58,14 +58,53 @@ describe('Document', () => {
     expect(margeWithCozyMetas.cozyMetadata).toBeDefined()
     expect(margeWithCozyMetas.cozyMetadata.createdByApp).not.toBeDefined()
 
-    Simpson.createdByApp = 'simpsoncreator'
+    class MetadataSimpson extends Simpson {}
+    MetadataSimpson.createdByApp = 'simpsoncreator'
     const bart = { name: 'Bart' }
-    const bartWithCozyMetas = Simpson.addCozyMetadata(bart)
-
+    const bartWithCozyMetas = MetadataSimpson.addCozyMetadata(bart)
     expect(bartWithCozyMetas.cozyMetadata).toBeDefined()
     expect(bartWithCozyMetas.cozyMetadata.createdByApp).toEqual(
       'simpsoncreator'
     )
+  })
+
+  describe('updated by apps', () => {
+    const marge = { name: 'Marge' }
+    const bart = { name: 'Bart' }
+
+    class MetadataSimpson extends Simpson {}
+    MetadataSimpson.createdByApp = 'simpsoncreator'
+
+    it('should not add updatedByApps if createdByApp not defined', () => {
+      const margeWithCozyMetas = Simpson.addCozyMetadata(marge)
+      expect(margeWithCozyMetas.cozyMetadata).toBeDefined()
+      expect(margeWithCozyMetas.cozyMetadata.createdByApp).not.toBeDefined()
+      expect(margeWithCozyMetas.cozyMetadata.updatedByApps).not.toBeDefined()
+    })
+
+    it('should add updatedByApps cozyMetadata on create or update', async () => {
+      const bartWithCozyMetas = MetadataSimpson.addCozyMetadata(bart)
+      expect(bartWithCozyMetas.cozyMetadata).toBeDefined()
+      expect(bartWithCozyMetas.cozyMetadata.updatedByApps).toBeDefined()
+
+      const updateInfo = bartWithCozyMetas.cozyMetadata.updatedByApps.find(
+        x => x.slug === 'simpsoncreator'
+      )
+      expect(updateInfo).toMatchObject({
+        date: expect.any(Date)
+      })
+    })
+
+    it('should not add updatedByApps twice', () => {
+      const bartWithCozyMetas2 = MetadataSimpson.addCozyMetadata(
+        MetadataSimpson.addCozyMetadata(bart)
+      )
+      expect(
+        bartWithCozyMetas2.cozyMetadata.updatedByApps.filter(
+          x => x.slug === 'simpsoncreator'
+        ).length
+      ).toBe(1)
+    })
   })
 
   it('should do bulk fetch', async () => {


### PR DESCRIPTION
Automatically add the slug of the application updating the
document when creating/updating the document.

Contrary to the docs [here](https://github.com/cozy/cozy-doctypes/#document-metadata),
`updatedByApps` is not a list but an object with slug -> update date. We think it
would be more useful and it's clearer than the convention "last app updating is first".

If this PR is accepted, I will update the docs there.

```
{
  cozyMetadata: {
   updatedByApps: {
     boursorama: new Date()
   }
  }
}
```

EDIT: Fixed example