### PR TITLE
Harvest: Improve keyboard nav on mobile

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -36,6 +36,7 @@
     "babel-jest": "24.1.0",
     "babel-preset-cozy-app": "^1.5.1",
     "cozy-client": "6.21.0",
+    "cozy-device-helper": "1.7.1",
     "cozy-realtime": "2.0.8",
     "cozy-ui": "19.24.3",
     "enzyme": "3.9.0",
@@ -50,6 +51,7 @@
   },
   "peerDependencies": {
     "cozy-client": "6.21.0",
+    "cozy-device-helper": "1.7.1",
     "cozy-realtime": "2.0.8",
     "cozy-ui": "19.28.0"
   }

--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -51,6 +51,6 @@
   "peerDependencies": {
     "cozy-client": "6.21.0",
     "cozy-realtime": "2.0.8",
-    "cozy-ui": "19.24.3"
+    "cozy-ui": "19.28.0"
   }
 }

--- a/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
@@ -36,6 +36,11 @@ export class AccountField extends PureComponent {
 
   setInputRef(element) {
     this.inputRef = element
+
+    const { inputRef } = this.props
+    if (typeof inputRef === 'function') {
+      inputRef(element)
+    }
   }
 
   render() {
@@ -129,6 +134,10 @@ AccountField.propTypes = {
    * Initial value of the field
    */
   initialValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /**
+   * A callback to call on Field input ref.
+   */
+  inputRef: PropTypes.func,
   /**
    * Optionnal predefined label, used as locale key.
    */

--- a/packages/cozy-harvest-lib/src/components/AccountForm/AccountFields.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/AccountFields.jsx
@@ -20,7 +20,14 @@ const parse = type => value => {
  */
 export class AccountFields extends PureComponent {
   render() {
-    const { container, disabled, fields, hasError, initialValues } = this.props
+    const {
+      container,
+      disabled,
+      fields,
+      hasError,
+      initialValues,
+      onInputRef
+    } = this.props
 
     // Ready to use named fields array
     const namedFields = Object.keys(fields).map(fieldName => ({
@@ -47,6 +54,7 @@ export class AccountFields extends PureComponent {
                   initialValues[field.name] ||
                   initialValues[getEncryptedFieldName(field.name)]
                 }
+                onInputRef={onInputRef}
               />
             )}
           </FinalFormField>

--- a/packages/cozy-harvest-lib/src/components/AccountForm/AccountFields.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/AccountFields.jsx
@@ -26,7 +26,7 @@ export class AccountFields extends PureComponent {
       fields,
       hasError,
       initialValues,
-      onInputRef
+      inputRefByName
     } = this.props
 
     // Ready to use named fields array
@@ -54,7 +54,7 @@ export class AccountFields extends PureComponent {
                   initialValues[field.name] ||
                   initialValues[getEncryptedFieldName(field.name)]
                 }
-                onInputRef={onInputRef}
+                inputRef={inputRefByName(field.name)}
               />
             )}
           </FinalFormField>
@@ -89,7 +89,13 @@ AccountFields.propTypes = {
    * Initial data as key/value pairs
    * @type {Object}
    */
-  initialValues: PropTypes.object
+  initialValues: PropTypes.object,
+  /**
+   * A callback, which call with a name should return another callback to handle
+   * react ref to Field input element.
+   * @type {Function}
+   */
+  inputRefByName: PropTypes.func
 }
 
 export default AccountFields

--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react'
 import { Form } from 'react-final-form'
 import PropTypes from 'prop-types'
 
+import { isMobile } from 'cozy-device-helper'
 import Button from 'cozy-ui/react/Button'
 import { translate, extend } from 'cozy-ui/react/I18n'
 
@@ -97,11 +98,14 @@ export class AccountForm extends PureComponent {
    * @param  {Object} values        Actual form values data
    */
   handleKeyUp(event, { dirty, form, initialValues, valid, values }) {
-    if (
-      event.key === 'Enter' &&
-      this.isSubmittable({ dirty, initialValues, valid })
-    ) {
-      this.handleSubmit(values, form)
+    if (event.key === 'Enter') {
+      const changedFocus = isMobile() && !!this.focusNext()
+      if (
+        !changedFocus &&
+        this.isSubmittable({ dirty, initialValues, valid })
+      ) {
+        this.handleSubmit(values, form)
+      }
     }
   }
 

--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -32,6 +32,14 @@ export class AccountForm extends PureComponent {
     if (locales && lang) {
       extend(locales[lang])
     }
+
+    this.inputs = {}
+    this.inputFocused = null
+
+    this.inputRefByName = this.inputRefByName.bind(this)
+    this.handleFocus = this.handleFocus.bind(this)
+    this.handleKeyUp = this.handleKeyUp.bind(this)
+    this.focusNext = this.focusNext.bind(this)
   }
 
   /**
@@ -42,6 +50,39 @@ export class AccountForm extends PureComponent {
   isSubmittable({ dirty, error, initialValues, valid }) {
     const untouched = initialValues && !dirty
     return error || (valid && !untouched)
+  }
+
+  /**
+   * Give focus to next input in the form.
+   * Fallback for mobile devices as we are using a div element instead of a
+   * form.
+   * @return {Element} Focused element or null if no element has been focused
+   */
+  focusNext() {
+    if (!this.inputs) return null
+
+    const inputs = Object.values(this.inputs)
+
+    const currentIndex = inputs.indexOf(this.inputFocused)
+
+    let nextIndex = currentIndex + 1
+    let nextInput = inputs[nextIndex]
+
+    if (nextInput) {
+      nextInput.focus()
+    }
+
+    return nextInput || null
+  }
+
+  /**
+   * Capture input with focus and store the current focused input
+   * @param  {Event} event Focus event
+   */
+  handleFocus(event) {
+    if (Object.values(this.inputs).includes(event.target)) {
+      this.inputFocused = event.target
+    }
   }
 
   /**
@@ -74,6 +115,22 @@ export class AccountForm extends PureComponent {
     // Reset form with new values to set back dirty to false
     form.reset(values)
     onSubmit(values)
+  }
+
+  /**
+   * Callback passed to `<AccountFields />` element. Called with a field name,
+   * it return a callback wich take an input ref as argument. It then stores
+   * the input ref into AccountForm's inner `inputs` property.
+   * With this method we keep a list of inputs existing in the form.
+   * The inputs inner property is indexed with names to avoid duplicates in case
+   * of re-render of input children.
+   * @param  {string} fieldName Field name
+   * @return {function}         Callback which take an input ref as argument.
+   */
+  inputRefByName(fieldName) {
+    return input => {
+      this.inputs[fieldName] = input
+    }
   }
 
   validate = (fields, initialValues) => vals => {
@@ -130,6 +187,7 @@ export class AccountForm extends PureComponent {
                 values
               })
             }
+            onFocusCapture={this.handleFocus}
             ref={element => {
               container = element
             }}
@@ -147,6 +205,7 @@ export class AccountForm extends PureComponent {
                 error.isLoginError()
               }
               initialValues={initialAndDefaultValues}
+              inputRefByName={this.inputRefByName}
               t={t}
             />
             <Button

--- a/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
+++ b/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
@@ -2,8 +2,9 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import { AccountForm } from 'components/AccountForm'
+import { isMobile } from 'cozy-device-helper'
 
+import { AccountForm } from 'components/AccountForm'
 import { KonnectorJobError } from 'helpers/konnectors'
 
 const fixtures = {
@@ -36,6 +37,11 @@ const fixtures = {
 
 const onSubmit = jest.fn()
 const t = jest.fn()
+
+jest.mock('cozy-device-helper', () => ({
+  ...require.requireActual('cozy-device-helper'),
+  isMobile: jest.fn()
+}))
 
 describe('AccountForm', () => {
   beforeEach(() => {
@@ -276,6 +282,126 @@ describe('AccountForm', () => {
       wrapper.instance().inputFocused = passwordInput
       const secondFocus = wrapper.instance().focusNext()
       expect(secondFocus).toBeNull()
+    })
+  })
+
+  describe('handleKeyUp', () => {
+    it('should ignore other keys than ENTER', () => {
+      isMobile.mockReturnValue(false)
+      const wrapper = shallow(
+        <AccountForm
+          konnector={fixtures.konnector}
+          onSubmit={onSubmit}
+          t={t}
+        />,
+        // Avoid componentDidMount
+        { disableLifecycleMethods: true }
+      )
+
+      wrapper.instance().handleSubmit = jest.fn()
+
+      wrapper.instance().handleKeyUp({ key: 'Space' }, {})
+      expect(wrapper.instance().handleSubmit).not.toHaveBeenCalled()
+    })
+
+    it('should submit form', () => {
+      isMobile.mockReturnValue(false)
+      const wrapper = shallow(
+        <AccountForm
+          konnector={fixtures.konnector}
+          onSubmit={onSubmit}
+          t={t}
+        />,
+        // Avoid componentDidMount
+        { disableLifecycleMethods: true }
+      )
+
+      wrapper.instance().handleSubmit = jest.fn()
+      wrapper.instance().isSubmittable = jest.fn().mockReturnValue(true)
+
+      wrapper.instance().handleKeyUp({ key: 'Enter' }, {})
+      expect(wrapper.instance().handleSubmit).toHaveBeenCalled()
+    })
+
+    it('should not submit form', () => {
+      isMobile.mockReturnValue(false)
+      const wrapper = shallow(
+        <AccountForm
+          konnector={fixtures.konnector}
+          onSubmit={onSubmit}
+          t={t}
+        />,
+        // Avoid componentDidMount
+        { disableLifecycleMethods: true }
+      )
+
+      wrapper.instance().handleSubmit = jest.fn()
+      wrapper.instance().isSubmittable = jest.fn().mockReturnValue(false)
+
+      wrapper.instance().handleKeyUp({ key: 'Enter' }, {})
+      expect(wrapper.instance().handleSubmit).not.toHaveBeenCalled()
+    })
+
+    it('should focus next input on mobile', () => {
+      isMobile.mockReturnValue(true)
+      const wrapper = shallow(
+        <AccountForm
+          konnector={fixtures.konnector}
+          onSubmit={onSubmit}
+          t={t}
+        />,
+        // Avoid componentDidMount
+        { disableLifecycleMethods: true }
+      )
+
+      wrapper.instance().focusNext = jest
+        .fn()
+        .mockReturnValue(document.createElement('input'))
+
+      wrapper.instance().handleKeyUp({ key: 'Enter' }, {})
+      expect(wrapper.instance().focusNext).toHaveBeenCalled()
+    })
+
+    it('should submit form on mobile', () => {
+      isMobile.mockReturnValue(true)
+      const wrapper = shallow(
+        <AccountForm
+          konnector={fixtures.konnector}
+          onSubmit={onSubmit}
+          t={t}
+        />,
+        // Avoid componentDidMount
+        { disableLifecycleMethods: true }
+      )
+
+      wrapper.instance().focusNext = jest.fn().mockReturnValue(null)
+      wrapper.instance().isSubmittable = jest.fn().mockReturnValue(true)
+      wrapper.instance().handleSubmit = jest.fn()
+
+      wrapper.instance().handleKeyUp({ key: 'Enter' }, {})
+      expect(wrapper.instance().focusNext).toHaveBeenCalled()
+      expect(wrapper.instance().handleSubmit).toHaveBeenCalled()
+    })
+
+    it('should not submit form on mobile', () => {
+      isMobile.mockReturnValue(true)
+      const wrapper = shallow(
+        <AccountForm
+          konnector={fixtures.konnector}
+          onSubmit={onSubmit}
+          t={t}
+        />,
+        // Avoid componentDidMount
+        { disableLifecycleMethods: true }
+      )
+
+      wrapper.instance().focusNext = jest.fn().mockReturnValue(null)
+      wrapper.instance().isSubmittable = jest.fn().mockReturnValue(false)
+      wrapper.instance().handleSubmit = jest.fn()
+
+      wrapper.instance().handleKeyUp({ key: 'Enter' }, {})
+      expect(wrapper.instance().focusNext).toHaveBeenCalled()
+      expect(wrapper.instance().handleSubmit).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
+++ b/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
@@ -157,7 +157,11 @@ describe('AccountForm', () => {
       }
 
       assertButtonDisabled(
-        shallow(<AccountForm konnector={konnector} onSubmit={onSubmit} t={t} />)
+        shallow(
+          <AccountForm konnector={konnector} onSubmit={onSubmit} t={t} />,
+          // Avoid componentDidMount
+          { disableLifecycleMethods: true }
+        )
       )
     })
 
@@ -171,7 +175,11 @@ describe('AccountForm', () => {
         }
       }
       assertButtonEnabled(
-        shallow(<AccountForm konnector={konnector} onSubmit={onSubmit} t={t} />)
+        shallow(
+          <AccountForm konnector={konnector} onSubmit={onSubmit} t={t} />,
+          // Avoid componentDidMount
+          { disableLifecycleMethods: true }
+        )
       )
     })
 
@@ -182,7 +190,9 @@ describe('AccountForm', () => {
             konnector={fixtures.konnectorWithOptionalFields}
             onSubmit={onSubmit}
             t={t}
-          />
+          />,
+          // Avoid componentDidMount
+          { disableLifecycleMethods: true }
         )
       )
     })
@@ -202,7 +212,9 @@ describe('AccountForm', () => {
             konnector={fixtures.konnector}
             onSubmit={onSubmit}
             t={t}
-          />
+          />,
+          // Avoid componentDidMount
+          { disableLifecycleMethods: true }
         )
       )
     })
@@ -220,7 +232,9 @@ describe('AccountForm', () => {
             initialValues={values}
             onSubmit={onSubmit}
             t={t}
-          />
+          />,
+          // Avoid componentDidMount
+          { disableLifecycleMethods: true }
         )
       )
     })
@@ -241,5 +255,27 @@ describe('AccountForm', () => {
       .simulate('click')
 
     expect(onSubmit).toHaveBeenCalled()
+  })
+
+  describe('focusNext', () => {
+    const loginInput = document.createElement('input')
+    const passwordInput = document.createElement('input')
+
+    it('should focus next input', () => {
+      const wrapper = shallow(
+        <AccountForm konnector={fixtures.konnector} onSubmit={onSubmit} t={t} />
+      )
+
+      wrapper.instance().inputs = { login: loginInput, password: passwordInput }
+      wrapper.instance().inputs.login.focus()
+      wrapper.instance().inputFocused = loginInput
+
+      const firstFocus = wrapper.instance().focusNext()
+      expect(firstFocus).toEqual(passwordInput)
+
+      wrapper.instance().inputFocused = passwordInput
+      const secondFocus = wrapper.instance().focusNext()
+      expect(secondFocus).toBeNull()
+    })
   })
 })

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`AccountForm should always render login error 1`] = `
 <div
+  onFocusCapture={[Function]}
   onKeyUp={[Function]}
 >
   <Wrapper
@@ -53,6 +54,7 @@ exports[`AccountForm should always render login error 1`] = `
     }
     hasError={true}
     initialValues={Object {}}
+    inputRefByName={[Function]}
     t={
       [MockFunction] {
         "calls": Array [
@@ -81,6 +83,7 @@ exports[`AccountForm should always render login error 1`] = `
 
 exports[`AccountForm should not render error 1`] = `
 <div
+  onFocusCapture={[Function]}
   onKeyUp={[Function]}
 >
   <AccountFields
@@ -102,6 +105,7 @@ exports[`AccountForm should not render error 1`] = `
     }
     hasError={false}
     initialValues={Object {}}
+    inputRefByName={[Function]}
     t={
       [MockFunction] {
         "calls": Array [
@@ -140,6 +144,7 @@ exports[`AccountForm should redirect to OAuthForm 1`] = `
 
 exports[`AccountForm should render 1`] = `
 <div
+  onFocusCapture={[Function]}
   onKeyUp={[Function]}
 >
   <AccountFields
@@ -160,6 +165,7 @@ exports[`AccountForm should render 1`] = `
       }
     }
     initialValues={Object {}}
+    inputRefByName={[Function]}
     t={
       [MockFunction] {
         "calls": Array [
@@ -188,6 +194,7 @@ exports[`AccountForm should render 1`] = `
 
 exports[`AccountForm should render error 1`] = `
 <div
+  onFocusCapture={[Function]}
   onKeyUp={[Function]}
 >
   <Wrapper
@@ -239,6 +246,7 @@ exports[`AccountForm should render error 1`] = `
     }
     hasError={false}
     initialValues={Object {}}
+    inputRefByName={[Function]}
     t={
       [MockFunction] {
         "calls": Array [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3566,13 +3566,6 @@ cozy-device-helper@1.6.3:
   dependencies:
     lodash "4.17.11"
 
-cozy-device-helper@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.7.1.tgz#56c57a14b423de2700a0a695c3f7710cf6a2383d"
-  integrity sha512-CTEJOzRK+AtrGN/Wqjj5n0DM1mMMvNGSZDxKlTCvY0FNYYko05vX5qIEb9vFVm7UhH7GFZjZ+S73g3Kwq/hF4Q==
-  dependencies:
-    lodash "4.17.11"
-
 cozy-logger@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/cozy-logger/-/cozy-logger-1.3.1.tgz#27d9578756b318b1460a135cda94475c734b9f39"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3566,6 +3566,13 @@ cozy-device-helper@1.6.3:
   dependencies:
     lodash "4.17.11"
 
+cozy-device-helper@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.7.1.tgz#56c57a14b423de2700a0a695c3f7710cf6a2383d"
+  integrity sha512-CTEJOzRK+AtrGN/Wqjj5n0DM1mMMvNGSZDxKlTCvY0FNYYko05vX5qIEb9vFVm7UhH7GFZjZ+S73g3Kwq/hF4Q==
+  dependencies:
+    lodash "4.17.11"
+
 cozy-logger@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/cozy-logger/-/cozy-logger-1.3.1.tgz#27d9578756b318b1460a135cda94475c734b9f39"


### PR DESCRIPTION
This PR change how the account form reacts to keyboard key events on mobile.

When Enter key is pressed, the default behaviour is to submit the form.

Now on mobile, it focus the next input, and submit the form is no more input can be focused.

Managing focus could be made in different way, as the AccountForm component structure is as follow:

```
AccountForm
|- AccountFields
   |- AccountField
   |- AccountField
```

My firt guess was to implement a `focus()` method directly in `AccountField` component and manage to call it on expected AccountField. But this solution implied to use many refs and was not feeling really compatible with the React philosophy. It was also implying many callbacks, and dealing with `onFocus` events both on Input Fields and SelectBoxes.

So I eventually ended querying the DOM at the `AccountForm` level, retrieving all inputs and then dealing with them the old way.

I am not plenty satisified with this solution but it is cheap and effective.