### PR TITLE
fix: Support unexisting institutionLabel

### DIFF
--- a/packages/cozy-doctypes/src/banking/matching-accounts.js
+++ b/packages/cozy-doctypes/src/banking/matching-accounts.js
@@ -221,6 +221,5 @@ const matchAccounts = (fetchedAccounts, existingAccounts) => {
 module.exports = {
   matchAccounts,
   normalizeAccountNumber,
-  score,
-  getSlugFromInstitutionLabel
+  score
 }

--- a/packages/cozy-doctypes/src/banking/matching-accounts.spec.js
+++ b/packages/cozy-doctypes/src/banking/matching-accounts.spec.js
@@ -3,8 +3,7 @@ const path = require('path')
 const {
   matchAccounts,
   normalizeAccountNumber,
-  score,
-  getSlugFromInstitutionLabel
+  score
 } = require('./matching-accounts')
 
 const BANK_ACCOUNT_DOCTYPE = 'io.cozy.bank.accounts'
@@ -88,15 +87,6 @@ describe('slug match', () => {
       }).points
     ).toBeGreaterThan(0)
   })
-})
-
-it('should find the slug from the institutionLabel', () => {
-  expect(getSlugFromInstitutionLabel("caisse d'Épargne (particuliers)")).toBe(
-    'caissedepargne1'
-  )
-  expect(
-    getSlugFromInstitutionLabel('Crédit Mutuelle de Montigny Lengrain')
-  ).toBe('cic45')
 })
 
 it('should normalize account number', () => {

--- a/packages/cozy-doctypes/src/banking/slug-account.js
+++ b/packages/cozy-doctypes/src/banking/slug-account.js
@@ -10,7 +10,10 @@ const institutionLabelsCompiled = Object.entries(labelSlugs).map(
   }
 )
 
-export const getSlugFromInstitutionLabel = institutionLabel => {
+const getSlugFromInstitutionLabel = institutionLabel => {
+  if (!institutionLabel) {
+    return
+  }
   for (const [rx, slug] of institutionLabelsCompiled) {
     if (rx instanceof RegExp) {
       const match = institutionLabel.match(rx)
@@ -21,4 +24,8 @@ export const getSlugFromInstitutionLabel = institutionLabel => {
       return slug
     }
   }
+}
+
+module.exports = {
+  getSlugFromInstitutionLabel
 }

--- a/packages/cozy-doctypes/src/banking/slug-account.spec.js
+++ b/packages/cozy-doctypes/src/banking/slug-account.spec.js
@@ -1,0 +1,11 @@
+const { getSlugFromInstitutionLabel } = require('./slug-account')
+
+it('should find the slug from the institutionLabel', () => {
+  expect(getSlugFromInstitutionLabel("caisse d'Épargne (particuliers)")).toBe(
+    'caissedepargne1'
+  )
+  expect(
+    getSlugFromInstitutionLabel('Crédit Mutuel de Montigny Lengrain')
+  ).toBe('cic45')
+  expect(getSlugFromInstitutionLabel()).toBeUndefined()
+})


### PR DESCRIPTION
On my local cozy, I had some accounts without institutionLabel but I had not run into this case "into the wild".