### PR TITLE
feat(mjml): Add css classes for HTML elements

### DIFF
--- a/packages/cozy-mjml/src/components/MJDefaults.js
+++ b/packages/cozy-mjml/src/components/MJDefaults.js
@@ -55,6 +55,17 @@ class MJDefaults extends core.HeadComponent {
       padding: '0',
       'inner-padding': '10px 8px'
     })
+
+    // Create some styles duplication for HTML elements
+    add('style', 'primary-link', {
+      color: '#297ef2',
+      'text-decoration': 'none',
+      'font-weight': 'bold'
+    })
+    add('style', 'highlight', {
+      color: '#297ef2',
+      'font-weight': 'bold'
+    })
   }
 }
 

--- a/packages/cozy-mjml/src/components/MJDefaults.js
+++ b/packages/cozy-mjml/src/components/MJDefaults.js
@@ -1,14 +1,33 @@
 const validator = require('mjml-validator')
 const core = require('mjml-core')
+const reduce = require('lodash/reduce')
 
 validator.registerDependencies({
   'mj-head': ['mj-defaults'],
   'mj-defaults': []
 })
 
+function buildCSS(className, styles) {
+  const rules = reduce(
+    styles,
+    (output, value, name) => {
+      return `${output}${name}:${value};`
+    },
+    ''
+  )
+  return `.${className}{${rules}}\n`
+}
+
 class MJDefaults extends core.HeadComponent {
   handler() {
     const { add } = this.context
+
+    const highlight = { color: '#297ef2', 'font-weight': 'bold' }
+    const primaryLink = {
+      color: '#297ef2',
+      'text-decoration': 'none',
+      'font-weight': 'bold'
+    }
 
     // Load the Lato font from Google APIs
     add('fonts', 'Lato', 'https://fonts.googleapis.com/css?family=Lato')
@@ -26,7 +45,7 @@ class MJDefaults extends core.HeadComponent {
     add('classes', 'content-medium', { padding: '0 24px 16px' })
     add('classes', 'content-large', { padding: '0 24px 24px' })
     add('classes', 'content-xlarge', { padding: '0 24px 32px' })
-    add('classes', 'highlight', { color: '#297ef2', 'font-weight': 'bold' })
+    add('classes', 'highlight', highlight)
     add('classes', 'title', {
       color: '#95999d',
       'text-transform': 'uppercase',
@@ -47,25 +66,22 @@ class MJDefaults extends core.HeadComponent {
       'font-weight': 'bold',
       'line-height': '1.43'
     })
-    add('classes', 'primary-link', {
-      'background-color': 'transparent',
-      color: '#297ef2',
-      'text-decoration': 'none',
-      'font-weight': 'bold',
-      padding: '0',
-      'inner-padding': '10px 8px'
-    })
+    add(
+      'classes',
+      'primary-link',
+      Object.assign(
+        {
+          'background-color': 'transparent',
+          padding: '0',
+          'inner-padding': '10px 8px'
+        },
+        primaryLink
+      )
+    )
 
     // Create some styles duplication for HTML elements
-    add('style', 'primary-link', {
-      color: '#297ef2',
-      'text-decoration': 'none',
-      'font-weight': 'bold'
-    })
-    add('style', 'highlight', {
-      color: '#297ef2',
-      'font-weight': 'bold'
-    })
+    add('style', buildCSS('primary-link', primaryLink))
+    add('style', buildCSS('highlight', highlight))
   }
 }
 

--- a/packages/cozy-mjml/test/__snapshots__/components.spec.js.snap
+++ b/packages/cozy-mjml/test/__snapshots__/components.spec.js.snap
@@ -76,7 +76,9 @@ Object {
     }
   
         </style>
-        
+        <style type=\\"text/css\\">.primary-link{color:#297ef2;text-decoration:none;font-weight:bold;}
+.highlight{color:#297ef2;font-weight:bold;}
+</style>
         
       </head>
       <body style=\\"background-color:#f5f6f7;\\">


### PR DESCRIPTION
Added same `highlight` & `primary-link` CSS classes for HTML elements.

It's already defined by `mj-class` tags but you can't use those with HTML elements so you need css classes for that and you can't use those css classes for MJML elements as the DOM doesn't fit.

Not very happy about this duplication but… I can't find something else.