### PR TITLE
feat: Show LogIn view while logging in

### DIFF
--- a/packages/cozy-authentication/Procfile
+++ b/packages/cozy-authentication/Procfile
@@ -1,0 +1,2 @@
+example-server: yarn example-server
+transpilation: yarn build --watch

--- a/packages/cozy-authentication/examples/index.jsx
+++ b/packages/cozy-authentication/examples/index.jsx
@@ -6,17 +6,27 @@ import PropTypes from 'prop-types'
 import { Route, hashHistory } from 'react-router'
 import 'date-fns/locale/en/index'
 
+import CozyClient, { CozyProvider, withClient } from 'cozy-client'
+import CozyStackClient from 'cozy-stack-client'
 import 'cozy-ui/transpiled/react/stylesheet.css'
+import IconSprite from 'cozy-ui/transpiled/react/Icon/Sprite'
 import { I18n, translate, Button } from 'cozy-ui/transpiled/react'
 import { getUniversalLinkDomain } from 'cozy-ui/transpiled/react/AppLinker'
-
-import CozyClient, { CozyProvider, withClient } from 'cozy-client'
 
 import { MobileRouter } from '../dist'
 import icon from './icon.png'
 
+const sleep = duration => new Promise(resolve => setTimeout(resolve, duration))
 const client = new CozyClient({
   scope: ['io.cozy.files'],
+  links: [
+    new CozyStackClient(),
+    {
+      onLogin: async function() {
+        await sleep(2000) // So that we can see the logging in view
+      }
+    }
+  ],
   oauth: {
     clientName: 'Example App',
     softwareID: 'io.cozy.example',
@@ -193,6 +203,7 @@ class App extends React.Component {
             </CozyProvider>
           </I18n>
         </LocaleContext>
+        <IconSprite />
       </ErrorBoundary>
     )
   }

--- a/packages/cozy-authentication/package.json
+++ b/packages/cozy-authentication/package.json
@@ -21,7 +21,7 @@
     "@babel/core": "^7.3.4",
     "babel-plugin-css-modules-transform": "^1.6.2",
     "babel-preset-cozy-app": "^1.5.1",
-    "cozy-client": "^6.26.0",
+    "cozy-client": "^6.27.0",
     "cozy-ui": "^19.28.0",
     "cssnano-preset-advanced": "^4.0.7",
     "date-fns": "^1.29.0",
@@ -68,7 +68,7 @@
     }
   },
   "peerDependencies": {
-    "cozy-client": "^6.26.0",
+    "cozy-client": "^6.27.0",
     "cozy-ui": "^19.28.0"
   }
 }

--- a/packages/cozy-authentication/package.json
+++ b/packages/cozy-authentication/package.json
@@ -14,7 +14,8 @@
     "test": "env USE_REACT=true yarn jest src",
     "copy-files": "cp -r src/locales/ dist/locales/",
     "lint": "cd ..; yarn lint packages/cozy-authentication",
-    "example": "env USE_REACT=true npx parcel $(pwd)/examples/index.html"
+    "example": "nf start",
+    "example-server": "env USE_REACT=true parcel --port 1234 $(pwd)/examples/index.html"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
@@ -28,6 +29,7 @@
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.11.2",
     "eslint-cli": "1.1.1",
+    "foreman": "^3.0.1",
     "jest": "24.5.0",
     "parcel": "^1.12.3",
     "postcss-merge-rules": "4.0.3",

--- a/packages/cozy-authentication/package.json
+++ b/packages/cozy-authentication/package.json
@@ -30,21 +30,19 @@
     "eslint-cli": "1.1.1",
     "jest": "24.5.0",
     "parcel": "^1.12.3",
