### PR TITLE
fix: Copy files after build

### DIFF
--- a/packages/cozy-procedures/package.json
+++ b/packages/cozy-procedures/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "scripts": {
     "prepare": "yarn build; yarn copy-files",
-    "build": "env BABEL_ENV=transpilation yarn babel src/ --out-dir dist",
+    "build": "env BABEL_ENV=transpilation yarn babel src/ --out-dir dist && yarn run copy-files",
     "copy-files": "cp -rf src/locales dist/",
     "test": "jest --verbose",
     "lint": "cd ..; yarn lint packages/cozy-procedures"


### PR DESCRIPTION
After build, I expect dist/ to be ready. I added --copy-files to the babel task.