### PR TITLE
docs(playground): Add note about http/https

### DIFF
--- a/packages/cozy-authentication/src/steps/SelectServer.jsx
+++ b/packages/cozy-authentication/src/steps/SelectServer.jsx
@@ -106,7 +106,10 @@ export class SelectServer extends Component {
     }
 
     const url = this.getUrl(value)
-    if (url === '' || (/^http:/.test(url) && !__ALLOW_HTTP__)) {
+    if (
+      url === '' ||
+      (/^http:/.test(url) && typeof __ALLOW_HTTP__ === undefined)
+    ) {
       error = ERR_WRONG_ADDRESS
     }
     if (error) {

--- a/packages/playgrounds/README.md
+++ b/packages/playgrounds/README.md
@@ -1,0 +1,17 @@
+## How to use it
+
+```jsx
+yarn start
+```
+
+If you work on a local cozy and you don't have https enabled you have to define a global `ALLOW_HTTP` var at start to be able to login (see this line in cozy-authentication https://github.com/cozy/cozy-libs/blob/master/packages/cozy-authentication/src/steps/SelectServer.jsx#L111). With `parcel` you can use the `--global` option to do so
+
+```
+yarn start --global ALLOW_HTTP
+```
+
+Don't forget to launch your browser with disabled CORS and write the full domain for your cozy when reaching http://localhost:1234/index.html :
+
+```
+http://cozy.tools:8080
+```


### PR DESCRIPTION
If you don't have https enabled on your stack, you can set ALLOW_HTTP
to allow the connexion though http