### PR TITLE
Harvest: Improve margin bottom in KonnectorModal

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -116,7 +116,7 @@ export class KonnectorModal extends PureComponent {
             />
           </ModalContent>
         ) : (
-          <ModalContent>
+          <ModalContent className="u-pb-0">
             <SubTitle className="u-mb-1 u-ta-center">
               {t('modal.konnector.title', { name: konnector.name })}
             </SubTitle>
@@ -132,7 +132,7 @@ export class KonnectorModal extends PureComponent {
                 isImportant
               />
             ) : (
-              <div>
+              <div className="u-mb-2">
                 <TriggerManager
                   account={account}
                   konnector={konnector}


### PR DESCRIPTION
When scrolling in Firefox, bottom margin was missing.

Before

![Capture_du_2019-06-17_10-59-08](https://user-images.githubusercontent.com/776764/59696675-c1213880-91ec-11e9-94ec-b5b001e57153.png)


After

![Capture d’écran 2019-06-18 à 17 11 01](https://user-images.githubusercontent.com/776764/59696627-abac0e80-91ec-11e9-9178-fda5bc6a2532.png)
