### PR TITLE
feat: Use argparse

### DIFF
--- a/packages/cozy-app-publish/cozy-app-publish.js
+++ b/packages/cozy-app-publish/cozy-app-publish.js
@@ -2,7 +2,7 @@
 
 'use strict'
 
-const commander = require('commander')
+const { ArgumentParser } = require('argparse')
 const colorize = require('./utils/colorize')
 const scripts = require('./index')
 const capitalize = require('lodash/capitalize')
@@ -14,57 +14,65 @@ const MODES = {
   MANUAL: 'manual'
 }
 
-const program = new commander.Command(pkg.name)
-  .version(pkg.version)
-  .usage(`[options]`)
-  .option(
-    '--token <editor-token>',
-    'Registry token matching the provided editor (required)'
-  )
-  .option(
-    '--space <space-name>',
+const parser = new ArgumentParser({
+  version: pkg.version,
+  description:
+    'This tool allows you to publish a Cozy application to the Cozy registry.'
+})
+parser.addArgument('--token', {
+  metavar: 'editor-token',
+  help: 'Registry token matching the provided editor (required)'
+})
+parser.addArgument('--space', {
+  metavar: 'space-name',
+  help:
     'Registry space name to publish the application to (default __default__)'
-  )
-  .option(
-    '--build-dir <relative-path>',
+})
+parser.addArgument('--build-dir', {
+  metavar: 'relative-path',
+  help:
     'Path of the build directory relative to the current directory (default ./build)'
-  )
-  .option('--build-url <url>', 'URL of the application archive')
-  .option(
-    '--build-commit <commit-hash>',
-    'Hash of the build commit matching the build archive to publish'
-  )
-  .option(
-    '--manual-version <version>',
+})
+parser.addArgument('--build-url', {
+  metavar: 'url',
+  help: 'URL of the application archive'
+})
+parser.addArgument('--build-commit', {
+  metavar: 'commit-hash',
+  help: 'Hash of the build commit matching the build archive to publish'
+})
+parser.addArgument('--manual-version', {
+  metavar: 'version',
+  help:
     'Specify a version manually (must not be already published in the registry)'
-  )
-  .option(
-    '--prepublish <script-path>',
+})
+parser.addArgument('--prepublish', {
+  metavar: 'script-path',
+  help:
     'Hook to process parameters just before publishing, typically to upload archive on custom host'
-  )
-  .option(
-    '--postpublish <script-path>',
+})
+parser.addArgument('--postpublish', {
+  metavar: 'script-path',
+  help:
     'Hook to process parameters just after publishing, typically to deploy app'
-  )
-  .option(
-    '--tag-prefix <tag-prefix>',
+})
+parser.addArgument('--tag-prefix', {
+  metavar: 'tag-prefix',
+  help:
     'When publishing from a monorepo, only consider tags with tagPrefix, ex: cozy-banks/1.0.1.'
-  )
-  .option('--yes', 'Force confirmation when publishing manually')
-  .option(
-    '--registry-url <url>',
-    'Registry URL to publish to a different one from the default URL'
-  )
-  .option('--verbose', 'print additional logs')
-  .on('--help', () => {
-    console.log()
-    console.log(`\t--- ${colorize.bold('USAGE INFORMATIONS')} ---`)
-    console.log()
-    console.log(
-      `\tThis tool allows you to publish a Cozy application to the Cozy registry.`
-    )
-  })
-  .parse(process.argv)
+})
+parser.addArgument('--registry-url', {
+  metavar: 'url',
+  help: 'Registry URL to publish to a different one from the default URL'
+})
+parser.addArgument('--yes', {
+  help: 'Force confirmation when publishing manually',
+  action: 'storeTrue'
+})
+parser.addArgument('--verbose', {
+  help: 'print additional logs',
+  action: 'storeTrue'
+})
 
 const handleError = error => {
   console.log(colorize.red(`Publishing failed: ${error.message}`))
@@ -72,7 +80,8 @@ const handleError = error => {
 }
 
 try {
-  publishApp(program).catch(handleError)
+  const args = parser.parseArgs()
+  publishApp(args).catch(handleError)
 } catch (error) {
   handleError(error)
 }

--- a/packages/cozy-app-publish/package.json
+++ b/packages/cozy-app-publish/package.json
@@ -12,8 +12,8 @@
     "cozy-app-publish": "./cozy-app-publish.js"
   },
   "dependencies": {
+    "argparse": "^1.0.10",
     "chalk": "2.4.2",
-    "commander": "2.19.0",
     "cross-spawn": "6.0.5",
     "fs-extra": "7.0.1",
     "lodash": "4.17.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2584,7 +2584,7 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
-argparse@^1.0.7:
+argparse@^1.0.10, argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
@@ -4103,7 +4103,7 @@ commander@2.17.x:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
-commander@2.19.0, commander@^2.11.0, commander@^2.15.1, commander@^2.19.0, commander@^2.8.1, commander@^2.9.0, commander@~2.19.0:
+commander@^2.11.0, commander@^2.15.1, commander@^2.19.0, commander@^2.8.1, commander@^2.9.0, commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==


### PR DESCRIPTION
Change CLI args parser from commander to argparse.

1. reacts better when an argument is not present. The most important is the fact that commander fails on 

```
./script --flag-accepting-argument --other-flag
```

And puts `"other-flag"` in `args['flag-accepting-argument']` which is IMHO a bad thing to do since in cases where shell variables are used for CLI args, the failure mode is confusing.

```
./script --token $REGISTRY_TOKEN --other-flag
```

Here, when using commander, if `REGISTRY_TOKEN` is not set, `--other-flag` is not set and `args.token == '--other-flag'` 😱 .

---

2. Previous help (more compact but less readable)

```
Usage: cozy-app-publish [options]

Options:
  -V, --version                 output the version number
  --token <editor-token>        Registry token matching the provided editor (required)
  --space <space-name>          Registry space name to publish the application to (default __default__)
  --build-dir <relative-path>   Path of the build directory relative to the current directory (default ./build)
  --build-url <url>             URL of the application archive
  --build-commit <commit-hash>  Hash of the build commit matching the build archive to publish
  --manual-version <version>    Specify a version manually (must not be already published in the registry)
  --prepublish <script-path>    Hook to process parameters just before publishing, typically to upload archive on custom host
  --postpublish <script-path>   Hook to process parameters just after publishing, typically to deploy app
  --tag-prefix <tag-prefix>     When publishing from a monorepo, only consider tags with tagPrefix, ex: cozy-banks/1.0.1.
  --yes                         Force confirmation when publishing manually
  --registry-url <url>          Registry URL to publish to a different one from the default URL
  --verbose                     print additional logs
  -h, --help                    output usage information
```


Help with argparse, more readable IMHO.

```
usage: cozy-app-publish.js [-h] [-v] [--token editor-token]
                           [--space space-name] [--build-dir relative-path]
                           [--build-url url] [--build-commit commit-hash]
                           [--manual-version version]
                           [--prepublish script-path]
                           [--postpublish script-path]
                           [--tag-prefix tag-prefix] [--registry-url url]
                           [--yes] [--verbose]
                           

This tool allows you to publish a Cozy application to the Cozy registry.

Optional arguments:
  -h, --help            Show this help message and exit.
  -v, --version         Show program's version number and exit.
  --token editor-token  Registry token matching the provided editor (required)
  --space space-name    Registry space name to publish the application to 
                        (default __default__)
  --build-dir relative-path
                        Path of the build directory relative to the current 
                        directory (default ./build)
  --build-url url       URL of the application archive
  --build-commit commit-hash
                        Hash of the build commit matching the build archive 
                        to publish
  --manual-version version
                        Specify a version manually (must not be already 
                        published in the registry)
  --prepublish script-path
                        Hook to process parameters just before publishing, 
                        typically to upload archive on custom host
  --postpublish script-path
                        Hook to process parameters just after publishing, 
                        typically to deploy app
  --tag-prefix tag-prefix
                        When publishing from a monorepo, only consider tags 
                        with tagPrefix, ex: cozy-banks/1.0.1.
  --registry-url url    Registry URL to publish to a different one from the 
                        default URL
  --yes                 Force confirmation when publishing manually
  --verbose             print additional logs
```