### PR TITLE
feat: Support tag prefix

### DIFF
--- a/packages/cozy-app-publish/cozy-app-publish.js
+++ b/packages/cozy-app-publish/cozy-app-publish.js
@@ -59,6 +59,10 @@ const program = new commander.Command(pkg.name)
     '--postpublish <script-path>',
     'Hook to process parameters just after publishing, typically to deploy app'
   )
+  .option(
+    '--tag-prefix <tag-prefix>',
+    'When publishing from a monorepo, only consider tags with tagPrefix, ex: cozy-banks/1.0.1.'
+  )
   .option('--yes', 'Force confirmation when publishing manually')
   .option(
     '--registry-url <url>',
@@ -92,7 +96,8 @@ try {
     yes: program.yes,
     registryUrl: program.registryUrl,
     space: program.space,
-    verbose: program.verbose
+    verbose: program.verbose,
+    tagPrefix: program.tagPrefix
   }).catch(handleError)
 } catch (error) {
   handleError(error)
@@ -135,6 +140,7 @@ async function publishApp(cliOptions) {
       registryToken: cliOptions.token,
       registryUrl: cliOptions.registryUrl,
       spaceName: cliOptions.space,
+      tagPrefix: cliOptions.tagPrefix,
       verbose: cliOptions.verbose,
       yes: cliOptions.yes
     })

--- a/packages/cozy-app-publish/cozy-app-publish.js
+++ b/packages/cozy-app-publish/cozy-app-publish.js
@@ -5,7 +5,6 @@
 const commander = require('commander')
 const colorize = require('./utils/colorize')
 const scripts = require('./index')
-const pickBy = require('lodash/pickBy')
 const capitalize = require('lodash/capitalize')
 
 const pkg = require('./package.json')
@@ -96,21 +95,19 @@ async function publishApp(cliOptions) {
     `${colorize.bold(capitalize(publishMode))} ${colorize.blue('publish mode')}`
   )
   console.log()
-  return publishFn(
-    pickBy({
-      appBuildUrl: cliOptions.buildUrl,
-      buildCommit: cliOptions.buildCommit,
-      buildDir: cliOptions.buildDir,
-      buildUrl: cliOptions.buildUrl,
-      manualVersion: cliOptions.manualVersion,
-      postpublishHook: cliOptions.postpublish,
-      prepublishHook: cliOptions.prepublish,
-      registryToken: cliOptions.token,
-      registryUrl: cliOptions.registryUrl,
-      spaceName: cliOptions.space,
-      tagPrefix: cliOptions.tagPrefix,
-      verbose: cliOptions.verbose,
-      yes: cliOptions.yes
-    })
-  )
+  return publishFn({
+    appBuildUrl: cliOptions.buildUrl,
+    buildCommit: cliOptions.buildCommit,
+    buildDir: cliOptions.buildDir,
+    buildUrl: cliOptions.buildUrl,
+    manualVersion: cliOptions.manualVersion,
+    postpublishHook: cliOptions.postpublish,
+    prepublishHook: cliOptions.prepublish,
+    registryToken: cliOptions.token,
+    registryUrl: cliOptions.registryUrl,
+    spaceName: cliOptions.space,
+    tagPrefix: cliOptions.tagPrefix,
+    verbose: cliOptions.verbose,
+    yes: cliOptions.yes
+  })
 }

--- a/packages/cozy-app-publish/cozy-app-publish.js
+++ b/packages/cozy-app-publish/cozy-app-publish.js
@@ -73,20 +73,7 @@ const handleError = error => {
 }
 
 try {
-  publishApp({
-    token: program.token,
-    buildDir: program.buildDir,
-    buildUrl: program.buildUrl,
-    buildCommit: program.buildCommit,
-    manualVersion: program.manualVersion,
-    prepublishHook: program.prepublish,
-    postpublishHook: program.postpublish,
-    yes: program.yes,
-    registryUrl: program.registryUrl,
-    space: program.space,
-    verbose: program.verbose,
-    tagPrefix: program.tagPrefix
-  }).catch(handleError)
+  publishApp(program).catch(handleError)
 } catch (error) {
   handleError(error)
 }
