### PR TITLE
Harvest: Success callbacks may be undefined

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -158,10 +158,10 @@ export class TriggerManager extends Component {
     })
 
     if (['queued', 'running'].includes(job.state)) {
-      return onLoginSuccess(trigger)
+      return typeof onLoginSuccess === 'function' && onLoginSuccess(trigger)
     }
 
-    return onSuccess(trigger)
+    return typeof onSuccess === 'function' && onSuccess(trigger)
   }
 
   render() {
@@ -198,7 +198,7 @@ TriggerManager.propTypes = {
   statDirectoryByPath: PropTypes.func,
   waitForLoginSuccess: PropTypes.func.isRequired,
   // hooks
-  onLoginSuccess: PropTypes.func.isRequired,
+  onLoginSuccess: PropTypes.func,
   onSuccess: PropTypes.func
 }
 


### PR DESCRIPTION
When editing an Account in Cozy-Home, the account form is still displayed without any other change in UI, so in this case we do not need need to provide any success callback.

Following https://github.com/cozy/cozy-home/pull/1171