### PR TITLE
Interapp: Export correctly as default module

### DIFF
--- a/packages/cozy-interapp/src/index.js
+++ b/packages/cozy-interapp/src/index.js
@@ -1,3 +1,3 @@
 import Intents from './intents'
 
-export { Intents }
+export { Intents as default, Intents }


### PR DESCRIPTION
As said in the readme, we should be able to do `import Intents from 'cozy-interapp'`