### PR TITLE
fix(babel-preset-cozy-app): Publish validate.js file

### DIFF
--- a/packages/babel-preset-cozy-app/package.json
+++ b/packages/babel-preset-cozy-app/package.json
@@ -13,7 +13,8 @@
     "url": "https://github.com/cozy/cozy-libs/issues"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "validate.js"
   ],
   "dependencies": {
     "@babel/core": "7.2.2",


### PR DESCRIPTION
Since this file is imported by `index.js` but not published, we get the
following error when we use it in apps:

```
Module build failed (from ./node_modules/babel-loader/lib/index.js):
Error: Cannot find module './validate'
```