### PR TITLE
fix(cozy-doctypes): Remove Document.dangerousUnregisterClient method

### DIFF
--- a/packages/cozy-doctypes/src/Document.js
+++ b/packages/cozy-doctypes/src/Document.js
@@ -82,15 +82,6 @@ class Document {
   }
 
   /**
-   * Unregisters a client
-   *
-   * This method is dangerous and is meant to be used only by tests.
-   */
-  static dangerousUnregisterClient() {
-    this.cozyClient = null
-  }
-
-  /**
    * Returns true if Document uses a CozyClient (from cozy-client package)
    *
    * @returns {boolean} true if Document uses a CozyClient

--- a/packages/cozy-doctypes/src/Document.spec.js
+++ b/packages/cozy-doctypes/src/Document.spec.js
@@ -19,7 +19,7 @@ describe('Document', () => {
 
   afterEach(() => {
     jest.restoreAllMocks()
-    Document.dangerousUnregisterClient()
+    Document.cozyClient = null
   })
 
   describe('registerClient', () => {
@@ -391,7 +391,7 @@ describe('Document used with CozyClient', () => {
 
   afterEach(() => {
     jest.restoreAllMocks()
-    Document.dangerousUnregisterClient()
+    Document.cozyClient = null
   })
 
   describe('usesCozyClient', () => {


### PR DESCRIPTION
See discussion here: https://github.com/cozy/cozy-libs/pull/455#discussion_r287279803
We don't want `Document.dangerousUnregisterClient` method. Just set the `cozyClient` to `null` manually when we need to in the tests.