### PR TITLE
fix: Use now() to set the metadata datetime during upload

### DIFF
--- a/packages/cozy-procedures/src/components/documents/EmptyDocumentHolder.jsx
+++ b/packages/cozy-procedures/src/components/documents/EmptyDocumentHolder.jsx
@@ -30,9 +30,7 @@ class EmptyDocumentHolder extends Component {
       if (classification) {
         metadata = {
           classification,
-          datetime: file.lastModifiedDate
-            ? file.lastModifiedDate.toISOString()
-            : new Date().toISOString()
+          datetime: new Date().toISOString()
         }
       }
       const dirId = await filesCollection.ensureDirectoryExists(dirPath)


### PR DESCRIPTION
ATM it's pretty confusing for an user to upload a file and set the metadata datetime to the lastEdited date. 

We should work again on this subject pretty soon 