### PR TITLE
Harvest: Make HandleOAuthResponse return boolean value

### DIFF
--- a/packages/cozy-harvest-lib/src/helpers/oauth.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.js
@@ -39,13 +39,14 @@ export const checkOAuthData = (konnector, data) => {
  * ```js
  * document.addEventListener('DOMContentLoaded', handleOAuthResponse)
  * ```
+ * @return {boolean} `true` if an OAuth response has been handled, `false` otherwise
  */
 export const handleOAuthResponse = () => {
   /* global URLSearchParams */
   const queryParams = new URLSearchParams(window.location.search)
 
   const accountId = queryParams.get('account')
-  if (!accountId) return
+  if (!accountId) return false
 
   /** As we are in a popup, get the opener window */
   const opener = window.opener
@@ -55,6 +56,7 @@ export const handleOAuthResponse = () => {
    * that data are the ones we are expecting.
    */
   const oAuthStateKey = queryParams.get('state')
+  if (!oAuthStateKey) return false
 
   opener.postMessage(
     {
@@ -69,6 +71,8 @@ export const handleOAuthResponse = () => {
      */
     '*'
   )
+
+  return true
 }
 
 /**

--- a/packages/cozy-harvest-lib/test/helpers/oauth.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/oauth.spec.js
@@ -37,5 +37,28 @@ describe('Oauth helper', () => {
         '*'
       )
     })
+
+    it('should return true', () => {
+      const result = handleOAuthResponse()
+      expect(result).toBe(true)
+    })
+
+    it('should return false when no account is present in query string', () => {
+      window.location = {
+        search: 'state=70720eb0-6204-484d'
+      }
+
+      const result = handleOAuthResponse()
+      expect(result).toBe(false)
+    })
+
+    it('should return false when no state is present in query string', () => {
+      window.location = {
+        search: 'account=bc2aca6566cf4a72afe6c615aa1e3d31'
+      }
+
+      const result = handleOAuthResponse()
+      expect(result).toBe(false)
+    })
   })
 })


### PR DESCRIPTION
It's eventually convenient to know if an OAuth response has been handled.

For example in Cozy-Home we will be able to not render anything when an OAuth response is handled.