### PR TITLE
Harvest: Manage margin issues

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -190,6 +190,10 @@ export class AccountForm extends PureComponent {
             ref={element => {
               container = element
             }}
+            // Hacking manually the style here, waiting for Cozy-UI to remove
+            // top margin on Field's label elements.
+            // See https://github.com/cozy/cozy-libs/issues/629
+            style={{ marginTop: '-1rem' }}
           >
             {error && showError && (
               <TriggerErrorInfo

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -178,6 +178,7 @@ export class KonnectorModal extends PureComponent {
                   />
                 )}
                 <LaunchTriggerCard
+                  className="u-mb-1"
                   trigger={trigger}
                   onError={this.handleKonnectorJobError}
                   onLaunch={this.handleTriggerLaunch}

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
@@ -4,6 +4,11 @@ exports[`AccountForm should not render error 1`] = `
 <div
   onFocusCapture={[Function]}
   onKeyUp={[Function]}
+  style={
+    Object {
+      "marginTop": "-1rem",
+    }
+  }
 >
   <AccountFields
     container={null}
@@ -55,6 +60,11 @@ exports[`AccountForm should render 1`] = `
 <div
   onFocusCapture={[Function]}
   onKeyUp={[Function]}
+  style={
+    Object {
+      "marginTop": "-1rem",
+    }
+  }
 >
   <AccountFields
     container={null}
@@ -105,6 +115,11 @@ exports[`AccountForm should render error 1`] = `
 <div
   onFocusCapture={[Function]}
   onKeyUp={[Function]}
+  style={
+    Object {
+      "marginTop": "-1rem",
+    }
+  }
 >
   <Wrapper
     className="u-mb-1"


### PR DESCRIPTION
Related to https://github.com/cozy/cozy-ui/pull/1094

For OAuth konnectors, LaunchTriggerCard did not have bottom margin with DeleteButtonCard.

We using a dirty hack here while waiting Cozy-UI to introduce breaking changes for Field label issue.

BEFORE

![Capture d’écran 2019-07-08 à 17 28 09](https://user-images.githubusercontent.com/776764/60822741-58ebc400-a1a6-11e9-9101-05b5ebafc360.png)


AFTER

![Capture d’écran 2019-07-08 à 17 11 53](https://user-images.githubusercontent.com/776764/60821280-871bd480-a1a3-11e9-8811-f54486664eff.png)

![Capture d’écran 2019-07-08 à 17 11 41](https://user-images.githubusercontent.com/776764/60821291-8c791f00-a1a3-11e9-9b7c-b06c21fd30c1.png)
