### PR TITLE
Babel preset app options for presets and plugins

### DIFF
--- a/packages/babel-preset-cozy-app/README.md
+++ b/packages/babel-preset-cozy-app/README.md
@@ -90,6 +90,32 @@ By default, this babel preset uses [`babel-plugin-transform-runtime`](https://ba
 }
 ```
 
+#### Preset and plugin options
+
+You can have control on the options passed to `babel-preset-env` and `babel-plugin-transform-runtime`:
+
+* `presetEnv` will be passed to `babel-preset-env`
+* `transformRuntime` will be passed to `babel-plugin-transform-runtime`
+
+```json
+{
+  "presets": [
+    ["cozy-app", {
+      "presetEnv": { "modules": false },
+      "transformRuntime": { "helpers": true }
+    }]
+  ]
+}
+```
+
+In this case, we do not want `preset-env` to touch to `import/export` and want the inlined Babel helpers
+to be replaced by imports from `babel-runtime`.
+
+See the options on the official docs :
+
+https://babeljs.io/docs/en/babel-preset-env#modules
+https://babeljs.io/docs/en/babel-plugin-transform-runtime#helpers 
+
 ## Community
 
 ### What's Cozy?

--- a/packages/babel-preset-cozy-app/index.js
+++ b/packages/babel-preset-cozy-app/index.js
@@ -40,7 +40,7 @@ const optionConfigs = {
 const validators = mapValues(optionConfigs, x => x.validator)
 const defaultOptions = mapValues(optionConfigs, x => x.default)
 
-module.exports = declare((api, options) => {
+const mkConfig = (api, options) => {
   const presetOptions = {
     ...defaultOptions,
     ...options
@@ -97,4 +97,11 @@ module.exports = declare((api, options) => {
   }
   config.plugins = plugins
   return config
-})
+}
+
+module.exports = declare(mkConfig)
+
+if (require.main === module) {
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(mkConfig(null, {}), null, 2))
+}

--- a/packages/babel-preset-cozy-app/index.js
+++ b/packages/babel-preset-cozy-app/index.js
@@ -2,7 +2,7 @@
 
 const { declare } = require('@babel/helper-plugin-utils')
 const browserslist = require('browserslist-config-cozy')
-const { validate, isOfType } = require('./validate')
+const { validate, isOfType, deprecated } = require('./validate')
 const mapValues = require('lodash/mapValues')
 const merge = require('lodash/merge')
 
@@ -29,8 +29,11 @@ const optionConfigs = {
     validator: isOfType('boolean')
   },
   transformRegenerator: {
-    default: true,
-    validator: isOfType('boolean')
+    default: undefined,
+    validator: deprecated(
+      isOfType('boolean'),
+      'Please use transformRuntime options.'
+    )
   },
   presetEnv: {
     default: {},
@@ -68,6 +71,11 @@ const mkConfig = (api, options) => {
 
   const config = {}
 
+  // transformRegenerator is deprecated, should be removed
+  if (transformRegenerator !== undefined) {
+    transformRuntime.regenerator = transformRegenerator
+  }
+
   // Latest ECMAScript features on previous browsers versions
   const presetEnvOptions = {
     ...(node ? presetEnvNodeOptions : presetEnvBrowserOptions),
@@ -94,7 +102,7 @@ const mkConfig = (api, options) => {
       }
     ]
   ]
-  if (!node && transformRegenerator) {
+  if (!node) {
     plugins.push(
       // Polyfills generator functions (for async/await usage)
       [require.resolve('@babel/plugin-transform-runtime'), transformRuntime]

--- a/packages/babel-preset-cozy-app/index.js
+++ b/packages/babel-preset-cozy-app/index.js
@@ -107,6 +107,7 @@ const mkConfig = (api, options) => {
 module.exports = declare(mkConfig)
 
 if (require.main === module) {
+  const options = process.argv[2] ? JSON.parse(process.argv[2]) : {}
   // eslint-disable-next-line no-console
-  console.log(JSON.stringify(mkConfig(null, {}), null, 2))
+  console.log(JSON.stringify(mkConfig(null, options), null, 2))
 }

--- a/packages/babel-preset-cozy-app/index.js
+++ b/packages/babel-preset-cozy-app/index.js
@@ -2,7 +2,13 @@
 
 const { declare } = require('@babel/helper-plugin-utils')
 const browserslist = require('browserslist-config-cozy')
-const { validate, isOfType, deprecated } = require('./validate')
+const {
+  validate,
+  isFalse,
+  isOfType,
+  deprecated,
+  either
+} = require('./validate')
 const mapValues = require('lodash/mapValues')
 const merge = require('lodash/merge')
 
@@ -44,7 +50,7 @@ const optionConfigs = {
       helpers: false,
       regenerator: true
     },
-    validator: isOfType('object')
+    validator: either(isOfType('object'), isFalse)
   }
 }
 
@@ -102,7 +108,7 @@ const mkConfig = (api, options) => {
       }
     ]
   ]
-  if (!node) {
+  if (!node && transformRuntime !== false) {
     plugins.push(
       // Polyfills generator functions (for async/await usage)
       [require.resolve('@babel/plugin-transform-runtime'), transformRuntime]

--- a/packages/babel-preset-cozy-app/index.js
+++ b/packages/babel-preset-cozy-app/index.js
@@ -5,12 +5,12 @@ const browserslist = require('browserslist-config-cozy')
 const { validate, isOfType } = require('./validate')
 const mapValues = require('lodash/mapValues')
 
-const browserEnv = {
+const presetEnvBrowserOptions = {
   targets: browserslist,
   useBuiltIns: false
 }
 
-const nodeEnv = {
+const presetEnvNodeOptions = {
   targets: {
     node: 8
   },
@@ -54,17 +54,15 @@ module.exports = declare((api, options) => {
   const config = {}
 
   // Latest ECMAScript features on previous browsers versions
-  let env = [require.resolve('@babel/preset-env')]
-  if (node) {
-    env.push(nodeEnv)
-  } else {
-    env.push(browserEnv)
+  const presetEnvOptions = {
+    ...(node ? presetEnvNodeOptions : presetEnvBrowserOptions)
   }
 
-  let presets = [env]
-  // if (P)React app
-  if (!node && react) presets.push(require.resolve('@babel/preset-react'))
-  config.presets = presets
+  config.presets = [
+    [require.resolve('@babel/preset-env'), presetEnvOptions],
+    // if (P)React app
+    !node && react ? require.resolve('@babel/preset-react') : null
+  ].filter(Boolean)
 
   const plugins = [
     // transform class attributes and methods with auto-binding

--- a/packages/babel-preset-cozy-app/index.js
+++ b/packages/babel-preset-cozy-app/index.js
@@ -30,6 +30,10 @@ const optionConfigs = {
   transformRegenerator: {
     default: true,
     validator: isOfType('boolean')
+  },
+  presetEnv: {
+    default: {},
+    validator: isOfType('object')
   }
 }
 
@@ -49,13 +53,14 @@ module.exports = declare((api, options) => {
     throw e
   }
 
-  const { node, react, transformRegenerator } = presetOptions
+  const { node, react, transformRegenerator, presetEnv } = presetOptions
 
   const config = {}
 
   // Latest ECMAScript features on previous browsers versions
   const presetEnvOptions = {
-    ...(node ? presetEnvNodeOptions : presetEnvBrowserOptions)
+    ...(node ? presetEnvNodeOptions : presetEnvBrowserOptions),
+    ...presetEnv
   }
 
   config.presets = [

--- a/packages/babel-preset-cozy-app/index.js
+++ b/packages/babel-preset-cozy-app/index.js
@@ -4,6 +4,7 @@ const { declare } = require('@babel/helper-plugin-utils')
 const browserslist = require('browserslist-config-cozy')
 const { validate, isOfType } = require('./validate')
 const mapValues = require('lodash/mapValues')
+const merge = require('lodash/merge')
 
 const presetEnvBrowserOptions = {
   targets: browserslist,
@@ -34,6 +35,13 @@ const optionConfigs = {
   presetEnv: {
     default: {},
     validator: isOfType('object')
+  },
+  transformRuntime: {
+    default: {
+      helpers: false,
+      regenerator: true
+    },
+    validator: isOfType('object')
   }
 }
 
@@ -41,10 +49,7 @@ const validators = mapValues(optionConfigs, x => x.validator)
 const defaultOptions = mapValues(optionConfigs, x => x.default)
 
 const mkConfig = (api, options) => {
-  const presetOptions = {
-    ...defaultOptions,
-    ...options
-  }
+  const presetOptions = merge(defaultOptions, options)
 
   try {
     validate(presetOptions, validators)
@@ -53,7 +58,13 @@ const mkConfig = (api, options) => {
     throw e
   }
 
-  const { node, react, transformRegenerator, presetEnv } = presetOptions
+  const {
+    node,
+    react,
+    presetEnv,
+    transformRuntime,
+    transformRegenerator
+  } = presetOptions
 
   const config = {}
 
@@ -86,13 +97,7 @@ const mkConfig = (api, options) => {
   if (!node && transformRegenerator) {
     plugins.push(
       // Polyfills generator functions (for async/await usage)
-      [
-        require.resolve('@babel/plugin-transform-runtime'),
-        {
-          helpers: false,
-          regenerator: true
-        }
-      ]
+      [require.resolve('@babel/plugin-transform-runtime'), transformRuntime]
     )
   }
   config.plugins = plugins

--- a/packages/babel-preset-cozy-app/package.json
+++ b/packages/babel-preset-cozy-app/package.json
@@ -24,6 +24,7 @@
     "@babel/preset-env": "7.2.3",
     "@babel/preset-react": "7.0.0",
     "@babel/runtime": "7.2.0",
-    "browserslist-config-cozy": "^0.2.0"
+    "browserslist-config-cozy": "^0.2.0",
+    "lodash": "4.17.11"
   }
 }

--- a/packages/babel-preset-cozy-app/validate.js
+++ b/packages/babel-preset-cozy-app/validate.js
@@ -1,14 +1,42 @@
 const isOfType = type => (value, key) => {
   if (!(typeof value === type)) {
-    throw new Error(`Error: "${key}" must be a ${type}`)
+    throw new Error(`"${key}" must be a ${type}`)
   }
+}
+
+const isFalse = (value, key) => {
+  if (value !== false) {
+    throw new Error(`"${key}" must be false`)
+  }
+}
+
+const either = (...validators) => (value, key) => {
+  let errors = []
+  for (const validator of validators) {
+    try {
+      validator(value, key)
+      return
+    } catch (e) {
+      errors.push(e)
+    }
+  }
+  throw new Error(
+    `"${value}" at ${key} did not pass either validator : ${errors
+      .map(e => e.message)
+      .join('\n')}`
+  )
 }
 
 const validate = (obj, validators) => {
   for (const key of Object.keys(obj)) {
     const validator = validators[key]
     if (validator) {
-      validator(obj[key], key)
+      try {
+        validator(obj[key], key)
+      } catch (e) {
+        e.message = 'Validation error: ' + e.message
+        throw e
+      }
     }
   }
 }
@@ -23,5 +51,7 @@ const deprecated = (fn, msg) => (value, key) => {
 module.exports = {
   validate,
   isOfType,
-  deprecated
+  deprecated,
+  either,
+  isFalse
 }

--- a/packages/babel-preset-cozy-app/validate.js
+++ b/packages/babel-preset-cozy-app/validate.js
@@ -1,0 +1,19 @@
+const isOfType = type => (value, key) => {
+  if (!(typeof value === type)) {
+    throw new Error(`Error: "${key}" must be a ${type}`)
+  }
+}
+
+const validate = (obj, validators) => {
+  for (const key of Object.keys(obj)) {
+    const validator = validators[key]
+    if (validator) {
+      validator(obj[key], key)
+    }
+  }
+}
+
+module.exports = {
+  validate,
+  isOfType
+}

--- a/packages/babel-preset-cozy-app/validate.js
+++ b/packages/babel-preset-cozy-app/validate.js
@@ -13,7 +13,15 @@ const validate = (obj, validators) => {
   }
 }
 
+const deprecated = (fn, msg) => (value, key) => {
+  if (value !== undefined) {
+    // eslint-disable-next-line no-console
+    console.warn(key, 'is deprecated.', msg)
+  }
+}
+
 module.exports = {
   validate,
-  isOfType
+  isOfType,
+  deprecated
 }


### PR DESCRIPTION
In this PR, more flexibility is given to users of babel-preset-cozy-app to configure presets and plugins that babel-preset-cozy-apps uses.

## babel-preset-env

To use webpack tree shaking features, we need to have our modules shipped on npm using es6 imports.

For `babel-preset-env` not to transpile import/exports, we have to pass `modules: false` https://babeljs.io/docs/en/babel-preset-env#modules.

`babel-preset-env` was not configurable when using `babel-preset-cozy-app` so this PR adds an option `presetEnv` to the options of `babel-preset-cozy-app`.

## transform-runtime

I wanted to experiment with `helpers: true` and cozy-ui and babel-preset-cozy-app did not give enough flexibility on the options pased. `transformRuntime` options are passed directly to `transform-runtime` plugin (they are merged with the defaults `{ regenerator: true, helpers: false }`.


## validation

`babel-preset-cozy-app` options were validated but were supposed to all be Booleans, in contrast to `presetEnv`/`transformRuntime` which are object.s To be able to add these options and keep existing validation, validation has been refactored to use validator functions and a config objects specifying for each field the kind of validator it needs.