### PR TITLE
fix(cozy-doctypes): Don't use class property

### DIFF
--- a/packages/cozy-doctypes/src/File.js
+++ b/packages/cozy-doctypes/src/File.js
@@ -78,7 +78,7 @@ class CozyFile extends Document {
    * @param {Object} file An io.cozy.files
    * @return {Object}  return an object with {filename: , extension: }
    */
-  static splitFilename = file => {
+  static splitFilename(file) {
     if (!file.name) throw new Error('file should have a name property ')
     return file.type === 'directory'
       ? { filename: file.name, extension: '' }


### PR DESCRIPTION
This syntax is only usable since Node 12 (see https://node.green/#ESNEXT-candidate--stage-3--instance-class-fields). Since this is not required for the method to work here, we can just drop it and use a classic static method definition that works since Node 6 (see https://node.green/#ES2015-functions-class-static-methods).

More practically, this is causing the cozy-banks build to fail (see https://travis-ci.org/cozy/cozy-banks/builds/551944775?utm_source=github_status&utm_medium=notification).

Since the original and transpiled versions are shipped or npm (we have `main` and `browser` properties in the package.json), having it compatible with the widest range of node versions possible is the best. But I wonder if doing this is really necessary, since:

* If used in apps: the `browser` version will be used by the bundler
* If used in services: services are bundled, so the `browser` version will also be used
* If used in a connector: they are bundled for production use, but not while developing => so it can break while developing but work when bundled (which is better than the inverse, but still inconsistent)

I think there are some gotchas in cozy-doctypes' tests because they are passing on Node versions that doesn't support this syntax (Node 8 on my machine or even on [travis](https://travis-ci.org/cozy/cozy-libs/builds/551780641)). Which is weird, since you can open a Node 8 or 10 REPL and test this syntax in it: it will fail.