### PR TITLE
feat: Use stackClient to not print deprecated warning

### DIFF
--- a/packages/cozy-interapp/src/intents.spec.js
+++ b/packages/cozy-interapp/src/intents.spec.js
@@ -2,7 +2,7 @@ import Intents from './intents'
 import { mockAPI, sleep } from './testUtils'
 
 describe('Interapp', () => {
-  let client,
+  let cozyClient,
     intents,
     api = mockAPI()
 
@@ -38,17 +38,17 @@ describe('Interapp', () => {
   }
 
   beforeEach(() => {
-    client = {
-      client: {
+    cozyClient = {
+      stackClient: {
         fetchJSON: jest.fn()
       }
     }
-    intents = new Intents({ client })
-    client.client.fetchJSON.mockImplementation(api.fetch)
+    intents = new Intents({ client: cozyClient })
+    cozyClient.stackClient.fetchJSON.mockImplementation(api.fetch)
   })
 
   it('should initialise with cozy client', () => {
-    expect(intents.request.client).toEqual(client.client)
+    expect(intents.request.stackClient).toEqual(cozyClient.stackClient)
   })
 
   describe('creation', () => {

--- a/packages/cozy-interapp/src/request.js
+++ b/packages/cozy-interapp/src/request.js
@@ -1,16 +1,16 @@
 class Request {
   constructor(cozyClient) {
-    this.client = cozyClient.client
+    this.stackClient = cozyClient.stackClient
   }
 
   get(id) {
-    return this.client
+    return this.stackClient
       .fetchJSON('GET', `/intents/${id}`)
       .then(resp => resp.data)
   }
 
   post(action, type, data, permissions) {
-    return this.client
+    return this.stackClient
       .fetchJSON('POST', '/intents', {
         data: {
           type: 'io.cozy.intents',

--- a/packages/cozy-interapp/src/request.spec.js
+++ b/packages/cozy-interapp/src/request.spec.js
@@ -5,7 +5,7 @@ describe('[Interapp] Request', () => {
 
   beforeEach(() => {
     cozyClient = {
-      client: {
+      stackClient: {
         fetchJSON: jest.fn().mockReturnValue(Promise.resolve({ data: [] }))
       }
     }
@@ -13,16 +13,16 @@ describe('[Interapp] Request', () => {
   })
 
   it('should initialise with cozyFetchJSON function', () => {
-    expect(request.client).toEqual(cozyClient.client)
+    expect(request.stackClient).toEqual(cozyClient.stackClient)
   })
 
   it('should get an intent', () => {
     request.get()
-    expect(cozyClient.client.fetchJSON).toHaveBeenCalledTimes(1)
+    expect(cozyClient.stackClient.fetchJSON).toHaveBeenCalledTimes(1)
   })
 
   it('should post an intent', () => {
     request.post()
-    expect(cozyClient.client.fetchJSON).toHaveBeenCalledTimes(1)
+    expect(cozyClient.stackClient.fetchJSON).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
To remove warning:
> Using cozyClient.client is deprecated, please use cozyClient.stackClient.

[Cozy Client code](https://github.com/cozy/cozy-client/blob/e8b03cd8005470f5b267b8191666a12bd273effb/packages/cozy-client/src/CozyClient.js#L682-L688)