### PR TITLE
Handle missing password for encrypted placeholder

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
@@ -47,6 +47,7 @@ export class AccountField extends PureComponent {
     const {
       disabled,
       hasError,
+      forceEncryptedPlaceholder,
       initialValue,
       label,
       name,
@@ -78,7 +79,8 @@ export class AccountField extends PureComponent {
       }),
       placeholder: getFieldPlaceholder(
         this.props,
-        t(`fields.${name}.placeholder`, { _: '' })
+        t(`fields.${name}.placeholder`, { _: '' }),
+        { forceEncryptedPlaceholder }
       ),
       side: required ? null : t('accountForm.fields.optional'),
       size: 'medium'

--- a/packages/cozy-harvest-lib/src/components/AccountForm/AccountFields.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/AccountFields.jsx
@@ -55,6 +55,7 @@ export class AccountFields extends PureComponent {
                   initialValues[getEncryptedFieldName(field.name)]
                 }
                 inputRef={inputRefByName(field.name)}
+                forceEncryptedPlaceholder={!!initialValues}
               />
             )}
           </FinalFormField>

--- a/packages/cozy-harvest-lib/src/helpers/fields.js
+++ b/packages/cozy-harvest-lib/src/helpers/fields.js
@@ -16,17 +16,22 @@ export const getEncryptedFieldName = name => {
 }
 
 /**
- * If the field is encrypted and has an initial value, return a placeholder
- * that indicate that the value exists.
+ * If the field is encrypted and has initial value (or placeholder is forced),
+ * return a placeholder that indicate that the value exists.
  *
  * @param  {object} props AccountField component props
+ * @param  {object} fallback the placeholder to fall back
+ * @param  {object} options Extra options object
  * @return {string}       The encrypted placeholder or en empty string if the
  *                        field does not need encrypted placeholder
  */
-export const getFieldPlaceholder = (props, fallback) => {
+export const getFieldPlaceholder = (props, fallback, options = {}) => {
   const { encrypted, initialValue, placeholder } = props
+  const { forceEncryptedPlaceholder } = options
   return (
-    (encrypted && initialValue && ENCRYPTED_PLACEHOLDER) ||
+    (encrypted &&
+      (initialValue || forceEncryptedPlaceholder) &&
+      ENCRYPTED_PLACEHOLDER) ||
     placeholder ||
     fallback ||
     ''

--- a/packages/cozy-harvest-lib/test/helpers/fields.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/fields.spec.js
@@ -63,6 +63,19 @@ describe('Fields Helper', () => {
         )
       ).toBe('*************')
     })
+
+    it('should return placeholder for encrypted fields if no initialValue but forceEncryptedPlaceholder provided', () => {
+      expect(
+        getFieldPlaceholder(
+          {
+            encrypted: true,
+            placeholder: 'Random placeholder'
+          },
+          'Fallback placeholder',
+          { forceEncryptedPlaceholder: true }
+        )
+      ).toBe('*************')
+    })
   })
 
   describe('sanitizeSelectProps', () => {


### PR DESCRIPTION
Some connectors don't keep the password, with this fix, if an account is already configured but encrypted fields are missing, we force the placeholder