### PR TITLE
feat(cozy-doctypes): Allow Document to use a CozyClient

### DIFF
--- a/packages/cozy-doctypes/package.json
+++ b/packages/cozy-doctypes/package.json
@@ -18,8 +18,12 @@
     "@babel/cli": "7.2.3",
     "babel-preset-cozy-app": "^1.5.1",
     "btoa": "1.2.1",
+    "cozy-client": "6.34.0",
     "cozy-client-js": "0.14.2",
     "jest": "24.1.0"
+  },
+  "peerDependencies": {
+    "cozy-client": "6.34.0"
   },
   "scripts": {
     "lint": "cd ../../; yarn lint packages/cozy-doctypes",

--- a/packages/cozy-doctypes/src/banking/BalanceHistory.spec.js
+++ b/packages/cozy-doctypes/src/banking/BalanceHistory.spec.js
@@ -1,13 +1,13 @@
 const BalanceHistory = require('./BalanceHistory')
 const Document = require('../Document')
-const { cozyClient } = require('../testUtils')
+const { cozyClientJS } = require('../testUtils')
 
 describe('Balance history', () => {
   let queryResult = []
 
   beforeAll(() => {
-    Document.registerClient(cozyClient)
-    cozyClient.data.query.mockImplementation(() => {
+    Document.registerClient(cozyClientJS)
+    cozyClientJS.data.query.mockImplementation(() => {
       return Promise.resolve(queryResult)
     })
   })
@@ -25,13 +25,13 @@ describe('Balance history', () => {
 
   it('should update or create on year + account linked', async () => {
     await BalanceHistory.createOrUpdate(doc)
-    expect(cozyClient.data.query).toHaveBeenCalledWith(expect.anything(), {
+    expect(cozyClientJS.data.query).toHaveBeenCalledWith(expect.anything(), {
       selector: {
         year: 2018,
         'relationships.account.data._id': 3
       }
     })
-    expect(cozyClient.data.create).toHaveBeenCalledTimes(1)
+    expect(cozyClientJS.data.create).toHaveBeenCalledTimes(1)
 
     queryResult = [
       {
@@ -47,6 +47,6 @@ describe('Balance history', () => {
     ]
 
     await BalanceHistory.createOrUpdate(doc)
-    expect(cozyClient.data.create).toHaveBeenCalledTimes(1)
+    expect(cozyClientJS.data.create).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/cozy-doctypes/src/testUtils.js
+++ b/packages/cozy-doctypes/src/testUtils.js
@@ -1,5 +1,10 @@
+const CozyClient = require('cozy-client').default
+const CozyStackClient = require('cozy-stack-client').default
+
+jest.mock('cozy-stack-client')
+
 module.exports = {
-  cozyClient: {
+  cozyClientJS: {
     data: {
       defineIndex: jest.fn().mockResolvedValue({ name: 'index' }),
       query: jest.fn().mockResolvedValue([]),
@@ -7,5 +12,8 @@ module.exports = {
       create: jest.fn()
     },
     fetchJSON: jest.fn().mockReturnValue({ rows: [] })
-  }
+  },
+  cozyClient: new CozyClient({
+    stackClient: new CozyStackClient()
+  })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3764,6 +3764,23 @@ cozy-client@^6.27.0:
     redux-thunk "2.3.0"
     sift "6.0.0"
 
+cozy-client@^6.34.0:
+  version "6.34.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-6.34.0.tgz#fcaac796f9689757c5b1f540e9d3b013f4c60f71"
+  integrity sha512-PmE4xeg9mtCWTlJjnTNO3NYzDbnuZADFA26KuMsihZEjgQZ/AQaVi0z+6julEEo10fTrRqQ+rWjYFMHUox2c0Q==
+  dependencies:
+    cozy-device-helper "1.6.3"
+    cozy-stack-client "^6.33.0"
+    lodash "4.17.11"
+    microee "0.0.6"
+    prop-types "15.6.2"
+    react "16.7.0"
+    react-redux "5.0.7"
+    redux "3.7.2"
+    redux-thunk "2.3.0"
+    sift "6.0.0"
+    url-search-params-polyfill "^6.0.0"
+
 cozy-device-helper@1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.6.3.tgz#186cf0682921fa3ec7c2343d94fb84f317c992ba"
@@ -3789,6 +3806,15 @@ cozy-stack-client@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-6.25.0.tgz#4fc50087d900be4b0976ceca3606c77703cf5f52"
   integrity sha512-SY7450Yg9n9HDcPsMaNgfTcId5rXOR7hpzyCo1OUZoLINOGlG9Crd10p01aiOLSbvw8z1piKJnGyxYSSrmBOXA==
+  dependencies:
+    detect-node "2.0.4"
+    mime-types "2.1.24"
+    qs "6.7.0"
+
+cozy-stack-client@^6.33.0:
+  version "6.33.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-6.33.0.tgz#62eca6b63f1d7202ae5032b28b47461be5e85199"
+  integrity sha512-7S8xPcd03BoEd/VFhBv/vxB/2P0U2SLK/wgFoLor7lPHJ00Al8q/pFFgDIb8r1eoK247augH/JrcDUGbSIhVQA==
   dependencies:
     detect-node "2.0.4"
     mime-types "2.1.24"
@@ -15206,6 +15232,11 @@ url-polyfill@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.1.0.tgz#d34e1a596d954b864bc8608f84c592820df422db"
   integrity sha512-QAbzqCwd84yA6VyjV30aZXla+lrRmczDurvlsVnK+tFOu677ZNGz8shcFWQRp5BF9/z7qvNiCQLqpWPtVoUEBg==
+
+url-search-params-polyfill@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-6.0.0.tgz#f5e5fc230d56125f5b0ba67d9cbcd6555fa347e3"
+  integrity sha512-69Bl5s3SiEgcHe8SMpzLGOyag27BQeTeSaP/CfVHkKc/VdUHtNjaP2PnhshFVC021221ItueOzuMMGofZ/HDmQ==
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
This is a first step to allow users to choose between `cozy-client` and `cozy-client-js` when they register a client for their models.

~~This is still at draft state since I would like to do the following before merge:~~
- ~~rename `  newCozyClient` :arrow_right: `cozyClient` and `cozyClient` :arrow_right: `cozyClientJS` in `testUtils.js`~~
- ~~add tests for methods that use "the `stackClient` trick" (`getAll`, `fetchChanges`, `fetchAll`, `updateAll`). To do this, I need to be able to mock the stack client that `CozyClient` uses, it may not be easy.~~
- ~~we could also be more explicit in the methods names (e.g `_ccjs_getIndex` instead of `_getIndex` ?)~~