### PR TITLE
Harvest: avoid warnings in tests

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm.jsx
@@ -75,7 +75,7 @@ export class AccountField extends PureComponent {
         this.props,
         t(`fields.${name}.placeholder`, { _: '' })
       ),
-      side: !required && t('accountForm.fields.optional'),
+      side: required ? null : t('accountForm.fields.optional'),
       size: 'medium'
     }
     const passwordLabels = {

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
@@ -60,7 +60,7 @@ exports[`AccountForm AccountField render a dropdown field 1`] = `
     placeholder="fields.multiple.placeholder"
     required={true}
     secondaryLabels={Object {}}
-    side={false}
+    side={null}
     size="medium"
     t={
       [MockFunction] {

--- a/packages/cozy-harvest-lib/test/connections/accounts.spec.js
+++ b/packages/cozy-harvest-lib/test/connections/accounts.spec.js
@@ -103,13 +103,6 @@ describe('Account mutations', () => {
       })
     })
 
-    it('throws an error when konnector have no aggregator attribute', async () => {
-      const konnector = {}
-      expect(createAccount(konnector, fixtures.simpleAccount)).rejects.toEqual(
-        new Error('Konnector does not provide aggregator account id')
-      )
-    })
-
     it('throws an error when konnector have no aggregator.accountId attribute', async () => {
       const konnector = { aggregator: {} }
       expect(createAccount(konnector, fixtures.simpleAccount)).rejects.toEqual(

--- a/packages/cozy-harvest-lib/test/connections/accounts.spec.js
+++ b/packages/cozy-harvest-lib/test/connections/accounts.spec.js
@@ -105,7 +105,9 @@ describe('Account mutations', () => {
 
     it('throws an error when konnector have no aggregator.accountId attribute', async () => {
       const konnector = { aggregator: {} }
-      expect(createAccount(konnector, fixtures.simpleAccount)).rejects.toEqual(
+      await expect(
+        createAccount(konnector, fixtures.simpleAccount)
+      ).rejects.toEqual(
         new Error('Konnector does not provide aggregator account id')
       )
     })


### PR DESCRIPTION
This PR cleans tests and fix a few typos to avoid warning in tests.