### PR TITLE
Harvest: Do not show error on KonnectorModal when konnector job is running

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -7,7 +7,7 @@ import Button from 'cozy-ui/transpiled/react/Button'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 
 import AccountFields from './AccountFields'
-import AccountFormError from './Error'
+import TriggerErrorInfo from '../infos/TriggerErrorInfo'
 import { getEncryptedFieldName } from '../../helpers/fields'
 import { KonnectorJobError } from '../../helpers/konnectors'
 import manifest from '../../helpers/manifest'
@@ -190,7 +190,7 @@ export class AccountForm extends PureComponent {
             }}
           >
             {error && showError && (
-              <AccountFormError error={error} konnector={konnector} t={t} />
+              <TriggerErrorInfo error={error} konnector={konnector} />
             )}
             <AccountFields
               container={container}

--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -4,13 +4,14 @@ import PropTypes from 'prop-types'
 
 import { isMobile } from 'cozy-device-helper'
 import Button from 'cozy-ui/transpiled/react/Button'
-import { translate, extend } from 'cozy-ui/transpiled/react/I18n'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 
 import AccountFields from './AccountFields'
 import AccountFormError from './Error'
 import { getEncryptedFieldName } from '../../helpers/fields'
 import { KonnectorJobError } from '../../helpers/konnectors'
 import manifest from '../../helpers/manifest'
+import withKonnectorLocales from '../hoc/withKonnectorLocales'
 
 const VALIDATION_ERROR_REQUIRED_FIELD = 'VALIDATION_ERROR_REQUIRED_FIELD'
 
