### PR TITLE
fix: Add lodash as dependency

### DIFF
--- a/packages/cozy-app-publish/package.json
+++ b/packages/cozy-app-publish/package.json
@@ -16,6 +16,7 @@
     "commander": "2.19.0",
     "cross-spawn": "6.0.5",
     "fs-extra": "7.0.1",
+    "lodash": "4.17.11",
     "node-fetch": "2.3.0",
     "prompt": "1.0.0",
     "request": "2.88.0",


### PR DESCRIPTION
Lodash is needed by cozy-app-publish