### PR TITLE
Harvest: Add DeleteAccountCard component

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -40,7 +40,7 @@
     "cozy-client": "6.26.0",
     "cozy-device-helper": "^1.7.2",
     "cozy-realtime": "3.0.0",
-    "cozy-ui": "20.6.0",
+    "cozy-ui": "20.14.0",
     "enzyme": "3.9.0",
     "enzyme-adapter-react-16": "1.11.2",
     "identity-obj-proxy": "3.0.0",
@@ -55,6 +55,6 @@
     "cozy-client": "6.26.0",
     "cozy-device-helper": "1.7.1",
     "cozy-realtime": "3.0.0",
-    "cozy-ui": "20.6.0"
+    "cozy-ui": "20.14.0"
   }
 }

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -12,7 +12,7 @@ import { SubTitle } from 'cozy-ui/react/Text'
 import accountMutations from '../connections/accounts'
 import * as triggers from '../helpers/triggers'
 import TriggerManager from './TriggerManager'
-import DeleteAccountButton from './DeleteAccountButton'
+import DeleteAccountCard from './cards/DeleteAccountCard'
 import withLocales from './hoc/withLocales'
 
 /**
@@ -138,10 +138,9 @@ export class KonnectorModal extends PureComponent {
                   onLoginSuccess={onLoginSuccess}
                   onSuccess={onSuccess}
                 />
-                <DeleteAccountButton
+                <DeleteAccountCard
                   account={account}
                   onSuccess={dismissAction}
-                  extension="full"
                 />
               </div>
             )}

--- a/packages/cozy-harvest-lib/src/components/cards/DeleteAccountCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/DeleteAccountCard.jsx
@@ -1,0 +1,32 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+
+import Card from 'cozy-ui/react/Card'
+import { translate } from 'cozy-ui/react/I18n'
+import { SubTitle, Text } from 'cozy-ui/react/Text'
+
+import DeleteAccountButton from '../DeleteAccountButton'
+
+export class DeleteAccountCard extends PureComponent {
+  render() {
+    const { account, onSuccess, t } = this.props
+    return (
+      <Card>
+        <SubTitle className="u-mb-1">{t('card.deleteAccount.title')}</SubTitle>
+        <Text className="u-mb-1">{t('card.deleteAccount.description')}</Text>
+        <DeleteAccountButton
+          account={account}
+          onSuccess={onSuccess}
+          extension="full"
+        />
+      </Card>
+    )
+  }
+}
+
+DeleteAccountCard.propTypes = {
+  ...DeleteAccountButton.propTypes,
+  t: PropTypes.func.isRequired
+}
+
+export default translate()(DeleteAccountCard)

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -14,6 +14,12 @@
       "button": "Disconnect this account"
     }
   },
+  "card": {
+    "deleteAccount": {
+      "title": "Disconnection",
+      "description": "Your will be disconnected from this account, but imported data will be kept"
+    }
+  },
   "default": {
     "dateFormat": "MM/DD/YYYY",
     "baseDir": "/Administrative"

--- a/packages/cozy-harvest-lib/test/components/cards/DeleteAccountCard.spec.js
+++ b/packages/cozy-harvest-lib/test/components/cards/DeleteAccountCard.spec.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import DeleteAccountCard from 'components/cards/DeleteAccountCard'
+
+const fixtures = {
+  account: {
+    _id: '1865a2e044414a15aebbad75ca96c5cc'
+  }
+}
+
+const props = {
+  account: fixtures.account,
+  onSuccess: jest.fn(),
+  t: key => key
+}
+
+describe('DeleteAccountCard', () => {
+  it('should render', () => {
+    const component = shallow(<DeleteAccountCard {...props} />).getElement()
+    expect(component).toMatchSnapshot()
+  })
+})

--- a/packages/cozy-harvest-lib/test/components/cards/__snapshots__/DeleteAccountCard.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/cards/__snapshots__/DeleteAccountCard.spec.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DeleteAccountCard should render 1`] = `
+<DeleteAccountCard
+  account={
+    Object {
+      "_id": "1865a2e044414a15aebbad75ca96c5cc",
+    }
+  }
+  onSuccess={[MockFunction]}
+/>
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4563,10 +4563,10 @@ cozy-stack-client@^6.33.0:
     mime-types "2.1.24"
     qs "6.7.0"
 
-cozy-ui@20.6.0:
-  version "20.6.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-20.6.0.tgz#9435fc5ff949ecaf1702811ff6a41cfb501599c9"
-  integrity sha512-CvwWTpn4kGf94t62hDZSUYS9NuLJCQzvrSYgrjZ5yOD0uqMx1F3Qv51OGzPCb2iTKiiq1wxtcSgpwuxKkG0hpg==
+cozy-ui@20.14.0:
+  version "20.14.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-20.14.0.tgz#4d5510caa5fe9d75f031a6e2dff5075a6c4177a5"
+  integrity sha512-0Spt/Yzjw/OkRbYOxqxHnGFKLpxy8puyQkQ2iHAkDLMuESatlNyuhRQxHpzFiYGUf1p5jXlN/k7p1dmv39iZyQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"


### PR DESCRIPTION
~~🚫 Blocked by https://github.com/cozy/cozy-ui/pull/1032~~

DeleteAccountCard is based on Cozy UI's `Card` component. It group title, description and `DeleteAccountButton` component.

It is used in `KonnectorModal`.

Web:

![Capture d’écran 2019-06-10 à 19 14 44](https://user-images.githubusercontent.com/776764/59215577-df1de600-8bb9-11e9-9554-31b72b9c3331.png)

Mobile:

![Capture d’écran 2019-06-10 à 19 14 36](https://user-images.githubusercontent.com/776764/59215596-e80eb780-8bb9-11e9-8245-6b21f39f87ce.png)