@@ -116,8 +103,8 @@ async function publishApp(cliOptions) {
       buildDir: cliOptions.buildDir,
       buildUrl: cliOptions.buildUrl,
       manualVersion: cliOptions.manualVersion,
-      postpublishHook: cliOptions.postpublishHook,
-      prepublishHook: cliOptions.prepublishHook,
+      postpublishHook: cliOptions.postpublish,
+      prepublishHook: cliOptions.prepublish,
       registryToken: cliOptions.token,
       registryUrl: cliOptions.registryUrl,
       spaceName: cliOptions.space,

--- a/packages/cozy-app-publish/cozy-app-publish.js
+++ b/packages/cozy-app-publish/cozy-app-publish.js
@@ -102,13 +102,6 @@ function _getPublishMode() {
 
 async function publishApp(cliOptions) {
   const publishMode = _getPublishMode()
-  const acceptedModes = Object.values(MODES).includes(publishMode)
-  if (!acceptedModes.includes(publishMode)) {
-    throw new Error(
-      `Absent or unrecognized mode, you passed ${publishMode}. Accepted modes: ${acceptedModes}.`
-    )
-  }
-
   const publishFn = scripts[publishMode]
 
   console.log()

--- a/packages/cozy-app-publish/cozy-app-publish.js
+++ b/packages/cozy-app-publish/cozy-app-publish.js
@@ -15,18 +15,6 @@ const MODES = {
   MANUAL: 'manual'
 }
 
-var currentNodeVersion = process.versions.node
-var semver = currentNodeVersion.split('.')
-var major = semver[0]
-
-if (major < 6) {
-  console.error(
-    colorize.red(`You are running Node v${currentNodeVersion}.
-    cozy-app-publish requires Node v6 minimum, please update you version of Node.`)
-  )
-  process.exit(1)
-}
-
 const program = new commander.Command(pkg.name)
   .version(pkg.version)
   .usage(`[options]`)

--- a/packages/cozy-app-publish/cozy-app-publish.js
+++ b/packages/cozy-app-publish/cozy-app-publish.js
@@ -38,7 +38,7 @@ const program = new commander.Command(pkg.name)
   )
   .option(
     '--build-dir <relative-path>',
-    'Path fo the build directory relative to the current directory (default ./build)'
+    'Path of the build directory relative to the current directory (default ./build)'
   )
   .option('--build-url <url>', 'URL of the application archive')
   .option(

--- a/packages/cozy-app-publish/lib/manual.js
+++ b/packages/cozy-app-publish/lib/manual.js
@@ -11,11 +11,21 @@ const getManifestManual = ctx => {
 }
 
 const getAppVersionManual = async ctx => {
-  let autoVersion
+  let tagVersion, devVersion
   if (!ctx.manualVersion) {
-    autoVersion = await tags.getAutoVersion()
+    const versionTags = (await tags.getVersionTags()).filter(tag =>
+      ctx.tagPrefix ? ctx.tagPrefix === tag.prefix : true
+    )
+    tagVersion = versionTags.length > 0 ? versionTags[0].fullVersion : undefined
+    if (tagVersion) {
+      tags.assertOKWithVersion(tagVersion, ctx.appManifestObj.version)
+    } else {
+      devVersion = await tags.getDevVersion(ctx.appManifestObj.version)
+    }
   }
-  return autoVersion || ctx.manualVersion || ctx.appManifestObj.version
+  return (
+    tagVersion || devVersion || ctx.manualVersion || ctx.appManifestObj.version
+  )
 }
 
 const manualPublish = publisher({

--- a/packages/cozy-app-publish/lib/tags.js
+++ b/packages/cozy-app-publish/lib/tags.js
@@ -5,24 +5,37 @@ const getDevVersion = async (shortCommit, pkgVersion) => {
   return `${pkgVersion}-dev.${shortCommit}${Date.now()}`
 }
 
+const PREFIX = String.raw`([a-z-]+)/`
 const VERSION = String.raw`(?:v)?(\d+\.\d+\.\d+)`
 const BETA = String.raw`-beta.(\d{1,4})`
 const DEV = String.raw`-dev\.([a-z0-9]+)`
-const COMPLETE = new RegExp(`^${VERSION}(?:${BETA})?(?:${DEV})?$`)
+const COMPLETE = new RegExp(`^(?:${PREFIX})?${VERSION}(?:${BETA})?(?:${DEV})?$`)
 
+/**
+ * Returns a structured version of a git version tag.
+ * If the tag can be parsed, returns an object containing :
+ *   prefix, channel, beta, dev, version, fullVersion
+ *
+ * If the tag cannot be parsed, returns null.
+ */
 const parse = tag => {
+  if (!tag) {
+    return null
+  }
   const match = tag.match(COMPLETE)
   if (!match) {
     return null
   } else {
-    const version = match[1]
-    const beta = match[2]
-    const dev = match[3]
+    const prefix = match[1]
+    const version = match[2]
+    const beta = match[3]
+    const dev = match[4]
     if (beta && dev) {
       throw new Error(`Invalid tag ${tag}, beta and dev are present`)
     }
     const channel = dev ? 'dev' : beta ? 'beta' : 'stable'
     return {
+      prefix,
       channel: channel,
       beta: beta ? parseInt(beta) : null,
       dev: dev || null,

--- a/packages/cozy-app-publish/lib/tags.spec.js
+++ b/packages/cozy-app-publish/lib/tags.spec.js
@@ -34,4 +34,13 @@ describe('parse', () => {
     expect(tagInfo.beta).toBe(null)
     expect(tagInfo.channel).toBe('dev')
   })
+
+  it('should correctly parse a version with prefix', () => {
+    const tagInfo = tags.parse('cozy-banks/v1.0.0-dev.deadbeef1456')
+    expect(tagInfo.prefix).toBe('cozy-banks')
+    expect(tagInfo.version).toBe('1.0.0')
+    expect(tagInfo.dev).toBe('deadbeef1456')
+    expect(tagInfo.beta).toBe(null)
+    expect(tagInfo.channel).toBe('dev')
+  })
 })

--- a/packages/cozy-app-publish/lib/travis.js
+++ b/packages/cozy-app-publish/lib/travis.js
@@ -1,40 +1,53 @@
 const path = require('path')
 const getManifestAsObject = require('../utils/getManifestAsObject')
 const getTravisVariables = require('../utils/getTravisVariables')
+const tags = require('./tags')
 const { getDevVersion } = require('./tags')
 const publisher = require('./publisher')
 
 const getAutoTravisVersion = async ctx => {
-  const { TRAVIS_TAG, TRAVIS_COMMIT } = getTravisVariables()
-  if (TRAVIS_TAG) {
-    return TRAVIS_TAG
+  const tag = getRelevantTagTravis(ctx)
+  const { TRAVIS_COMMIT } = getTravisVariables()
+  if (tag) {
+    return tag
   } else {
     const shortCommit = TRAVIS_COMMIT.slice(0, 7)
-    return await getDevVersion(shortCommit, ctx.appManifestObj.version)
+    return await getDevVersion(ctx.appManifestObj.version, shortCommit)
+  }
+}
+
+const getRelevantTagTravis = ctx => {
+  const { TRAVIS_TAG } = getTravisVariables()
+  const parsed = tags.parse(TRAVIS_TAG)
+  if (ctx.tagPrefix) {
+    if (parsed.prefix === ctx.tagPrefix) {
+      return TRAVIS_TAG
+    }
+  } else {
+    return TRAVIS_TAG
   }
 }
 
 const getAppBuildURLFromTravis = ctx => {
-  const { TRAVIS_TAG, TRAVIS_COMMIT, TRAVIS_REPO_SLUG } = getTravisVariables()
+  const { TRAVIS_REPO_SLUG, TRAVIS_COMMIT } = getTravisVariables()
+  const tag = getRelevantTagTravis(ctx)
   // get archive url from github repo
   // FIXME push directly the archive to the registry
   // for now, the registry needs an external URL
-  let appBuildUrl = ''
   const buildUrl = ctx.buildUrl
   const buildCommit = ctx.buildCommit
   const githubUrl = `https://github.com/${TRAVIS_REPO_SLUG}/archive`
   const buildHash = buildCommit || TRAVIS_COMMIT
   if (buildUrl) {
-    appBuildUrl = buildUrl
-  } else if (!buildCommit && TRAVIS_TAG) {
+    return buildUrl
+  } else if (!buildCommit && tag) {
     // if we use --build-commit => we are not on the build branch
     // so we can't use this branch tag directly for the url
     // if not, we suppose that we are on the build tagged branch here
-    appBuildUrl = `${githubUrl}/${TRAVIS_TAG}.tar.gz`
+    return `${githubUrl}/${tag}.tar.gz`
   } else {
-    appBuildUrl = `${githubUrl}/${buildHash}.tar.gz`
+    return `${githubUrl}/${buildHash}.tar.gz`
   }
-  return appBuildUrl
 }
 
 const getTravisRegistryToken = () => {

--- a/packages/cozy-app-publish/package.json
+++ b/packages/cozy-app-publish/package.json
@@ -38,5 +38,8 @@
     "setupFiles": [
       "./test/jestLibs/setupJest.js"
     ]
+  },
+  "engines": {
+    "node": ">=6"
   }
 }

--- a/packages/cozy-app-publish/test/__snapshots__/manual.spec.js.snap
+++ b/packages/cozy-app-publish/test/__snapshots__/manual.spec.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Manual publishing script should support prefix 1`] = `
+Object {
+  "appBuildUrl": "https://mock.getarchive.cc/12345.tar.gz",
+  "appSlug": "mock-app",
+  "appType": "webapp",
+  "appVersion": "2.1.8-beta.2",
+  "buildCommit": undefined,
+  "prepublishHook": undefined,
+  "registryEditor": "Cozy",
+  "registryToken": "registryTokenForTest123",
+  "registryUrl": "https://mock.registry.cc",
+  "sha256Sum": "fakeshasum5644545",
+  "spaceName": "mock_space",
+}
+`;
+
 exports[`Manual publishing script should throw an error if the token is missing 1`] = `"Registry token is missing. Publishing failed."`;
 
 exports[`Manual publishing script should work correctly if expected options provided 1`] = `

--- a/packages/cozy-app-publish/test/__snapshots__/travis.spec.js.snap
+++ b/packages/cozy-app-publish/test/__snapshots__/travis.spec.js.snap
@@ -6,6 +6,38 @@ exports[`Travis publishing script should fail on prePublish error 1`] = `[Error:
 
 exports[`Travis publishing script should fail on publish error 1`] = `[Error: Publish failed: Publish test error]`;
 
+exports[`Travis publishing script should support prefix 1`] = `
+Object {
+  "appBuildUrl": "https://github.com/mock-app/archive/f4a98378271c17e91faa9e70a2718c34c04cfc27.tar.gz",
+  "appSlug": "mock-app",
+  "appType": "webapp",
+  "appVersion": "2.1.8-dev.f4a9837123456",
+  "buildCommit": undefined,
+  "prepublishHook": undefined,
+  "registryEditor": "Cozy",
+  "registryToken": "registryTokenForTest123",
+  "registryUrl": "https://apps-registry.cozycloud.cc",
+  "sha256Sum": "fakeshasum5644545",
+  "spaceName": "mock_space",
+}
+`;
+
+exports[`Travis publishing script should support prefix 2`] = `
+Object {
+  "appBuildUrl": "https://github.com/mock-app/archive/cozy-drive/2.1.8-beta.2.tar.gz",
+  "appSlug": "mock-app",
+  "appType": "webapp",
+  "appVersion": "cozy-drive/2.1.8-beta.2",
+  "buildCommit": undefined,
+  "prepublishHook": undefined,
+  "registryEditor": "Cozy",
+  "registryToken": "registryTokenForTest123",
+  "registryUrl": "https://apps-registry.cozycloud.cc",
+  "sha256Sum": "fakeshasum5644545",
+  "spaceName": "mock_space",
+}
+`;
+
 exports[`Travis publishing script should throw an error if the editor is missing 1`] = `"Registry editor is missing in the manifest. Publishing failed."`;
 
 exports[`Travis publishing script should throw an error if the token is missing 1`] = `"Registry token is missing. Publishing failed."`;

--- a/packages/cozy-app-publish/test/travis.spec.js
+++ b/packages/cozy-app-publish/test/travis.spec.js
@@ -157,4 +157,25 @@ describe('Travis publishing script', () => {
     expect(publishLib).toHaveBeenCalledTimes(1)
     expect(postpublish).toHaveBeenCalledTimes(1)
   })
+
+  it('should support prefix', async () => {
+    const badTag = 'cozy-banks/2.1.8-beta.1'
+    const goodTag = 'cozy-drive/2.1.8-beta.2'
+    jest.spyOn(global.Date, 'now').mockReturnValue(123456)
+    for (const tag of [badTag, goodTag]) {
+      publishLib.mockReset()
+      getTravisVariables.mockImplementation(() => ({
+        TRAVIS_BUILD_DIR: mockCommons.buildDir,
+        TRAVIS_TAG: tag,
+        TRAVIS_COMMIT: mockCommons.commitHash,
+        TRAVIS_REPO_SLUG: mockCommons.slug,
+        // encrypted variables
+        REGISTRY_TOKEN: mockCommons.token
+      }))
+      const options = getOptions()
+      await travisScript({ ...options, tagPrefix: 'cozy-drive' })
+      expect(publishLib).toHaveBeenCalledTimes(1)
+      expect(publishLib.mock.calls[0][0]).toMatchSnapshot()
+    }
+  })
 })


### PR DESCRIPTION
Since we have to be able to publish beta versions of customized
banks, from the customization repository, without publishing
other components, we introduce here the notion of prefix for
tags.

When publishing from a monorepo, instead of tagging only
with a version `1.0.0`, you tag with a prefix `cozy-banks/1.0.0`
and then you tell cozy-app-publish to only consider tags
with this prefix `cozy-app-publish --tag-prefix cozy-banks`.