### PR TITLE
Correctly check initialValues if exists

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/AccountFields.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/AccountFields.jsx
@@ -25,7 +25,7 @@ export class AccountFields extends PureComponent {
       disabled,
       fields,
       hasError,
-      initialValues,
+      initialValues = {},
       inputRefByName
     } = this.props
 
@@ -55,7 +55,7 @@ export class AccountFields extends PureComponent {
                   initialValues[getEncryptedFieldName(field.name)]
                 }
                 inputRef={inputRefByName(field.name)}
-                forceEncryptedPlaceholder={!!initialValues}
+                forceEncryptedPlaceholder={!!Object.keys(initialValues).length}
               />
             )}
           </FinalFormField>


### PR DESCRIPTION
`initialValues` is an empty object if there is no account