### PR TITLE
feat: Deprecate options.cozyClient, use options.client

### DIFF
--- a/packages/cozy-realtime/src/index.js
+++ b/packages/cozy-realtime/src/index.js
@@ -124,10 +124,21 @@ class CozyRealtime {
    * - unsubscribeAll if window unload
    *
    * @constructor
-   * @param {CozyClient} cozyClient  A cozy client
+   * @param {CozyClient} client  A cozy client
+   * @param {CozyClient} cozyClient  A cozy client [DEPRECATED]
    */
-  constructor({ cozyClient }) {
-    this._cozyClient = cozyClient
+  constructor({ cozyClient, client }) {
+    if (cozyClient) {
+      console.warn(
+        'Realtime: options.cozyClient is deprecated, please use options.client'
+      )
+    }
+    this._cozyClient = client || cozyClient
+    if (!this._cozyClient) {
+      throw new Error(
+        'Realtime must be initialized with a client. Ex: new Realtime({ client })'
+      )
+    }
 
     this._updateAuthentication = this._updateAuthentication.bind(this)
     this.unsubscribeAll = this.unsubscribeAll.bind(this)

--- a/packages/cozy-realtime/src/index.spec.js
+++ b/packages/cozy-realtime/src/index.spec.js
@@ -25,7 +25,7 @@ describe('CozyRealtime', () => {
   let realtime, cozyStack
 
   beforeEach(() => {
-    realtime = new CozyRealtime({ cozyClient })
+    realtime = new CozyRealtime({ client: cozyClient })
     cozyStack = new Server(WS_URL)
     cozyStack.emitMessage = (type, doc, event, id) => {
       cozyStack.emit(


### PR DESCRIPTION
Intents / Bar etc..  use options.client for the CozyClient, it will be
easier to have the plugin system if all classes depending on the client
use the same attribute to initialize.

Fixes https://github.com/cozy/cozy-libs/pull/456
