### PR TITLE
Harvest: When refetching, trigger must be retrieved from state

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -253,7 +253,8 @@ export class TriggerManager extends Component {
   }
 
   async refetchTrigger() {
-    const { fetchTrigger, trigger } = this.props
+    const { fetchTrigger } = this.props
+    const { trigger } = this.state
     try {
       return await fetchTrigger(trigger._id)
     } catch (error) {


### PR DESCRIPTION
TriggerManager must retrieve trigger from state before refetching.