### PR TITLE
Use the correct realtime version

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "cozy-client": "6.19.0",
-    "cozy-realtime": "1.2.8",
+    "cozy-realtime": "2.0.7",
     "cozy-ui": "19.21.2",
     "final-form": "4.11.1",
     "lodash": "4.17.11",

--- a/packages/cozy-harvest-lib/src/connections/triggers.js
+++ b/packages/cozy-harvest-lib/src/connections/triggers.js
@@ -55,7 +55,7 @@ const waitForLoginSuccess = async (
       url: client.options.uri
     },
     JOBS_DOCTYPE,
-    job
+    { docId: job._id }
   )
 
   return new Promise((resolve, reject) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3514,11 +3514,6 @@ cozy-logger@1.3.1:
   dependencies:
     json-stringify-safe "5.0.1"
 
-cozy-realtime@1.2.8:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-1.2.8.tgz#c94c4bd8eb36009a381739062bd41947ddd516fc"
-  integrity sha512-G4seWPh7Ys+XApe1p165xKWq2jNKfmR/icUx45YplVZZm5wJk5pPGVrc70Rccr0DYuA8oHh1i/wpG/a5cHhpYQ==
-
 cozy-stack-client@^6.18.1:
   version "6.18.1"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-6.18.1.tgz#d3e4b27cb17576eb780d491941a81cead4d0cd0e"


### PR DESCRIPTION
Harvest was using an old version of realtime that was make all apps that use Harvest using this old realtime package