+    "postcss-merge-rules": "4.0.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "react-redux": "^7.0.2",
+    "react-router": "3",
     "react-styleguidist": "6.5.3",
     "stylus": "^0.54.5"
   },
   "dependencies": {
     "cozy-device-helper": "1.7.1",
-    "cozy-flags": "^1.6.1",
     "localforage": "1.7.3",
-    "postcss-merge-rules": "4.0.3",
     "prop-types": "15.7.2",
-    "react": ">=15",
     "react-markdown": "4.0.6",
-    "react-router": "3",
     "url-polyfill": "1.1.0"
   },
   "jest": {
@@ -69,6 +67,8 @@
   },
   "peerDependencies": {
     "cozy-client": "^6.27.0",
-    "cozy-ui": "^19.28.0"
+    "cozy-ui": "^19.28.0",
+    "react": ">=15",
+    "react-router": "3"
   }
 }

--- a/packages/cozy-authentication/src/MobileRouter.spec.jsx
+++ b/packages/cozy-authentication/src/MobileRouter.spec.jsx
@@ -74,6 +74,7 @@ describe('MobileRouter', () => {
             {...props}
             loginPath="/afterLogin"
             logoutPath="/afterLogout"
+            initialTriedToReconnect={true}
             LogoutComponent={LogoutComponent}
           />
         </I18n>

--- a/packages/cozy-authentication/src/MobileRouter.spec.jsx
+++ b/packages/cozy-authentication/src/MobileRouter.spec.jsx
@@ -7,7 +7,8 @@ import { I18n } from 'cozy-ui/transpiled/react/I18n'
 import Authentication from './Authentication'
 import MobileRouter, {
   DumbMobileRouter,
-  LoggingInViaOnboarding
+  LoggingInViaOnboarding,
+  LoginInComponent
 } from './MobileRouter'
 import Revoked from './Revoked'
 import * as onboarding from './utils/onboarding'
@@ -151,6 +152,19 @@ describe('MobileRouter', () => {
       window.handleOpenURL = jest.fn()
       instance.handleUniversalLink({ url: 'http://fake.url.com' })
       expect(window.handleOpenURL).toHaveBeenCalledWith('http://fake.url.com')
+    })
+  })
+
+  describe('Logging in', () => {
+    it('should show LogInComponent during logout', () => {
+      LogoutComponent = LoggingOut
+      setup()
+      client.emit('beforeLogin')
+      app.update()
+      expect(app.find(LoginInComponent).length).toBe(1)
+      client.emit('login')
+      app.update()
+      expect(app.find(LoginInComponent).length).toBe(0)
     })
   })
 

