### PR TITLE
feat: Add method to detect incoherent createdByApp

### DIFF
--- a/packages/cozy-doctypes/src/banking/BankAccount.js
+++ b/packages/cozy-doctypes/src/banking/BankAccount.js
@@ -1,6 +1,7 @@
 const groupBy = require('lodash/groupBy')
 const Document = require('../Document')
 const matching = require('./matching-accounts')
+const { getSlugFromInstitutionLabel } = require('./slug-account')
 
 class BankAccount extends Document {
   /**
@@ -35,6 +36,15 @@ class BankAccount extends Document {
       }
     }
     return res
+  }
+
+  static hasIncoherentCreatedByApp(account) {
+    const predictedSlug = getSlugFromInstitutionLabel(account.institutionLabel)
+    const createdByApp =
+      account.cozyMetadata && account.cozyMetadata.createdByApp
+    return Boolean(
+      predictedSlug && createdByApp && predictedSlug !== createdByApp
+    )
   }
 }
 

--- a/packages/cozy-doctypes/src/banking/BankAccount.spec.js
+++ b/packages/cozy-doctypes/src/banking/BankAccount.spec.js
@@ -49,3 +49,43 @@ describe('deleteDuplicateBankAccountsWithNoOperations', () => {
     expect(res.map(x => x._id)).toEqual(['empty'])
   })
 })
+
+describe('incoherences', () => {
+  const incoherent = {
+    institutionLabel: "Caisse d'épargne",
+    cozyMetadata: {
+      createdByApp: 'boursorama'
+    }
+  }
+
+  const coherent = {
+    institutionLabel: "Caisse d'épargne",
+    cozyMetadata: {
+      createdByApp: 'caissedepargne1'
+    }
+  }
+
+  const unknown = {
+    institutionLabel: 'Unknown bank',
+    cozyMetadata: {
+      createdByApp: 'unknown1337'
+    }
+  }
+
+  const noMetadata = {
+    institutionLabel: "Caisse d'épargne"
+  }
+
+  const noCreatedByApp = {
+    institutionLabel: "Caisse d'épargne",
+    cozyMetadata: {}
+  }
+
+  it('should detect when slug is not coherent with createdByApp', () => {
+    expect(BankAccount.hasIncoherentCreatedByApp(incoherent)).toBe(true)
+    expect(BankAccount.hasIncoherentCreatedByApp(coherent)).toBe(false)
+    expect(BankAccount.hasIncoherentCreatedByApp(unknown)).toBe(false)
+    expect(BankAccount.hasIncoherentCreatedByApp(noMetadata)).toBe(false)
+    expect(BankAccount.hasIncoherentCreatedByApp(noCreatedByApp)).toBe(false)
+  })
+})

--- a/packages/cozy-doctypes/src/banking/matching-accounts.js
+++ b/packages/cozy-doctypes/src/banking/matching-accounts.js
@@ -1,16 +1,6 @@
 const sortBy = require('lodash/sortBy')
 const { eitherIncludes } = require('./matching-tools')
-const labelSlugs = require('./label-slugs')
-
-const institutionLabelsCompiled = Object.entries(labelSlugs).map(
-  ([ilabelRx, slug]) => {
-    if (ilabelRx[0] === '/' && ilabelRx[ilabelRx.length - 1] === '/') {
-      return [new RegExp(ilabelRx.substr(1, ilabelRx.length - 2), 'i'), slug]
-    } else {
-      return [ilabelRx, slug]
-    }
-  }
-)
+const { getSlugFromInstitutionLabel } = require('./slug-account')
 
 const findExactMatch = (attr, account, existingAccounts) => {
   const sameAttr = existingAccounts.filter(
@@ -92,19 +82,6 @@ const creditCardMatch = (account, existingAccount) => {
   const other = ccAccount === account ? existingAccount : account
   if (other.number.slice(-4) === lastDigits) {
     return true
-  }
-}
-
-const getSlugFromInstitutionLabel = institutionLabel => {
-  for (let [rx, slug] of institutionLabelsCompiled) {
-    if (rx instanceof RegExp) {
-      const match = institutionLabel.match(rx)
-      if (match) {
-        return slug
-      }
-    } else if (rx.toLowerCase() === institutionLabel.toLowerCase()) {
-      return slug
-    }
   }
 }
 

--- a/packages/cozy-doctypes/src/banking/slug-account.js
+++ b/packages/cozy-doctypes/src/banking/slug-account.js
@@ -1,0 +1,24 @@
+const labelSlugs = require('./label-slugs')
+
+const institutionLabelsCompiled = Object.entries(labelSlugs).map(
+  ([ilabelRx, slug]) => {
+    if (ilabelRx[0] === '/' && ilabelRx[ilabelRx.length - 1] === '/') {
+      return [new RegExp(ilabelRx.substr(1, ilabelRx.length - 2), 'i'), slug]
+    } else {
+      return [ilabelRx, slug]
+    }
+  }
+)
+
+export const getSlugFromInstitutionLabel = institutionLabel => {
+  for (let [rx, slug] of institutionLabelsCompiled) {
+    if (rx instanceof RegExp) {
+      const match = institutionLabel.match(rx)
+      if (match) {
+        return slug
+      }
+    } else if (rx.toLowerCase() === institutionLabel.toLowerCase()) {
+      return slug
+    }
+  }
+}

--- a/packages/cozy-doctypes/src/banking/slug-account.js
+++ b/packages/cozy-doctypes/src/banking/slug-account.js
@@ -11,7 +11,7 @@ const institutionLabelsCompiled = Object.entries(labelSlugs).map(
 )
 
 export const getSlugFromInstitutionLabel = institutionLabel => {
-  for (let [rx, slug] of institutionLabelsCompiled) {
+  for (const [rx, slug] of institutionLabelsCompiled) {
     if (rx instanceof RegExp) {
       const match = institutionLabel.match(rx)
       if (match) {


### PR DESCRIPTION
In the banking connector, we send events to Matomo if we detect
accounts with incoherent data. The `hasIncoherentCreatedByApp`
method was previously there, but it is better if it is shared.