### PR TITLE
Initialize realtime with uri from CozyClient

### DIFF
--- a/packages/cozy-harvest-lib/src/connections/triggers.js
+++ b/packages/cozy-harvest-lib/src/connections/triggers.js
@@ -50,8 +50,7 @@ const waitForLoginSuccess = async (
   const jobSubscription = await subscribe(
     {
       token: client.client.token.token,
-      domain: client.client.uri,
-      secure: window.location.protocol === 'https:'
+      url: client.client.uri
     },
     JOBS_DOCTYPE,
     job


### PR DESCRIPTION
It seems that recent updates on CozyClient uri broke realtime in Cozy-Harvest.

![Capture d’écran 2019-03-28 à 21 03 46](https://user-images.githubusercontent.com/776764/55190308-dcf1e100-519f-11e9-9633-cc64d7fba67e.png)
