### PR TITLE
fix: Use cozy-realtime 2.0 in harvest

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "cozy-client": "6.3.0",
-    "cozy-realtime": "1.2.8",
+    "cozy-realtime": "2.0.3",
     "cozy-ui": "19.3.0",
     "final-form": "4.11.1",
     "lodash": "4.17.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2424,11 +2424,6 @@ cozy-logger@1.3.1:
   dependencies:
     json-stringify-safe "5.0.1"
 
-cozy-realtime@1.2.8:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-1.2.8.tgz#c94c4bd8eb36009a381739062bd41947ddd516fc"
-  integrity sha512-G4seWPh7Ys+XApe1p165xKWq2jNKfmR/icUx45YplVZZm5wJk5pPGVrc70Rccr0DYuA8oHh1i/wpG/a5cHhpYQ==
-
 cozy-stack-client@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-6.3.0.tgz#0117bf416e8898e587e21ff58d67ecec91d895af"


### PR DESCRIPTION
In the package.json of cozy-harvest-lib, we were saying to use cozy-realtime 1.2.8, but as we are in a monorepo, it was already cozy-realtime 2 that was used in fact.