### PR TITLE
[Harvest] Reset the account state before running the konnector

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -164,7 +164,10 @@ export class TriggerManager extends Component {
     try {
       const accountToSave = isUpdate
         ? accounts.mergeAuth(
-            accounts.setSessionResetIfNecessary(account, data),
+            accounts.setSessionResetIfNecessary(
+              accounts.resetState(account),
+              data
+            ),
             data
           )
         : accounts.build(konnector, data)

--- a/packages/cozy-harvest-lib/src/helpers/accounts.js
+++ b/packages/cozy-harvest-lib/src/helpers/accounts.js
@@ -68,7 +68,8 @@ export const build = (konnector, authData) => {
   return {
     auth: authData,
     account_type: konnector.slug,
-    identifier: manifest.getIdentifier(konnector.fields)
+    identifier: manifest.getIdentifier(konnector.fields),
+    state: null
   }
 }
 
@@ -90,11 +91,21 @@ export const mergeAuth = (account, authData) => ({
  * @return {object}           io.cozy.accounts attributes
  */
 export const updateTwoFaCode = (account, code) => ({
-  ...account,
-  // reset the state,
-  state: null,
+  // reset the state since the konnector is listening it
+  ...resetState(account),
   twofa_code: code
 })
+
+/**
+ * Reset the account state
+ * @param  {Object} account Account document
+ * @return {object}         Changed account document
+ */
+export const resetState = account => ({
+  ...account,
+  state: null
+})
+
 /**
  * Set a state to reset the konnector session into io.cozy.accounts document
  * only if necessary, if password/passphrase have changed
@@ -119,6 +130,7 @@ export default {
   isTwoFANeeded,
   isTwoFARetry,
   mergeAuth,
+  resetState,
   setSessionResetIfNecessary,
   updateTwoFaCode
 }

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -301,7 +301,7 @@ describe('TriggerManager', () => {
       wrapper.instance().handleSubmit(fixtures.data)
       expect(saveAccountMock).toHaveBeenCalledWith(
         fixtures.konnector,
-        fixtures.account
+        expect.objectContaining(fixtures.account)
       )
     })
 
@@ -310,7 +310,7 @@ describe('TriggerManager', () => {
       wrapper.instance().handleSubmit({ login: 'test' })
       expect(saveAccountMock).toHaveBeenCalledWith(
         fixtures.konnector,
-        fixtures.existingAccount
+        expect.objectContaining(fixtures.existingAccount)
       )
     })
 

--- a/packages/cozy-harvest-lib/test/helpers/accounts.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/accounts.spec.js
@@ -1,4 +1,10 @@
-import { build, getLabel, mergeAuth } from 'helpers/accounts'
+import {
+  build,
+  getLabel,
+  mergeAuth,
+  updateTwoFaCode,
+  resetState
+} from 'helpers/accounts'
 
 const fixtures = {
   konnector: {
@@ -45,14 +51,47 @@ describe('Accounts Helper', () => {
   })
 
   describe('build', () => {
-    it('should prepare account data', () => {
+    it('should prepare account data with a reset state', () => {
       expect(build(fixtures.konnector, fixtures.data)).toEqual({
         account_type: 'konnectest',
         auth: {
           username: 'foo',
           passphrase: 'bar'
         },
-        identifier: 'username'
+        identifier: 'username',
+        state: null
+      })
+    })
+  })
+
+  describe('updateTwoFaCode', () => {
+    it('should set the 2FA code and reset the state', () => {
+      expect(
+        updateTwoFaCode(
+          {
+            ...fixtures.account,
+            state: 'TWOFA_NEEDED'
+          },
+          'atwofacode'
+        )
+      ).toEqual({
+        ...fixtures.account,
+        state: null,
+        twofa_code: 'atwofacode'
+      })
+    })
+  })
+
+  describe('resetState', () => {
+    it('should reset the state', () => {
+      expect(
+        resetState({
+          ...fixtures.account,
+          state: 'TWOFA_NEEDED'
+        })
+      ).toEqual({
+        ...fixtures.account,
+        state: null
       })
     })
   })


### PR DESCRIPTION
Since the konnector and Harvest use the account state to communicate about the connector running process, it's better to be sure to reset it each time before running a konnector, so let's Harvest doing it.