### PR TITLE
Harvest: Fix undefined proptypes when transpiled

### DIFF
--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
@@ -15,9 +15,9 @@ import TriggerLauncher, {
 
 export class LaunchTriggerCard extends PureComponent {
   render() {
-    const { className, f, t, ...rest } = this.props
+    const { className, f, t } = this.props
     return (
-      <Card className={className} {...pick(rest, Object.keys(Card.propTypes))}>
+      <Card className={className}>
         <TriggerLauncher
           {...pick(this.props, Object.keys(DumbTriggerLauncher.propTypes))}
         >


### PR DESCRIPTION
Once transpiled, accessing `Object.keys(Card.propTypes)` was throwing an error : Card.propTypes seems undefined.

As we don't really need to expose all Card props in LaunchTriggerCard, let's remove this stuff.