### PR TITLE
Harvest: Better synchronisation between components in KonnectorModal

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
@@ -70,7 +70,7 @@ export class AccountField extends PureComponent {
       autoComplete: 'off',
       className: 'u-m-0', // 0 margin
       disabled: disabled || !isEditable,
-      error: hasError,
+      error: !disabled && hasError,
       fullwidth: true,
       inputRef: this.setInputRef,
       label: t(`fields.${localeKey}.label`, {

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -175,6 +175,7 @@ export class KonnectorModal extends PureComponent {
                 />
                 <DeleteAccountCard
                   account={account}
+                  disabled={isJobRunning}
                   onSuccess={dismissAction}
                 />
               </div>

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -161,6 +161,7 @@ export class KonnectorModal extends PureComponent {
                   onError={this.handleKonnectorJobError}
                   onLaunch={this.handleTriggerLaunch}
                   onSuccess={this.handleKonnectorJobSuccess}
+                  submitting={isJobRunning}
                 />
                 <TriggerManager
                   account={account}

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -13,6 +13,7 @@ import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import { SubTitle } from 'cozy-ui/transpiled/react/Text'
 
 import accountMutations from '../connections/accounts'
+import triggersMutations from '../connections/triggers'
 import * as triggers from '../helpers/triggers'
 import TriggerManager from './TriggerManager'
 import DeleteAccountCard from './cards/DeleteAccountCard'
@@ -90,8 +91,13 @@ export class KonnectorModal extends PureComponent {
     })
   }
 
-  handleKonnectorJobError(trigger) {
-    this.setState({ isJobRunning: false, trigger })
+  async handleKonnectorJobError() {
+    const { fetchTrigger } = this.props
+    const { trigger } = this.state
+    this.setState({
+      isJobRunning: false,
+      trigger: await fetchTrigger(trigger._id)
+    })
   }
 
   handleKonnectorJobSuccess(trigger) {
@@ -103,15 +109,7 @@ export class KonnectorModal extends PureComponent {
   }
 
   render() {
-    const {
-      dismissAction,
-      konnector,
-      into,
-      onLoginSuccess,
-      onSuccess,
-      running,
-      t
-    } = this.props
+    const { dismissAction, konnector, into, t } = this.props
 
     const { account, error, fetching, isJobRunning, trigger } = this.state
     const triggerError = triggers.getError(trigger)
@@ -168,9 +166,10 @@ export class KonnectorModal extends PureComponent {
                   account={account}
                   konnector={konnector}
                   trigger={trigger}
-                  running={running}
-                  onLoginSuccess={onLoginSuccess}
-                  onSuccess={onSuccess}
+                  onError={this.handleKonnectorJobError}
+                  onLaunch={this.handleTriggerLaunch}
+                  onSuccess={this.handleKonnectorJobSuccess}
+                  running={isJobRunning}
                   showError={false}
                 />
                 <DeleteAccountCard
@@ -190,4 +189,6 @@ KonnectorModal.contextTypes = {
   client: PropTypes.object.isRequired
 }
 
-export default withMutations(accountMutations)(withLocales(KonnectorModal))
+export default withMutations(accountMutations, triggersMutations)(
+  withLocales(KonnectorModal)
+)

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -70,7 +70,11 @@ export class KonnectorModal extends PureComponent {
 
     try {
       const account = await findAccount(triggers.getAccountId(trigger))
-      this.setState({ account, trigger })
+      this.setState({
+        account,
+        trigger,
+        konnectorJobError: triggers.getError(trigger)
+      })
     } catch (error) {
       this.setState({
         error
@@ -91,28 +95,45 @@ export class KonnectorModal extends PureComponent {
     })
   }
 
-  async handleKonnectorJobError() {
-    const { fetchTrigger } = this.props
-    const { trigger } = this.state
+  handleKonnectorJobError(konnectorJobError) {
     this.setState({
-      isJobRunning: false,
-      trigger: await fetchTrigger(trigger._id)
+      konnectorJobError,
+      isJobRunning: false
     })
+
+    this.refetchTrigger()
   }
 
   handleKonnectorJobSuccess(trigger) {
     this.setState({ isJobRunning: false, trigger })
+    this.refetchTrigger()
   }
 
   handleTriggerLaunch() {
-    this.setState({ isJobRunning: true })
+    this.setState({ isJobRunning: true, konnectorJobError: null })
+  }
+
+  async refetchTrigger() {
+    const { fetchTrigger } = this.props
+    const { trigger } = this.state
+
+    const upToDateTrigger = await fetchTrigger(trigger._id)
+    this.setState({
+      trigger: upToDateTrigger
+    })
   }
 
   render() {
     const { dismissAction, konnector, into, t } = this.props
 
-    const { account, error, fetching, isJobRunning, trigger } = this.state
-    const triggerError = triggers.getError(trigger)
+    const {
+      account,
+      error,
+      fetching,
+      isJobRunning,
+      konnectorJobError,
+      trigger
+    } = this.state
 
     return (
       <Modal
@@ -149,10 +170,10 @@ export class KonnectorModal extends PureComponent {
               />
             ) : (
               <div className="u-mb-2">
-                {!isJobRunning && triggerError && (
+                {!isJobRunning && konnectorJobError && (
                   <TriggerErrorInfo
                     className="u-mb-1"
-                    error={triggerError}
+                    error={konnectorJobError}
                     konnector={konnector}
                   />
                 )}

--- a/packages/cozy-harvest-lib/src/components/TriggerLauncher.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerLauncher.jsx
@@ -81,7 +81,7 @@ export class TriggerLauncher extends Component {
     const trigger = await this.refetchTrigger()
     this.setState({ error, running: false, trigger })
     const { onError } = this.props
-    if (typeof onError === 'function') onError(trigger)
+    if (typeof onError === 'function') onError(error)
   }
 
   async handleSuccess() {

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -158,6 +158,9 @@ export class TriggerManager extends Component {
       error,
       status: ERRORED
     })
+
+    const { onError } = this.props
+    if (typeof onError === 'function') onError(error)
   }
 
   handleTwoFACodeAsked(statusCode) {
@@ -221,10 +224,11 @@ export class TriggerManager extends Component {
    * @param  {Function} successCallback Typically onLoginSuccess or onSuccess
    * @param  {Array} args            Callback arguments
    */
-  handleSuccess(successCallback, args) {
-    this.setState({ status: IDLE })
+  async handleSuccess(successCallback) {
+    const trigger = await this.refetchTrigger()
+    this.setState({ status: IDLE, trigger })
     if (typeof successCallback !== 'function') return
-    successCallback(...args)
+    successCallback(triggers)
   }
 
   /**
@@ -235,18 +239,27 @@ export class TriggerManager extends Component {
   async launch(trigger) {
     const {
       launchTrigger,
+      onLaunch,
       onLoginSuccess,
       onSuccess,
       watchKonnectorJob
     } = this.props
     this.jobWatcher = watchKonnectorJob(await launchTrigger(trigger))
     this.jobWatcher.on('error', this.handleError)
-    this.jobWatcher.on('loginSuccess', () =>
-      this.handleSuccess(onLoginSuccess, [trigger])
-    )
-    this.jobWatcher.on('success', () =>
-      this.handleSuccess(onSuccess, [trigger])
-    )
+    this.jobWatcher.on('loginSuccess', () => this.handleSuccess(onLoginSuccess))
+    this.jobWatcher.on('success', () => this.handleSuccess(onSuccess))
+
+    if (typeof onLaunch === 'function') onLaunch(trigger)
+  }
+
+  async refetchTrigger() {
+    const { fetchTrigger, trigger } = this.props
+    try {
+      return await fetchTrigger(trigger._id)
+    } catch (error) {
+      this.setState({ error, running: false })
+      throw error
+    }
   }
 
   render() {
@@ -390,6 +403,16 @@ TriggerManager.propTypes = {
   //
   // Callbacks
   //
+  /**
+   * Callback invoke when the konnector job fails
+   * @type {Function}
+   */
+  onError: PropTypes.func,
+  /**
+   * Callback invoked when the trigger is launch
+   * @type {Function}
+   */
+  onLaunch: PropTypes.func,
   /**
    * Callback invoked when the trigger has been launched and the login to the
    * remote service has succeeded.

--- a/packages/cozy-harvest-lib/src/components/cards/DeleteAccountCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/DeleteAccountCard.jsx
@@ -9,13 +9,14 @@ import DeleteAccountButton from '../DeleteAccountButton'
 
 export class DeleteAccountCard extends PureComponent {
   render() {
-    const { account, onSuccess, t } = this.props
+    const { account, disabled, onSuccess, t } = this.props
     return (
       <Card>
         <SubTitle className="u-mb-1">{t('card.deleteAccount.title')}</SubTitle>
         <Text className="u-mb-1">{t('card.deleteAccount.description')}</Text>
         <DeleteAccountButton
           account={account}
+          disabled={disabled}
           onSuccess={onSuccess}
           extension="full"
         />
@@ -26,6 +27,11 @@ export class DeleteAccountCard extends PureComponent {
 
 DeleteAccountCard.propTypes = {
   ...DeleteAccountButton.propTypes,
+  /**
+   * Indicates if the card should be disabled
+   * @type {boolean}
+   */
+  disabled: PropTypes.bool,
   t: PropTypes.func.isRequired
 }
 

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import pick from 'lodash/pick'
 
@@ -13,7 +13,7 @@ import TriggerLauncher, {
   TriggerLauncher as DumbTriggerLauncher
 } from '../TriggerLauncher'
 
-export class LaunchTriggerCard extends PureComponent {
+export class LaunchTriggerCard extends Component {
   render() {
     const { className, f, t, ...rest } = this.props
     return (

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
@@ -91,7 +91,13 @@ LaunchTriggerCard.propTypes = {
   ...Card.propTypes,
   ...TriggerLauncher.propTypes,
   f: PropTypes.func.isRequired,
-  t: PropTypes.func.isRequired
+  t: PropTypes.func.isRequired,
+  /**
+   * Indicates if a konnector job for the current trigger is already running
+   * TODO: rename all running props to hasJobRunning to make its role clearer
+   * @type {boolean}
+   */
+  submitting: PropTypes.bool
 }
 
 export default translate()(LaunchTriggerCard)

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -160,6 +160,7 @@ const addReferencesToMock = jest.fn()
 const createTriggerMock = jest.fn()
 const createDirectoryByPathMock = jest.fn()
 const statDirectoryByPathMock = jest.fn()
+const fetchTriggerMock = jest.fn()
 const launchTriggerMock = jest.fn()
 const saveAccountMock = jest.fn()
 const watchKonnectorJobMock = jest.fn()
@@ -177,6 +178,7 @@ const props = {
   createTrigger: createTriggerMock,
   createDirectoryByPath: createDirectoryByPathMock,
   statDirectoryByPath: statDirectoryByPathMock,
+  fetchTrigger: fetchTriggerMock,
   launchTrigger: launchTriggerMock,
   onSuccess: onSuccessSpy,
   onLoginSuccess: onLoginSuccessSpy,
@@ -203,6 +205,7 @@ const shallowWithAccount = () =>
 describe('TriggerManager', () => {
   beforeEach(() => {
     createTriggerMock.mockResolvedValue(fixtures.createdTrigger)
+    fetchTriggerMock.mockResolvedValue(fixtures.existingTrigger)
     launchTriggerMock.mockResolvedValue(fixtures.launchedJob)
     saveAccountMock.mockResolvedValue(fixtures.createdAccount)
     watchKonnectorJobMock.mockReturnValue(
@@ -257,9 +260,9 @@ describe('TriggerManager', () => {
       createDirectoryByPathMock.mockResolvedValue(fixtures.folder)
     })
 
-    it('should render error', () => {
+    it('should render error', async () => {
       const wrapper = shallowWithAccount()
-      wrapper.instance().handleError(new Error('Test error'))
+      await wrapper.instance().handleError(new Error('Test error'))
       expect(wrapper.getElement()).toMatchSnapshot()
     })
 


### PR DESCRIPTION
This PR make all the components in KonnectorModal up to date when a job is launched, succeed or throw error.

* AccountErrorInfo si displayed if TriggerManager get errors
* Both TriggerManager and LaunchTriggerCard are rendered as running when a job is launched
* DeleteAccountCard is disabled when a job is launched

As this PR is almost an UX quickfix, it will be followed by another one unifying prop names like running/submitting/isJobRunning and error/konnectorJobError