### PR TITLE
[harvest]: Correctly set fetched trigger in state in KonnectorModal

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -61,7 +61,7 @@ export class KonnectorModal extends PureComponent {
 
     try {
       const account = await findAccount(triggers.getAccountId(trigger))
-      this.setState({ account })
+      this.setState({ account, trigger })
     } catch (error) {
       this.setState({
         error

--- a/packages/cozy-harvest-lib/test/components/KonnectorModal.spec.js
+++ b/packages/cozy-harvest-lib/test/components/KonnectorModal.spec.js
@@ -1,0 +1,35 @@
+/* eslint-env jest */
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import { KonnectorModal } from 'components/KonnectorModal'
+import TriggerManager from 'components/TriggerManager'
+
+const t = key => key
+
+const findAccountMock = jest.fn().mockImplementation(() => ({
+  id: 123,
+  doctype: 'io.cozy.accounts'
+}))
+
+describe('KonnectorModal', () => {
+  it('should pass trigger if konnector has triggers', async () => {
+    const mockKonnector = {
+      slug: 'mock',
+      name: 'Mock',
+      triggers: {
+        data: [{ id: 784, doctype: 'io.cozy.triggers' }]
+      }
+    }
+    const props = {
+      findAccount: findAccountMock,
+      dismissAction: jest.fn(),
+      onSuccess: jest.fn(),
+      konnector: mockKonnector,
+      t
+    }
+    const component = await shallow(<KonnectorModal {...props} />)
+    const manager = component.find(TriggerManager)
+    expect(manager.props().trigger).toBeDefined()
+  })
+})


### PR DESCRIPTION
The trigger was not stored into the state to be used correctly by the component