### PR TITLE
Harvest: Fetch job right after subscribing realtime

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -25,6 +25,7 @@
     "watch:doc:react": "(cd ../.. && TARGET=cozy-harvest-lib yarn watch:doc:react)"
   },
   "dependencies": {
+    "cozy-realtime": "3.1.0",
     "final-form": "4.11.1",
     "lodash": "4.17.11",
     "microee": "^0.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4699,13 +4699,6 @@ cozy-logger@1.3.1:
   dependencies:
     json-stringify-safe "5.0.1"
 
-cozy-realtime@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-3.0.0.tgz#3328ff853683ff21b28026810c7f5c2f8382d8c3"
-  integrity sha512-5HTZ4VM/RSLrhAta4oMhnckj9f2klonj9Hx9FfzOyg7ObSq/eKrXJaAGFmepLYQEMewx9ynU4VmsyDXPZ2QV3A==
-  dependencies:
-    minilog "3.1.0"
-
 cozy-stack-client@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-6.25.0.tgz#4fc50087d900be4b0976ceca3606c77703cf5f52"


### PR DESCRIPTION
In rare case the job was updated - with an error - just before realtime subscribing was done, so no update was sent throuhought realtime and KonnectorJobWatcher could never know that the job errored - or succeed.