### PR TITLE
fix: Use needclick on the fileinput label

### DIFF
--- a/packages/cozy-procedures/src/components/documents/UploadInputLabel.jsx
+++ b/packages/cozy-procedures/src/components/documents/UploadInputLabel.jsx
@@ -10,7 +10,6 @@ const UploadInputLabel = ({ t, breakpoints }) => {
   if (isIOSApp()) {
     return (
       <span className="needsclick">
-        {' '}
         {t('documents.upload.from_my_device_scan')}
       </span>
     )

--- a/packages/cozy-procedures/src/components/documents/UploadInputLabel.jsx
+++ b/packages/cozy-procedures/src/components/documents/UploadInputLabel.jsx
@@ -8,7 +8,12 @@ import { translate, withBreakpoints } from 'cozy-ui/transpiled/react'
 const UploadInputLabel = ({ t, breakpoints }) => {
   const { isMobile } = breakpoints
   if (isIOSApp()) {
-    return <span> {t('documents.upload.from_my_device_scan')}</span>
+    return (
+      <span className="needsclick">
+        {' '}
+        {t('documents.upload.from_my_device_scan')}
+      </span>
+    )
   } else if (isAndroidApp()) {
     return <span>{t('documents.upload.from_my_mobile')}</span>
   } else {


### PR DESCRIPTION
Fastclick is causing issue on our iOS App. We need to use `needsclick` to tell fastclick to go away