### PR TITLE
Harvest: detect user errors

### DIFF
--- a/packages/cozy-harvest-lib/src/helpers/konnectors.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectors.js
@@ -22,6 +22,14 @@ const KNOWN_ERRORS = [
   VENDOR_DOWN
 ]
 
+const USER_ERRORS = [
+  CHALLENGE_ASKED,
+  DISK_QUOTA_EXCEEDED,
+  LOGIN_FAILED,
+  NOT_EXISTING_DIRECTORY,
+  USER_ACTION_NEEDED
+]
+
 /**
  * Custom error to handle errors returnes by konnector.
  * Konnectors are returning error codes in error messages.
@@ -59,6 +67,14 @@ export class KonnectorJobError extends Error {
    */
   isLoginError() {
     return this.type === LOGIN_FAILED
+  }
+
+  /**
+   * Test if the konnector error is a user error
+   * @return {Boolean} [description]
+   */
+  isUserError() {
+    return USER_ERRORS.includes(this.type)
   }
 }
 

--- a/packages/cozy-harvest-lib/src/index.js
+++ b/packages/cozy-harvest-lib/src/index.js
@@ -3,6 +3,8 @@ import I18n from 'cozy-ui/react/I18n'
 import TranslatedAccountForm from './components/AccountForm'
 import TranslatedTriggerManager from './components/TriggerManager'
 
+export { KonnectorJobError } from './helpers/konnectors'
+
 const dictRequire = lang => require(`./locales/${lang}.json`)
 
 export const AccountForm = (props, context) => (

--- a/packages/cozy-harvest-lib/test/helpers/konnectors.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/konnectors.spec.js
@@ -53,7 +53,7 @@ describe('Konnectors Helpers', () => {
       expect(error.type).toBe('USER_ACTION_NEEDED')
     })
 
-    for (var message of [
+    for (const message of [
       'DISK_QUOTA_EXCEEDED',
       'CHALLENGE_ASKED',
       'LOGIN_FAILED',
@@ -78,6 +78,21 @@ describe('Konnectors Helpers', () => {
             'LOGIN_FAILED',
             'LOGIN_FAILED.NEEDS_SECRET',
             'LOGIN_FAILED.TOO_MANY_ATTEMPTS'
+          ].includes(message)
+        )
+        expect(error.isUserError()).toBe(
+          [
+            'CHALLENGE_ASKED',
+            'DISK_QUOTA_EXCEEDED',
+            'LOGIN_FAILED',
+            'LOGIN_FAILED.NEEDS_SECRET',
+            'LOGIN_FAILED.TOO_MANY_ATTEMPTS',
+            'NOT_EXISTING_DIRECTORY',
+            'USER_ACTION_NEEDED',
+            'USER_ACTION_NEEDED.OAUTH_OUTDATED',
+            'USER_ACTION_NEEDED.ACCOUNT_REMOVED',
+            'USER_ACTION_NEEDED.CHANGE_PASSWORD',
+            'USER_ACTION_NEEDED.PERMISSIONS_CHANGED'
           ].includes(message)
         )
       })

--- a/packages/cozy-harvest-lib/test/index.spec.js
+++ b/packages/cozy-harvest-lib/test/index.spec.js
@@ -1,0 +1,5 @@
+describe('index', () => {
+  it('should export KonnectorJobError', () => {
+    expect(require('index').KonnectorJobError).toBeDefined()
+  })
+})


### PR DESCRIPTION
To facilitate error detection on konnector triggers, KonnectorJobError is now exported by the module.

It also have a new method `isUserError()` to detect user errors like in Cozy-Home.

Example:

```js
const error = new KonnectorJobError('LOGIN_FAILED')
console.log(error.isUserError())
// true
```