### PR TITLE
Harvest: Handle onKeyUp on whole AccountFields component

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm.jsx
@@ -45,7 +45,6 @@ export class AccountField extends PureComponent {
       initialValue,
       label,
       name,
-      onKeyUp,
       required,
       role,
       t,
@@ -70,7 +69,6 @@ export class AccountField extends PureComponent {
       label: t(`fields.${localeKey}.label`, {
         _: t(`legacy.fields.${localeKey}.label`, { _: name })
       }),
-      onKeyUp: onKeyUp,
       placeholder: getFieldPlaceholder(
         this.props,
         t(`fields.${name}.placeholder`, { _: '' })
@@ -116,7 +114,6 @@ AccountField.propTypes = {
   initialValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   label: PropTypes.string,
   name: PropTypes.string.isRequired,
-  onKeyUp: PropTypes.func,
   role: PropTypes.string,
   type: PropTypes.oneOf(['date', 'dropdown', 'email', 'password', 'text']),
   t: PropTypes.func
@@ -148,7 +145,7 @@ export class AccountFields extends PureComponent {
     }))
 
     return (
-      <div>
+      <div onKeyUp={onKeyUp}>
         {namedFields.map((field, index) => (
           <FinalFormField
             key={index}
@@ -166,7 +163,6 @@ export class AccountFields extends PureComponent {
                   initialValues[field.name] ||
                   initialValues[getEncryptedFieldName(field.name)]
                 }
-                onKeyUp={onKeyUp}
                 t={t}
               />
             )}


### PR DESCRIPTION
~~The underlying component in our SelectBox (ReactSelect) does
not allow handler for KeyUp events. The cheapest way to handle
them is to wrap our SelectBox into a div element to capture
keyUp events.~~

Move the onKeyUp handler to the AccountFields component main container.

EDIT:

Why keyUp ? To prevent browser for filling password in Cozy-Home, the "best" solution we found so far is to:
* Set the password autocomplete property to `new-password`.
* Do not provide a form wrapper and use a div isntead.

Using a div is forcing us to implement some form native behaviour, [like submitting on `Enter`](https://github.com/cozy/cozy-libs/blob/master/packages/cozy-harvest-lib/src/components/AccountForm.jsx#L209) key, and for this we need to handle the `onKeyUp` event.

We are aware that replacing a form with a div is an anti-pattern but we did not find another option, and we are using this hack since the beginning of Cozy-Home.

This will disappear as soon as we will have Harvest applications with their own domain, which will prevent a form to be filled with another service information.