--- a/packages/cozy-authentication/src/locales/fr.json
+++ b/packages/cozy-authentication/src/locales/fr.json
@@ -12,9 +12,9 @@
       "server_selection": {
         "title": "Vous connecter à votre Cozy",
         "lostpwd": "[J'ai oublié l'adresse de mon Cozy](https://manager.cozycloud.cc/cozy/reminder)",
-        "description": "Exemple: https://**camillenimbus**.mycozy.cloud\n",
+        "description": "Exemple: https://**claude**.mycozy.cloud\n",
         "label": "Entrez l'adresse de votre Cozy",
-        "cozy_address_placeholder": "camillenimbus.mycozy.cloud",
+        "cozy_address_placeholder": "claude.mycozy.cloud",
         "button": "Suivant",
         "previous": "Précédent",
         "wrong_address_with_email": "Vous avez entré une adresse email. Pour vous connecter à votre Cozy vous devez entrer son url, sous la forme https://camillenimbus.mycozy.cloud",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12178,7 +12178,7 @@ react@16.7.0:
     prop-types "^15.6.2"
     scheduler "^0.12.0"
 
-react@16.8.6, react@>=15:
+react@16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
   integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3528,10 +3528,26 @@ cozy-client-js@0.14.2:
     pouchdb-adapter-cordova-sqlite "https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
     pouchdb-find "6.4.3"
 
-cozy-client@6.26.0, cozy-client@^6.26.0:
+cozy-client@6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-6.26.0.tgz#6d8882a190d0dfbed46ed2240bc04f446e408a80"
   integrity sha512-Zw/bnQ03YxfK9+nHWxGEdPN1gdlmwv1xbLF5DhSOCHDk3oXL5dSnGIqaA+DPIC/vetemIxdm9skMIaOT0k7Q+Q==
+  dependencies:
+    cozy-device-helper "1.6.3"
+    cozy-stack-client "^6.25.0"
+    lodash "4.17.11"
+    microee "0.0.6"
+    prop-types "15.6.2"
+    react "16.7.0"
+    react-redux "5.0.7"
+    redux "3.7.2"
+    redux-thunk "2.3.0"
+    sift "6.0.0"
+
+cozy-client@^6.27.0:
+  version "6.27.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-6.27.0.tgz#27cd1c9e1e6827f7fcc431f8ef1294056b4d3cd7"
+  integrity sha512-lKdWvKrBsBs8SimfvSqb3ExInH/pGA00GfZXr4Ki8bDV0Z/d/g7geQVUepIIpwyun+PqKaIQ/Fko5a1lYfx89Q==
   dependencies:
     cozy-device-helper "1.6.3"
     cozy-stack-client "^6.25.0"
@@ -3567,10 +3583,25 @@ cozy-stack-client@^6.25.0:
     mime-types "2.1.24"
     qs "6.7.0"
 
-cozy-ui@19.28.2, cozy-ui@^19.28.0:
+cozy-ui@19.28.2:
   version "19.28.2"
   resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-19.28.2.tgz#aa48d2a5a73025b26071673d14d6235a747082e5"
   integrity sha512-cLv++BlkPXT7S3+CMJWsISpjsDJ6v3kKZsEQktei1HJ+hNQMWIGKHup32sd6mKXMhbF6toWYCnoLyz60WEZXQQ==
+  dependencies:
+    "@babel/runtime" "^7.3.4"
+    body-scroll-lock "^2.5.8"
+    classnames "^2.2.5"
+    date-fns "^1.28.5"
+    hammerjs "^2.0.8"
+    node-polyglot "^2.2.2"
+    normalize.css "^7.0.0"
+    react-hot-loader "^4.3.11"
+    react-select "2.2.0"
+
+cozy-ui@^19.28.0:
+  version "19.29.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-19.29.0.tgz#35ca922a2eab052fb54ffbd4a6767703e02c536d"
+  integrity sha512-IPHzEpyrP9D0Kl870ABgpJelYXXnH7mJt12p21qjz2XAZx1FaK8OtYIHrwU/Jm233FsO6g72FD5FF6ATvm4P2A==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5494,6 +5494,16 @@ foreach@^2.0.5:
   resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
   integrity sha1-C+4AUBiusmDQo6865ljdATbsG5k=
 
+foreman@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/foreman/-/foreman-3.0.1.tgz#805f28afc5a4bbaf08dbb1f5018c557dcbb8a410"
+  integrity sha512-ek/qoM0vVKpxzkBUQN9k4Fs7l0XsHv4bqxuEW6oqIS4s0ouYKsQ19YjBzUJKTFRumFiSpUv7jySkrI6lfbhjlw==
+  dependencies:
+    commander "^2.15.1"
+    http-proxy "^1.17.0"
+    mustache "^2.2.1"
+    shell-quote "^1.6.1"
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -9409,6 +9419,11 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
+mustache@^2.2.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.2.tgz#a6d4d9c3f91d13359ab889a812954f9230a3d0c5"
+  integrity sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==
+
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
@@ -13195,7 +13210,7 @@ shebang-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
-shell-quote@1.6.1:
+shell-quote@1.6.1, shell-quote@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
   integrity sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=


### PR DESCRIPTION
When the MobileRouter mounts, it tries to reconnect, based on information it has saved in localStorage.

`client.login` being async (since it instantiates the links, and some of them can be asynced, for example PouchLink), it can take a while to `login()` (hopefully not so much).

In the past, while logging in, we would show the `AuthenticationView`. This was a problem since the user had already logged in, and it is not expected to see a login form when you have already logged in.

Now, we show a component showing a spinner. It can be customized via the LogInComponent prop.

Another problem was a flash of AuthenticationView since the `tryToReconnect` is done after mouting. To mitigate the problem, the component shows null while it has not tried to reconnect yet. It will be during a very short time (a frame).