### PR TITLE
[authentication] feat: Translation context wraps MobileRouter

### DIFF
--- a/packages/cozy-authentication/examples/index.jsx
+++ b/packages/cozy-authentication/examples/index.jsx
@@ -7,12 +7,11 @@ import { Route, hashHistory } from 'react-router'
 import 'date-fns/locale/en/index'
 
 import 'cozy-ui/transpiled/react/stylesheet.css'
-import { translate, I18n, Button } from 'cozy-ui/transpiled/react'
+import { translate, Button } from 'cozy-ui/transpiled/react'
 import CozyClient, { CozyProvider, withClient } from 'cozy-client'
 
 import { MobileRouter } from '../dist'
 import icon from './icon.png'
-import enLocale from '../src/locales/en.json'
 
 const client = new CozyClient({
   scope: ['io.cozy.files'],
@@ -97,7 +96,7 @@ const LangChooser = translate()(({ lang, onChange }) => (
   <div style={{ position: 'fixed', zIndex: 1 }}>
     <button onClick={onChange.bind(null, 'en')}>en</button>
     <button onClick={onChange.bind(null, 'fr')}>fr</button>
-    locale: { lang }
+    locale: {lang}
   </div>
 ))
 

--- a/packages/cozy-authentication/examples/index.jsx
+++ b/packages/cozy-authentication/examples/index.jsx
@@ -39,6 +39,7 @@ const styles = {
   }
 }
 
+/** After login, show logout and revok buttons */
 const LoggedIn = withClient(({ client }) => (
   <div style={styles.wrapper}>
     Logged In !<br />
@@ -57,6 +58,7 @@ const Error = ({ error }) => (
   <pre style={styles.error}>An error occured {error.stack}</pre>
 )
 
+/** Catch error and show it */
 class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props)
@@ -76,6 +78,7 @@ class ErrorBoundary extends React.Component {
   }
 }
 
+/** Provides lang passed in props inside context */
 class LocaleContext extends React.Component {
   getChildContext() {
     return {
@@ -92,6 +95,7 @@ LocaleContext.childContextTypes = {
   lang: PropTypes.string
 }
 
+/** Buttons to change language */
 const LangChooser = translate()(({ lang, onChange }) => (
   <div style={{ position: 'fixed', zIndex: 1 }}>
     <button onClick={onChange.bind(null, 'en')}>en</button>

--- a/packages/cozy-authentication/examples/index.jsx
+++ b/packages/cozy-authentication/examples/index.jsx
@@ -7,7 +7,7 @@ import { Route, hashHistory } from 'react-router'
 import 'date-fns/locale/en/index'
 
 import 'cozy-ui/transpiled/react/stylesheet.css'
-import { translate, Button } from 'cozy-ui/transpiled/react'
+import { I18n, translate, Button } from 'cozy-ui/transpiled/react'
 import CozyClient, { CozyProvider, withClient } from 'cozy-client'
 
 import { MobileRouter } from '../dist'
@@ -39,20 +39,32 @@ const styles = {
   }
 }
 
-/** After login, show logout and revok buttons */
-const LoggedIn = withClient(({ client }) => (
+/** After login, show logout and revoke buttons */
+const LoggedIn = translate()(withClient(({ client, t }) => (
   <div style={styles.wrapper}>
-    Logged In !<br />
-    Client id: {client.stackClient.oauthOptions.clientID}
+    {t('logged-in.title')}<br />
+    URL: {client.stackClient.uri}<br/>
+    {t('logged-in.client-id')}: {client.stackClient.oauthOptions.clientID}
     <div>
-      <Button label="Logout" onClick={() => client.logout()} />
+      <Button label={t('logged-in.logout')} onClick={() => client.logout()} />
       <Button
-        label="Revoke"
+        label={t('logged-in.revoke')}
         onClick={() => client.handleRevocationChange(true)}
       />
     </div>
   </div>
-))
+)))
+
+const exampleLocales = {
+  en: {
+    'logged-in': {
+      title: 'Logged in !',
+      'client-id': 'Client ID',
+      logout: 'Logout',
+      revoke: 'Revoke'
+    }
+  }
+}
 
 const Error = ({ error }) => (
   <pre style={styles.error}>An error occured {error.stack}</pre>
@@ -124,16 +136,18 @@ class App extends React.Component {
       <ErrorBoundary>
         <LocaleContext lang={this.state.lang}>
           <LangChooser onChange={this.handleChangeLocale.bind(this)} />
-          <CozyProvider client={client}>
-            <MobileRouter
-              history={hashHistory}
-              protocol="cozyexample://"
-              appTitle={title}
-              appIcon={icon}
-            >
-              <Route path="/" component={LoggedIn} />
-            </MobileRouter>
-          </CozyProvider>
+          <I18n dictRequire={lang => exampleLocales[lang]} lang={this.state.lang}>
+            <CozyProvider client={client}>
+              <MobileRouter
+                history={hashHistory}
+                protocol="cozyexample://"
+                appTitle={title}
+                appIcon={icon}
+              >
+                <Route path="/" component={LoggedIn} />
+              </MobileRouter>
+            </CozyProvider>
+          </I18n>
         </LocaleContext>
       </ErrorBoundary>
     )

--- a/packages/cozy-authentication/examples/index.jsx
+++ b/packages/cozy-authentication/examples/index.jsx
@@ -40,20 +40,24 @@ const styles = {
 }
 
 /** After login, show logout and revoke buttons */
-const LoggedIn = translate()(withClient(({ client, t }) => (
-  <div style={styles.wrapper}>
-    {t('logged-in.title')}<br />
-    URL: {client.stackClient.uri}<br/>
-    {t('logged-in.client-id')}: {client.stackClient.oauthOptions.clientID}
-    <div>
-      <Button label={t('logged-in.logout')} onClick={() => client.logout()} />
-      <Button
-        label={t('logged-in.revoke')}
-        onClick={() => client.handleRevocationChange(true)}
-      />
+const LoggedIn = translate()(
+  withClient(({ client, t }) => (
+    <div style={styles.wrapper}>
+      {t('logged-in.title')}
+      <br />
+      URL: {client.stackClient.uri}
+      <br />
+      {t('logged-in.client-id')}: {client.stackClient.oauthOptions.clientID}
+      <div>
+        <Button label={t('logged-in.logout')} onClick={() => client.logout()} />
+        <Button
+          label={t('logged-in.revoke')}
+          onClick={() => client.handleRevocationChange(true)}
+        />
+      </div>
     </div>
-  </div>
-)))
+  ))
+)
 
 const exampleLocales = {
   en: {
@@ -136,7 +140,10 @@ class App extends React.Component {
       <ErrorBoundary>
         <LocaleContext lang={this.state.lang}>
           <LangChooser onChange={this.handleChangeLocale.bind(this)} />
-          <I18n dictRequire={lang => exampleLocales[lang]} lang={this.state.lang}>
+          <I18n
+            dictRequire={lang => exampleLocales[lang]}
+            lang={this.state.lang}
+          >
             <CozyProvider client={client}>
               <MobileRouter
                 history={hashHistory}

--- a/packages/cozy-authentication/package.json
+++ b/packages/cozy-authentication/package.json
@@ -40,6 +40,7 @@
     "cozy-device-helper": "1.7.1",
     "cozy-flags": "1.6.0",
     "localforage": "1.7.3",
+    "postcss-merge-rules": "4.0.3",
     "react": ">=15",
     "react-markdown": "4.0.6",
     "react-router": "3",

--- a/packages/cozy-authentication/src/Authentication.jsx
+++ b/packages/cozy-authentication/src/Authentication.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import Welcome from './steps/Welcome'
 import SelectServer from './steps/SelectServer'
 import { withClient } from 'cozy-client'
+import withLocales from './withLocales'
 import { registerAndLogin } from './utils/onboarding'
 
 const STEP_WELCOME = 'STEP_WELCOME'
@@ -114,4 +115,4 @@ Authentication.defaultProps = {
 
 export const DumbAuthentication = Authentication
 
-export default withClient(Authentication)
+export default withLocales(withClient(Authentication))

--- a/packages/cozy-authentication/src/Authentication.spec.jsx
+++ b/packages/cozy-authentication/src/Authentication.spec.jsx
@@ -1,4 +1,4 @@
-import Authentication from './Authentication'
+import { DumbAuthentication } from './Authentication'
 import React from 'react'
 import { shallow } from 'enzyme'
 
@@ -15,18 +15,15 @@ describe('Authentication', () => {
     }
     onComplete = jest.fn()
     onException = jest.fn()
-    const options = {
-      context: { client }
-    }
     root = shallow(
-      <Authentication
+      <DumbAuthentication
+        client={client}
         appIcon="icon.png"
         onComplete={onComplete}
         onException={onException}
-      />,
-      options
+      />
     )
-    instance = root.dive().instance()
+    instance = root.instance()
   }
 
   it('should connect to server with cozy-client', async () => {

--- a/packages/cozy-authentication/src/MobileRouter.jsx
+++ b/packages/cozy-authentication/src/MobileRouter.jsx
@@ -3,7 +3,7 @@ import { Router } from 'react-router'
 import PropTypes from 'prop-types'
 
 import { withClient } from 'cozy-client'
-
+import { I18n, translate } from 'cozy-ui/transpiled/react/I18n'
 import Authentication from './Authentication'
 import Revoked from './Revoked'
 import deeplink from './utils/deeplink'
@@ -197,6 +197,7 @@ MobileRouter.propTypes = {
   onLogout: PropTypes.func,
   onException: PropTypes.func.isRequired,
 
+  /** CozyClient instance, should be provided via <CozyProvider /> */
   client: PropTypes.object.isRequired,
 
   /** After login, where do we go */
@@ -205,6 +206,17 @@ MobileRouter.propTypes = {
   logoutPath: PropTypes.string
 }
 
+const locales = {
+  en: require(`./locales/en.json`),
+  fr: require(`./locales/fr.json`),
+}
+
+const withLocales = Component => translate()(props => {
+  return <I18n dictRequire={localeCode => locales[localeCode]} lang={props.lang}>
+    <Component {...props} />
+  </I18n>
+})
+
 export const DumbMobileRouter = MobileRouter
 
-export default withClient(MobileRouter)
+export default withLocales(withClient(MobileRouter))

--- a/packages/cozy-authentication/src/MobileRouter.jsx
+++ b/packages/cozy-authentication/src/MobileRouter.jsx
@@ -208,14 +208,17 @@ MobileRouter.propTypes = {
 
 const locales = {
   en: require(`./locales/en.json`),
-  fr: require(`./locales/fr.json`),
+  fr: require(`./locales/fr.json`)
 }
 
-const withLocales = Component => translate()(props => {
-  return <I18n dictRequire={localeCode => locales[localeCode]} lang={props.lang}>
-    <Component {...props} />
-  </I18n>
-})
+const withLocales = Component =>
+  translate()(props => {
+    return (
+      <I18n dictRequire={localeCode => locales[localeCode]} lang={props.lang}>
+        <Component {...props} />
+      </I18n>
+    )
+  })
 
 export const DumbMobileRouter = MobileRouter
 

--- a/packages/cozy-authentication/src/MobileRouter.jsx
+++ b/packages/cozy-authentication/src/MobileRouter.jsx
@@ -206,20 +206,7 @@ MobileRouter.propTypes = {
   logoutPath: PropTypes.string
 }
 
-const locales = {
-  en: require(`./locales/en.json`),
-  fr: require(`./locales/fr.json`)
-}
-
-const withLocales = Component =>
-  translate()(props => {
-    return (
-      <I18n dictRequire={localeCode => locales[localeCode]} lang={props.lang}>
-        <Component {...props} />
-      </I18n>
-    )
-  })
 
 export const DumbMobileRouter = MobileRouter
 
-export default withLocales(withClient(MobileRouter))
+export default withClient(MobileRouter)

--- a/packages/cozy-authentication/src/MobileRouter.jsx
+++ b/packages/cozy-authentication/src/MobileRouter.jsx
@@ -3,7 +3,6 @@ import { Router } from 'react-router'
 import PropTypes from 'prop-types'
 
 import { withClient } from 'cozy-client'
-import { I18n, translate } from 'cozy-ui/transpiled/react/I18n'
 import Authentication from './Authentication'
 import Revoked from './Revoked'
 import deeplink from './utils/deeplink'
@@ -205,7 +204,6 @@ MobileRouter.propTypes = {
   /** After logout, where do we go */
   logoutPath: PropTypes.string
 }
-
 
 export const DumbMobileRouter = MobileRouter
 

--- a/packages/cozy-authentication/src/Revoked.jsx
+++ b/packages/cozy-authentication/src/Revoked.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import Modal from 'cozy-ui/transpiled/react/Modal'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import { withClient } from 'cozy-client'
+import withLocales from './withLocales'
 
 const Revoked = ({ t, onLogBackIn, onLogout }) => (
   <Modal
@@ -22,4 +23,4 @@ Revoked.propTypes = {
   onLogBackIn: PropTypes.func.isRequired
 }
 
-export default withClient(translate()(Revoked))
+export default withLocales(withClient(translate()(Revoked)))

--- a/packages/cozy-authentication/src/locales/fr.json
+++ b/packages/cozy-authentication/src/locales/fr.json
@@ -5,9 +5,13 @@
         "title1": "Bienvenue sur Cozy",
         "title2": "Votre propre cloud personnel",
         "button": "Vous connecter à votre Cozy",
-        "no_account_link": "Vous n'avez pas de compte? Demandez-en un ici."
+        "no_account_link": "Vous n'avez pas de compte? Demandez-en un ici.",
+        "create_my_cozy": "Créer mon Cozy",
+        "desc": "Créer un Cozy ou connectez vous pour accéder à %{appTitle}."
       },
       "server_selection": {
+        "title": "Vous connecter à votre Cozy",
+        "lostpwd": "[J'ai oublié l'adresse de mon Cozy](https://manager.cozycloud.cc/cozy/reminder)",
         "description": "Exemple: https://**camillenimbus**.mycozy.cloud\n",
         "label": "Entrez l'adresse de votre Cozy",
         "cozy_address_placeholder": "camillenimbus.mycozy.cloud",

--- a/packages/cozy-authentication/src/withLocales.jsx
+++ b/packages/cozy-authentication/src/withLocales.jsx
@@ -1,0 +1,17 @@
+import { I18n } from 'cozy-ui/transpiled/react/I18n'
+
+const locales = {
+  en: require(`./locales/en.json`),
+  fr: require(`./locales/fr.json`)
+}
+
+const withLocales = Component =>
+  translate()(props => {
+    return (
+      <I18n dictRequire={localeCode => locales[localeCode]} lang={props.lang}>
+        <Component {...props} />
+      </I18n>
+    )
+  })
+
+export default withLocales

--- a/packages/cozy-authentication/src/withLocales.jsx
+++ b/packages/cozy-authentication/src/withLocales.jsx
@@ -1,4 +1,5 @@
-import { I18n } from 'cozy-ui/transpiled/react/I18n'
+import React from 'react'
+import { I18n, translate } from 'cozy-ui/transpiled/react/I18n'
 
 const locales = {
   en: require(`./locales/en.json`),

--- a/yarn.lock
+++ b/yarn.lock
@@ -10684,18 +10684,7 @@ postcss-merge-longhand@^4.0.11:
     postcss-value-parser "^3.0.0"
     stylehacks "^4.0.0"
 
-postcss-merge-rules@^2.0.3:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz#d1df5dfaa7b1acc3be553f0e9e10e87c61b5f721"
-  integrity sha1-0d9d+qexrMO+VT8OnhDofGG19yE=
-  dependencies:
-    browserslist "^1.5.2"
-    caniuse-api "^1.5.2"
-    postcss "^5.0.4"
-    postcss-selector-parser "^2.2.2"
-    vendors "^1.0.0"
-
-postcss-merge-rules@^4.0.3:
+postcss-merge-rules@4.0.3, postcss-merge-rules@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz#362bea4ff5a1f98e4075a713c6cb25aefef9a650"
   integrity sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==
@@ -10705,6 +10694,17 @@ postcss-merge-rules@^4.0.3:
     cssnano-util-same-parent "^4.0.0"
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
+    vendors "^1.0.0"
+
+postcss-merge-rules@^2.0.3:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz#d1df5dfaa7b1acc3be553f0e9e10e87c61b5f721"
+  integrity sha1-0d9d+qexrMO+VT8OnhDofGG19yE=
+  dependencies:
+    browserslist "^1.5.2"
+    caniuse-api "^1.5.2"
+    postcss "^5.0.4"
+    postcss-selector-parser "^2.2.2"
     vendors "^1.0.0"
 
 postcss-message-helpers@^2.0.0:


### PR DESCRIPTION
- MobileRouter brings its own translation strings so that the application
does not have to copy/paste and maintain translation strings that are not
part of the application

- The example has buttons to change the language

- Fixed missing translation strings in French

Only English and French translation strings are available at the moment. This will change when we plug the transifex project here.