### PR TITLE
fix(cozy-mjml): Tell to webpack to not handle require

### DIFF
--- a/packages/cozy-mjml/webpack.config.js
+++ b/packages/cozy-mjml/webpack.config.js
@@ -23,6 +23,16 @@ module.exports = {
       })
     ]
   },
+  /**
+   * Needed in order to be able to build cozy-mjml on Mac OS.
+   * cozy-mjml `require(mjml)` and mjml use fsevents > node-pre-gyp.
+   * See this comment for more information : https://github.com/mapbox/node-pre-gyp/issues/238#issuecomment-267889753
+   *
+   * We simply tell webpack that fsevents should be required at runtime and not during the build
+   */
+  externals: {
+    fsevents: 'fsevents'
+  },
   module: {
     rules: [{ test: /node_modules\/datauri\/index.js$/, use: 'shebang-loader' }]
   },


### PR DESCRIPTION
Before, when building on Mac OS we got an error : 
```
Module not found: Error: Cannot resolve module 'aws-sdk' in my-project/app/node_modules/fsevents/node_modules/node-pre-gyp/lib
```

Latest solution: 
- We say that `fsevents` is an external : from the webpack doc : 
> Prevent bundling of certain imported packages and instead retrieve these external dependencies at runtime.




First solution : 
The solution : we simply tell to webpack to not handle require()


cozy-mjml `require(mjml)` and mjml use fsevents > node-pre-gyp.
See this comment for more information : https://github.com/mapbox/node-pre-gyp/issues/238#issuecomment-267889753


