### PR TITLE
Fix completed fields count (personal data)

### DIFF
--- a/packages/cozy-procedures/src/redux/personalDataSlice.js
+++ b/packages/cozy-procedures/src/redux/personalDataSlice.js
@@ -6,7 +6,7 @@ import { AdministrativeProcedure } from 'cozy-doctypes'
 function getDefaultValue(field) {
   const typeValueMapping = {
     string: '',
-    number: 0
+    number: ''
   }
 
   return get(typeValueMapping, field.type, undefined)
@@ -91,7 +91,8 @@ export function fetchMyself(client) {
   }
 }
 
-const countCompletedFields = data => Object.values(data).filter(Boolean).length
+const countCompletedFields = data =>
+  Object.values(data).filter(v => v !== '').length
 
 const getSlice = state => get(state, personalDataSlice.slice)
 const getData = state => get(state, [personalDataSlice.slice, 'data'], {})

--- a/packages/cozy-procedures/src/redux/personalDataSlice.spec.js
+++ b/packages/cozy-procedures/src/redux/personalDataSlice.spec.js
@@ -23,7 +23,7 @@ describe('Personal data', () => {
       data: {
         firstname: '',
         lastname: '',
-        salary: 0
+        salary: ''
       },
       loading: false,
       error: ''
@@ -207,9 +207,9 @@ describe('fetchMyself action', () => {
           firstname: 'John',
           lastname: 'Doe',
           email: 'john.doe@me.com',
-          phone: undefined,
-          address: null,
-          salary: ''
+          phone: '',
+          address: '',
+          salary: 0
         }
       }
     }
@@ -223,9 +223,9 @@ describe('fetchMyself action', () => {
             firstname: 'John',
             lastname: 'Doe',
             email: 'john.doe@me.com',
-            phone: undefined,
-            address: null,
-            salary: ''
+            phone: '',
+            address: '',
+            salary: 0
           }
         })
       })
@@ -238,9 +238,9 @@ describe('fetchMyself action', () => {
           firstname: 'John',
           lastname: 'Doe',
           email: 'john.doe@me.com',
-          phone: undefined,
-          address: null,
-          salary: ''
+          phone: '',
+          address: '',
+          salary: 0
         })
       })
     })
@@ -255,7 +255,7 @@ describe('fetchMyself action', () => {
     describe('getCompletedFields', () => {
       it('should return the number of completed fields', () => {
         const result = getCompletedFields(state)
-        expect(result).toEqual(3)
+        expect(result).toEqual(4)
       })
     })
 


### PR DESCRIPTION
We had to fix the completed fields count in the overview, to do so, `we use an empty string as default value for all fields. 
Note that `getDefaultValue` has become not very useful but in case we want to handle array values someday, it will be. I can remove it for now if you prefer