### PR TITLE
fix(cozy-realtime): Imperfect fix for unsubscribe

### DIFF
--- a/packages/cozy-realtime/src/index.js
+++ b/packages/cozy-realtime/src/index.js
@@ -303,15 +303,18 @@ export function subscribe(config, doctype, { docId, parse = doc => doc } = {}) {
   const subscription = {
     onUpdate: listener => {
       updateListener = parseCurried(listener)
-      cozySocket.subscribe(doctype, 'updated', updateListener, docId)
+      cozySocket &&
+        cozySocket.subscribe(doctype, 'updated', updateListener, docId)
       return subscription
     },
     onDelete: listener => {
       deleteListener = parseCurried(listener)
-      cozySocket.subscribe(doctype, 'deleted', deleteListener, docId)
+      cozySocket &&
+        cozySocket.subscribe(doctype, 'deleted', deleteListener, docId)
       return subscription
     },
     unsubscribe: () => {
+      if (!cozySocket) return
       if (subscribeAllDocs) {
         cozySocket.unsubscribe(doctype, 'created', createListener)
       }
@@ -323,7 +326,7 @@ export function subscribe(config, doctype, { docId, parse = doc => doc } = {}) {
   if (subscribeAllDocs) {
     subscription.onCreate = listener => {
       createListener = parseCurried(listener)
-      cozySocket.subscribe(doctype, 'created', createListener)
+      cozySocket && cozySocket.subscribe(doctype, 'created', createListener)
       return subscription
     }
   }


### PR DESCRIPTION
Si le socket est fermée pour une raison ou une autre, l'application qui appelle le realtime ne peut pas être au courant. Et donc il est possible qu'elle appelle le unsubsribe alors que le socket est déjà fermé. Et ça va faire null.unsubscribe() 

C'est un fix temporaire parce que @gregorylegarec est en train de ré-écrire l'ensemble du code de ce projet ;) 