### PR TITLE
(procedures) fix: Handle missing ME contact

### DIFF
--- a/packages/cozy-procedures/src/redux/personalDataSlice.js
+++ b/packages/cozy-procedures/src/redux/personalDataSlice.js
@@ -73,8 +73,9 @@ export function fetchMyself(client) {
       const response = await client.collection('io.cozy.contacts').find({
         me: true
       })
-      if (response.data) {
-        dispatch(fetchMyselfSuccess(response.data[0]))
+      const contactSelf = get(response, 'data[0]')
+      if (contactSelf) {
+        dispatch(fetchMyselfSuccess(contactSelf))
       }
     } catch (error) {
       dispatch(

--- a/packages/cozy-procedures/src/redux/personalDataSlice.spec.js
+++ b/packages/cozy-procedures/src/redux/personalDataSlice.spec.js
@@ -179,6 +179,20 @@ describe('fetchMyself action', () => {
     })
   })
 
+  it('should dispatch fetchMyselfSuccess with "myself" contact', async () => {
+    findSpy.mockResolvedValueOnce({ data: [] })
+    await fetchMyself(fakeClient)(dispatchSpy)
+    expect(dispatchSpy).toHaveBeenCalled()
+    expect(dispatchSpy).toHaveBeenNthCalledWith(1, {
+      type: 'personalData/fetchMyselfLoading',
+      payload: { loading: true }
+    })
+    expect(dispatchSpy).toHaveBeenNthCalledWith(2, {
+      type: 'personalData/fetchMyselfLoading',
+      payload: { loading: false }
+    })
+  })
+
   describe('selectors', () => {
     const state = {
       personalData: {


### PR DESCRIPTION
Don't fail if there is no contact with `me: true`.