### PR TITLE
feat(auth): Update cozy-ui

### DIFF
--- a/packages/cozy-authentication/package.json
+++ b/packages/cozy-authentication/package.json
@@ -23,7 +23,7 @@
     "babel-plugin-css-modules-transform": "^1.6.2",
     "babel-preset-cozy-app": "^1.5.1",
     "cozy-client": "^6.27.0",
-    "cozy-ui": "^19.28.0",
+    "cozy-ui": "^21",
     "cssnano-preset-advanced": "^4.0.7",
     "date-fns": "^1.29.0",
     "enzyme": "^3.9.0",

--- a/packages/cozy-authentication/src/steps/Welcome.jsx
+++ b/packages/cozy-authentication/src/steps/Welcome.jsx
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import { Button, MainTitle, Icon } from 'cozy-ui/transpiled/react'
-import 'cozy-ui/assets/icons/ui/cozy-negative.svg'
+import 'cozy-ui/assets/icons/ui/cloud.svg'
 import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
 
 import styles from '../styles.styl'
@@ -63,12 +63,7 @@ export class Welcome extends Component {
                 focusable="false"
               />
               <div className={styles['wizard-logo-badge']}>
-                <Icon
-                  icon="cozy-negative"
-                  width="20"
-                  height="20"
-                  color="white"
-                />
+                <Icon icon="cloud" width="20" height="20" color="white" />
               </div>
             </div>
             <MainTitle


### PR DESCRIPTION
If an app use the newest version of cozy-ui, with new icons, cozy-authentication does not work anymore.

- Update cozy-ui dependency in cozy-authentication
- Ran the codemod to update icons path