### PR TITLE
Harvest: quick refactor for a better translation mechanism

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -39,7 +39,7 @@
     "cozy-client": "6.26.0",
     "cozy-device-helper": "1.7.1",
     "cozy-realtime": "3.0.0",
-    "cozy-ui": "19.35.4",
+    "cozy-ui": "20.6.0",
     "enzyme": "3.9.0",
     "enzyme-adapter-react-16": "1.11.2",
     "identity-obj-proxy": "3.0.0",
@@ -54,6 +54,6 @@
     "cozy-client": "6.26.0",
     "cozy-device-helper": "1.7.1",
     "cozy-realtime": "3.0.0",
-    "cozy-ui": "19.35.4"
+    "cozy-ui": "20.6.0"
   }
 }

--- a/packages/cozy-harvest-lib/src/components/DeleteAccountButton.jsx
+++ b/packages/cozy-harvest-lib/src/components/DeleteAccountButton.jsx
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types'
 import omit from 'lodash/omit'
 
 import { Button } from 'cozy-ui/react/Button'
-import { translate } from 'cozy-ui/react/I18n'
 import { withMutations } from 'cozy-client'
 
 import accountsMutations from '../connections/accounts'
+import withLocales from './hoc/withLocales'
 
 export class DeleteAccountButton extends Component {
   constructor(props) {
@@ -74,6 +74,6 @@ DeleteAccountButton.propTypes = {
   t: PropTypes.func.isRequired
 }
 
-export default translate()(
+export default withLocales(
   withMutations(accountsMutations)(DeleteAccountButton)
 )

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
 import { withMutations } from 'cozy-client'
-import { translate } from 'cozy-ui/react/I18n'
 
 import AccountForm from './AccountForm'
 import TwoFAForm from './TwoFAForm'
@@ -15,6 +14,7 @@ import cron from '../helpers/cron'
 import konnectors from '../helpers/konnectors'
 import { slugify } from '../helpers/slug'
 import triggers from '../helpers/triggers'
+import withLocales from './hoc/withLocales'
 
 const ERRORED = 'ERRORED'
 const IDLE = 'IDLE'
@@ -368,7 +368,7 @@ TriggerManager.propTypes = {
   onSuccess: PropTypes.func
 }
 
-export default translate()(
+export default withLocales(
   withMutations(
     accountsMutations,
     filesMutations,

--- a/packages/cozy-harvest-lib/src/components/hoc/withLocales.js
+++ b/packages/cozy-harvest-lib/src/components/hoc/withLocales.js
@@ -1,0 +1,5 @@
+import withLocales from 'cozy-ui/transpiled/react/I18n/withLocales'
+
+const dictRequire = lang => require(`../../locales/${lang}.json`)
+
+export default withLocales(dictRequire)

--- a/packages/cozy-harvest-lib/src/index.js
+++ b/packages/cozy-harvest-lib/src/index.js
@@ -1,39 +1,7 @@
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
-import I18n from 'cozy-ui/react/I18n'
-
-import TranslatedDeleteAccountButton from './components/DeleteAccountButton'
-import TranslatedTriggerManager from './components/TriggerManager'
-import TranslatedTriggerLauncher from './components/TriggerLauncher'
+export {
+  default as DeleteAccountButton
+} from './components/DeleteAccountButton'
+export { default as TriggerManager } from './components/TriggerManager'
+export { default as TriggerLauncher } from './components/TriggerLauncher'
 
 export { KonnectorJobError } from './helpers/konnectors'
-
-const dictRequire = lang => require(`./locales/${lang}.json`)
-
-const withLocales = WrappedComponent =>
-  class ComponentWithLocales extends Component {
-    static contextTypes = {
-      lang: PropTypes.string.isRequired
-    }
-
-    render() {
-      const { lang } = this.context
-      return (
-        <I18n dictRequire={dictRequire} lang={lang}>
-          <WrappedComponent {...this.props} />
-        </I18n>
-      )
-    }
-  }
-
-export const DeleteAccountButton = withLocales(TranslatedDeleteAccountButton)
-
-export const TriggerManager = withLocales(TranslatedTriggerManager)
-
-export const TriggerLauncher = withLocales(TranslatedTriggerLauncher)
-
-export default {
-  DeleteAccountButton,
-  TriggerLauncher,
-  TriggerManager
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3836,10 +3836,10 @@ cozy-stack-client@^6.33.0:
     mime-types "2.1.24"
     qs "6.7.0"
 
-cozy-ui@19.35.4:
-  version "19.35.4"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-19.35.4.tgz#c8225cd0dda36b7cc440b02d3066e8b04828b990"
-  integrity sha512-kp5OIexzi1qzv0U3nj1TjuIhjvVcbmgYWZ1Q6RK3LXgkhGMBV5bEd7G9XXRDcf+e4YweEJ+18ihMQ3SBFlgYnA==
+cozy-ui@20.6.0:
+  version "20.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-20.6.0.tgz#9435fc5ff949ecaf1702811ff6a41cfb501599c9"
+  integrity sha512-CvwWTpn4kGf94t62hDZSUYS9NuLJCQzvrSYgrjZ5yOD0uqMx1F3Qv51OGzPCb2iTKiiq1wxtcSgpwuxKkG0hpg==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"


### PR DESCRIPTION
This PR uses `withLocales` from Cozy-UI.

Default exports from components are now directly translated.

It will allow us to export HOC wrapping component with translated component.