### PR TITLE
Harvest: Fix TriggerErrorInfo bottom margin

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -192,7 +192,11 @@ export class AccountForm extends PureComponent {
             }}
           >
             {error && showError && (
-              <TriggerErrorInfo error={error} konnector={konnector} />
+              <TriggerErrorInfo
+                className="u-mb-1"
+                error={error}
+                konnector={konnector}
+              />
             )}
             <AccountFields
               container={container}

--- a/packages/cozy-harvest-lib/src/components/infos/TriggerErrorInfo.jsx
+++ b/packages/cozy-harvest-lib/src/components/infos/TriggerErrorInfo.jsx
@@ -67,11 +67,12 @@ export class TriggerErrorInfo extends PureComponent {
   }
 
   render() {
-    const { error } = this.props
+    const { className, error } = this.props
     /* eslint-disable-next-line no-console */
     console.error(error)
     return (
       <Infos
+        className={className}
         isImportant
         text={<Markdown source={this.getErrorLocale('description')} />}
         title={this.getErrorLocale('title')}

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
@@ -107,6 +107,7 @@ exports[`AccountForm should render error 1`] = `
   onKeyUp={[Function]}
 >
   <Wrapper
+    className="u-mb-1"
     error={[Error: Test error]}
     konnector={
       Object {


### PR DESCRIPTION
When extracting TriggerErrorInfo, margin bottom has been lost.