### PR TITLE
Fix PropTypes in Contact model

### DIFF
--- a/packages/cozy-doctypes/src/contacts/Contact.js
+++ b/packages/cozy-doctypes/src/contacts/Contact.js
@@ -153,12 +153,14 @@ const ContactShape = PropTypes.shape({
       formattedAddress: PropTypes.string
     })
   ),
-  phone: PropTypes.arrayOf({
-    number: PropTypes.string.isRequired,
-    type: PropTypes.string,
-    label: PropTypes.string,
-    primary: PropTypes.bool
-  }),
+  phone: PropTypes.arrayOf(
+    PropTypes.shape({
+      number: PropTypes.string.isRequired,
+      type: PropTypes.string,
+      label: PropTypes.string,
+      primary: PropTypes.bool
+    })
+  ),
   cozy: PropTypes.arrayOf(
     PropTypes.shape({
       url: PropTypes.string.isRequired,
@@ -172,16 +174,20 @@ const ContactShape = PropTypes.shape({
   me: PropTypes.bool.isRequired,
   relationships: PropTypes.shape({
     accounts: PropTypes.shape({
-      data: PropTypes.arrayOf({
-        _id: PropTypes.string.isRequired,
-        _type: PropTypes.string.isRequired
-      })
+      data: PropTypes.arrayOf(
+        PropTypes.shape({
+          _id: PropTypes.string.isRequired,
+          _type: PropTypes.string.isRequired
+        })
+      )
     }),
     groups: PropTypes.shape({
-      data: PropTypes.arrayOf({
-        _id: PropTypes.string.isRequired,
-        _type: PropTypes.string.isRequired
-      })
+      data: PropTypes.arrayOf(
+        PropTypes.shape({
+          _id: PropTypes.string.isRequired,
+          _type: PropTypes.string.isRequired
+        })
+      )
     })
   })
 })

--- a/packages/cozy-doctypes/src/contacts/Contact.js
+++ b/packages/cozy-doctypes/src/contacts/Contact.js
@@ -171,7 +171,7 @@ const ContactShape = PropTypes.shape({
   company: PropTypes.string,
   jobTitle: PropTypes.string,
   trashed: PropTypes.bool,
-  me: PropTypes.bool.isRequired,
+  me: PropTypes.bool,
   relationships: PropTypes.shape({
     accounts: PropTypes.shape({
       data: PropTypes.arrayOf(


### PR DESCRIPTION
Some proptypes were not right in Contact model: 
- `me` should not be required since it is not present on all contacts (or we should add it to the migration script)
- unfortunately `{...}` is not a valid propType format, we have to use `PropTypes.shape({...})` :cry: 