### PR TITLE
Harvest: Ensure trigger can be launched, even after creation error

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountFormError.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountFormError.jsx
@@ -61,9 +61,10 @@ export class AccountFormError extends PureComponent {
   }
 
   render() {
-    const errorDescription = this.getDescription()
+    const { error } = this.props
     /* eslint-disable-next-line no-console */
-    console.error(errorDescription)
+    console.error(error)
+    const errorDescription = this.getDescription()
     return (
       <div className="u-error">
         <Markdown source={errorDescription} />

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -26,11 +26,6 @@ const RUNNING = 'RUNNING'
  * @type {Component}
  */
 export class TriggerManager extends Component {
-  state = {
-    account: null,
-    status: IDLE
-  }
-
   constructor(props) {
     super(props)
 
@@ -42,7 +37,8 @@ export class TriggerManager extends Component {
 
     this.state = {
       account: props.account,
-      status: IDLE
+      status: IDLE,
+      trigger: props.trigger
     }
   }
 
@@ -91,6 +87,10 @@ export class TriggerManager extends Component {
         })
       )
 
+      this.setState({
+        trigger
+      })
+
       return await this.launch(trigger)
     } catch (error) {
       return this.handleError(error)
@@ -107,7 +107,7 @@ export class TriggerManager extends Component {
       account
     })
 
-    const { trigger } = this.props
+    const { trigger } = this.state
     return await this.launch(trigger)
   }
 

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -29,10 +29,7 @@ export class TriggerManager extends Component {
   constructor(props) {
     super(props)
 
-    this.handleAccountCreationSuccess = this.handleAccountCreationSuccess.bind(
-      this
-    )
-    this.handleAccountUpdateSuccess = this.handleAccountUpdateSuccess.bind(this)
+    this.handleAccountSaveSuccess = this.handleAccountSaveSuccess.bind(this)
     this.handleSubmit = this.handleSubmit.bind(this)
 
     this.state = {
@@ -91,35 +88,13 @@ export class TriggerManager extends Component {
   }
 
   /**
-   * Account creation success handler
+   * Account save success handler
    * @param  {Object}  account Created io.cozy.accounts document
    * @return {Object}          io.cozy.jobs document, runned with account data
    */
-  async handleAccountCreationSuccess(account) {
-    this.setState({
-      account
-    })
-
-    try {
-      const trigger = await this.ensureTrigger()
-      return await this.launch(trigger)
-    } catch (error) {
-      return this.handleError(error)
-    }
-  }
-
-  /**
-   * Account update success handler
-   * @param  {Object}  account Updated io.cozy.accounts document
-   * @return {Object}          io.cozy.jobs document, runned with account data
-   */
-  async handleAccountUpdateSuccess(account) {
-    this.setState({
-      account
-    })
-
+  async handleAccountSaveSuccess(account) {
+    this.setState({ account })
     const trigger = await this.ensureTrigger()
-
     return await this.launch(trigger)
   }
 
@@ -151,10 +126,7 @@ export class TriggerManager extends Component {
         ),
         data
       )
-
-      return isUpdate
-        ? this.handleAccountUpdateSuccess(savedAccount)
-        : this.handleAccountCreationSuccess(savedAccount)
+      return this.handleAccountSaveSuccess(savedAccount)
     } catch (error) {
       return this.handleError(error)
     }

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -118,7 +118,8 @@ export class TriggerManager extends Component {
       account
     })
 
-    const { trigger } = this.state
+    const trigger = await this.ensureTrigger()
+
     return await this.launch(trigger)
   }
 

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -272,36 +272,36 @@ describe('TriggerManager', () => {
       )
     })
 
