### PR TITLE
Harvest: s/twofa_code/twoFACode

### DIFF
--- a/packages/cozy-harvest-lib/src/helpers/accounts.js
+++ b/packages/cozy-harvest-lib/src/helpers/accounts.js
@@ -103,7 +103,7 @@ export const mergeAuth = (account, authData) => ({
 export const updateTwoFaCode = (account, code) => ({
   // reset the state since the konnector is listening it
   ...resetState(account),
-  twofa_code: code
+  twoFACode: code
 })
 
 /**

--- a/packages/cozy-harvest-lib/test/helpers/accounts.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/accounts.spec.js
@@ -77,7 +77,7 @@ describe('Accounts Helper', () => {
       ).toEqual({
         ...fixtures.account,
         state: null,
-        twofa_code: 'atwofacode'
+        twoFACode: 'atwofacode'
       })
     })
   })


### PR DESCRIPTION
We used to have camelCase in documents properties