### PR TITLE
fix(harvest): Remove unsubscribingAll for realtime

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerLauncher.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerLauncher.jsx
@@ -50,6 +50,10 @@ export class TriggerLauncher extends Component {
       .on(TWO_FA_MISMATCH_EVENT, this.displayTwoFAModal)
   }
 
+  componentWillUnmount() {
+    this.props.konnectorJob.unwatch()
+  }
+
   dismissTwoFAModal() {
     // TODO: Make the modal not closable, or offer possibility to re-open it.
     this.setState({ showTwoFAModal: false })

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -44,6 +44,7 @@ export class TriggerManager extends Component {
     this.handleSubmitTwoFACode = this.handleSubmitTwoFACode.bind(this)
 
     this.jobWatcher = null
+    this.accountWatcher = null
 
     this.state = {
       account,
@@ -51,6 +52,11 @@ export class TriggerManager extends Component {
       status: IDLE,
       trigger
     }
+  }
+
+  componentWillUnmount() {
+    if (this.jobWatcher) this.jobWatcher.unsubscribeAll()
+    if (this.accountWatcher) this.accountWatcher.unsubscribeAll()
   }
 
   closeTwoFAModal() {
@@ -122,7 +128,7 @@ export class TriggerManager extends Component {
     this.setState({ account })
     const trigger = await this.ensureTrigger()
     this.setState({ trigger })
-    this.props.watchKonnectorAccount(account, {
+    this.accountWatcher = this.props.watchKonnectorAccount(account, {
       onTwoFACodeAsked: this.handleTwoFACodeAsked,
       onLoginSuccess: this.handleLoginSuccessState,
       onLoginSuccessHandled: this.disableSuccessTimer

--- a/packages/cozy-harvest-lib/src/models/konnector/KonnectorAccountWatcher.js
+++ b/packages/cozy-harvest-lib/src/models/konnector/KonnectorAccountWatcher.js
@@ -37,6 +37,10 @@ export class KonnectorAccountWatcher {
       this.handleAccountUpdated
     )
   }
+
+  unsubscribeAll() {
+    this.realtime.unsubscribeAll()
+  }
 }
 
 export default KonnectorAccountWatcher

--- a/packages/cozy-harvest-lib/src/models/konnector/KonnectorJobWatcher.js
+++ b/packages/cozy-harvest-lib/src/models/konnector/KonnectorJobWatcher.js
@@ -89,6 +89,10 @@ export class KonnectorJobWatcher {
       this.handleJobUpdated
     )
   }
+
+  unsubscribeAll() {
+    this.realtime.unsubscribeAll()
+  }
 }
 
 MicroEE.mixin(KonnectorJobWatcher)

--- a/packages/cozy-harvest-lib/src/models/konnector/KonnectorJobWatcher.js
+++ b/packages/cozy-harvest-lib/src/models/konnector/KonnectorJobWatcher.js
@@ -60,7 +60,6 @@ export class KonnectorJobWatcher {
       clearTimeout(this.successTimer)
       this.successTimer = null
     }
-    this.realtime.unsubscribeAll()
   }
 
   enableSuccessTimer(time) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3778,6 +3778,13 @@ cozy-logger@1.3.1:
   dependencies:
     json-stringify-safe "5.0.1"
 
+cozy-realtime@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-3.0.0.tgz#3328ff853683ff21b28026810c7f5c2f8382d8c3"
+  integrity sha512-5HTZ4VM/RSLrhAta4oMhnckj9f2klonj9Hx9FfzOyg7ObSq/eKrXJaAGFmepLYQEMewx9ynU4VmsyDXPZ2QV3A==
+  dependencies:
+    minilog "3.1.0"
+
 cozy-stack-client@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-6.25.0.tgz#4fc50087d900be4b0976ceca3606c77703cf5f52"


### PR DESCRIPTION
We will have to unsubscribe at term to handle correctly not used Realtime instances, but for now this unsubscribeAll just close the Job real-time instance and makes it unusable