### PR TITLE
feat: Loading state

### DIFF
--- a/packages/cozy-procedures/src/Procedure.jsx
+++ b/packages/cozy-procedures/src/Procedure.jsx
@@ -12,7 +12,7 @@ class Procedure extends React.Component {
       initPersonalData,
       initDocuments,
       fetchMyself,
-      fetchDocument,
+      fetchDocumentsByCategory,
       client,
       setProcedureStatus
     } = this.props
@@ -29,9 +29,9 @@ class Procedure extends React.Component {
     setProcedureStatus({ initiated: true })
     fetchMyself(client)
 
-    const { documents: documentsTemplate } = creditApplicationTemplate
-    Object.keys(documentsTemplate).map(document => {
-      fetchDocument(client, document)
+    const { documents: documentsCategory } = creditApplicationTemplate
+    Object.keys(documentsCategory).map(document => {
+      fetchDocumentsByCategory(document)
     })
   }
 

--- a/packages/cozy-procedures/src/Procedure.jsx
+++ b/packages/cozy-procedures/src/Procedure.jsx
@@ -53,7 +53,7 @@ Procedure.propTypes = {
   initPersonalData: PropTypes.func.isRequired,
   initDocuments: PropTypes.func.isRequired,
   fetchMyself: PropTypes.func.isRequired,
-  fetchDocument: PropTypes.func.isRequired,
+  fetchDocumentsByCategory: PropTypes.func.isRequired,
   setProcedureStatus: PropTypes.func.isRequired,
   initiated: PropTypes.bool.isRequired,
   client: PropTypes.object.isRequired

--- a/packages/cozy-procedures/src/components/Documents.jsx
+++ b/packages/cozy-procedures/src/components/Documents.jsx
@@ -53,15 +53,15 @@ class Documents extends React.Component {
         <Title className="u-ta-center u-mb-2">{t('documents.subtitle')}</Title>
         <CompletedFromDriveStatus />
         {Object.keys(populatedTemplateDocsWithFiles).map(
-          (documentId, index) => {
-            const { files, count } = populatedTemplateDocsWithFiles[documentId]
-            const filesStatusByCategory = filesStatus[documentId]
+          (categoryId, index) => {
+            const { files, count } = populatedTemplateDocsWithFiles[categoryId]
+            const filesStatusByCategory = filesStatus[categoryId]
             return (
               <section key={index}>
                 <Label>
                   {t(
                     `documents.labels.${
-                      populatedTemplateDocsWithFiles[documentId].label
+                      populatedTemplateDocsWithFiles[categoryId].label
                     }`
                   )}
                 </Label>
@@ -69,7 +69,7 @@ class Documents extends React.Component {
                   files={files}
                   filesStatusByCategory={filesStatusByCategory}
                   templateDocumentsCount={count}
-                  documentId={documentId}
+                  categoryId={categoryId}
                 />
               </section>
             )

--- a/packages/cozy-procedures/src/components/Documents.jsx
+++ b/packages/cozy-procedures/src/components/Documents.jsx
@@ -40,7 +40,7 @@ export const mergeDocsFromStoreAndTemplate = (
 }
 class Documents extends React.Component {
   render() {
-    const { t, router, files: docsFromStore } = this.props
+    const { t, router, files: docsFromStore, filesStatus } = this.props
     const { documents: documentsTemplate } = creditApplicationTemplate
     const populatedTemplateDocsWithFiles = mergeDocsFromStoreAndTemplate(
       docsFromStore,
@@ -55,6 +55,7 @@ class Documents extends React.Component {
         {Object.keys(populatedTemplateDocsWithFiles).map(
           (documentId, index) => {
             const { files, count } = populatedTemplateDocsWithFiles[documentId]
+            const filesStatusByCategory = filesStatus[documentId]
             return (
               <section key={index}>
                 <Label>
@@ -66,6 +67,7 @@ class Documents extends React.Component {
                 </Label>
                 <DocumentsGroup
                   files={files}
+                  filesStatusByCategory={filesStatusByCategory}
                   templateDocumentsCount={count}
                   documentId={documentId}
                 />
@@ -91,7 +93,8 @@ Documents.propTypes = {
   router: PropTypes.shape({
     goBack: PropTypes.func.isRequired
   }).isRequired,
-  files: PropTypes.object
+  files: PropTypes.object,
+  filesStatus: PropTypes.object
 }
 
 export default withRouter(translate()(DocumentsContainer(Documents)))

--- a/packages/cozy-procedures/src/components/documents/DocumentHolder.jsx
+++ b/packages/cozy-procedures/src/components/documents/DocumentHolder.jsx
@@ -21,7 +21,7 @@ class DocumentHolder extends Component {
   }
 
   render() {
-    const { document, unlinkDocument, documentId, t, index } = this.props
+    const { document, unlinkDocument, categoryId, t, index } = this.props
     const { isUnlinkConfirmationModalOpened, isViewerModalOpened } = this.state
 
     const splittedName = CozyFile.splitFilename(document)
@@ -30,7 +30,7 @@ class DocumentHolder extends Component {
         {isUnlinkConfirmationModalOpened && (
           <Modal
             primaryText={t('documents.unlink.unlink')}
-            primaryAction={() => unlinkDocument({ documentId, index })}
+            primaryAction={() => unlinkDocument({ categoryId, index })}
             secondaryText={t('cancel')}
             secondaryAction={() =>
               this.setState({ isUnlinkConfirmationModalOpened: false })
@@ -91,7 +91,7 @@ class DocumentHolder extends Component {
 
 DocumentHolder.propTypes = {
   unlinkDocument: PropTypes.func.isRequired,
-  documentId: PropTypes.string.isRequired,
+  categoryId: PropTypes.string.isRequired,
   //io.cozy.files
   document: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,

--- a/packages/cozy-procedures/src/components/documents/DocumentHolder.jsx
+++ b/packages/cozy-procedures/src/components/documents/DocumentHolder.jsx
@@ -21,7 +21,7 @@ class DocumentHolder extends Component {
   }
 
   render() {
-    const { document, unlinkDocument, documentId, t } = this.props
+    const { document, unlinkDocument, documentId, t, index } = this.props
     const { isUnlinkConfirmationModalOpened, isViewerModalOpened } = this.state
 
     const splittedName = CozyFile.splitFilename(document)
@@ -30,7 +30,7 @@ class DocumentHolder extends Component {
         {isUnlinkConfirmationModalOpened && (
           <Modal
             primaryText={t('documents.unlink.unlink')}
-            primaryAction={() => unlinkDocument({ document, documentId })}
+            primaryAction={() => unlinkDocument({ documentId, index })}
             secondaryText={t('cancel')}
             secondaryAction={() =>
               this.setState({ isUnlinkConfirmationModalOpened: false })
@@ -94,6 +94,7 @@ DocumentHolder.propTypes = {
   documentId: PropTypes.string.isRequired,
   //io.cozy.files
   document: PropTypes.object.isRequired,
-  t: PropTypes.func.isRequired
+  t: PropTypes.func.isRequired,
+  index: PropTypes.number.isRequired
 }
 export default flow(translate())(DocumentsDataFormContainer(DocumentHolder))

--- a/packages/cozy-procedures/src/components/documents/DocumentsGroup.jsx
+++ b/packages/cozy-procedures/src/components/documents/DocumentsGroup.jsx
@@ -6,7 +6,7 @@ import LoadingDocumentHolder from './LoadingDocumentHolder'
 const DocumentsGroup = ({
   files,
   templateDocumentsCount,
-  documentId,
+  categoryId,
   filesStatusByCategory
 }) => {
   const slots = [...files, ...new Array(templateDocumentsCount - files.length)]
@@ -15,13 +15,13 @@ const DocumentsGroup = ({
       <DocumentHolder
         document={value}
         key={index}
-        documentId={documentId}
+        categoryId={categoryId}
         index={index}
       />
     ) : filesStatusByCategory[index].loading ? (
       <LoadingDocumentHolder key={index} />
     ) : (
-      <EmptyDocumentHolder key={index} documentId={documentId} index={index} />
+      <EmptyDocumentHolder key={index} categoryId={categoryId} index={index} />
     )
   )
 }
@@ -29,7 +29,7 @@ const DocumentsGroup = ({
 DocumentsGroup.propTypes = {
   files: PropTypes.array.isRequired,
   templateDocumentsCount: PropTypes.number.isRequired,
-  documentId: PropTypes.string.isRequired,
+  categoryId: PropTypes.string.isRequired,
   filesStatusByCategory: PropTypes.array.isRequired
 }
 export default DocumentsGroup

--- a/packages/cozy-procedures/src/components/documents/DocumentsGroup.jsx
+++ b/packages/cozy-procedures/src/components/documents/DocumentsGroup.jsx
@@ -2,14 +2,26 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import DocumentHolder from './DocumentHolder'
 import EmptyDocumentHolder from './EmptyDocumentHolder'
-
-const DocumentsGroup = ({ files, templateDocumentsCount, documentId }) => {
+import LoadingDocumentHolder from './LoadingDocumentHolder'
+const DocumentsGroup = ({
+  files,
+  templateDocumentsCount,
+  documentId,
+  filesStatusByCategory
+}) => {
   const slots = [...files, ...new Array(templateDocumentsCount - files.length)]
   return slots.map((value, index) =>
     value ? (
-      <DocumentHolder document={value} key={index} documentId={documentId} />
+      <DocumentHolder
+        document={value}
+        key={index}
+        documentId={documentId}
+        index={index}
+      />
+    ) : filesStatusByCategory[index].loading ? (
+      <LoadingDocumentHolder key={index} />
     ) : (
-      <EmptyDocumentHolder key={index} documentId={documentId} />
+      <EmptyDocumentHolder key={index} documentId={documentId} index={index} />
     )
   )
 }
@@ -17,6 +29,7 @@ const DocumentsGroup = ({ files, templateDocumentsCount, documentId }) => {
 DocumentsGroup.propTypes = {
   files: PropTypes.array.isRequired,
   templateDocumentsCount: PropTypes.number.isRequired,
-  documentId: PropTypes.string.isRequired
+  documentId: PropTypes.string.isRequired,
+  filesStatusByCategory: PropTypes.array.isRequired
 }
 export default DocumentsGroup

--- a/packages/cozy-procedures/src/components/documents/EmptyDocumentHolder.jsx
+++ b/packages/cozy-procedures/src/components/documents/EmptyDocumentHolder.jsx
@@ -24,10 +24,10 @@ class EmptyDocumentHolder extends Component {
       linkDocumentSuccess,
       t,
       index,
-      fetchDocumentLoading,
+      setDocumentLoading,
       fetchDocumentError
     } = this.props
-    fetchDocumentLoading({ idDoctemplate: categoryId, index })
+    setDocumentLoading({ idDoctemplate: categoryId, index })
     const dirPath = creditApplicationTemplate.pathToSave
     const filesCollection = client.collection('io.cozy.files')
     const classification = get(
@@ -80,7 +80,7 @@ EmptyDocumentHolder.propTypes = {
   breakpoints: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
   index: PropTypes.number.isRequired,
-  fetchDocumentLoading: PropTypes.func.isRequired,
+  setDocumentLoading: PropTypes.func.isRequired,
   fetchDocumentError: PropTypes.func.isRequired
 }
 

--- a/packages/cozy-procedures/src/components/documents/EmptyDocumentHolder.jsx
+++ b/packages/cozy-procedures/src/components/documents/EmptyDocumentHolder.jsx
@@ -19,7 +19,7 @@ class EmptyDocumentHolder extends Component {
 
   async onChange(file) {
     const {
-      documentId,
+      categoryId,
       client,
       linkDocumentSuccess,
       t,
@@ -27,11 +27,11 @@ class EmptyDocumentHolder extends Component {
       fetchDocumentLoading,
       fetchDocumentError
     } = this.props
-    fetchDocumentLoading({ idDoctemplate: documentId, index })
+    fetchDocumentLoading({ idDoctemplate: categoryId, index })
     const dirPath = creditApplicationTemplate.pathToSave
     const filesCollection = client.collection('io.cozy.files')
     const classification = get(
-      creditApplicationTemplate.documents[documentId],
+      creditApplicationTemplate.documents[categoryId],
       `rules.metadata.classification`
     )
     try {
@@ -48,10 +48,10 @@ class EmptyDocumentHolder extends Component {
         .collection('io.cozy.files')
         .createFile(file, { dirId, metadata })
 
-      linkDocumentSuccess({ document: createdFile.data, documentId, index })
+      linkDocumentSuccess({ document: createdFile.data, categoryId, index })
     } catch (uploadError) {
       fetchDocumentError({
-        idDoctemplate: documentId,
+        idDoctemplate: categoryId,
         index,
         error: uploadError.message
       })
@@ -59,7 +59,6 @@ class EmptyDocumentHolder extends Component {
         Alerter.error(t('documents.upload.conflict_error'))
       } else {
         Alerter.error(t('documents.upload.error'))
-        console.log('Upload error : ', uploadError)
       }
     }
   }
@@ -76,7 +75,7 @@ class EmptyDocumentHolder extends Component {
 }
 
 EmptyDocumentHolder.propTypes = {
-  documentId: PropTypes.string.isRequired,
+  categoryId: PropTypes.string.isRequired,
   linkDocumentSuccess: PropTypes.func.isRequired,
   breakpoints: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,

--- a/packages/cozy-procedures/src/components/documents/EmptyDocumentHolder.jsx
+++ b/packages/cozy-procedures/src/components/documents/EmptyDocumentHolder.jsx
@@ -24,9 +24,10 @@ class EmptyDocumentHolder extends Component {
       linkDocumentSuccess,
       t,
       index,
-      setLoadingForDocument
+      fetchDocumentLoading,
+      fetchDocumentError
     } = this.props
-    setLoadingForDocument(documentId, index)
+    fetchDocumentLoading({ idDoctemplate: documentId, index })
     const dirPath = creditApplicationTemplate.pathToSave
     const filesCollection = client.collection('io.cozy.files')
     const classification = get(
@@ -49,6 +50,11 @@ class EmptyDocumentHolder extends Component {
 
       linkDocumentSuccess({ document: createdFile.data, documentId, index })
     } catch (uploadError) {
+      fetchDocumentError({
+        idDoctemplate: documentId,
+        index,
+        error: uploadError.message
+      })
       if (uploadError.status === 409) {
         Alerter.error(t('documents.upload.conflict_error'))
       } else {
@@ -75,7 +81,8 @@ EmptyDocumentHolder.propTypes = {
   breakpoints: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
   index: PropTypes.number.isRequired,
-  setLoadingForDocument: PropTypes.func.isRequired
+  fetchDocumentLoading: PropTypes.func.isRequired,
+  fetchDocumentError: PropTypes.func.isRequired
 }
 
 export default flow(

--- a/packages/cozy-procedures/src/components/documents/EmptyDocumentHolder.jsx
+++ b/packages/cozy-procedures/src/components/documents/EmptyDocumentHolder.jsx
@@ -18,7 +18,15 @@ class EmptyDocumentHolder extends Component {
   }
 
   async onChange(file) {
-    const { documentId, client, linkDocumentSuccess, t } = this.props
+    const {
+      documentId,
+      client,
+      linkDocumentSuccess,
+      t,
+      index,
+      setLoadingForDocument
+    } = this.props
+    setLoadingForDocument(documentId, index)
     const dirPath = creditApplicationTemplate.pathToSave
     const filesCollection = client.collection('io.cozy.files')
     const classification = get(
@@ -39,7 +47,7 @@ class EmptyDocumentHolder extends Component {
         .collection('io.cozy.files')
         .createFile(file, { dirId, metadata })
 
-      linkDocumentSuccess({ document: createdFile.data, documentId })
+      linkDocumentSuccess({ document: createdFile.data, documentId, index })
     } catch (uploadError) {
       if (uploadError.status === 409) {
         Alerter.error(t('documents.upload.conflict_error'))
@@ -65,7 +73,9 @@ EmptyDocumentHolder.propTypes = {
   documentId: PropTypes.string.isRequired,
   linkDocumentSuccess: PropTypes.func.isRequired,
   breakpoints: PropTypes.object.isRequired,
-  t: PropTypes.func.isRequired
+  t: PropTypes.func.isRequired,
+  index: PropTypes.number.isRequired,
+  setLoadingForDocument: PropTypes.func.isRequired
 }
 
 export default flow(

--- a/packages/cozy-procedures/src/components/documents/LoadingDocumentHolder.jsx
+++ b/packages/cozy-procedures/src/components/documents/LoadingDocumentHolder.jsx
@@ -1,13 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { translate, Icon, Spinner } from 'cozy-ui/transpiled/react/'
+import { translate, Spinner } from 'cozy-ui/transpiled/react/'
 import Card from 'cozy-ui/transpiled/react/Card'
 
 const LoadingDocumentHolder = ({ t }) => (
   <Card className="u-flex u-flex-row u-flex-items-center">
     <Spinner className="u-ml-0 u-mr-1" size="large" />
     <span className="u-flex-grow-1 u-coolGrey">{t('documents.importing')}</span>
-    <Icon icon="cross" size={16} className="u-pr-1" />
   </Card>
 )
 

--- a/packages/cozy-procedures/src/containers/DocumentsDataForm.jsx
+++ b/packages/cozy-procedures/src/containers/DocumentsDataForm.jsx
@@ -1,20 +1,24 @@
 import { connect } from 'react-redux'
 import context from '../redux/context'
 import {
-  fetchDocument,
+  fetchDocumentsByCategory,
   getFiles,
   unlinkDocument,
-  linkDocumentSuccess
+  linkDocumentSuccess,
+  getFilesStatus,
+  setLoadingForDocument
 } from '../redux/documentsDataSlice'
 
 const mapStateToProps = state => ({
-  files: getFiles(state)
+  files: getFiles(state),
+  filesStatus: getFilesStatus(state)
 })
 
 const mapDispatchToProps = {
-  fetchDocument,
+  fetchDocumentsByCategory,
   unlinkDocument,
-  linkDocumentSuccess
+  linkDocumentSuccess,
+  setLoadingForDocument
 }
 
 const DocumentsDataFormContainer = Component =>

--- a/packages/cozy-procedures/src/containers/DocumentsDataForm.jsx
+++ b/packages/cozy-procedures/src/containers/DocumentsDataForm.jsx
@@ -6,7 +6,7 @@ import {
   unlinkDocument,
   linkDocumentSuccess,
   getFilesStatus,
-  fetchDocumentLoading,
+  setDocumentLoading,
   fetchDocumentError
 } from '../redux/documentsDataSlice'
 
@@ -19,7 +19,7 @@ const mapDispatchToProps = {
   fetchDocumentsByCategory,
   unlinkDocument,
   linkDocumentSuccess,
-  fetchDocumentLoading,
+  setDocumentLoading,
   fetchDocumentError
 }
 

--- a/packages/cozy-procedures/src/containers/DocumentsDataForm.jsx
+++ b/packages/cozy-procedures/src/containers/DocumentsDataForm.jsx
@@ -6,7 +6,8 @@ import {
   unlinkDocument,
   linkDocumentSuccess,
   getFilesStatus,
-  setLoadingForDocument
+  fetchDocumentLoading,
+  fetchDocumentError
 } from '../redux/documentsDataSlice'
 
 const mapStateToProps = state => ({
@@ -18,7 +19,8 @@ const mapDispatchToProps = {
   fetchDocumentsByCategory,
   unlinkDocument,
   linkDocumentSuccess,
-  setLoadingForDocument
+  fetchDocumentLoading,
+  fetchDocumentError
 }
 
 const DocumentsDataFormContainer = Component =>

--- a/packages/cozy-procedures/src/containers/Procedure.jsx
+++ b/packages/cozy-procedures/src/containers/Procedure.jsx
@@ -7,7 +7,7 @@ import {
 } from '../redux/personalDataSlice'
 import {
   init as initDocuments,
-  fetchDocument,
+  fetchDocumentsByCategory,
   setProcedureStatus,
   getInitiated
 } from '../redux/documentsDataSlice'
@@ -22,7 +22,7 @@ const mapDispatchToProps = {
   initPersonalData,
   fetchMyself,
   initDocuments,
-  fetchDocument,
+  fetchDocumentsByCategory,
   setProcedureStatus
 }
 

--- a/packages/cozy-procedures/src/redux/documentsDataSlice.js
+++ b/packages/cozy-procedures/src/redux/documentsDataSlice.js
@@ -156,7 +156,10 @@ export function fetchDocumentsByCategory(documentTemplate) {
           )
         })
       }
-
+      /**
+       * If we got less files that required, let's remove the loading state.
+       * It's just because we don't have a file
+       */
       if (files.data.length < docWithRules.count) {
         for (let i = files.data.length; i < docWithRules.count; i++) {
           dispatch(
@@ -170,6 +173,7 @@ export function fetchDocumentsByCategory(documentTemplate) {
       }
     } catch (error) {
       const docWithRules = creditApplicationTemplate.documents[documentTemplate]
+      //If we had a global error for a category, let's set the error everywhere
       for (let i = 0; i < docWithRules.count; i++) {
         dispatch(
           fetchDocumentError({

--- a/packages/cozy-procedures/src/redux/documentsDataSlice.js
+++ b/packages/cozy-procedures/src/redux/documentsDataSlice.js
@@ -35,18 +35,23 @@ const documentsSlice = createSlice({
           }
           return acc
         }, {}),
-        ui: Object.keys(action.payload).reduce((acc, fieldId) => {
-          const count = action.payload[fieldId].count
-          acc[fieldId] = Array.from(Array(count))
-          for (let i = 0; i < count; i++) {
-            acc[fieldId][i] = {
-              loading: false,
-              error: false
+        ui: Object.keys(action.payload).reduce(
+          (acc, fieldId) => {
+            const count = action.payload[fieldId].count
+            acc[fieldId] = Array.from(Array(count))
+            for (let i = 0; i < count; i++) {
+              acc[fieldId][i] = {
+                loading: false,
+                error: false
+              }
             }
-          }
 
-          return acc
-        }, {})
+            return acc
+          },
+          {
+            initiated: false
+          }
+        )
       }
     },
 
@@ -86,10 +91,14 @@ const documentsSlice = createSlice({
 const getData = state => get(state, [documentsSlice.slice, 'data'], {})
 
 const getCompletedCount = state =>
-  Object.values(getData(state)).reduce(
-    (acc, { files }) => acc + files.length,
-    0
-  )
+  Object.values(getData(state)).reduce((acc, { files }) => {
+    files.map(file => {
+      if (file !== undefined) {
+        acc++
+      }
+    })
+    return acc
+  }, 0)
 
 const selectors = {
   getFiles: getData,
@@ -98,10 +107,12 @@ const selectors = {
   getCompletedDocumentsCount: getCompletedCount,
   getDocumentsTotal: () => {
     // FIXME: don't use the template directly here
-    return Object.values(creditApplicationTemplate.documents).reduce(
+    const test = Object.values(creditApplicationTemplate.documents).reduce(
       (acc, { count }) => acc + count,
       0
     )
+    console.log('test', test)
+    return test
   },
   getInitiated: state =>
     get(state, [documentsSlice.slice, 'ui', ['initiated']], {}),

--- a/packages/cozy-procedures/src/redux/documentsDataSlice.js
+++ b/packages/cozy-procedures/src/redux/documentsDataSlice.js
@@ -107,12 +107,10 @@ const selectors = {
   getCompletedDocumentsCount: getCompletedCount,
   getDocumentsTotal: () => {
     // FIXME: don't use the template directly here
-    const test = Object.values(creditApplicationTemplate.documents).reduce(
+    return Object.values(creditApplicationTemplate.documents).reduce(
       (acc, { count }) => acc + count,
       0
     )
-    console.log('test', test)
-    return test
   },
   getInitiated: state =>
     get(state, [documentsSlice.slice, 'ui', ['initiated']], {}),

--- a/packages/cozy-procedures/src/redux/documentsDataSlice.js
+++ b/packages/cozy-procedures/src/redux/documentsDataSlice.js
@@ -74,12 +74,12 @@ const documentsSlice = createSlice({
       state.ui.initiated = action.payload.initiated
     },
     unlinkDocument: (state, action) => {
-      const { documentId, index } = action.payload
-      state.data[documentId].files[index] = undefined
+      const { categoryId, index } = action.payload
+      state.data[categoryId].files[index] = undefined
     },
     linkDocumentSuccess: (state, action) => {
-      const { document, documentId, index } = action.payload
-      state.data[documentId].files[index] = document
+      const { document, categoryId, index } = action.payload
+      state.data[categoryId].files[index] = document
     },
     setLoadingFalse: (state, action) => {
       const { idDoctemplate, index } = action.payload

--- a/packages/cozy-procedures/src/redux/documentsDataSlice.js
+++ b/packages/cozy-procedures/src/redux/documentsDataSlice.js
@@ -55,7 +55,7 @@ const documentsSlice = createSlice({
       }
     },
 
-    fetchDocumentLoading: (state, action) => {
+    setDocumentLoading: (state, action) => {
       const { idDoctemplate, index } = action.payload
       state.ui[idDoctemplate][index].loading = true
     },
@@ -121,7 +121,7 @@ const { actions, reducer } = documentsSlice
 export const {
   init,
   update,
-  fetchDocumentLoading,
+  setDocumentLoading,
   fetchDocumentSuccess,
   fetchDocumentError,
   setProcedureStatus,
@@ -136,7 +136,7 @@ export function fetchDocumentsByCategory(documentTemplate) {
       const docWithRules = creditApplicationTemplate.documents[documentTemplate]
       for (let i = 0; i < docWithRules.count; i++) {
         dispatch(
-          fetchDocumentLoading({
+          setDocumentLoading({
             idDoctemplate: documentTemplate,
             index: i
           })

--- a/packages/cozy-procedures/src/templates/creditApplicationTemplate.js
+++ b/packages/cozy-procedures/src/templates/creditApplicationTemplate.js
@@ -172,7 +172,7 @@ const documents = {
   payslip: {
     label: 'payslip',
     order: 3,
-    count: 1,
+    count: 3,
     rules: {
       metadata: {
         classification: 'payslip'

--- a/packages/cozy-procedures/src/templates/creditApplicationTemplate.js
+++ b/packages/cozy-procedures/src/templates/creditApplicationTemplate.js
@@ -172,7 +172,7 @@ const documents = {
   payslip: {
     label: 'payslip',
     order: 3,
-    count: 3,
+    count: 1,
     rules: {
       metadata: {
         classification: 'payslip'


### PR DESCRIPTION
a few things in this PR : 

- having an "importing" state in order to display a "loading" component. 
- dealing with error during import 
- no need to pass loading: true / false, we already know what we're doing 

In order to have a loading state, we need to init the documents store with the same numbers of document required in the template. Like that, we can use the  `index` to populate at the right place