-    it('should call handleAccountUpdateSuccess', async () => {
+    it('should call handleAccountSaveSuccess with account', async () => {
       const wrapper = shallowWithAccount()
       const instance = wrapper.instance()
       jest
-        .spyOn(instance, 'handleAccountUpdateSuccess')
+        .spyOn(instance, 'handleAccountSaveSuccess')
         .mockResolvedValue(fixtures.launchedJob)
 
       await instance.handleSubmit(fixtures.data)
 
-      expect(instance.handleAccountUpdateSuccess).toHaveBeenCalledWith(
+      expect(instance.handleAccountSaveSuccess).toHaveBeenCalledWith(
         fixtures.createdAccount
       )
     })
 
-    it('should call handleAccountCreationSuccess', async () => {
+    it('should call handleAccountSaveSuccess without account', async () => {
       const wrapper = shallowWithoutAccount()
       const instance = wrapper.instance()
       jest
-        .spyOn(instance, 'handleAccountCreationSuccess')
+        .spyOn(instance, 'handleAccountSaveSuccess')
         .mockResolvedValue(fixtures.launchedJob)
 
       await instance.handleSubmit(fixtures.data)
 
-      expect(instance.handleAccountCreationSuccess).toHaveBeenCalledWith(
+      expect(instance.handleAccountSaveSuccess).toHaveBeenCalledWith(
         fixtures.createdAccount
       )
     })
   })
 
-  describe('handleAccountCreationSuccess', () => {
+  describe('handleAccountSaveSuccess', () => {
     beforeAll(() => {
       jest.spyOn(cronHelpers, 'fromFrequency').mockReturnValue('0 0 0 * * 0')
     })
@@ -316,16 +316,14 @@ describe('TriggerManager', () => {
 
     it('should create trigger', async () => {
       const wrapper = shallowWithoutAccount()
-      await wrapper
-        .instance()
-        .handleAccountCreationSuccess(fixtures.createdAccount)
+      await wrapper.instance().handleAccountSaveSuccess(fixtures.createdAccount)
       expect(createTriggerMock).toHaveBeenCalledTimes(1)
       expect(createTriggerMock).toHaveBeenCalledWith(fixtures.triggerAttributes)
     })
 
-    it('should launch trigger', async () => {
+    it('should launch trigger without account', async () => {
       const wrapper = shallowWithoutAccount()
-      await wrapper.instance().handleAccountCreationSuccess(fixtures.account)
+      await wrapper.instance().handleAccountSaveSuccess(fixtures.account)
       expect(launchTriggerMock).toHaveBeenCalledTimes(1)
       expect(launchTriggerMock).toHaveBeenCalledWith(fixtures.createdTrigger)
     })
@@ -336,7 +334,7 @@ describe('TriggerManager', () => {
         createDirectoryByPathMock.mockReturnValue(fixtures.folder)
 
         const wrapper = shallowWithoutAccount(fixtures.konnectorWithFolder)
-        await wrapper.instance().handleAccountCreationSuccess(fixtures.account)
+        await wrapper.instance().handleAccountSaveSuccess(fixtures.account)
 
         expect(statDirectoryByPathMock).toHaveBeenCalledTimes(1)
         expect(createDirectoryByPathMock).toHaveBeenCalledTimes(1)
@@ -359,7 +357,7 @@ describe('TriggerManager', () => {
         statDirectoryByPathMock.mockResolvedValue(fixtures.folder)
 
         const wrapper = shallowWithoutAccount(fixtures.konnectorWithFolder)
-        await wrapper.instance().handleAccountCreationSuccess(fixtures.account)
+        await wrapper.instance().handleAccountSaveSuccess(fixtures.account)
 
         expect(statDirectoryByPathMock).toHaveBeenCalledTimes(1)
         expect(createDirectoryByPathMock).toHaveBeenCalledTimes(0)
@@ -376,23 +374,17 @@ describe('TriggerManager', () => {
         )
       })
     })
-  })
 
-  describe('handleAccountUpdateSuccess', () => {
-    it('should launch trigger', async () => {
+    it('should launch trigger with account', async () => {
       const wrapper = shallowWithAccount()
-      await wrapper
-        .instance()
-        .handleAccountUpdateSuccess(fixtures.updatedAccount)
+      await wrapper.instance().handleAccountSaveSuccess(fixtures.updatedAccount)
       expect(launchTriggerMock).toHaveBeenCalledTimes(1)
       expect(launchTriggerMock).toHaveBeenCalledWith(fixtures.createdTrigger)
     })
 
-    it('should keep update account in state', async () => {
+    it('should keep updated account in state', async () => {
       const wrapper = shallowWithAccount()
-      await wrapper
-        .instance()
-        .handleAccountUpdateSuccess(fixtures.updatedAccount)
+      await wrapper.instance().handleAccountSaveSuccess(fixtures.updatedAccount)
       expect(wrapper.state().account).toEqual(fixtures.updatedAccount)
     })
   })


### PR DESCRIPTION
After a creation error, re-submitting the form was
throwing an error, because the trigger in TriggerManager
was not saved in state. This PR solves this point in
the second commit.

Then it ensures that the trigger exists on update, in the
case of an error between account creation and trigger
creation.

At last, it merge `handleAccountCreationSuccess` and
`handleAccountUpdateSucces` into a single one handler
as they are now identical.

**NB: This PR concern a logic part being still in `TriggerManager`, but which need to be extracted in a dedicated logic component (a Model for example).**