### PR TITLE
fix(harvest): Call Delete button callbacks after setState

### DIFF
--- a/packages/cozy-harvest-lib/src/components/DeleteAccountButton.jsx
+++ b/packages/cozy-harvest-lib/src/components/DeleteAccountButton.jsx
@@ -17,6 +17,14 @@ export class DeleteAccountButton extends Component {
     this.handleDelete = this.handleDelete.bind(this)
   }
 
+  componentDidMount() {
+    this._mounted = true
+  }
+
+  componentWillUnmount() {
+    this._mounted = false
+  }
+
   async handleDelete() {
     this.setState({ deleting: true })
     const { account, deleteAccount, onError, onSuccess } = this.props
@@ -31,7 +39,7 @@ export class DeleteAccountButton extends Component {
         console.error(e)
       }
     } finally {
-      this.setState({ deleting: false })
+      if (this._mounted) this.setState({ deleting: false })
     }
   }
 

--- a/packages/cozy-harvest-lib/test/components/DeleteAccountButton.spec.js
+++ b/packages/cozy-harvest-lib/test/components/DeleteAccountButton.spec.js
@@ -44,18 +44,15 @@ describe('DeleteAccountButton', () => {
 
   it('should change state on click and handle onSuccess', done => {
     const component = shallow(
-      <DeleteAccountButton account={fixtures.account} {...props} />
+      <DeleteAccountButton
+        account={fixtures.account}
+        onSuccess={() => done()}
+        {...props}
+      />
     )
     expect(component.state().deleting).toBe(false)
-
-    // async assertions
-    const onSuccessAssert = () => {
-      expect(component.state().deleting).toBe(true)
-      done()
-    }
-    component.setProps({ onSuccess: onSuccessAssert })
-
     component.simulate('click')
+    expect(component.state().deleting).toBe(true)
   })
 
   it('should handle onError if provided', done => {


### PR DESCRIPTION
We get some warnings if we use onSuccess/onError to unmount the component or a parent of containing this component