### PR TITLE
Harvest: Disable button when editing if an error exists

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -49,7 +49,7 @@ export class AccountForm extends PureComponent {
    */
   isSubmittable({ dirty, error, initialValues, valid }) {
     const untouched = initialValues && !dirty
-    return error || (valid && !untouched)
+    return !untouched && (error || valid)
   }
 
   /**

--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -49,6 +49,8 @@ export class AccountForm extends PureComponent {
    */
   isSubmittable({ dirty, error, initialValues, valid }) {
     const modified = !initialValues || dirty
+    // Here error is not a validation error but an instance of a
+    // KonnectorJobError, so submitting again is possible
     return modified && (error || valid)
   }
 

--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -48,8 +48,8 @@ export class AccountForm extends PureComponent {
    * @return {Boolean}
    */
   isSubmittable({ dirty, error, initialValues, valid }) {
-    const untouched = initialValues && !dirty
-    return !untouched && (error || valid)
+    const modified = !initialValues || dirty
+    return modified && (error || valid)
   }
 
   /**

--- a/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
+++ b/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
@@ -198,6 +198,33 @@ describe('AccountForm', () => {
       )
     })
 
+    /**
+     * This case corresponds to an account edition of a trigger already having
+     * an error. We are not supposed to submit it without modifications.
+     */
+    it('should be disabled with initialValues AND error', () => {
+      const account = {
+        auth: {
+          username: 'foo',
+          passphrase: 'bar'
+        }
+      }
+
+      assertButtonDisabled(
+        shallow(
+          <AccountForm
+            account={account}
+            error={new Error('Existing trigger error')}
+            konnector={fixtures.konnector}
+            onSubmit={onSubmit}
+            t={t}
+          />,
+          // Avoid componentDidMount
+          { disableLifecycleMethods: true }
+        )
+      )
+    })
+
     it('should be enabled when an error exists', () => {
       const values = {
         username: 'foo',


### PR DESCRIPTION
AccountForm was designed to enable the submit button after an error occured, to allow user to re-submit the form.

When editing an account, we do not need the form to be submittable when an error already exists.