### PR TITLE
Add status to form

### DIFF
--- a/packages/cozy-procedures/src/components/FormFillingStatus.jsx
+++ b/packages/cozy-procedures/src/components/FormFillingStatus.jsx
@@ -9,9 +9,12 @@ export const FormFillingStatus = ({ completed, total, t }) => {
   return (
     <div>
       <span className="u-weirdGreen">
-        {t('personalDataForm.completedStatus.main', { completed, total })}
+        {t('personalDataForm.completedStatus.main', {
+          smart_count: completed,
+          total
+        })}
       </span>{' '}
-      {t('personalDataForm.completedStatus.rest')}
+      {t('personalDataForm.completedStatus.rest', { smart_count: completed })}
     </div>
   )
 }

--- a/packages/cozy-procedures/src/components/FormFillingStatus.jsx
+++ b/packages/cozy-procedures/src/components/FormFillingStatus.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
+
+export const FormFillingStatus = ({ completed, total, t }) => {
+  if (completed === '0') {
+    return null
+  }
+
+  return (
+    <div>
+      <span className="u-weirdGreen">
+        {t('personalDataForm.completedStatus.main', { completed, total })}
+      </span>{' '}
+      {t('personalDataForm.completedStatus.rest')}
+    </div>
+  )
+}
+
+export default translate()(FormFillingStatus)

--- a/packages/cozy-procedures/src/components/FormFillingStatus.spec.jsx
+++ b/packages/cozy-procedures/src/components/FormFillingStatus.spec.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+import { FormFillingStatus } from './FormFillingStatus'
+
+const fakeT = (msgId, args) => {
+  return `${msgId} ${JSON.stringify(args)}`
+}
+
+describe('FormFillingStatus component', () => {
+  it('should display nothing if no data is filled', () => {
+    const component = shallow(
+      <FormFillingStatus completed="0" total="10" t={fakeT} />
+    ).getElement()
+    expect(component).toBeNull()
+  })
+
+  it('should display a status if there are some completed data', () => {
+    const component = mount(
+      <FormFillingStatus completed="5" total="10" t={fakeT} />
+    )
+    expect(component).toMatchSnapshot()
+  })
+})