@@ -27,11 +28,6 @@ const VALIDATION_ERROR_REQUIRED_FIELD = 'VALIDATION_ERROR_REQUIRED_FIELD'
 export class AccountForm extends PureComponent {
   constructor(props) {
     super(props)
-    const { konnector, lang } = props
-    const { locales } = konnector
-    if (locales && lang) {
-      extend(locales[lang])
-    }
 
     this.inputs = {}
     this.inputFocused = null
@@ -269,4 +265,4 @@ AccountForm.defaultProps = {
   showError: true
 }
 
-export default translate()(AccountForm)
+export default translate()(withKonnectorLocales(AccountForm))

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -37,6 +37,9 @@ export class KonnectorModal extends PureComponent {
   constructor(props) {
     super(props)
     this.fetchIcon = this.fetchIcon.bind(this)
+    this.handleKonnectorJobError = this.handleKonnectorJobError.bind(this)
+    this.handleKonnectorJobSuccess = this.handleKonnectorJobSuccess.bind(this)
+    this.handleTriggerLaunch = this.handleTriggerLaunch.bind(this)
   }
 
   componentDidMount() {
@@ -87,6 +90,18 @@ export class KonnectorModal extends PureComponent {
     })
   }
 
+  handleKonnectorJobError(trigger) {
+    this.setState({ isJobRunning: false, trigger })
+  }
+
+  handleKonnectorJobSuccess(trigger) {
+    this.setState({ isJobRunning: false, trigger })
+  }
+
+  handleTriggerLaunch() {
+    this.setState({ isJobRunning: true })
+  }
+
   render() {
     const {
       dismissAction,
@@ -98,7 +113,7 @@ export class KonnectorModal extends PureComponent {
       t
     } = this.props
 
-    const { account, error, fetching, trigger } = this.state
+    const { account, error, fetching, isJobRunning, trigger } = this.state
     const triggerError = triggers.getError(trigger)
 
     return (
@@ -136,14 +151,19 @@ export class KonnectorModal extends PureComponent {
               />
             ) : (
               <div className="u-mb-2">
-                {triggerError && (
+                {!isJobRunning && triggerError && (
                   <TriggerErrorInfo
                     className="u-mb-1"
                     error={triggerError}
                     konnector={konnector}
                   />
                 )}
-                <LaunchTriggerCard trigger={trigger} />
+                <LaunchTriggerCard
+                  trigger={trigger}
+                  onError={this.handleKonnectorJobError}
+                  onLaunch={this.handleTriggerLaunch}
+                  onSuccess={this.handleKonnectorJobSuccess}
+                />
                 <TriggerManager
                   account={account}
                   konnector={konnector}

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -17,6 +17,7 @@ import * as triggers from '../helpers/triggers'
 import TriggerManager from './TriggerManager'
 import DeleteAccountCard from './cards/DeleteAccountCard'
 import LaunchTriggerCard from './cards/LaunchTriggerCard'
+import TriggerErrorInfo from './infos/TriggerErrorInfo'
 import withLocales from './hoc/withLocales'
 
 /**
@@ -98,6 +99,7 @@ export class KonnectorModal extends PureComponent {
     } = this.props
 
     const { account, error, fetching, trigger } = this.state
+    const triggerError = triggers.getError(trigger)
 
     return (
       <Modal
@@ -134,7 +136,14 @@ export class KonnectorModal extends PureComponent {
               />
             ) : (
               <div className="u-mb-2">
-                <LaunchTriggerCard className="u-mb-1" trigger={trigger} />
+                {triggerError && (
+                  <TriggerErrorInfo
+                    className="u-mb-1"
+                    error={triggerError}
+                    konnector={konnector}
+                  />
+                )}
+                <LaunchTriggerCard trigger={trigger} />
                 <TriggerManager
                   account={account}
                   konnector={konnector}
@@ -142,6 +151,7 @@ export class KonnectorModal extends PureComponent {
                   running={running}
                   onLoginSuccess={onLoginSuccess}
                   onSuccess={onSuccess}
+                  showError={false}
                 />
                 <DeleteAccountCard
                   account={account}

--- a/packages/cozy-harvest-lib/src/components/TriggerLauncher.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerLauncher.jsx
@@ -47,7 +47,7 @@ export class TriggerLauncher extends Component {
   }
 
   launch() {
-    const { client, trigger } = this.props
+    const { client, onLaunch, trigger } = this.props
     const konnectorJob = new KonnectorJob(client, trigger)
     konnectorJob
       .on(ERROR_EVENT, this.handleError)
@@ -60,6 +60,8 @@ export class TriggerLauncher extends Component {
       konnectorJob,
       running: true
     })
+
+    if (typeof onLaunch === 'function') onLaunch(trigger)
 
     konnectorJob.launch()
   }
@@ -78,6 +80,8 @@ export class TriggerLauncher extends Component {
     this.stopWatchingKonnectorJob()
     const trigger = await this.refetchTrigger()
     this.setState({ error, running: false, trigger })
+    const { onError } = this.props
+    if (typeof onError === 'function') onError(trigger)
   }
 
   async handleSuccess() {
@@ -85,6 +89,8 @@ export class TriggerLauncher extends Component {
     this.stopWatchingKonnectorJob()
     const trigger = await this.refetchTrigger()
     this.setState({ running: false, trigger })
+    const { onSuccess } = this.props
+    if (typeof onSuccess === 'function') onSuccess(trigger)
   }
 
   handleTwoFA() {
@@ -138,6 +144,18 @@ TriggerLauncher.propTypes = {
    * CozyClient instance
    */
   client: PropTypes.object.isRequired,
+  /**
+   * Callback to call when the trigger is launched
+   */
+  onLaunch: PropTypes.func,
+  /**
+   * Callback to call when the konnector job succeeds
+   */
+  onSuccess: PropTypes.func,
+  /**
+   * Callback to call when the konnector job fails
+   */
+  onError: PropTypes.func,
   /**
    * Indicates if trigger is already runnning
    */

--- a/packages/cozy-harvest-lib/src/components/TriggerLauncher.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerLauncher.jsx
@@ -159,7 +159,11 @@ TriggerLauncher.propTypes = {
   /**
    * Indicates if trigger is already runnning
    */
-  submitting: PropTypes.bool
+  submitting: PropTypes.bool,
+  /**
+   * Trigger to launch
+   */
+  trigger: PropTypes.object.isRequired
 }
 
 export default withLocales(

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
+import pick from 'lodash/pick'
 
 import Button from 'cozy-ui/transpiled/react/Button'
 import Card from 'cozy-ui/transpiled/react/Card'
@@ -8,14 +9,18 @@ import Icon from 'cozy-ui/transpiled/react/Icon'
 import { Uppercase, Text } from 'cozy-ui/transpiled/react/Text'
 
 import * as triggers from '../../helpers/triggers'
-import TriggerLauncher from '../TriggerLauncher'
+import TriggerLauncher, {
+  TriggerLauncher as DumbTriggerLauncher
+} from '../TriggerLauncher'
 
 export class LaunchTriggerCard extends PureComponent {
   render() {
-    const { className, f, trigger, t, ...rest } = this.props
+    const { className, f, t, ...rest } = this.props
     return (
-      <Card className={className} {...rest}>
-        <TriggerLauncher trigger={trigger}>
+      <Card className={className} {...pick(rest, Object.keys(Card.propTypes))}>
+        <TriggerLauncher
+          {...pick(this.props, Object.keys(DumbTriggerLauncher.propTypes))}
+        >
           {({ error, launch, running, trigger }) => {
             const lastSuccessDate = triggers.getLastSuccessDate(trigger)
             return (
@@ -82,7 +87,7 @@ export class LaunchTriggerCard extends PureComponent {
 
 LaunchTriggerCard.propTypes = {
   ...Card.propTypes,
-  trigger: PropTypes.object.isRequired,
+  ...TriggerLauncher.propTypes,
   f: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired
 }

--- a/packages/cozy-harvest-lib/src/components/hoc/withKonnectorLocales.jsx
+++ b/packages/cozy-harvest-lib/src/components/hoc/withKonnectorLocales.jsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { extend } from 'cozy-ui/transpiled/react/I18n'
+
+import { getDisplayName } from './utils'
+
+/**
+ * Index of konnectors which locales have already extended the I18n.
+ * For now we are not supposed to update konnector locales at runtime and we
+ * should just load them once for all.
+ */
+const loadedKonnectors = []
+
+/**
+ * HOC which ensures that a component get extended I18n with locales data from
+ * konnector manifest.
+ */
+export const withKonnectorLocales = Component => {
+  class WrappedComponent extends Component {
+    constructor(props, context) {
+      super(props, context)
+      const { konnector, lang } = this.props
+      if (loadedKonnectors.includes(konnector.slug)) return
+
+      const { locales } = konnector
+      if (locales && lang) {
+        extend(locales[lang])
+        loadedKonnectors.push(konnector.slug)
+      }
+    }
+
+    render() {
+      return <Component {...this.props} />
+    }
+  }
+
+  WrappedComponent.displayName = `withKonnectorLocales(${getDisplayName(
+    Component
+  )}`
+
+  WrappedComponent.propTypes = {
+    ...Component.propTypes,
+    konnector: PropTypes.object.isRequired,
+    lang: PropTypes.string.isRequired
+  }
+
+  return WrappedComponent
+}
+
+export default withKonnectorLocales

--- a/packages/cozy-harvest-lib/src/components/infos/TriggerErrorInfo.jsx
+++ b/packages/cozy-harvest-lib/src/components/infos/TriggerErrorInfo.jsx
@@ -5,6 +5,7 @@ import { translate } from 'cozy-ui/transpiled/react/I18n'
 import Infos from 'cozy-ui/transpiled/react/Infos'
 
 import { KonnectorJobError } from '../../helpers/konnectors'
+import withKonnectorLocales from '../hoc/withKonnectorLocales'
 import Markdown from '../Markdown'
 
 /**
@@ -22,7 +23,7 @@ const getKonnectorJobKey = code => `error.job.${code}`
  * This component is strongly related with the content of locales files and
  * deals mainly with translation concerns.
  */
-export class AccountFormError extends PureComponent {
+export class TriggerErrorInfo extends PureComponent {
   defaultKey = 'error.job.UNKNOWN_ERROR'
 
   /**
@@ -71,18 +72,18 @@ export class AccountFormError extends PureComponent {
     console.error(error)
     return (
       <Infos
-        title={this.getErrorLocale('title')}
-        text={<Markdown source={this.getErrorLocale('description')} />}
         isImportant
+        text={<Markdown source={this.getErrorLocale('description')} />}
+        title={this.getErrorLocale('title')}
       />
     )
   }
 }
 
-AccountFormError.proptTypes = {
+TriggerErrorInfo.proptTypes = {
   error: PropTypes.object.isRequired,
   konnector: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired
 }
 
-export default translate()(AccountFormError)
+export default translate()(withKonnectorLocales(TriggerErrorInfo))

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
@@ -120,21 +120,6 @@ exports[`AccountForm should render error 1`] = `
         },
       }
     }
-    t={
-      [MockFunction] {
-        "calls": Array [
-          Array [
-            "accountForm.submit.label",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": "accountForm.submit.label",
-          },
-        ],
-      }
-    }
   />
   <AccountFields
     container={null}

--- a/packages/cozy-harvest-lib/test/components/infos/TriggerErrorInfo.spec.js
+++ b/packages/cozy-harvest-lib/test/components/infos/TriggerErrorInfo.spec.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import { AccountFormError } from 'components/AccountForm/Error'
+import { TriggerErrorInfo } from 'components/infos/TriggerErrorInfo'
 import { KonnectorJobError } from 'helpers/konnectors'
 
 const fixtures = {
@@ -14,7 +14,7 @@ const fixtures = {
 
 const tMock = jest.fn().mockImplementation(key => key)
 
-describe('AccountFormError', () => {
+describe('TriggerErrorInfo', () => {
   beforeAll(() => {
     jest.spyOn(console, 'error').mockImplementation(() => {})
   })
@@ -30,13 +30,13 @@ describe('AccountFormError', () => {
   }
 
   it('should render', () => {
-    const component = shallow(<AccountFormError {...props} />).getElement()
+    const component = shallow(<TriggerErrorInfo {...props} />).getElement()
     expect(component).toMatchSnapshot()
   })
 
   it('should render regular Error', () => {
     const component = shallow(
-      <AccountFormError
+      <TriggerErrorInfo
         {...props}
         error={new Error('Something is undefined')}
       />

--- a/packages/cozy-harvest-lib/test/components/infos/__snapshots__/TriggerErrorInfo.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/infos/__snapshots__/TriggerErrorInfo.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AccountFormError should render 1`] = `
+exports[`TriggerErrorInfo should render 1`] = `
 <Infos
   icon={null}
   isImportant={true}
@@ -13,7 +13,7 @@ exports[`AccountFormError should render 1`] = `
 />
 `;
 
-exports[`AccountFormError should render regular Error 1`] = `
+exports[`TriggerErrorInfo should render regular Error 1`] = `
 <Infos
   icon={null}
   isImportant={true}


### PR DESCRIPTION
To do so we need to:
* Extract Errors from AccountForm, don't show them in AccountForm from KonnectorModal
* Include directly error in KonnectorModal
* Listen to TriggerLauncher lifecycle to show/hide errors

Also, error is now shown at top of Konnector Modal.

![Capture d’écran 2019-06-27 à 12 52 05](https://user-images.githubusercontent.com/776764/60260729-8305d200-98da-11e9-8714-33372b3d596f.png)

![Capture d’écran 2019-06-27 à 12 51 37](https://user-images.githubusercontent.com/776764/60260737-87ca8600-98da-11e9-85a1-5db88f251f82.png)
