### PR TITLE
feat: --yes flag for cozy-app-publish manual

### DIFF
--- a/packages/cozy-app-publish/cozy-app-publish.js
+++ b/packages/cozy-app-publish/cozy-app-publish.js
@@ -57,6 +57,7 @@ const program = new commander.Command(pkg.name)
     '--postpublish <script-path>',
     'Hook to process parameters just after publishing, typically to deploy app'
   )
+  .option('--yes', 'Force confirmation when publishing manually')
   .option(
     '--registry-url <url>',
     'Registry URL to publish to a different one from the default URL'
@@ -86,6 +87,7 @@ try {
     manualVersion: program.manualVersion,
     prepublishHook: program.prepublish,
     postpublishHook: program.postpublish,
+    yes: program.yes,
     registryUrl: program.registryUrl,
     space: program.space,
     verbose: program.verbose
@@ -136,6 +138,7 @@ async function publishApp(cliOptions) {
       manualVersion: cliOptions.manualVersion,
       prepublishHook: cliOptions.prepublishHook,
       postpublishHook: cliOptions.postpublishHook,
+      yes: cliOptions.yes,
       registryUrl: cliOptions.registryUrl,
       spaceName: cliOptions.space,
       verbose: cliOptions.verbose

--- a/packages/cozy-app-publish/cozy-app-publish.js
+++ b/packages/cozy-app-publish/cozy-app-publish.js
@@ -30,24 +30,24 @@ const program = new commander.Command(pkg.name)
   .usage(`[options]`)
   .option(
     '--token <editor-token>',
-    'the registry token matching the provided editor (required)'
+    'Registry token matching the provided editor (required)'
   )
   .option(
     '--space <space-name>',
-    'the registry space name to publish the application to (default __default__)'
+    'Registry space name to publish the application to (default __default__)'
   )
   .option(
     '--build-dir <relative-path>',
-    'path fo the build directory relative to the current directory (default ./build)'
+    'Path fo the build directory relative to the current directory (default ./build)'
   )
   .option('--build-url <url>', 'URL of the application archive')
   .option(
     '--build-commit <commit-hash>',
-    'hash of the build commit matching the build archive to publish'
+    'Hash of the build commit matching the build archive to publish'
   )
   .option(
     '--manual-version <version>',
-    'publishing a specific version manually (must not be already published in the registry)'
+    'Specify a version manually (must not be already published in the registry)'
   )
   .option(
     '--prepublish <script-path>',
@@ -59,7 +59,7 @@ const program = new commander.Command(pkg.name)
   )
   .option(
     '--registry-url <url>',
-    'the registry URL to publish to a different one from the default URL'
+    'Registry URL to publish to a different one from the default URL'
   )
   .option('--verbose', 'print additional logs')
   .on('--help', () => {

--- a/packages/cozy-app-publish/cozy-app-publish.js
+++ b/packages/cozy-app-publish/cozy-app-publish.js
@@ -72,6 +72,11 @@ const program = new commander.Command(pkg.name)
   })
   .parse(process.argv)
 
+const handleError = error => {
+  console.log(colorize.red(`Publishing failed: ${error.message}`))
+  process.exit(1)
+}
+
 try {
   publishApp({
     token: program.token,
@@ -84,10 +89,9 @@ try {
     registryUrl: program.registryUrl,
     space: program.space,
     verbose: program.verbose
-  })
+  }).catch(handleError)
 } catch (error) {
-  console.log(colorize.red(`Publishing failed: ${error.message}`))
-  process.exit(1)
+  handleError(error)
 }
 
 function _getPublishMode() {

--- a/packages/cozy-app-publish/lib/confirm.js
+++ b/packages/cozy-app-publish/lib/confirm.js
@@ -1,0 +1,31 @@
+const prompt = require('prompt')
+const colorize = require('../utils/colorize')
+
+const promptConfirm = question =>
+  new Promise((resolve, reject) => {
+    prompt.start()
+    prompt.message = colorize.bold('Confirmation:')
+    prompt.delimiter = ' '
+    const promptProperties = [
+      {
+        name: 'confirm',
+        description: colorize.orange(question),
+        pattern: /^y(es)?$|^n(o)?$/i,
+        message: 'Yes (y) or No (n)',
+        required: true
+      }
+    ]
+
+    return prompt.get(promptProperties, function(err, received) {
+      console.log()
+      if (err) {
+        reject(new Error(colorize.red(`prompt: ${err}`)))
+      } else if (received.confirm.match(/^y(es)?$/i)) {
+        resolve(true)
+      } else {
+        resolve(false)
+      }
+    }).output
+  })
+
+module.exports = promptConfirm

--- a/packages/cozy-app-publish/lib/manual.js
+++ b/packages/cozy-app-publish/lib/manual.js
@@ -11,22 +11,18 @@ const promptConfirm = require('./confirm')
 
 const { DEFAULT_REGISTRY_URL, DEFAULT_BUILD_DIR } = constants
 
-
-
-async function manualPublish(
-  {
-    buildCommit,
-    postpublishHook,
-    prepublishHook,
-    registryToken,
-    buildDir = DEFAULT_BUILD_DIR,
-    manualVersion,
-    registryUrl = DEFAULT_REGISTRY_URL,
-    spaceName,
-    appBuildUrl,
-    yes
-  }
-) {
+async function manualPublish({
+  buildCommit,
+  postpublishHook,
+  prepublishHook,
+  registryToken,
+  buildDir = DEFAULT_BUILD_DIR,
+  manualVersion,
+  registryUrl = DEFAULT_REGISTRY_URL,
+  spaceName,
+  appBuildUrl,
+  yes
+}) {
   // registry editor token (required)
   if (!registryToken) {
     throw new Error('Registry token is missing. Publishing failed.')
@@ -84,7 +80,9 @@ async function manualPublish(
   console.log()
 
   if (!yes) {
-    const goFurther = await promptConfirm('Are you sure you want to publish this application above?')
+    const goFurther = await promptConfirm(
+      'Are you sure you want to publish this application above?'
+    )
     if (!goFurther) {
       console.log('Publishing cancelled')
       return

--- a/packages/cozy-app-publish/lib/manual.js
+++ b/packages/cozy-app-publish/lib/manual.js
@@ -23,9 +23,9 @@ async function manualPublish(
     manualVersion,
     registryUrl = DEFAULT_REGISTRY_URL,
     spaceName,
-    appBuildUrl
-  },
-  override
+    appBuildUrl,
+    yes
+  }
 ) {
   // registry editor token (required)
   if (!registryToken) {
@@ -83,7 +83,7 @@ async function manualPublish(
   )
   console.log()
 
-  if (!override) {
+  if (!yes) {
     const goFurther = await promptConfirm('Are you sure you want to publish this application above?')
     if (!goFurther) {
       console.log('Publishing cancelled')

--- a/packages/cozy-app-publish/lib/manual.js
+++ b/packages/cozy-app-publish/lib/manual.js
@@ -3,15 +3,16 @@ const fs = require('fs-extra')
 const postpublish = require('./postpublish')
 const prepublish = require('./prepublish')
 const publish = require('./publish')
-const prompt = require('prompt')
 const colorize = require('../utils/colorize')
 const getManifestAsObject = require('../utils/getManifestAsObject')
 const constants = require('./constants')
 const tags = require('./tags')
+const promptConfirm = require('./confirm')
 
 const { DEFAULT_REGISTRY_URL, DEFAULT_BUILD_DIR } = constants
 
-// override is used only for test to skip prompt (cf prompt.override)
+
+
 async function manualPublish(
   {
     buildCommit,
@@ -55,21 +56,6 @@ async function manualPublish(
   const appSlug = appManifestObj.slug
   const appType = appManifestObj.type || 'webapp'
 
-  const promptProperties = [
-    {
-      name: 'confirm',
-      description: colorize.orange(
-        'Are you sure you want to publish this application above?'
-      ),
-      pattern: /^y(es)?$|^n(o)?$/i,
-      message: 'Yes (y) or No (n)',
-      required: true
-    }
-  ]
-
-  // useful for testing
-  if (override) prompt.override = override
-
   const publishOptions = await prepublish({
     buildCommit,
     prepublishHook,
@@ -97,36 +83,27 @@ async function manualPublish(
   )
   console.log()
 
-  prompt.start()
-  prompt.message = colorize.bold('Confirmation:')
-  prompt.delimiter = ' '
-  return prompt.get(promptProperties, async function(err, received) {
-    console.log()
-    if (err) throw new Error(colorize.red(`prompt: ${err}`))
-    if (received.confirm.match(/^y(es)?$/i)) {
-      try {
-        await publish(publishOptions)
-      } catch (e) {
-        const errorMessage = '↳ ❌  Publishing failed. Publishing aborted.'
-        console.error(e)
-        console.error(errorMessage)
-      }
-    } else {
-      const errorMessage =
-        '↳ ❌  Publishing manually cancelled. Publishing aborted.'
-      if (jest) {
-        console.error(errorMessage)
-      } else {
-        throw new Error(errorMessage)
-      }
+  if (!override) {
+    const goFurther = await promptConfirm('Are you sure you want to publish this application above?')
+    if (!goFurther) {
+      console.log('Publishing cancelled')
+      return
     }
+  }
 
-    try {
-      await postpublish({ ...publishOptions, postpublishHook })
-    } catch (error) {
-      console.error(`↳ ⚠️  Postpublish hooks failed: ${error.message}`)
-    }
-  }).output
+  try {
+    await publish(publishOptions)
+  } catch (e) {
+    const errorMessage = '↳ ❌  Publishing failed. Publishing aborted.'
+    console.error(e)
+    console.error(errorMessage)
+  }
+
+  try {
+    await postpublish({ ...publishOptions, postpublishHook })
+  } catch (error) {
+    console.error(`↳ ⚠️  Postpublish hooks failed: ${error.message}`)
+  }
 }
 
 const manualPublishCLI = function() {

--- a/packages/cozy-app-publish/test/manual.spec.js
+++ b/packages/cozy-app-publish/test/manual.spec.js
@@ -106,7 +106,7 @@ describe('Manual publishing script', () => {
   })
 
   it('should handle error if the publishing is canceled by the user via the prompt and not publishing', async () => {
-    promptConfirm.mockImplementation(question => Promise.resolve(false))
+    promptConfirm.mockImplementation(() => Promise.resolve(false))
     const options = getOptions(commons.token)
     await manualScript({ ...options, yes: false })
     expect(publishLib).toHaveBeenCalledTimes(0)

--- a/packages/cozy-app-publish/test/manual.spec.js
+++ b/packages/cozy-app-publish/test/manual.spec.js
@@ -11,7 +11,9 @@ const rootPath = process.cwd()
 const testFolder = '.tmp_test'
 const testPath = path.join(rootPath, testFolder)
 const mockAppDir = path.join(__dirname, 'mockApps/mockApp')
+const promptConfirm = require('../lib/confirm')
 
+jest.mock('../lib/confirm')
 jest.mock('../lib/publish', () => jest.fn())
 jest.mock('../lib/tags', () => ({}))
 
@@ -30,7 +32,8 @@ function getOptions(token, buildDir) {
     appBuildUrl: 'https://mock.getarchive.cc/12345.tar.gz',
     manualVersion: '2.1.8-dev.12345',
     registryUrl: 'https://mock.registry.cc',
-    spaceName: 'mock_space'
+    spaceName: 'mock_space',
+    yes: true
   }
   if (buildDir) options.buildDir = buildDir
   return options
@@ -63,13 +66,13 @@ describe('Manual publishing script', () => {
   })
 
   it('should work correctly if expected options provided', async () => {
-    await manualScript(getOptions(commons.token, './build'), { confirm: 'yes' })
+    await manualScript(getOptions(commons.token, './build'))
     expect(publishLib).toHaveBeenCalledTimes(1)
     expect(publishLib.mock.calls[0][0]).toMatchSnapshot()
   })
 
   it('should work correctly with default buildDir value "build"', async () => {
-    await manualScript(getOptions(commons.token), { confirm: 'yes' })
+    await manualScript(getOptions(commons.token))
     expect(publishLib).toHaveBeenCalledTimes(1)
     expect(publishLib.mock.calls[0][0]).toMatchSnapshot()
   })
@@ -78,7 +81,7 @@ describe('Manual publishing script', () => {
     const options = getOptions(commons.token)
     delete options.spaceName
 
-    await manualScript(options, { confirm: 'yes' })
+    await manualScript(options)
     expect(publishLib).toHaveBeenCalledTimes(1)
     expect(publishLib.mock.calls[0][0]).toMatchSnapshot()
   })
@@ -87,7 +90,7 @@ describe('Manual publishing script', () => {
     const options = getOptions(commons.token)
     delete options.manualVersion
 
-    await manualScript(options, { confirm: 'yes' })
+    await manualScript(options)
     expect(publishLib).toHaveBeenCalledTimes(1)
     expect(publishLib.mock.calls[0][0]).toMatchSnapshot()
   })
@@ -97,19 +100,21 @@ describe('Manual publishing script', () => {
     delete options.appBuildUrl
     prepublishResult.appBuildUrl = 'https://mock.getarchive.cc/12345.tar.gz'
 
-    await manualScript(options, { confirm: 'yes' })
+    await manualScript(options)
     expect(publishLib).toHaveBeenCalledTimes(1)
     expect(publishLib.mock.calls[0][0]).toMatchSnapshot()
   })
 
   it('should handle error if the publishing is canceled by the user via the prompt and not publishing', async () => {
-    await manualScript(getOptions(commons.token), { confirm: 'no' })
+    promptConfirm.mockImplementation(question => Promise.resolve(false))
+    const options = getOptions(commons.token)
+    await manualScript({ ...options, yes: false })
     expect(publishLib).toHaveBeenCalledTimes(0)
   })
 
   it('should throw an error if the token is missing', async () => {
     await expect(
-      manualScript(getOptions(null), { confirm: 'yes' })
+      manualScript(getOptions(null))
     ).rejects.toThrowErrorMatchingSnapshot()
   })
 })


### PR DESCRIPTION
On Jenkins, we must not have a confirmation prompt.

- Refactored the prompt outside the main `manual` function.
Convert the prompt based callback to Promise based confirmation
prompt.

- Bypass the prompt if --yes is provided via the CLI flags