### PR TITLE
Harvest: Prevent undefined Error.captureStackTrace()

### DIFF
--- a/packages/cozy-harvest-lib/src/helpers/konnectors.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectors.js
@@ -32,7 +32,9 @@ const KNOWN_ERRORS = [
 export class KonnectorJobError extends Error {
   constructor(...args) {
     super(...args)
-    Error.captureStackTrace(this, KonnectorJobError)
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, KonnectorJobError)
+    }
 
     /**
      * Konnector job are throwing error with a message containing the error


### PR DESCRIPTION
`Error.captureStackTrace()` is not available in all engines.
Firefox is throwing an error when calling this method.

More info: https://www.bennadel.com/blog/2828-creating-custom-error-objects-in-node-js-with-error-capturestacktrace.htm