### PR TITLE
fix(cozy-app-publish): Argparse generates null default values

### DIFF
--- a/packages/cozy-app-publish/cozy-app-publish.js
+++ b/packages/cozy-app-publish/cozy-app-publish.js
@@ -6,6 +6,7 @@ const { ArgumentParser } = require('argparse')
 const colorize = require('./utils/colorize')
 const scripts = require('./index')
 const capitalize = require('lodash/capitalize')
+const omitBy = require('lodash/omitBy')
 
 const pkg = require('./package.json')
 
@@ -86,7 +87,9 @@ const handleError = error => {
 }
 
 try {
-  const args = parser.parseArgs()
+  // ignore null value which are defaults to argparse (instead of undefined).
+  // null values break lodash/defaults
+  const args = omitBy(parser.parseArgs(), val => val === null)
   publishApp(args).catch(handleError)
 } catch (error) {
   handleError(error)


### PR DESCRIPTION
And lodash.defaults only handle undefined values as "not defined values"
Fixes it by ignoring null values returned from argparse.

As an example, if you do not pass the --build-dir option, cozy-app-publish will not replace it with the default value (./build) which make cozy-app-publish fail for the connectors like [here](https://travis-ci.com/konnectors/edf/builds/116412016)