### PR TITLE
Better proptypes handling to avoid React warnings

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
@@ -125,7 +125,7 @@ AccountField.propTypes = {
    * The element wrapping the <Field /> component.
    * Passed to <SelectBox /> component.
    */
-  container: PropTypes.node,
+  container: PropTypes.instanceOf(Element),
   /**
    * Indicates if the <Field /> should be rendered with an error style.
    */

--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -25,8 +25,8 @@ const VALIDATION_ERROR_REQUIRED_FIELD = 'VALIDATION_ERROR_REQUIRED_FIELD'
  * @see https://github.com/final-form/react-final-form#getting-started
  */
 export class AccountForm extends PureComponent {
-  constructor(props, context) {
-    super(props, context)
+  constructor(props) {
+    super(props)
     const { konnector, lang } = props
     const { locales } = konnector
     if (locales && lang) {

--- a/packages/cozy-harvest-lib/src/components/DeleteAccountButton.jsx
+++ b/packages/cozy-harvest-lib/src/components/DeleteAccountButton.jsx
@@ -6,7 +6,8 @@ import { Button } from 'cozy-ui/react/Button'
 import { withMutations } from 'cozy-client'
 
 import accountsMutations from '../connections/accounts'
-import withLocales from './hoc/withLocales'
+import withLocales, { i18nContextTypes } from './hoc/withLocales'
+import { getMutationsProptypes } from '../helpers/proptypes'
 
 export class DeleteAccountButton extends Component {
   constructor(props) {
@@ -38,6 +39,11 @@ export class DeleteAccountButton extends Component {
   render() {
     const { t } = this.props
     const { deleting } = this.state
+    const excludedButtonProptypes = {
+      ...DeleteAccountButton.propTypes,
+      ...getMutationsProptypes(accountsMutations),
+      ...i18nContextTypes
+    }
     return (
       <Button
         theme="danger-outline"
@@ -45,7 +51,7 @@ export class DeleteAccountButton extends Component {
         busy={deleting}
         onClick={this.handleDelete}
         label={t('accountForm.disconnect.button')}
-        {...omit(this.props, Object.keys(DeleteAccountButton.propTypes))}
+        {...omit(this.props, Object.keys(excludedButtonProptypes))}
       />
     )
   }

--- a/packages/cozy-harvest-lib/src/components/DeleteAccountButton.jsx
+++ b/packages/cozy-harvest-lib/src/components/DeleteAccountButton.jsx
@@ -6,7 +6,7 @@ import { Button } from 'cozy-ui/react/Button'
 import { withMutations } from 'cozy-client'
 
 import accountsMutations from '../connections/accounts'
-import withLocales, { i18nContextTypes } from './hoc/withLocales'
+import withLocales from './hoc/withLocales'
 import { getMutationsProptypes } from '../helpers/proptypes'
 
 export class DeleteAccountButton extends Component {
@@ -39,11 +39,6 @@ export class DeleteAccountButton extends Component {
   render() {
     const { t } = this.props
     const { deleting } = this.state
-    const excludedButtonProptypes = {
-      ...DeleteAccountButton.propTypes,
-      ...getMutationsProptypes(accountsMutations),
-      ...i18nContextTypes
-    }
     return (
       <Button
         theme="danger-outline"
@@ -78,6 +73,11 @@ DeleteAccountButton.propTypes = {
    * Provided by translate HOC
    */
   t: PropTypes.func.isRequired
+}
+
+const excludedButtonProptypes = {
+  ...DeleteAccountButton.propTypes,
+  ...getMutationsProptypes(accountsMutations)
 }
 
 export default withLocales(

--- a/packages/cozy-harvest-lib/src/components/TriggerLauncher.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerLauncher.jsx
@@ -7,6 +7,7 @@ import TwoFAModal from './TwoFAModal'
 import { accountsMutations } from '../connections/accounts'
 import { triggersMutations } from '../connections/triggers'
 import withKonnectorJob from './hoc/withKonnectorJob'
+import withLocales from './hoc/withLocales'
 
 import {
   ERROR_EVENT,
@@ -100,6 +101,8 @@ TriggerLauncher.propTypes = {
   submitting: PropTypes.bool
 }
 
-export default withKonnectorJob(
-  withMutations(accountsMutations, triggersMutations)(TriggerLauncher)
+export default withLocales(
+  withKonnectorJob(
+    withMutations(accountsMutations, triggersMutations)(TriggerLauncher)
+  )
 )

--- a/packages/cozy-harvest-lib/src/components/hoc/withLocales.js
+++ b/packages/cozy-harvest-lib/src/components/hoc/withLocales.js
@@ -1,5 +1,8 @@
 import withLocales from 'cozy-ui/transpiled/react/I18n/withLocales'
+import I18n from 'cozy-ui/transpiled/react/I18n'
 
 const dictRequire = lang => require(`../../locales/${lang}.json`)
+
+export const i18nContextTypes = I18n.childContextTypes
 
 export default withLocales(dictRequire)

--- a/packages/cozy-harvest-lib/src/helpers/proptypes.js
+++ b/packages/cozy-harvest-lib/src/helpers/proptypes.js
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types'
+
+function getMutationsProptypes(mutations) {
+  return {
+    ...Object.keys(mutations()).reduce((propTypes, mutationName) => {
+      propTypes[mutationName] = PropTypes.func
+      return propTypes
+    }, {}),
+    // FIXME use directly proptypes from cozy-client when available
+    createDocument: PropTypes.func,
+    saveDocument: PropTypes.func,
+    deleteDocument: PropTypes.func
+  }
+}
+
+export { getMutationsProptypes }


### PR DESCRIPTION
* Don't pass too many props to Button from DeleteAccountButton
* Expose mutations prop-types