### PR TITLE
Harvest: Prevent refresh on 2FA submit with enter

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
@@ -21,7 +21,10 @@ export class TwoFAForm extends PureComponent {
     this.setState({ twoFACode: e.currentTarget.value })
   }
 
-  handleSubmit() {
+  handleSubmit(e) {
+    // prevent refreshing the page when submitting
+    // (happens not systematically)
+    e.preventDefault()
     this.props.konnectorJob.sendTwoFACode(this.state.twoFACode)
   }
 


### PR DESCRIPTION
~~Returning false in a form submit function allow to disable refreshing the page on submitting with enter key~~
Edit: Finally, after testing, a `e.preventDefault` is doing the job