### PR TITLE
feat(cozy-doctypes): Add BankAccountStats model

### DIFF
--- a/packages/cozy-doctypes/src/banking/BankAccountStats.js
+++ b/packages/cozy-doctypes/src/banking/BankAccountStats.js
@@ -1,0 +1,10 @@
+const Document = require('../Document')
+
+class BankAccountStats extends Document {}
+
+BankAccountStats.doctype = 'io.cozy.bank.accounts.stats'
+BankAccountStats.idAttributes = ['_id']
+BankAccountStats.version = 1
+BankAccountStats.checkedAttributes = null
+
+module.exports = BankAccountStats

--- a/packages/cozy-doctypes/src/index.js
+++ b/packages/cozy-doctypes/src/index.js
@@ -6,6 +6,7 @@ const BalanceHistory = require('./banking/BalanceHistory')
 const BankAccount = require('./banking/BankAccount')
 const BankingReconciliator = require('./banking/BankingReconciliator')
 const BankTransaction = require('./banking/BankTransaction')
+const BankAccountStats = require('./banking/BankAccountStats')
 const Contact = require('./contacts/Contact')
 const Group = require('./contacts/Group')
 const Permission = require('./Permission')
@@ -20,6 +21,7 @@ module.exports = {
   BankAccount,
   BankingReconciliator,
   BankTransaction,
+  BankAccountStats,
   Contact,
   Group,
   registerClient: Document.registerClient,


### PR DESCRIPTION
For now this model does nothing special. It is just usable with methods inherited from `Document`. But I prefer to create it here directly instead of in banks.