### PR TITLE
feat(mjml): Avoid warnings on es,ja,pl... locales

### DIFF
--- a/packages/cozy-mjml/src/components/MJFooter.js
+++ b/packages/cozy-mjml/src/components/MJFooter.js
@@ -125,7 +125,7 @@ class MJFooter extends core.BodyComponent {
 MJFooter.endingTag = true
 
 MJFooter.allowedAttributes = {
-  locale: 'enum(fr,en)',
+  locale: 'string',
   instance: 'string'
 }
 

--- a/packages/cozy-mjml/src/components/MJHeader.js
+++ b/packages/cozy-mjml/src/components/MJHeader.js
@@ -39,7 +39,7 @@ class MJHeader extends core.BodyComponent {
 MJHeader.endingTag = true
 
 MJHeader.allowedAttributes = {
-  locale: 'enum(fr,en)',
+  locale: 'string',
   mycozy: 'boolean'
 }
 


### PR DESCRIPTION
Cozy-mjml will default to the english locale, without a warning, when using a locale other fr or en.