### PR TITLE
Harvest: Add a konnector modal to edit existing accounts

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -91,14 +91,27 @@ export class KonnectorModal extends PureComponent {
             <SubTitle className="u-mb-1 u-ta-center">
               {t('modal.konnector.title', { name: konnector.name })}
             </SubTitle>
-            <TriggerManager
-              account={account}
-              konnector={konnector}
-              trigger={trigger}
-              running={running}
-              onLoginSuccess={onLoginSuccess}
-              onSuccess={onSuccess}
-            />
+            {error ? (
+              <Infos
+                actionButton={
+                  <Button theme="danger">
+                    {t('modal.konnector.error.button')}
+                  </Button>
+                }
+                title={t('modal.konnector.error.title')}
+                text={t('modal.konnector.error.description', error)}
+                isImportant
+              />
+            ) : (
+              <TriggerManager
+                account={account}
+                konnector={konnector}
+                trigger={trigger}
+                running={running}
+                onLoginSuccess={onLoginSuccess}
+                onSuccess={onSuccess}
+              />
+            )}
           </ModalContent>
         )}
       </Modal>

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 
 import { withMutations } from 'cozy-client'
 import AppIcon from 'cozy-ui/react/AppIcon'
+import Button from 'cozy-ui/react/Button'
+import Infos from 'cozy-ui/react/Infos'
 import Modal, { ModalContent, ModalHeader } from 'cozy-ui/react/Modal'
 import Spinner from 'cozy-ui/react/Spinner'
 import { SubTitle } from 'cozy-ui/react/Text'
