### PR TITLE
Harvest: Show error when editing

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm.jsx
@@ -253,7 +253,15 @@ export class AccountForm extends PureComponent {
   }
 
   render() {
-    const { account, error, konnector, onSubmit, submitting, t } = this.props
+    const {
+      account,
+      error,
+      konnector,
+      onSubmit,
+      showError,
+      submitting,
+      t
+    } = this.props
     const { fields, oauth } = konnector
 
     if (oauth) return <OAuthForm initialValues={initialValues} oauth={oauth} />
@@ -264,6 +272,9 @@ export class AccountForm extends PureComponent {
     const initialAndDefaultValues = { ...defaultValues, ...initialValues }
 
     let container = null
+
+    const isLoginError =
+      error instanceof KonnectorJobError && error.isLoginError()
 
     return (
       <Form
@@ -276,7 +287,7 @@ export class AccountForm extends PureComponent {
               container = element
             }}
           >
-            {error && (
+            {error && (showError || isLoginError) && (
               <AccountFormError error={error} konnector={konnector} t={t} />
             )}
             <AccountFields
@@ -322,7 +333,12 @@ AccountForm.propTypes = {
   account: PropTypes.object,
   konnector: PropTypes.object.isRequired,
   error: PropTypes.object,
+  showError: PropTypes.bool,
   submitting: PropTypes.bool
+}
+
+AccountForm.defaultProps = {
+  showError: true
 }
 
 export default translate()(AccountForm)

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -166,7 +166,7 @@ export class TriggerManager extends Component {
   }
 
   render() {
-    const { konnector, running } = this.props
+    const { konnector, running, showError } = this.props
     const { account, error, status } = this.state
     const submitting = status === RUNNING || running
 
@@ -176,6 +176,7 @@ export class TriggerManager extends Component {
         error={error}
         konnector={konnector}
         onSubmit={this.handleSubmit}
+        showError={showError}
         submitting={submitting}
       />
     )
@@ -185,6 +186,7 @@ export class TriggerManager extends Component {
 TriggerManager.propTypes = {
   account: PropTypes.object,
   konnector: PropTypes.object.isRequired,
+  showError: PropTypes.bool,
   trigger: PropTypes.object,
   running: PropTypes.bool,
   // mutations

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -34,6 +34,7 @@ export class TriggerManager extends Component {
 
     this.state = {
       account: props.account,
+      error: triggers.getError(props.trigger),
       status: IDLE,
       trigger: props.trigger
     }

--- a/packages/cozy-harvest-lib/src/helpers/triggers.js
+++ b/packages/cozy-harvest-lib/src/helpers/triggers.js
@@ -1,3 +1,6 @@
+import get from 'lodash/get'
+import { KonnectorJobError } from './konnectors'
+
 const DEFAULT_CRON = '0 0 0 * * 0' // Once a week, sunday at midnight
 
 /**
@@ -29,8 +32,21 @@ export const buildAttributes = ({
   }
 }
 
+/**
+ * Get error for a given trigger document
+ * @param  {Object} trigger io.cozy.trigger as returned by stack
+ * @return {KonnectorJobError}         [description]
+ */
+export const getError = trigger => {
+  const status = get(trigger, 'current_state.status')
+  return status === 'errored'
+    ? new KonnectorJobError(get(trigger, 'current_state.last_error'))
+    : null
+}
+
 const helpers = {
-  buildAttributes
+  buildAttributes,
+  getError
 }
 
 export default helpers

--- a/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
+++ b/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
@@ -8,6 +8,8 @@ import {
   AccountField
 } from 'components/AccountForm'
 
+import { KonnectorJobError } from 'helpers/konnectors'
+
 const fixtures = {
   konnector: {
     fields: {
@@ -61,6 +63,47 @@ describe('AccountForm', () => {
   it('should render', () => {
     const wrapper = shallow(
       <AccountForm konnector={fixtures.konnector} onSubmit={onSubmit} t={t} />
+    )
+    const component = wrapper.dive().getElement()
+    expect(component).toMatchSnapshot()
+  })
+
+  it('should render error', () => {
+    const wrapper = shallow(
+      <AccountForm
+        error={new Error('Test error')}
+        konnector={fixtures.konnector}
+        onSubmit={onSubmit}
+        t={t}
+      />
+    )
+    const component = wrapper.dive().getElement()
+    expect(component).toMatchSnapshot()
+  })
+
+  it('should not render error', () => {
+    const wrapper = shallow(
+      <AccountForm
+        error={new Error('Test error')}
+        konnector={fixtures.konnector}
+        onSubmit={onSubmit}
+        showError={false}
+        t={t}
+      />
+    )
+    const component = wrapper.dive().getElement()
+    expect(component).toMatchSnapshot()
+  })
+
+  it('should always render login error', () => {
+    const wrapper = shallow(
+      <AccountForm
+        error={new KonnectorJobError('LOGIN_FAILED')}
+        konnector={fixtures.konnector}
+        onSubmit={onSubmit}
+        showError={false}
+        t={t}
+      />
     )
     const component = wrapper.dive().getElement()
     expect(component).toMatchSnapshot()

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
@@ -214,6 +214,132 @@ exports[`AccountForm AccountFields should render encrypted fields with placehold
 </div>
 `;
 
+exports[`AccountForm should always render login error 1`] = `
+<div>
+  <Wrapper
+    error={[Error: LOGIN_FAILED]}
+    konnector={
+      Object {
+        "fields": Object {
+          "passphrase": Object {
+            "type": "password",
+          },
+          "username": Object {
+            "type": "text",
+          },
+        },
+      }
+    }
+    t={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "accountForm.submit.label",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": "accountForm.submit.label",
+          },
+        ],
+      }
+    }
+  />
+  <AccountFields
+    container={null}
+    hasError={true}
+    initialValues={Object {}}
+    manifestFields={
+      Object {
+        "passphrase": Object {
+          "encrypted": true,
+          "required": true,
+          "type": "password",
+        },
+        "username": Object {
+          "encrypted": false,
+          "required": true,
+          "role": "identifier",
+          "type": "text",
+        },
+      }
+    }
+    onKeyUp={[Function]}
+    t={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "accountForm.submit.label",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": "accountForm.submit.label",
+          },
+        ],
+      }
+    }
+  />
+  <DefaultButton
+    className="u-mt-2 u-mb-1-half"
+    disabled={false}
+    extension="full"
+    label="accountForm.submit.label"
+    onClick={[Function]}
+  />
+</div>
+`;
+
+exports[`AccountForm should not render error 1`] = `
+<div>
+  <AccountFields
+    container={null}
+    hasError={false}
+    initialValues={Object {}}
+    manifestFields={
+      Object {
+        "passphrase": Object {
+          "encrypted": true,
+          "required": true,
+          "type": "password",
+        },
+        "username": Object {
+          "encrypted": false,
+          "required": true,
+          "role": "identifier",
+          "type": "text",
+        },
+      }
+    }
+    onKeyUp={[Function]}
+    t={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "accountForm.submit.label",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": "accountForm.submit.label",
+          },
+        ],
+      }
+    }
+  />
+  <DefaultButton
+    className="u-mt-2 u-mb-1-half"
+    disabled={false}
+    extension="full"
+    label="accountForm.submit.label"
+    onClick={[Function]}
+  />
+</div>
+`;
+
 exports[`AccountForm should redirect to OAuthForm 1`] = `
 <Wrapper
   oauth={
@@ -264,6 +390,84 @@ exports[`AccountForm should render 1`] = `
   <DefaultButton
     className="u-mt-2 u-mb-1-half"
     disabled={true}
+    extension="full"
+    label="accountForm.submit.label"
+    onClick={[Function]}
+  />
+</div>
+`;
+
+exports[`AccountForm should render error 1`] = `
+<div>
+  <Wrapper
+    error={[Error: Test error]}
+    konnector={
+      Object {
+        "fields": Object {
+          "passphrase": Object {
+            "type": "password",
+          },
+          "username": Object {
+            "type": "text",
+          },
+        },
+      }
+    }
+    t={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "accountForm.submit.label",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": "accountForm.submit.label",
+          },
+        ],
+      }
+    }
+  />
+  <AccountFields
+    container={null}
+    hasError={false}
+    initialValues={Object {}}
+    manifestFields={
+      Object {
+        "passphrase": Object {
+          "encrypted": true,
+          "required": true,
+          "type": "password",
+        },
+        "username": Object {
+          "encrypted": false,
+          "required": true,
+          "role": "identifier",
+          "type": "text",
+        },
+      }
+    }
+    onKeyUp={[Function]}
+    t={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "accountForm.submit.label",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": "accountForm.submit.label",
+          },
+        ],
+      }
+    }
+  />
+  <DefaultButton
+    className="u-mt-2 u-mb-1-half"
+    disabled={false}
     extension="full"
     label="accountForm.submit.label"
     onClick={[Function]}

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
@@ -44,6 +44,7 @@ exports[`TriggerManager should render with account 1`] = `
       "identifier": "username",
     }
   }
+  error={null}
   konnector={
     Object {
       "fields": Object {
@@ -63,6 +64,7 @@ exports[`TriggerManager should render with account 1`] = `
 
 exports[`TriggerManager should render without account 1`] = `
 <Wrapper
+  error={null}
   konnector={
     Object {
       "fields": Object {

--- a/packages/cozy-harvest-lib/test/helpers/triggers.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/triggers.spec.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 
-import { buildAttributes } from 'helpers/triggers'
+import { buildAttributes, getError } from 'helpers/triggers'
+import { KonnectorJobError } from 'helpers/konnectors'
 
 describe('Triggers Helper', () => {
   describe('buildAttributes', () => {
@@ -44,6 +45,29 @@ describe('Triggers Helper', () => {
           konnector: 'konnectest'
         }
       })
+    })
+  })
+
+  describe('getError', () => {
+    it('returns known KonnectorJobError', () => {
+      const trigger = {
+        current_state: {
+          last_error: 'USER_ACTION_NEEDED.CHANGE_PASSWORD',
+          status: 'errored'
+        }
+      }
+      expect(getError(trigger)).toEqual(
+        new KonnectorJobError('USER_ACTION_NEEDED.CHANGE_PASSWORD')
+      )
+    })
+
+    it('returns null', () => {
+      const trigger = {
+        current_state: {
+          status: 'done'
+        }
+      }
+      expect(getError(trigger)).toBeNull()
     })
   })
 })


### PR DESCRIPTION
Errors were not shown in Cozy-Home when editing.

This PR: handle directly trigger error from trigger prop.
`error` is still passed to `<AccountForm />`.

As when editing only login errors are shown on `<AccountForm />`, Cozy-Home need to pass a prop `showError` to `<TriggerManager />` to indicate if errors have to be shown (See https://github.com/cozy/cozy-home/pull/1151). Login errors are bypassing this props and are always shown.