### PR TITLE
fix: A file can not have the lastModifiedInformation

### DIFF
--- a/packages/cozy-procedures/src/components/documents/EmptyDocumentHolder.jsx
+++ b/packages/cozy-procedures/src/components/documents/EmptyDocumentHolder.jsx
@@ -50,7 +50,9 @@ class EmptyDocumentHolder extends Component {
       if (classification) {
         metadata = {
           classification,
-          datetime: file.lastModifiedDate.toISOString()
+          datetime: file.lastModifiedDate
+            ? file.lastModifiedDate.toISOString()
+            : new Date().toISOString()
         }
       }
       const dirId = await filesCollection.ensureDirectoryExists(dirPath)


### PR DESCRIPTION
It appears that some file can have this prop missing (specially for the file coming from my ios simulator) . So if it's the case, we set the datetime to the current date 