### PR TITLE
feat(app-publish/downcloud): Use space name in remote path

### DIFF
--- a/packages/cozy-app-publish/lib/hooks/pre/helpers.spec.js
+++ b/packages/cozy-app-publish/lib/hooks/pre/helpers.spec.js
@@ -1,0 +1,61 @@
+const { getFullAppVersion, getRemoteDir, getAppBuildUrl } = require('./helpers')
+
+describe('getFullAppVersion', () => {
+  it('should return the good version if no buildCommit is specified', () => {
+    expect(getFullAppVersion({ appVersion: '1.2.3-dev.abcdef' })).toBe(
+      '1.2.3-dev.abcdef'
+    )
+
+    expect(getFullAppVersion({ appVersion: '1.2.3-beta.1' })).toBe(
+      '1.2.3-beta.1'
+    )
+
+    expect(getFullAppVersion({ appVersion: '1.2.3' })).toBe('1.2.3')
+  })
+
+  it('should return the good version if buildCommit is specified', () => {
+    const buildCommit = '12345abcdef'
+
+    expect(
+      getFullAppVersion({ appVersion: '1.2.3-dev.abcdef', buildCommit })
+    ).toBe('1.2.3-dev.abcdef-12345abcdef')
+
+    expect(getFullAppVersion({ appVersion: '1.2.3-beta.1', buildCommit })).toBe(
+      '1.2.3-beta.1-12345abcdef'
+    )
+
+    expect(getFullAppVersion({ appVersion: '1.2.3', buildCommit })).toBe(
+      '1.2.3-12345abcdef'
+    )
+  })
+})
+
+describe('getRemoteUploadPath', () => {
+  it('Should return the good dir if no space is specified', () => {
+    expect(getRemoteDir({ appSlug: 'test', appVersion: '1.2.3' })).toBe(
+      'test/1.2.3'
+    )
+  })
+
+  it('should return the good dir if space is specified', () => {
+    expect(
+      getRemoteDir({
+        appSlug: 'test',
+        appVersion: '1.2.3',
+        spaceName: 'space'
+      })
+    ).toBe('space/test/1.2.3')
+  })
+})
+
+describe('getAppBuildUrl', () => {
+  it('should return the good URL', () => {
+    expect(getAppBuildUrl('space/test/1.2.3/test.tar.gz')).toBe(
+      'https://downcloud.cozycloud.cc/upload/space/test/1.2.3/test.tar.gz'
+    )
+
+    expect(getAppBuildUrl('test/1.2.3/test.tar.gz')).toBe(
+      'https://downcloud.cozycloud.cc/upload/test/1.2.3/test.tar.gz'
+    )
+  })
+})


### PR DESCRIPTION
Use the space name in the remote upload path to avoid overwriting files
when publishing an app with the same version and same slug to two
different spaces.

Currently, if I publish "app" v1.2.3 without specifying a space name,
it's uploaded to `www-upload/app/1.2.3/app.tar.gz`. Then if I publish
"app" v1.2.3 and I specify the space name "space", it's uploaded to the
same directory on downcloud. So it overwrites "app" v1.2.3 archive for
the default registry space.

With this commit, if a space name is provided, it's used to determine
the directory in which the archive should be uploaded. So I will upload
to `www-upload/app/1.2.3/app.tar.gz` and
`www-upload/space/app/1.2.3/app.tar.gz`.