### PR TITLE
(procedures) fix: Set the slider step value

### DIFF
--- a/packages/cozy-procedures/src/components/Duration.jsx
+++ b/packages/cozy-procedures/src/components/Duration.jsx
@@ -63,6 +63,7 @@ class Duration extends React.PureComponent {
         <Slider
           min={min}
           max={max}
+          step={1}
           value={simulationDuration}
           aria-label={t('duration.label')}
           onChange={(event, value) => updateDuration(value)}


### PR DESCRIPTION
Avoids being able to select 3.45 months.