### PR TITLE
Don't close 2FA modal on clickoutside event

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -59,7 +59,10 @@ export class TriggerManager extends Component {
     if (this.accountWatcher) this.accountWatcher.unsubscribeAll()
   }
 
-  closeTwoFAModal() {
+  closeTwoFAModal(e) {
+    // disable click outside
+    // the click outside doesn't forward event object here
+    if (!e) return
     this.setState({
       status: RUNNING
     })


### PR DESCRIPTION
By disabling it the user can't close the modal by inadvertence and being blocked outside of the 2FA process