@@ -40,11 +42,19 @@ export class KonnectorModal extends PureComponent {
     this.setState({ fetching: true })
     const { konnector } = this.props
     const trigger = konnector.triggers.data[0]
-    const account = await findAccount(triggers.getAccountId(trigger))
-    this.setState({
-      account,
-      fetching: false
-    })
+
+    try {
+      const account = await findAccount(triggers.getAccountId(trigger))
+      this.setState({ account })
+    } catch (error) {
+      this.setState({
+        error
+      })
+    } finally {
+      this.setState({
+        fetching: false
+      })
+    }
   }
 
   fetchIcon() {
@@ -67,7 +77,7 @@ export class KonnectorModal extends PureComponent {
       t
     } = this.props
 
-    const { account, fetching, trigger } = this.state
+    const { account, error, fetching, trigger } = this.state
 
     return (
       <Modal
@@ -79,6 +89,16 @@ export class KonnectorModal extends PureComponent {
         <ModalHeader>
           <AppIcon fetchIcon={this.fetchIcon} className="u-mah-3 u-ml-1" />
         </ModalHeader>
+        {error && (
+          <Infos
+            actionButton={
+              <Button theme="danger">{t('modal.konector.error.button')}</Button>
+            }
+            title={t('modal.konnector.error.title')}
+            text={t('modal.konnector.error.description', error)}
+            isImportan
+          />
+        )}
         {fetching ? (
           <ModalContent>
             <Spinner

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -37,6 +37,21 @@ export class KonnectorModal extends PureComponent {
     this.fetchAccount()
   }
 
+  componentWillUnmount() {
+    const { into } = this.props
+    if (!into) return
+    // The Modal is never closed after a dismiss on Preact apps, even if it is
+    // not rendered anymore. The best hack we found is to explicitly empty the
+    // modal portal container.
+    setTimeout(() => {
+      try {
+        const modalRoot = document.querySelector(into)
+        modalRoot.innerHTML = ''
+        // eslint-disable-next-line no-empty
+      } catch (error) {}
+    }, 50)
+  }
+
   async fetchAccount() {
     const { findAccount } = this.props
     this.setState({ fetching: true })

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -1,0 +1,113 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+
+import { withMutations } from 'cozy-client'
+import AppIcon from 'cozy-ui/react/AppIcon'
+import Modal, { ModalContent, ModalHeader } from 'cozy-ui/react/Modal'
+import Spinner from 'cozy-ui/react/Spinner'
+import { SubTitle } from 'cozy-ui/react/Text'
+
+import accountMutations from '../connections/accounts'
+import * as triggers from '../helpers/triggers'
+import TriggerManager from './TriggerManager'
+import withLocales from './hoc/withLocales'
+
+/**
+ * KonnectorModal open a Modal related to a given konnector. It fetches the
+ * first account and then include a TriggerManager component.
+ *
+ * This component is aimed to offer an UI to manage all the konnector related
+ * triggers and accounts.
+ */
+export class KonnectorModal extends PureComponent {
+  state = {
+    account: null,
+    fetching: true,
+    trigger: null
+  }
+
+  constructor(props) {
+    super(props)
+    this.fetchIcon = this.fetchIcon.bind(this)
+  }
+
+  componentDidMount() {
+    this.fetchAccount()
+  }
+
+  async fetchAccount() {
+    const { findAccount } = this.props
+    this.setState({ fetching: true })
+    const { konnector } = this.props
+    const trigger = konnector.triggers.data[0]
+    const account = await findAccount(triggers.getAccountId(trigger))
+    this.setState({
+      account,
+      fetching: false
+    })
+  }
+
+  fetchIcon() {
+    const { client } = this.context
+    const { konnector } = this.props
+    return client.stackClient.getIconURL({
+      type: 'konnector',
+      slug: konnector.slug
+    })
+  }
+
+  render() {
+    const {
+      dismissAction,
+      konnector,
+      into,
+      onLoginSuccess,
+      onSuccess,
+      running,
+      t
+    } = this.props
+
+    const { account, fetching, trigger } = this.state
+
+    return (
+      <Modal
+        dismissAction={dismissAction}
+        mobileFullscreen
+        size="small"
+        into={into}
+      >
+        <ModalHeader>
+          <AppIcon fetchIcon={this.fetchIcon} className="u-mah-3 u-ml-1" />
+        </ModalHeader>
+        {fetching ? (
+          <ModalContent>
+            <Spinner
+              size="xxlarge"
+              className="u-flex u-flex-justify-center u-pv-3"
+            />
+          </ModalContent>
+        ) : (
+          <ModalContent>
+            <SubTitle className="u-mb-1 u-ta-center">
+              {t('modal.konnector.title', { name: konnector.name })}
+            </SubTitle>
+            <TriggerManager
+              account={account}
+              konnector={konnector}
+              trigger={trigger}
+              running={running}
+              onLoginSuccess={onLoginSuccess}
+              onSuccess={onSuccess}
+            />
+          </ModalContent>
+        )}
+      </Modal>
+    )
+  }
+}
+
+KonnectorModal.contextTypes = {
+  client: PropTypes.object.isRequired
+}
+
+export default withMutations(accountMutations)(withLocales(KonnectorModal))

--- a/packages/cozy-harvest-lib/src/components/hoc/withKonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/hoc/withKonnectorModal.jsx
@@ -1,0 +1,69 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+
+import KonnectorModal from '../KonnectorModal'
+
+export const withKonnectorModal = WrappedComponent => {
+  class WrappedComponentWithPropTypes extends WrappedComponent {
+    static propTypes = {
+      ...WrappedComponent.propTypes,
+      closeKonnectorModal: PropTypes.func.isRequired,
+      openKonnectorModal: PropTypes.func.isRequired
+    }
+  }
+
+  class ComponentWithKonnectorModal extends PureComponent {
+    state = {
+      opened: false
+    }
+
+    constructor(props, context) {
+      super(props, context)
+
+      this.handleOpenModal = this.handleOpenModal.bind(this)
+      this.handleCloseModal = this.handleCloseModal.bind(this)
+    }
+
+    handleOpenModal({ konnector, into }) {
+      this.setState({
+        konnector,
+        opened: true,
+        into
+      })
+    }
+
+    handleCloseModal() {
+      this.setState({
+        opened: false
+      })
+    }
+
+    render() {
+      const { konnector, into, opened } = this.state
+      return (
+        <>
+          <WrappedComponentWithPropTypes
+            {...this.props}
+            openKonnectorModal={this.handleOpenModal}
+            closeKonnectorModal={this.handleCloseModal}
+          />
+          {opened && (
+            <KonnectorModal
+              dismissAction={this.handleCloseModal}
+              konnector={konnector}
+              into={into}
+            />
+          )}
+        </>
+      )
+    }
+  }
+
+  ComponentWithKonnectorModal.propTypes = {
+    ...WrappedComponent.prop
+  }
+
+  return ComponentWithKonnectorModal
+}
+
+export default withKonnectorModal

--- a/packages/cozy-harvest-lib/src/index.js
+++ b/packages/cozy-harvest-lib/src/index.js
@@ -2,6 +2,9 @@ export {
   default as DeleteAccountButton
 } from './components/DeleteAccountButton'
 export { default as KonnectorModal } from './components/KonnectorModal'
+export {
+  default as withKonnectorModal
+} from './components/hoc/withKonnectorModal'
 export { default as TriggerManager } from './components/TriggerManager'
 export { default as TriggerLauncher } from './components/TriggerLauncher'
 

--- a/packages/cozy-harvest-lib/src/index.js
+++ b/packages/cozy-harvest-lib/src/index.js
@@ -1,6 +1,7 @@
 export {
   default as DeleteAccountButton
 } from './components/DeleteAccountButton'
+export { default as KonnectorModal } from './components/KonnectorModal'
 export { default as TriggerManager } from './components/TriggerManager'
 export { default as TriggerLauncher } from './components/TriggerLauncher'
 

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -243,7 +243,12 @@
   },
   "modal": {
     "konnector": {
-      "title": "Connect your %{name} account"
+      "title": "Connect your %{name} account",
+      "error": {
+        "title": "Unable to retrieve your account",
+        "description": "The account cannot be retrieved (%{message}).",
+        "button": "Close"
+      }
     }
   }
 }

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -240,5 +240,10 @@
         "label": "Tricount URL"
       }
     }
+  },
+  "modal": {
+    "konnector": {
+      "title": "Connect your %{name} account"
+    }
   }
 }


### PR DESCRIPTION
For now this modal just fetch the first account related to given konnector and then rely on TriggerManager, like it's done in Cozy-Home.

~~Blocked by https://github.com/cozy/cozy-libs/pull/467, both `KonnectorModal` and `withKonnectorModal` should be exported in index.js.~~

Replace both https://github.com/cozy/cozy-libs/pull/440 and https://github.com/cozy/cozy-libs/pull/461