### PR TITLE
Harvest: Check after tx pull ☑

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -21,6 +21,7 @@
     "prepublishOnly": "yarn build",
     "test": "jest --verbose",
     "tx": "tx pull --all",
+    "posttx": "./scripts/check-locales.sh",
     "watch": "yarn build --watch",
     "watch:doc:react": "(cd ../.. && TARGET=cozy-harvest-lib yarn watch:doc:react)"
   },

--- a/packages/cozy-harvest-lib/scripts/check-locales.sh
+++ b/packages/cozy-harvest-lib/scripts/check-locales.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+errormessage=`cmp <(jq 'path(..)|map(tostring)|join(".")' src/locales/en.json) <(jq 'path(..)|map(select(length > 0)|tostring)|join(".")' src/locales/fr.json) 2>&1`
+
+if [ ! -z "$errormessage" ]; then
+  echo "Locales en and fr mismatch: $errormessage"
+  exit 1
+fi


### PR DESCRIPTION
Reused the script from https://github.com/cozy/cozy-home/pull/1076.

This PR adds a locales check after a tx pull.

The build will fail if locales files do not match.

It will prevent releases with missing fr translations.