### PR TITLE
fix: Better procedure translations

### DIFF
--- a/packages/cozy-procedures/src/Procedure.jsx
+++ b/packages/cozy-procedures/src/Procedure.jsx
@@ -6,6 +6,7 @@ import store from './redux/store'
 import Context from './redux/context'
 import creditApplicationTemplate from './templates/creditApplicationTemplate'
 import { init as initPersonalData } from './redux/personalDataSlice'
+import withLocales from './withLocales'
 
 class Procedure extends React.Component {
   componentDidMount() {
@@ -23,12 +24,14 @@ const mapDispatchToProps = dispatch => ({
   initPersonalData: template => dispatch(initPersonalData(template))
 })
 
-const ProcedureContainer = connect(
-  null,
-  mapDispatchToProps,
-  null,
-  { context: Context }
-)(Procedure)
+const ProcedureContainer = withLocales(
+  connect(
+    null,
+    mapDispatchToProps,
+    null,
+    { context: Context }
+  )(Procedure)
+)
 
 const ProcedureWithStore = props => (
   <Provider store={store} context={Context}>

--- a/packages/cozy-procedures/src/components/PersonalDataForm.jsx
+++ b/packages/cozy-procedures/src/components/PersonalDataForm.jsx
@@ -13,7 +13,6 @@ import {
   TextareaAdapter
 } from './form'
 import creditApplicationTemplate from '../templates/creditApplicationTemplate'
-import withLocales from '../withLocales'
 
 const { schema, uiSchema } = creditApplicationTemplate.personalData
 
@@ -58,4 +57,4 @@ PersonalDataForm.defaultProps = {
   formData: {}
 }
 
-export default withLocales(withRouter(PersonalDataForm))
+export default withRouter(PersonalDataForm)

--- a/packages/cozy-procedures/src/components/form/FieldTemplate.jsx
+++ b/packages/cozy-procedures/src/components/form/FieldTemplate.jsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Label } from 'cozy-ui/transpiled/react'
-
-import withLocales from '../../withLocales'
+import { Label, translate } from 'cozy-ui/transpiled/react'
 
 const FieldTemplate = ({ children, label, id, t }) => (
   <div>
@@ -17,4 +15,4 @@ FieldTemplate.propTypes = {
   label: PropTypes.string
 }
 
-export default withLocales(FieldTemplate)
+export default translate()(FieldTemplate)

--- a/packages/cozy-procedures/src/components/form/InputAdapter.jsx
+++ b/packages/cozy-procedures/src/components/form/InputAdapter.jsx
@@ -1,9 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Input } from 'cozy-ui/transpiled/react'
+import { Input, translate } from 'cozy-ui/transpiled/react'
 
 import stripInvalidInputProps from './stripInvalidInputProps'
-import withLocales from '../../withLocales'
 
 const InputAdapter = props => (
   <Input
@@ -18,4 +17,4 @@ InputAdapter.propTypes = {
   onChange: PropTypes.func.isRequired
 }
 
-export default withLocales(InputAdapter)
+export default translate()(InputAdapter)

--- a/packages/cozy-procedures/src/components/form/InputWithUnit.jsx
+++ b/packages/cozy-procedures/src/components/form/InputWithUnit.jsx
@@ -1,9 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Input } from 'cozy-ui/transpiled/react'
+import { Input, translate } from 'cozy-ui/transpiled/react'
 
 import stripInvalidInputProps from './stripInvalidInputProps'
-import withLocales from '../../withLocales'
 
 const InputWithUnit = ({ onChange, t, ...otherProps }) => (
   <div>
@@ -25,4 +24,4 @@ InputWithUnit.propTypes = {
   t: PropTypes.func.isRequired
 }
 
-export default withLocales(InputWithUnit)
+export default translate()(InputWithUnit)

--- a/packages/cozy-procedures/src/components/form/SelectBoxAdapter.jsx
+++ b/packages/cozy-procedures/src/components/form/SelectBoxAdapter.jsx
@@ -1,9 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { SelectBox } from 'cozy-ui/transpiled/react'
+import { SelectBox, translate } from 'cozy-ui/transpiled/react'
 
 import stripInvalidInputProps from './stripInvalidInputProps'
-import withLocales from '../../withLocales'
 
 const SelectBoxAdapter = ({ onChange, options, t, value, ...otherProps }) => {
   const currentValue = options.enumOptions.find(o => o.value === value)
@@ -44,4 +43,4 @@ SelectBoxAdapter.propTypes = {
   value: ValuePropType
 }
 
-export default withLocales(SelectBoxAdapter)
+export default translate()(SelectBoxAdapter)


### PR DESCRIPTION
Only the top level component needs to be wrapped in `withLocales`, everything else further down the tree only needs `translate`.