### PR TITLE
fix: Playground dependencies

### DIFF
--- a/packages/playgrounds/package.json
+++ b/packages/playgrounds/package.json
@@ -7,18 +7,20 @@
   "scripts": {
     "start": "parcel src/*.html"
   },
-  "devDependencies": {
-    "@babel/runtime": "^7.4.5",
-    "babel-polyfill": "^6.26.0",
+  "dependencies": {
     "cozy-authentication": "^1.13.3",
     "cozy-client": "*",
     "cozy-device-helper": "^1.7.2",
     "cozy-ui": "^20.18.0",
-    "parcel": "^1.12.3",
     "react": "^16.8.3",
     "react-dom": "^16.5.2",
     "react-redux": "^7.0.3",
     "react-router": "3",
     "redux": "3.7.2"
+  },
+  "devDependencies": {
+    "@babel/runtime": "^7.4.5",
+    "babel-polyfill": "^6.26.0",
+    "parcel": "^1.12.3"
   }
 }


### PR DESCRIPTION
Since playground is an app, it has to come with : 
- cozy-ui
- cozy-client 
- react

As dep and not as devDep 