### PR TITLE
fix: Expose FlagSwitcher only in browser context

### DIFF
--- a/packages/cozy-flags/src/index.js
+++ b/packages/cozy-flags/src/index.js
@@ -1,17 +1,20 @@
 /* global __ENABLED_FLAGS__ */
 
-import isNode from 'detect-node'
-export { default as FlagSwitcher } from './browser/FlagSwitcher'
+const isNode = require('detect-node')
 
 const flag = isNode
   ? require('./node/flag').default
   : require('./browser/flag').default
 
+if (!isNode) {
+  flag.FlagSwitcher = require('./browser/FlagSwitcher').default
+}
+
 /**
  * Enables a list of flags
  * @param {string[]} flagsToEnable
  */
-export function enableFlags(flagsToEnable) {
+function enableFlags(flagsToEnable) {
   if (!Array.isArray(flagsToEnable)) {
     return
   }
@@ -25,4 +28,4 @@ if (typeof __ENABLED_FLAGS__ !== 'undefined') {
 
 flag.enable = enableFlags
 
-export default flag
+module.exports = flag

--- a/packages/cozy-flags/src/index.spec.js
+++ b/packages/cozy-flags/src/index.spec.js
@@ -1,23 +1,23 @@
-import flag, { enableFlags } from '.'
+import flag from '.'
 
-describe('enableFlags', () => {
+describe('enable', () => {
   afterEach(() => {
     flag.reset()
   })
 
   it('should do nothing if the parameter is not an array', () => {
-    enableFlags('blablabla')
-    enableFlags(42)
-    enableFlags(true)
-    enableFlags({})
-    enableFlags()
+    flag.enable('blablabla')
+    flag.enable(42)
+    flag.enable(true)
+    flag.enable({})
+    flag.enable()
 
     expect(flag.list()).toEqual([])
   })
 
   it('should enable the flags if the parameter is an array', () => {
     const flagsToEnable = ['hello', 'world']
-    enableFlags(flagsToEnable)
+    flag.enable(flagsToEnable)
 
     expect(flag.list()).toEqual(flagsToEnable)
   })


### PR DESCRIPTION
Exposing FlagSwitcher on node context was causing an error in Node
context because it's importing the flags browser implementation and
`localStorage` doesn't exist in this context.

Fixes #402 

This was making the banks' service crash.