### PR TITLE
fix(device): Check if window in the globals

### DIFF
--- a/packages/cozy-device-helper/src/cordova.js
+++ b/packages/cozy-device-helper/src/cordova.js
@@ -1,2 +1,3 @@
 // cordova
-export const isCordova = () => window.cordova !== undefined
+export const isCordova = () =>
+  typeof window !== 'undefined' && window.cordova !== undefined


### PR DESCRIPTION
Some of the helpers of AppLinker can be used in NodeJS environments (to build
emails for example). In nodeJS, window is absent from globals so I added a 
small check.