### PR TITLE
fix(playgrounds): Use react

### DIFF
--- a/packages/playgrounds/package.json
+++ b/packages/playgrounds/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start": "parcel src/*.html"
+    "start": "env USE_REACT=true parcel src/*.html"
   },
   "dependencies": {
     "cozy-authentication": "^1.14.0",


### PR DESCRIPTION
For example, we need this to be able to use cozy-ui's `Alerter` component without having strange preact errors ;-)