### PR TITLE
Harvest: Split concern between AccountField and manifest

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
@@ -5,8 +5,7 @@ import PropTypes from 'react-proptypes'
 import { translate } from 'cozy-ui/react/I18n'
 
 import { getFieldPlaceholder, sanitizeSelectProps } from '../../helpers/fields'
-
-const IDENTIFIER = 'identifier'
+import { ROLE_IDENTIFIER } from '../../helpers/manifest'
 
 const predefinedLabels = [
   'answer',
@@ -37,7 +36,7 @@ export class AccountField extends PureComponent {
 
   componentDidMount() {
     const { role } = this.props
-    if (role === IDENTIFIER && this.inputRef) {
+    if (role === ROLE_IDENTIFIER && this.inputRef) {
       this.inputRef.focus()
     }
   }
@@ -65,8 +64,9 @@ export class AccountField extends PureComponent {
         ? label
         : name
 
-    const isEditable = !(role === IDENTIFIER && initialValue)
+    const isEditable = !(role === ROLE_IDENTIFIER && initialValue)
 
+    // Cozy-UI <Field /> props
     const fieldProps = {
       ...this.props,
       autoComplete: 'off',

--- a/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
@@ -5,26 +5,11 @@ import PropTypes from 'react-proptypes'
 import { translate } from 'cozy-ui/react/I18n'
 
 import { getFieldPlaceholder, sanitizeSelectProps } from '../../helpers/fields'
-import { ROLE_IDENTIFIER } from '../../helpers/manifest'
-
-const predefinedLabels = [
-  'answer',
-  'birthdate',
-  'code',
-  'date',
-  'email',
-  'firstname',
-  'lastname',
-  'login',
-  'password',
-  'phone'
-]
-
-// Out of scope labels already used, should be transferred directly in manifests
-// in the future.
-const legacyLabels = [
-  'branchName' // Used in banking konnectors
-]
+import {
+  legacyLabels,
+  predefinedLabels,
+  ROLE_IDENTIFIER
+} from '../../helpers/manifest'
 
 export class AccountField extends PureComponent {
   constructor(props) {

--- a/packages/cozy-harvest-lib/src/helpers/manifest.js
+++ b/packages/cozy-harvest-lib/src/helpers/manifest.js
@@ -7,6 +7,11 @@ import _pickBy from 'lodash/pickBy'
 export const ROLE_IDENTIFIER = 'identifier'
 
 /**
+ * Legacy login fields declared by some konnectors
+ */
+const legacyLoginFields = ['login', 'identifier', 'new_identifier', 'email']
+
+/**
  * Returns a key/value object with field as key and default, if it exists in
  * fields parameter.
  * @example
@@ -57,8 +62,6 @@ const removeOldFields = fields => {
   delete sanitized.advancedFields
   return sanitized
 }
-
-const legacyLoginFields = ['login', 'identifier', 'new_identifier', 'email']
 
 /**
  * Ensures that fields has at least one field with the role 'identifier'

--- a/packages/cozy-harvest-lib/src/helpers/manifest.js
+++ b/packages/cozy-harvest-lib/src/helpers/manifest.js
@@ -7,6 +7,43 @@ import _pickBy from 'lodash/pickBy'
 export const ROLE_IDENTIFIER = 'identifier'
 
 /**
+ * We defined "predefined labels", as labels wich can be used in manifest, to
+ * refer to existing locales.
+ * @example
+ * This declaration expect that applications resolve automatically the label
+ * of the field "name", without relying on locales declared in konnector
+ * manifest.
+ * ```
+ * "fields": {
+ *   "name": {
+ *     "label": "firsname",
+ *     "type": "text"
+ *   }
+ * }
+ * ```
+ */
+export const predefinedLabels = [
+  'answer',
+  'birthdate',
+  'code',
+  'date',
+  'email',
+  'firstname',
+  'lastname',
+  'login',
+  'password',
+  'phone'
+]
+
+/**
+ * Out of scope labels already used, should be transferred directly in manifests
+ * in the future.
+ */
+export const legacyLabels = [
+  'branchName' // Used in banking konnectors
+]
+
+/**
  * Legacy login fields declared by some konnectors
  */
 const legacyLoginFields = ['login', 'identifier', 'new_identifier', 'email']

--- a/packages/cozy-harvest-lib/src/helpers/manifest.js
+++ b/packages/cozy-harvest-lib/src/helpers/manifest.js
@@ -4,7 +4,7 @@ import findKey from 'lodash/findKey'
 import _mapValues from 'lodash/mapValues'
 import _pickBy from 'lodash/pickBy'
 
-const IDENTIFIER = 'identifier'
+export const ROLE_IDENTIFIER = 'identifier'
 
 /**
  * Returns a key/value object with field as key and default, if it exists in
@@ -45,7 +45,7 @@ const defaultFieldsValues = fields => {
  * @return {[type]}        The key for the identifier field, example 'login'
  */
 const getIdentifier = (fields = {}) =>
-  findKey(sanitizeIdentifier(fields), field => field.role === IDENTIFIER)
+  findKey(sanitizeIdentifier(fields), field => field.role === ROLE_IDENTIFIER)
 
 /**
  * Ensures old fields are removed
@@ -69,7 +69,7 @@ const sanitizeIdentifier = fields => {
   const sanitized = _cloneDeep(fields)
   let hasIdentifier = false
   for (let fieldName in sanitized)
-    if (sanitized[fieldName].role === IDENTIFIER) {
+    if (sanitized[fieldName].role === ROLE_IDENTIFIER) {
       if (hasIdentifier) delete sanitized[fieldName].role
       else hasIdentifier = true
     }
@@ -77,13 +77,13 @@ const sanitizeIdentifier = fields => {
 
   for (let name of legacyLoginFields)
     if (sanitized[name]) {
-      sanitized[name].role = IDENTIFIER
+      sanitized[name].role = ROLE_IDENTIFIER
       return sanitized
     }
 
   for (let fieldName in sanitized)
     if (sanitized[fieldName].type !== 'password') {
-      sanitized[fieldName].role = IDENTIFIER
+      sanitized[fieldName].role = ROLE_IDENTIFIER
       return sanitized
     }
 


### PR DESCRIPTION
A quick refactoring to make AccountField lighter and store logic about predefined labels into manifest helper.