### PR TITLE
(procedures) chore: Added a watch task

### DIFF
--- a/packages/cozy-procedures/package.json
+++ b/packages/cozy-procedures/package.json
@@ -4,6 +4,7 @@
   "main": "dist/index.js",
   "scripts": {
     "prepare": "yarn build; yarn copy-files",
+    "watch": "env BABEL_ENV=transpilation yarn babel src/ --out-dir dist --watch",
     "build": "env BABEL_ENV=transpilation yarn babel src/ --out-dir dist && yarn run copy-files",
     "copy-files": "cp -rf src/locales dist/",
     "test": "jest --verbose",


### PR DESCRIPTION
We can't do `yarn build --watch` anymore because of the copy-files task that has been appended, but we need to keep the copy file. So this PR creates a dedicated watch command. In watch mode, copy files still needs to be done manually but I think that's ok.