### PR TITLE
Prevent undefined success callback

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -206,7 +206,7 @@ export class TriggerManager extends Component {
    */
   handleSuccess(successCallback, args) {
     this.setState({ status: IDLE })
-    successCallback(...args)
+    if (typeof successCallback === 'function') successCallback(...args)
   }
 
   /**


### PR DESCRIPTION
Throw error during the process if not provided, and this prop is optional