### PR TITLE
feat(doctypes): Add getUpdatedAt helper to BankAccount

### DIFF
--- a/packages/cozy-doctypes/src/banking/BankAccount.js
+++ b/packages/cozy-doctypes/src/banking/BankAccount.js
@@ -1,4 +1,5 @@
 const groupBy = require('lodash/groupBy')
+const get = require('lodash/get')
 const Document = require('../Document')
 const matching = require('./matching-accounts')
 const { getSlugFromInstitutionLabel } = require('./slug-account')
@@ -45,6 +46,22 @@ class BankAccount extends Document {
     return Boolean(
       predictedSlug && createdByApp && predictedSlug !== createdByApp
     )
+  }
+
+  static getUpdatedAt(account) {
+    const vendorUpdatedAt = get(account, 'metadata.updatedAt')
+
+    if (vendorUpdatedAt) {
+      return vendorUpdatedAt
+    }
+
+    const cozyUpdatedAt = get(account, 'cozyMetadata.updatedAt')
+
+    if (cozyUpdatedAt) {
+      return cozyUpdatedAt
+    }
+
+    return null
   }
 }
 

--- a/packages/cozy-doctypes/src/banking/BankAccount.spec.js
+++ b/packages/cozy-doctypes/src/banking/BankAccount.spec.js
@@ -89,3 +89,32 @@ describe('incoherences', () => {
     expect(BankAccount.hasIncoherentCreatedByApp(noCreatedByApp)).toBe(false)
   })
 })
+
+describe('getUpdatedAt', () => {
+  let account
+
+  beforeEach(() => {
+    account = {
+      metadata: {
+        updatedAt: '2019-05-01T16:09:00'
+      },
+      cozyMetadata: {
+        updatedAt: '2019-05-02T15:36:00'
+      }
+    }
+  })
+
+  it("should return metadata.updatedAt if it's defined", () => {
+    expect(BankAccount.getUpdatedAt(account)).toBe('2019-05-01T16:09:00')
+  })
+
+  it('should return cozyMetadata.updatedAt if metadata.updatedAt is not defined', () => {
+    delete account.metadata
+
+    expect(BankAccount.getUpdatedAt(account)).toBe('2019-05-02T15:36:00')
+  })
+
+  it('should return null if neither cozyMetadata.updatedAt nor metadata.updatedAt is defined', () => {
+    expect(BankAccount.getUpdatedAt({})).toBe(null)
+  })
+})


### PR DESCRIPTION
This helper is used only in Banks at the moment, but this way it's
reusable anywhere and it is easier to find it than in a `helpers` file
in Banks.

The banking konnector now saves the date on which BI updated the account
on its side in `metadata.updatedAt`. Since this is usually a more accurate
data that than our `cozyMetadata.updatedAt`, we now use it if it exists,
then fallback on `cozyMetadata.updatedAt` if it does not.