--- a/packages/cozy-procedures/src/components/Overview.jsx
+++ b/packages/cozy-procedures/src/components/Overview.jsx
@@ -20,13 +20,11 @@ class Overview extends React.Component {
   }
 
   render() {
-    const { personalData, t } = this.props
-
-    const personalDataFieldsTotal = Object.keys(personalData.data).length
-    const personalDataFieldsCompleted = Object.values(personalData.data).filter(
-      Boolean
-    ).length
-
+    const {
+      personalDataFieldsCompleted,
+      personalDataFieldsTotal,
+      t
+    } = this.props
     return (
       <div>
         <Topbar title={creditApplicationTemplate.name} />
@@ -77,11 +75,8 @@ class Overview extends React.Component {
 }
 
 Overview.propTypes = {
-  personalData: PropTypes.shape({
-    data: PropTypes.object,
-    loading: PropTypes.bool,
-    error: PropTypes.string
-  }),
+  personalDataFieldsCompleted: PropTypes.number,
+  personalDataFieldsTotal: PropTypes.number,
   location: PropTypes.shape({
     pathname: PropTypes.string
   }),
@@ -92,9 +87,8 @@ Overview.propTypes = {
 }
 
 Overview.defaultProps = {
-  personalData: {
-    data: {}
-  },
+  personalDataFieldsCompleted: 0,
+  personalDataFieldsTotal: 0,
   location: {
     pathname: '/'
   }

--- a/packages/cozy-procedures/src/components/PersonalDataForm.jsx
+++ b/packages/cozy-procedures/src/components/PersonalDataForm.jsx
@@ -13,6 +13,7 @@ import {
   SelectBoxAdapter,
   TextareaAdapter
 } from './form'
+import FormFillingStatus from '../containers/FormFillingStatus'
 import Topbar from './Topbar'
 import creditApplicationTemplate from '../templates/creditApplicationTemplate'
 
@@ -32,6 +33,7 @@ class PersonalDataForm extends React.Component {
       <div>
         <Topbar title={t('personalDataForm.title')} />
         <SubTitle>{t('personalDataForm.subtitle')}</SubTitle>
+        <FormFillingStatus />
         <Form
           formData={formData}
           schema={schema}

--- a/packages/cozy-procedures/src/components/__snapshots__/FormFillingStatus.spec.jsx.snap
+++ b/packages/cozy-procedures/src/components/__snapshots__/FormFillingStatus.spec.jsx.snap
@@ -10,10 +10,10 @@ exports[`FormFillingStatus component should display a status if there are some c
     <span
       className="u-weirdGreen"
     >
-      personalDataForm.completedStatus.main {"completed":"5","total":"10"}
+      personalDataForm.completedStatus.main {"smart_count":"5","total":"10"}
     </span>
      
-    personalDataForm.completedStatus.rest undefined
+    personalDataForm.completedStatus.rest {"smart_count":"5"}
   </div>
 </FormFillingStatus>
 `;

--- a/packages/cozy-procedures/src/components/__snapshots__/FormFillingStatus.spec.jsx.snap
+++ b/packages/cozy-procedures/src/components/__snapshots__/FormFillingStatus.spec.jsx.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FormFillingStatus component should display a status if there are some completed data 1`] = `
+<FormFillingStatus
+  completed="5"
+  t={[Function]}
+  total="10"
+>
+  <div>
+    <span
+      className="u-weirdGreen"
+    >
+      personalDataForm.completedStatus.main {"completed":"5","total":"10"}
+    </span>
+     
+    personalDataForm.completedStatus.rest undefined
+  </div>
+</FormFillingStatus>
+`;

--- a/packages/cozy-procedures/src/containers/FormFillingStatus.jsx
+++ b/packages/cozy-procedures/src/containers/FormFillingStatus.jsx
@@ -1,0 +1,17 @@
+import { connect } from 'react-redux'
+
+import context from '../redux/context'
+import FormFillingStatus from '../components/FormFillingStatus'
+import { getCompletedFields, getTotalFields } from '../redux/personalDataSlice'
+
+export const mapStateToProps = state => ({
+  completed: getCompletedFields(state),
+  total: getTotalFields(state)
+})
+
+export default connect(
+  mapStateToProps,
+  null,
+  null,
+  { context }
+)(FormFillingStatus)

--- a/packages/cozy-procedures/src/containers/FormFillingStatus.spec.jsx
+++ b/packages/cozy-procedures/src/containers/FormFillingStatus.spec.jsx
@@ -1,0 +1,26 @@
+import { mapStateToProps } from './FormFillingStatus'
+
+describe('FormFillingStatus container', () => {
+  describe('mapStateToProps', () => {
+    it('should map completed and total to props', () => {
+      const state = {
+        personalData: {
+          data: {
+            firstname: 'John',
+            lastname: 'Doe',
+            email: 'john.doe@me.com',
+            phone: undefined,
+            address: null,
+            salary: ''
+          }
+        }
+      }
+
+      const result = mapStateToProps(state)
+      expect(result).toEqual({
+        completed: 3,
+        total: 6
+      })
+    })
+  })
+})

--- a/packages/cozy-procedures/src/containers/Overview.jsx
+++ b/packages/cozy-procedures/src/containers/Overview.jsx
@@ -1,10 +1,11 @@
 import { connect } from 'react-redux'
 import context from '../redux/context'
 import Overview from '../components/Overview'
-import { getSlice } from '../redux/personalDataSlice'
+import { getCompletedFields, getTotalFields } from '../redux/personalDataSlice'
 
-const mapStateToProps = state => ({
-  personalData: getSlice(state) || {}
+export const mapStateToProps = state => ({
+  personalDataFieldsCompleted: getCompletedFields(state),
+  personalDataFieldsTotal: getTotalFields(state)
 })
 
 export default connect(

--- a/packages/cozy-procedures/src/locales/en.json
+++ b/packages/cozy-procedures/src/locales/en.json
@@ -21,6 +21,10 @@
   "personalDataForm": {
     "title": "Personal informations",
     "subtitle": "Please fill out the following information to complete your application",
+    "completedStatus": {
+      "main": "%{completed}/%{total} info",
+      "rest": "have been completed by the app."
+    },
     "form": {
       "lastname": {
         "title": "Lastname"

--- a/packages/cozy-procedures/src/locales/en.json
+++ b/packages/cozy-procedures/src/locales/en.json
@@ -22,8 +22,8 @@
     "title": "Personal informations",
     "subtitle": "Please fill out the following information to complete your application",
     "completedStatus": {
-      "main": "%{completed}/%{total} info",
-      "rest": "have been completed by the app."
+      "main": "%{smart_count} information out of %{total} |||| %{smart_count} informations out of %{total}",
+      "rest": "has been completed by the app. |||| have been completed by the app."
     },
     "form": {
       "lastname": {

--- a/packages/cozy-procedures/src/locales/fr.json
+++ b/packages/cozy-procedures/src/locales/fr.json
@@ -22,8 +22,8 @@
     "title": "Informations personnelles",
     "subtitle": "Complétez les informations suivantes pour finaliser votre dossier",
     "completedStatus": {
-      "main": "%{completed} sur %{total} informations",
-      "rest": "ont déjà été complétées."
+      "main": "%{smart_count} information sur %{total} |||| %{smart_count} informations sur %{total}",
+      "rest": "a déjà été complétée. |||| ont déjà été complétées."
     },
     "form": {
       "lastname": {

--- a/packages/cozy-procedures/src/locales/fr.json
+++ b/packages/cozy-procedures/src/locales/fr.json
@@ -21,6 +21,10 @@
   "personalDataForm": {
     "title": "Informations personnelles",
     "subtitle": "Complétez les informations suivantes pour finaliser votre dossier",
+    "completedStatus": {
+      "main": "%{completed} sur %{total} informations",
+      "rest": "ont déjà été complétées."
+    },
     "form": {
       "lastname": {
         "title": "Nom"

--- a/packages/cozy-procedures/src/redux/personalDataSlice.js
+++ b/packages/cozy-procedures/src/redux/personalDataSlice.js
@@ -56,11 +56,6 @@ const personalDataSlice = createSlice({
   }
 })
 
-const selectors = {
-  getSlice: state => get(state, personalDataSlice.slice),
-  getData: state => get(state, [personalDataSlice.slice, 'data'], {})
-}
-
 const { actions, reducer } = personalDataSlice
 
 export const {
@@ -93,6 +88,12 @@ export function fetchMyself(client) {
   }
 }
 
-export const { getData, getSlice } = selectors
+const getSlice = state => get(state, personalDataSlice.slice)
+const getData = state => get(state, [personalDataSlice.slice, 'data'], {})
+const getCompletedFields = state =>
+  Object.values(getData(state)).filter(Boolean).length
+const getTotalFields = state => Object.keys(getData(state)).length
+
+export { getData, getSlice, getCompletedFields, getTotalFields }
 
 export default reducer

--- a/packages/cozy-procedures/src/redux/personalDataSlice.spec.js
+++ b/packages/cozy-procedures/src/redux/personalDataSlice.spec.js
@@ -4,7 +4,11 @@ import reducer, {
   fetchMyself,
   fetchMyselfLoading,
   fetchMyselfSuccess,
-  fetchMyselfError
+  fetchMyselfError,
+  getData,
+  getSlice,
+  getCompletedFields,
+  getTotalFields
 } from './personalDataSlice'
 
 describe('Personal data', () => {
@@ -172,6 +176,65 @@ describe('fetchMyself action', () => {
     expect(dispatchSpy).toHaveBeenNthCalledWith(3, {
       type: 'personalData/fetchMyselfLoading',
       payload: { loading: false }
+    })
+  })
+
+  describe('selectors', () => {
+    const state = {
+      personalData: {
+        data: {
+          firstname: 'John',
+          lastname: 'Doe',
+          email: 'john.doe@me.com',
+          phone: undefined,
+          address: null,
+          salary: ''
+        }
+      }
+    }
+
+    describe('getSlice', () => {
+      it('should return the number of completed fields', () => {
+        const result = getSlice(state)
+        expect(result).toEqual({
+          data: {
+            firstname: 'John',
+            lastname: 'Doe',
+            email: 'john.doe@me.com',
+            phone: undefined,
+            address: null,
+            salary: ''
+          }
+        })
+      })
+    })
+
+    describe('getData', () => {
+      it('should return the number of completed fields', () => {
+        const result = getData(state)
+        expect(result).toEqual({
+          firstname: 'John',
+          lastname: 'Doe',
+          email: 'john.doe@me.com',
+          phone: undefined,
+          address: null,
+          salary: ''
+        })
+      })
+    })
+
+    describe('getCompletedFields', () => {
+      it('should return the number of completed fields', () => {
+        const result = getCompletedFields(state)
+        expect(result).toEqual(3)
+      })
+    })
+
+    describe('getTotalFields', () => {
+      it('should return the number of fields', () => {
+        const result = getTotalFields(state)
+        expect(result).toEqual(6)
+      })
     })
   })
 })


### PR DESCRIPTION
- add x/y status to the form `FormFillingStatus` component and container
- refactor selectors
- add tests for selectors
- use these selectors in `Overview`

`FormFillingStatus` is probably not a good name. I wanted to rename it to `FormStatus`, `FormFieldsStatus` or `FormCompletedStatus` but let's discuss it here before to do the changes.