### PR TITLE
feat(cozy-doctypes): Implement Document::queryAll with cozy-client

### DIFF
--- a/packages/cozy-doctypes/src/Document.js
+++ b/packages/cozy-doctypes/src/Document.js
@@ -415,10 +415,27 @@ class Document {
    */
   static async queryAll(selector, index) {
     if (this.usesCozyClient()) {
-      throw new Error('This method is not implemented yet with CozyClient')
+      return this.queryAllViaNewClient(selector)
     }
 
     return this.queryAllViaOldClient(selector, index)
+  }
+
+  static async queryAllViaNewClient(selector) {
+    if (!selector) {
+      return this.fetchAll()
+    }
+
+    const result = []
+
+    const query = this.cozyClient.find(this.doctype).where(selector)
+    let resp = { next: true }
+    while (resp && resp.next) {
+      resp = await this.cozyClient.query(query.offset(result.length))
+      result.push(...resp.data)
+    }
+
+    return result
   }
 
   static async queryAllViaOldClient(selector, index) {

--- a/packages/cozy-doctypes/src/__snapshots__/Document.spec.js.snap
+++ b/packages/cozy-doctypes/src/__snapshots__/Document.spec.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Document used with CozyClient queryAll should return all the documents while there are next documents 1`] = `
+Array [
+  Object {
+    "_id": 1,
+    "_type": "io.cozy.simpsons",
+    "name": "Lisa",
+  },
+  Object {
+    "_id": 2,
+    "_type": "io.cozy.simpsons",
+    "name": "Bart",
+  },
+  Object {
+    "_id": 3,
+    "_type": "io.cozy.simpsons",
+    "name": "Homer",
+  },
+  Object {
+    "_id": 4,
+    "_type": "io.cozy.simpsons",
+    "name": "Marge",
+  },
+]
+`;


### PR DESCRIPTION
While implementing a new service in banks, I wanted to use models with the new cozy-client, and the implementation of this method was missing.

Other missing methods may come in next PRs.