### PR TITLE
Harvest: Make 2FA modals not closeable

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TwoFAForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/TwoFAForm/index.jsx
@@ -52,7 +52,6 @@ export class TwoFAForm extends PureComponent {
       <Modal
         dismissAction={dismissAction}
         mobileFullscreen
-        closable
         containerClassName="u-pos-absolute"
         className={isMobile ? '' : 'u-mt-3'}
         size="xsmall"

--- a/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
@@ -43,7 +43,6 @@ export class TwoFAForm extends PureComponent {
       <Modal
         dismissAction={dismissAction}
         mobileFullscreen
-        closable
         containerClassName="u-pos-absolute"
         className={isMobile ? '' : 'u-mt-3'}
         size="xsmall"


### PR DESCRIPTION
To quickly avoid users being blocked by closing the 2FA modal (we don't have the resume feature yet)