### PR TITLE
Harvest: Fix style prop to not make React crash

### DIFF
--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
@@ -68,7 +68,9 @@ export class LaunchTriggerCard extends PureComponent {
                     disabled={running}
                     onClick={launch}
                     subtle
-                    style="line-height:1.4"
+                    // TODO: Extract this directly in Cozy-UI
+                    // (either with an utility class or a Button prop)
+                    style={{ lineHeight: '1.4' }}
                   />
                 </div>
               </div>


### PR DESCRIPTION
This simple proptype error developed under a preact Cozy-Home was making the whole cozy-bar to crash on React apps. This little error cost me a half day.

Ping @GoOz for information.