### PR TITLE
feat: Add codemod for flags accessible via "cozy-flags apply"

### DIFF
--- a/packages/cozy-flags/bin/cozy-flags
+++ b/packages/cozy-flags/bin/cozy-flags
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+const codemod = require.resolve('cozy-flags/dist/flag-codemod')
+const spawn = require('child_process').spawn
+
+const attachIO = stream => {
+  stream.stdout.on('data', d => process.stdout.write(d))
+  stream.stderr.on('data', d => process.stderr.write(d))
+}
+
+const sh = (command, args) => {
+  const s = spawn(command, args)
+  attachIO(s)
+}
+
+const applyJscodeshiftOptions = [
+  '--parser',
+  'babel',
+  '--extensions',
+  'js,jsx',
+]
+
+const applyFlag = (flag, ...args) => {
+  sh('env', [
+    `FLAG=${flag}`,
+    'jscodeshift',
+    '-t',
+    codemod,
+    ...applyJscodeshiftOptions,
+    ...args
+  ]);
+}
+
+const usage = () => {
+  console.log(`Usage: cozy-flags <mode> [modeOptions...]
+
+Modes:
+
+- apply : Applies a flag to a directory.
+  Usage: \`cozy-flags apply <flagName> [...jscodeshiftOptions]\`
+  Example: cozy-flags apply my-flag src/ducks
+  Already applied jscodeshift options : ${applyJscodeshiftOptions.join(' ')}`)
+}
+
+const main = (mode, ...args) => {
+  if (mode === 'apply') {
+    applyFlag(...args)
+  } else {
+    usage()
+    process.exit(1)
+  }
+}
+
+main(...process.argv.slice(2))
+

--- a/packages/cozy-flags/package.json
+++ b/packages/cozy-flags/package.json
@@ -13,6 +13,9 @@
   "bugs": {
     "url": "https://github.com/cozy/cozy-libs/issues"
   },
+  "bin": {
+    "cozy-flags": "./bin/cozy-flags"
+  },
   "scripts": {
     "build": "babel src -d dist --verbose",
     "prepublishOnly": "yarn build",

--- a/packages/cozy-flags/src/flag-codemod.js
+++ b/packages/cozy-flags/src/flag-codemod.js
@@ -1,0 +1,99 @@
+const flagCallFinder = name => ({
+  callee: { name: 'flag' },
+  arguments: [{ value: name }]
+})
+
+/** Returns true if path is Program or a Block */
+const isBlockLike = path => {
+  return path.value && path.value.length !== undefined && path.name === 'body'
+}
+
+/** Replace without keeping blocks, flattening the newNode into path */
+const flatReplace = (path, newNode) => {
+  if (
+    newNode &&
+    newNode.type === 'BlockStatement' &&
+    isBlockLike(path.parentPath)
+  ) {
+    const node = path.parentPath.value.find(n => n === path.node)
+    const index = path.parentPath.value.indexOf(node)
+    path.parentPath.value.splice(index, 0, ...newNode.body)
+    path.replace(null)
+  } else {
+    path.replace(newNode)
+  }
+}
+
+const simplifyConditions = (root, j) => {
+  // Unary expressions with true/false
+  for (let v of [true, false]) {
+    root
+      .find(j.UnaryExpression, {
+        operator: '!',
+        argument: { value: v }
+      })
+      .forEach(path => {
+        path.replace(v ? j.literal(false) : j.literal(true))
+      })
+  }
+
+  // Binary expressions with true/false
+  for (let v of [true, false]) {
+    for (let operator of ['&&', '||']) {
+      for (let dir of ['left', 'right']) {
+        const otherDir = dir === 'left' ? 'right' : 'left'
+        const exps = root.find(j.LogicalExpression, {
+          [dir]: { value: v },
+          operator: operator
+        })
+        exps.forEach(exp => {
+          if (operator == '&&') {
+            exp.replace(v ? exp.node[otherDir] : exp.node[dir])
+          } else {
+            exp.replace(exp.node[otherDir])
+          }
+        })
+      }
+    }
+  }
+
+  // Simplify ternary conditions
+  for (let v of [true, false]) {
+    const conditionals = root.find(j.ConditionalExpression, {
+      test: { value: v }
+    })
+    conditionals.forEach(conditional => {
+      conditional.replace(
+        v ? conditional.node.consequent : conditional.node.alternate
+      )
+    })
+  }
+
+  // Simplify ifs
+  for (let v of [true, false]) {
+    const ifs = root.find(j.IfStatement, { test: { value: v } })
+    ifs.forEach(ifStatement => {
+      flatReplace(
+        ifStatement,
+        v ? ifStatement.node.consequent : ifStatement.node.alternate
+      )
+    })
+  }
+}
+
+module.exports = function transformer(file, api) {
+  const j = api.jscodeshift
+  const root = j(file.source)
+
+  // Replace flags by true
+  const flagName =
+    typeof process !== 'undefined' ? process.env.FLAG : 'reimbursement-tag'
+  const flags = root.find(j.CallExpression, flagCallFinder(flagName))
+  flags.forEach(flagCall => {
+    flagCall.replace(j.literal(true))
+  })
+
+  simplifyConditions(root, j)
+
+  return root.toSource()
+}


### PR DESCRIPTION
Automatically applies a flag.

- replaces instances of `flag(FLAG_NAME)` by true
- resolves resulting logical expressions, unary expressions and ternary expressions.
- remove unused imports

```bash
$ yarn add cozy-flags
$ cozy-flags apply 'reimbursement-tag' src/ducks
```

Input

```js
class Blabla {
  render () {
    return flag('reimbursement-tag') ? <NewStuff /> : <OldStuff />
  }
}
  
flag('reimbursement-tag') ? 'ternary condition true': null
!flag('reimbursement-tag') ? false: 'ternary condition false'

if (flag('reimbursement-tag')) {
  console.log('if reimbursement-tag')
} else if (removed) {
} else {
}

if (!flag('reimbursement-tag')) {
  console.log('removed')
} else {
  console.log('else reimbursement-tag')
}

!true
!false

true && "True and"
false && "False and"
false || "False or"
true || "True or"
"True or right" || true
```

Output

```js
class Blabla {
  render () {
    return <NewStuff />;
  }
}

'ternary condition true'
'ternary condition false'

console.log('if reimbursement-tag')
console.log('else reimbursement-tag')

false
true

"True and"
false
"False or"
"True or"
"True or right"
```