### PR TITLE
Implement Document::create and Document::createOrUpdate with cozy-client

### DIFF
--- a/packages/cozy-doctypes/src/Document.js
+++ b/packages/cozy-doctypes/src/Document.js
@@ -220,10 +220,14 @@ class Document {
 
   static create(attributes) {
     if (this.usesCozyClient()) {
-      throw new Error('This method is not implemented yet with CozyClient')
+      return this.createViaNewClient(attributes)
     }
 
     return this.createViaOldClient(attributes)
+  }
+
+  static createViaNewClient(attributes) {
+    return this.cozyClient.create(this.doctype, attributes)
   }
 
   static createViaOldClient(attributes) {

--- a/packages/cozy-doctypes/src/Document.js
+++ b/packages/cozy-doctypes/src/Document.js
@@ -152,10 +152,67 @@ class Document {
 
   static async createOrUpdate(attributes) {
     if (this.usesCozyClient()) {
-      throw new Error('This method is not implemented yet with CozyClient')
+      return this.createOrUpdateViaNewClient(attributes)
     }
 
     return this.createOrUpdateViaOldClient(attributes)
+  }
+
+  static async createOrUpdateViaNewClient(attributes) {
+    const selector = fromPairs(
+      this.idAttributes.map(idAttribute => [
+        idAttribute,
+        get(attributes, sanitizeKey(idAttribute))
+      ])
+    )
+    let results = []
+    const compactedSelector = withoutUndefined(selector)
+    if (size(compactedSelector) === this.idAttributes.length) {
+      results = await this.queryAll(selector)
+    }
+
+    if (results.length === 0) {
+      return this.create(this.addCozyMetadata(attributes))
+    } else if (results.length === 1) {
+      const id = results[0]._id
+      const update = omit(attributes, userAttributes)
+
+      // only update if some fields are different
+      if (
+        !this.checkAttributes ||
+        isDifferent(
+          pick(results[0], this.checkAttributes),
+          pick(update, this.checkAttributes)
+        )
+      ) {
+        // do not emit a mail for those attribute updates
+        delete update.dateImport
+
+        const updated = this.addCozyMetadata({
+          ...results[0],
+          ...update
+        })
+
+        return this.cozyClient.save(updated)
+      } else {
+        log(
+          'debug',
+          `[createOrUpdate] Didn't update ${
+            results[0]._id
+          } because its \`checkedAttributes\` (${
+            this.checkAttributes
+          }) didn't change.`
+        )
+        return results[0]
+      }
+    } else {
+      throw new Error(
+        'Create or update with selectors that returns more than 1 result\n' +
+          JSON.stringify(selector) +
+          '\n' +
+          JSON.stringify(results)
+      )
+    }
   }
 
   static async createOrUpdateViaOldClient(attributes) {

--- a/packages/cozy-doctypes/src/Document.js
+++ b/packages/cozy-doctypes/src/Document.js
@@ -174,7 +174,6 @@ class Document {
     if (results.length === 0) {
       return this.create(this.addCozyMetadata(attributes))
     } else if (results.length === 1) {
-      const id = results[0]._id
       const update = omit(attributes, userAttributes)
 
       // only update if some fields are different

--- a/packages/cozy-doctypes/src/Document.spec.js
+++ b/packages/cozy-doctypes/src/Document.spec.js
@@ -418,10 +418,17 @@ describe('Document used with CozyClient', () => {
   })
 
   describe('create', () => {
-    it('should throw an error if used with a CozyClient', () => {
-      expect(() => Document.create({})).toThrow(
-        new Error('This method is not implemented yet with CozyClient')
-      )
+    afterEach(() => {
+      cozyClient.create.mockReset()
+    })
+
+    it('should create the document with the given attributes', async () => {
+      jest.spyOn(cozyClient, 'create').mockImplementation(() => {})
+
+      const marge = { name: 'Marge' }
+      await Simpson.create(marge)
+
+      expect(cozyClient.create).toHaveBeenCalledWith('io.cozy.simpsons', marge)
     })
   })
 

--- a/packages/cozy-doctypes/src/Document.spec.js
+++ b/packages/cozy-doctypes/src/Document.spec.js
@@ -409,10 +409,37 @@ describe('Document used with CozyClient', () => {
   })
 
   describe('createOrUpdate', () => {
-    it('should throw an error if used with a CozyClient', async () => {
-      expect.assertions(1)
-      await expect(Document.createOrUpdate({})).rejects.toEqual(
-        new Error('This method is not implemented yet with CozyClient')
+    afterEach(() => {
+      Simpson.queryAll.mockReset()
+    })
+
+    it('should throw an error if there are more than one corresponding documents', async () => {
+      jest
+        .spyOn(Simpson, 'queryAll')
+        .mockReturnValueOnce([{ name: 'Marge' }, { name: 'Marge' }])
+
+      await expect(Simpson.createOrUpdate({ name: 'Marge' })).rejects.toThrow()
+    })
+
+    it('should create the document if it does not exist', async () => {
+      jest.spyOn(Simpson, 'queryAll').mockReturnValueOnce([])
+      jest.spyOn(Simpson, 'create').mockReturnValueOnce()
+
+      await Simpson.createOrUpdate({ name: 'Marge' })
+
+      expect(Simpson.create).toHaveBeenCalledWith(
+        Simpson.addCozyMetadata({ name: 'Marge' })
+      )
+    })
+
+    it('should update the document if it already exists', async () => {
+      jest.spyOn(Simpson, 'queryAll').mockReturnValueOnce([{ name: 'Marge' }])
+      jest.spyOn(cozyClient, 'save').mockReturnValueOnce()
+
+      await Simpson.createOrUpdate({ name: 'Marge', son: 'Bart' })
+
+      expect(cozyClient.save).toHaveBeenCalledWith(
+        Simpson.addCozyMetadata({ name: 'Marge', son: 'Bart' })
       )
     })
   })


### PR DESCRIPTION
These two methods were not usable with cozy-client. Now they are. They will be used in banks' accounts stats service.