### PR TITLE
fix(cozy-doctypes): Remove isRequired for trashed props

### DIFF
--- a/packages/cozy-doctypes/src/contacts/Contact.js
+++ b/packages/cozy-doctypes/src/contacts/Contact.js
@@ -104,7 +104,7 @@ const ContactShape = PropTypes.shape({
   ),
   company: PropTypes.string,
   jobTitle: PropTypes.string,
-  trashed: PropTypes.bool.isRequired,
+  trashed: PropTypes.bool,
   me: PropTypes.bool.isRequired,
   relationships: PropTypes.shape({
     accounts: PropTypes.shape({

--- a/packages/cozy-doctypes/src/contacts/Group.js
+++ b/packages/cozy-doctypes/src/contacts/Group.js
@@ -8,7 +8,7 @@ const GroupShape = PropTypes.shape({
   _id: PropTypes.string.isRequired,
   _type: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  trashed: PropTypes.bool.isRequired
+  trashed: PropTypes.bool
 })
 
 Group.doctype = 'io.cozy.contacts.groups'


### PR DESCRIPTION
trashed prop is not required for contacts and groups