### PR TITLE
fix: Do not try to onboarding if required query argument are absent

### DIFF
--- a/packages/cozy-authentication/src/MobileRouter.jsx
+++ b/packages/cozy-authentication/src/MobileRouter.jsx
@@ -143,7 +143,14 @@ export class MobileRouter extends Component {
     const { client, history } = this.props
     try {
       const currentLocation = history.getCurrentLocation()
-      const { access_code, state, cozy_url } = currentLocation.query
+      const { access_code, state, cozy_url, code } = currentLocation.query
+      if (!code || !cozy_url) {
+        // Here it means that were are not in an onboarding login, we are
+        // in a normal login, the register() called in Authentication::selectServer
+        // should have completed
+        return
+      }
+
       // on iOS, hide() the ViewController since it is still active
       // when the application comes from background
       if (window.SafariViewController) window.SafariViewController.hide()


### PR DESCRIPTION
To differentiate between a normal login and an onboarding login we can check the presence of two query arguments:

- cozy_url
- code

Both of them should only be present while onboarding. Unfortunately, code is also present due to presumably a bug of the stack when through universal links, we have a redirect uri. Thus cozy_url is the only reliable query arg for now. The bug of the stack seem to be already fixed in staging.

This bug was introduced when refactoring the authentication code, it is not present in drive.