### PR TITLE
fix: Fix cozy-mjml with nsjail

### DIFF
--- a/packages/cozy-mjml/src/index.js
+++ b/packages/cozy-mjml/src/index.js
@@ -1,12 +1,12 @@
 // XXX Cozy-stack can execute node commands in a nsjail, but the script to do
 // that are quite complex and require to execute this file with no arguments on
 // the command line except the script to execute. Here, we detect when we are
-// in this case via the COZY_JOB_ID environ variable, and transform the options
-// to tell to mjml to read on stdin and output on stdout. It allows this script
-// to be used by the cloudery and the stack without having to do heavy
+// in this case via the COZY_URL environ variable, and transform the options to
+// tell to mjml to read on stdin and output on stdout. It allows this script to
+// be used by the cloudery and the stack without having to do heavy
 // modifications for integrating cozy-mjml in them.
 try {
-  if (process.env.COZY_JOB_ID) {
+  if (process.env.COZY_URL) {
     process.argv.push('-i')
     process.argv.push('-s')
   }


### PR DESCRIPTION
In our scripts to launch node via nsjail, the COZY_JOB_ID env variable is not forwarded to node. Let's use COZY_URL instead.