### PR TITLE
Harvest: Use existing trigger and avoir trigger duplication

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -56,7 +56,11 @@ export class TriggerManager extends Component {
       t
     } = this.props
 
-    const { account } = this.state
+    const { account, trigger } = this.state
+
+    if (trigger) {
+      return trigger
+    }
 
     let folder
 
@@ -72,7 +76,7 @@ export class TriggerManager extends Component {
       await addReferencesTo(konnector, [folder])
     }
 
-    const trigger = await createTrigger(
+    return await createTrigger(
       triggers.buildAttributes({
         account,
         cron: cron.fromKonnector(konnector),
@@ -80,12 +84,6 @@ export class TriggerManager extends Component {
         konnector
       })
     )
-
-    this.setState({
-      trigger
-    })
-
-    return trigger
   }
 
   /**
@@ -96,6 +94,7 @@ export class TriggerManager extends Component {
   async handleAccountSaveSuccess(account) {
     this.setState({ account })
     const trigger = await this.ensureTrigger()
+    this.setState({ trigger })
     return await this.launch(trigger)
   }
 

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -355,6 +355,12 @@ describe('TriggerManager', () => {
       expect(createTriggerMock).toHaveBeenCalledWith(fixtures.triggerAttributes)
     })
 
+    it('should not create trigger when one is passed as prop', async () => {
+      const wrapper = shallow(<TriggerManager {...propsWithAccount} />)
+      await wrapper.instance().handleAccountSaveSuccess(fixtures.updatedAccount)
+      expect(createTriggerMock).not.toHaveBeenCalled()
+    })
+
     it('should launch trigger without account', async () => {
       const wrapper = shallowWithoutAccount()
       await wrapper.instance().handleAccountSaveSuccess(fixtures.account)

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -78,6 +78,28 @@ const fixtures = {
       passphrase: 'fuz'
     }
   },
+  existingAccount: {
+    _id: '61c683295560485db0f34b859197c581',
+    account_type: 'konnectest',
+    auth: {
+      username: 'foo',
+      passphrase: 'bar'
+    },
+    identifier: 'username'
+  },
+  existingTrigger: {
+    id: '4b67e0bedd464704a6a995f5c2070ccf',
+    _type: 'io.cozy.triggers',
+    attributes: {
+      arguments: '0 0 0 * * 0',
+      type: '@cron',
+      worker: 'konnector',
+      message: {
+        account: '61c683295560485db0f34b859197c581',
+        konnector: 'konnectest'
+      }
+    }
+  },
   createdTrigger: {
     id: '669e9a7cc3064a97bc0aa20feef71cb2',
     _type: 'io.cozy.triggers',
@@ -163,7 +185,8 @@ const props = {
 
 const propsWithAccount = {
   ...props,
-  account: fixtures.createdAccount
+  account: fixtures.existingAccount,
+  trigger: fixtures.existingTrigger
 }
 
 const shallowWithoutAccount = konnector =>
@@ -279,7 +302,7 @@ describe('TriggerManager', () => {
       wrapper.instance().handleSubmit(fixtures.data)
       expect(saveAccountMock).toHaveBeenCalledWith(
         fixtures.konnector,
-        fixtures.createdAccount
+        fixtures.existingAccount
       )
     })
 
@@ -390,7 +413,7 @@ describe('TriggerManager', () => {
       const wrapper = shallowWithAccount()
       await wrapper.instance().handleAccountSaveSuccess(fixtures.updatedAccount)
       expect(launchTriggerMock).toHaveBeenCalledTimes(1)
-      expect(launchTriggerMock).toHaveBeenCalledWith(fixtures.createdTrigger)
+      expect(launchTriggerMock).toHaveBeenCalledWith(fixtures.existingTrigger)
     })
 
     it('should keep updated account in state', async () => {

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
@@ -4,7 +4,7 @@ exports[`TriggerManager handleError should render error 1`] = `
 <Wrapper
   account={
     Object {
-      "_id": "a87f9a8bd3884479a48811e7b7deec75",
+      "_id": "61c683295560485db0f34b859197c581",
       "account_type": "konnectest",
       "auth": Object {
         "passphrase": "bar",
@@ -35,7 +35,7 @@ exports[`TriggerManager should render with account 1`] = `
 <Wrapper
   account={
     Object {
-      "_id": "a87f9a8bd3884479a48811e7b7deec75",
+      "_id": "61c683295560485db0f34b859197c581",
       "account_type": "konnectest",
       "auth": Object {
         "passphrase": "bar",


### PR DESCRIPTION
`TriggerManager.ensureTrigger()` was always creating a new trigger on account update, causing duplication on Cozy-Home.