### PR TITLE
Harvest: Handle login success state to disable login success timeout

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -37,6 +37,7 @@ export class TriggerManager extends Component {
     this.handleSubmit = this.handleSubmit.bind(this)
     this.closeTwoFAModal = this.closeTwoFAModal.bind(this)
     this.disableSuccessTimer = this.disableSuccessTimer.bind(this)
+    this.handleLoginSuccessState = this.handleLoginSuccessState.bind(this)
     this.handleSuccess = this.handleSuccess.bind(this)
     this.handleError = this.handleError.bind(this)
     this.handleTwoFACodeAsked = this.handleTwoFACodeAsked.bind(this)
@@ -60,6 +61,10 @@ export class TriggerManager extends Component {
 
   disableSuccessTimer() {
     if (this.jobWatcher) this.jobWatcher.disableSuccessTimer()
+  }
+
+  handleLoginSuccessState() {
+    if (this.jobWatcher) this.jobWatcher.handleSuccess()
   }
 
   /**
@@ -119,6 +124,7 @@ export class TriggerManager extends Component {
     this.setState({ trigger })
     this.props.watchKonnectorAccount(account, {
       onTwoFACodeAsked: this.handleTwoFACodeAsked,
+      onLoginSuccess: this.handleLoginSuccessState,
       onLoginSuccessHandled: this.disableSuccessTimer
     })
     return await this.launch(trigger)

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -36,6 +36,7 @@ export class TriggerManager extends Component {
     this.handleAccountSaveSuccess = this.handleAccountSaveSuccess.bind(this)
     this.handleSubmit = this.handleSubmit.bind(this)
     this.closeTwoFAModal = this.closeTwoFAModal.bind(this)
+    this.disableSuccessTimer = this.disableSuccessTimer.bind(this)
     this.handleSuccess = this.handleSuccess.bind(this)
     this.handleError = this.handleError.bind(this)
     this.handleTwoFACodeAsked = this.handleTwoFACodeAsked.bind(this)
@@ -55,6 +56,10 @@ export class TriggerManager extends Component {
     this.setState({
       status: RUNNING
     })
+  }
+
+  disableSuccessTimer() {
+    if (this.jobWatcher) this.jobWatcher.disableSuccessTimer()
   }
 
   /**
@@ -113,7 +118,8 @@ export class TriggerManager extends Component {
     const trigger = await this.ensureTrigger()
     this.setState({ trigger })
     this.props.watchKonnectorAccount(account, {
-      onTwoFACodeAsked: this.handleTwoFACodeAsked
+      onTwoFACodeAsked: this.handleTwoFACodeAsked,
+      onLoginSuccessHandled: this.disableSuccessTimer
     })
     return await this.launch(trigger)
   }
@@ -129,7 +135,7 @@ export class TriggerManager extends Component {
     const { status } = this.state
     if (accounts.isTwoFANeeded(status)) return
     // disable successTimeout since asked Two FA code
-    if (this.jobWatcher) this.jobWatcher.disableSuccessTimer()
+    this.disableSuccessTimer()
     this.setState({
       status: statusCode
     })

--- a/packages/cozy-harvest-lib/src/helpers/accounts.js
+++ b/packages/cozy-harvest-lib/src/helpers/accounts.js
@@ -14,6 +14,7 @@ const TWOFA_NEEDED_STATUS = 'TWOFA_NEEDED'
 const TWOFA_NEEDED_RETRY_STATUS = 'TWOFA_NEEDED_RETRY'
 const RESET_SESSION_STATE = 'RESET_SESSION'
 const HANDLE_LOGIN_SUCCESS_STATE = 'HANDLE_LOGIN_SUCCESS'
+const LOGIN_SUCCESS_STATE = 'LOGIN_SUCCESS'
 
 /**
  * Return a boolean to know if the account is in a two fa code needed
@@ -33,6 +34,10 @@ export const isTwoFARetry = status => {
 
 export const isLoginSuccessHandled = status => {
   return status === HANDLE_LOGIN_SUCCESS_STATE
+}
+
+export const isLoginSuccess = status => {
+  return status === LOGIN_SUCCESS_STATE
 }
 
 /**
@@ -134,6 +139,7 @@ export default {
   getTwoFACodeProvider,
   isTwoFANeeded,
   isTwoFARetry,
+  isLoginSuccess,
   isLoginSuccessHandled,
   mergeAuth,
   resetState,

--- a/packages/cozy-harvest-lib/src/helpers/accounts.js
+++ b/packages/cozy-harvest-lib/src/helpers/accounts.js
@@ -13,6 +13,7 @@ const PROVIDERS = {
 const TWOFA_NEEDED_STATUS = 'TWOFA_NEEDED'
 const TWOFA_NEEDED_RETRY_STATUS = 'TWOFA_NEEDED_RETRY'
 const RESET_SESSION_STATE = 'RESET_SESSION'
+const HANDLE_LOGIN_SUCCESS_STATE = 'HANDLE_LOGIN_SUCCESS'
 
 /**
  * Return a boolean to know if the account is in a two fa code needed
@@ -28,6 +29,10 @@ export const isTwoFANeeded = status => {
 export const isTwoFARetry = status => {
   if (!status) return false
   return status.split('.')[0] === TWOFA_NEEDED_RETRY_STATUS
+}
+
+export const isLoginSuccessHandled = status => {
+  return status === HANDLE_LOGIN_SUCCESS_STATE
 }
 
 /**
@@ -129,6 +134,7 @@ export default {
   getTwoFACodeProvider,
   isTwoFANeeded,
   isTwoFARetry,
+  isLoginSuccessHandled,
   mergeAuth,
   resetState,
   setSessionResetIfNecessary,

--- a/packages/cozy-harvest-lib/src/models/KonnectorJob.js
+++ b/packages/cozy-harvest-lib/src/models/KonnectorJob.js
@@ -162,6 +162,7 @@ export class KonnectorJob {
 
     watchKonnectorAccount(this.account, {
       onTwoFACodeAsked: this.handleTwoFA,
+      onLoginSuccess: konnectorJob.handleSuccess,
       onLoginSuccessHandled: konnectorJob.disableSuccessTimer
     })
   }

--- a/packages/cozy-harvest-lib/src/models/KonnectorJob.js
+++ b/packages/cozy-harvest-lib/src/models/KonnectorJob.js
@@ -150,10 +150,6 @@ export class KonnectorJob {
       this.accountsMutations
     )
 
-    watchKonnectorAccount(this.account, {
-      onTwoFACodeAsked: this.handleTwoFA
-    })
-
     const konnectorJob = watchKonnectorJob(await launchTrigger(this.trigger))
     // Temporary reEmitting until merging of KonnectorJobWatcher and
     // KonnectorAccountWatcher into KonnectorJob
@@ -163,6 +159,11 @@ export class KonnectorJob {
       this.handleLegacyEvent(LOGIN_SUCCESS_EVENT)
     )
     konnectorJob.on(SUCCESS_EVENT, this.handleLegacyEvent(SUCCESS_EVENT))
+
+    watchKonnectorAccount(this.account, {
+      onTwoFACodeAsked: this.handleTwoFA,
+      onLoginSuccessHandled: konnectorJob.disableSuccessTimer
+    })
   }
 }
 

--- a/packages/cozy-harvest-lib/src/models/konnector/KonnectorAccountWatcher.js
+++ b/packages/cozy-harvest-lib/src/models/konnector/KonnectorAccountWatcher.js
@@ -14,9 +14,12 @@ export class KonnectorAccountWatcher {
   handleAccountUpdated(account) {
     this.account = account
     const { state } = this.account
+    const { onTwoFACodeAsked, onLoginSuccessHandled } = this.options
     if (accounts.isTwoFANeeded(state) || accounts.isTwoFARetry(state)) {
-      const { onTwoFACodeAsked } = this.options
       onTwoFACodeAsked(state)
+    }
+    if (accounts.isLoginSuccessHandled(state)) {
+      onLoginSuccessHandled(state)
     }
   }
 

--- a/packages/cozy-harvest-lib/src/models/konnector/KonnectorAccountWatcher.js
+++ b/packages/cozy-harvest-lib/src/models/konnector/KonnectorAccountWatcher.js
@@ -14,12 +14,18 @@ export class KonnectorAccountWatcher {
   handleAccountUpdated(account) {
     this.account = account
     const { state } = this.account
-    const { onTwoFACodeAsked, onLoginSuccessHandled } = this.options
+    const {
+      onTwoFACodeAsked,
+      onLoginSuccess,
+      onLoginSuccessHandled
+    } = this.options
     if (accounts.isTwoFANeeded(state) || accounts.isTwoFARetry(state)) {
       onTwoFACodeAsked(state)
     }
     if (accounts.isLoginSuccessHandled(state)) {
       onLoginSuccessHandled(state)
+    } else if (accounts.isLoginSuccess(state)) {
+      onLoginSuccess(state)
     }
   }
 


### PR DESCRIPTION
When the konnector handle the new `LOGIN_SUCCESS` feature, it will set the state `HANDLE_LOGIN_SUCCESS_STATE ` to disable the login timeout in Harvest