### PR TITLE
fix: :ambulance: Use static attribute for withLocales contextTypes

### DIFF
--- a/packages/cozy-harvest-lib/src/index.js
+++ b/packages/cozy-harvest-lib/src/index.js
@@ -11,7 +11,7 @@ const dictRequire = lang => require(`./locales/${lang}.json`)
 
 const withLocales = WrappedComponent =>
   class ComponentWithLocales extends Component {
-    contextTypes = {
+    static contextTypes = {
       lang: PropTypes.string.isRequired
     }
 


### PR DESCRIPTION
The previous version was not working on React, only on preact