### PR TITLE
feat: Display fully completed component when docs are ok

### DIFF
--- a/packages/cozy-procedures/src/components/overview/DocumentsFullyCompleted.jsx
+++ b/packages/cozy-procedures/src/components/overview/DocumentsFullyCompleted.jsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { InlineCard, Icon } from 'cozy-ui/transpiled/react'
+const DocumentsFullyCompleted = ({ documents, navigateTo }) => {
+  const flatenedFiles = []
+  Object.values(documents).map(document => {
+    Object.values(document['files']).map(file => {
+      flatenedFiles.push(file)
+    })
+  })
+  return (
+    <InlineCard
+      className="u-c-pointer u-p-1 u-flex u-flex-column"
+      onClick={() => navigateTo('documents')}
+    >
+      {flatenedFiles.map((file, index) => {
+        let style = 'u-ellipsis u-flex'
+        if (index !== 0) style += ' u-mt-1'
+        return (
+          <div className={style} key={index}>
+            <Icon icon="file-type-files" />
+            <span className="u-ml-half">{file.name}</span>
+          </div>
+        )
+      })}
+    </InlineCard>
+  )
+}
+
+DocumentsFullyCompleted.propTypes = {
+  documents: PropTypes.array.isRequired,
+  navigateTo: PropTypes.func.isRequired
+}
+export default DocumentsFullyCompleted

--- a/packages/cozy-procedures/src/components/overview/DocumentsNotFullyCompleted.jsx
+++ b/packages/cozy-procedures/src/components/overview/DocumentsNotFullyCompleted.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { Button, Chip, translate } from 'cozy-ui/transpiled/react'
+
+const DocumentsNotFullyCompleted = ({
+  documentsCompleted,
+  documentsTotal,
+  navigateTo,
+  t
+}) => {
+  return (
+    <Button
+      label={t('overview.complete')}
+      extraRight={
+        <Chip
+          theme="primary"
+          size="tiny"
+        >{`${documentsCompleted}/${documentsTotal}`}</Chip>
+      }
+      onClick={() => navigateTo('documents')}
+      theme="ghost"
+      extension="full"
+      size="large"
+      icon="pen"
+    />
+  )
+}
+
+DocumentsNotFullyCompleted.propTypes = {
+  documentsCompleted: PropTypes.number.isRequired,
+  documentsTotal: PropTypes.number.isRequired,
+  navigateTo: PropTypes.func.isRequired,
+  t: PropTypes.func.isRequired
+}
+
+export default translate()(DocumentsNotFullyCompleted)

--- a/packages/cozy-procedures/src/components/overview/Overview.jsx
+++ b/packages/cozy-procedures/src/components/overview/Overview.jsx
@@ -17,8 +17,9 @@ import {
 } from 'cozy-ui/transpiled/react'
 import InlineCard from 'cozy-ui/transpiled/react/InlineCard'
 
-import Topbar from './Topbar'
-
+import Topbar from '../Topbar'
+import DocumentsNotFullyCompleted from './DocumentsNotFullyCompleted'
+import DocumentsFullyCompleted from './DocumentsFullyCompleted'
 class Overview extends React.Component {
   realtime = null
 
@@ -223,20 +224,19 @@ class Overview extends React.Component {
         </section>
         <section className="u-mb-2">
           <SubTitle className="u-mb-1">{t('overview.documents')}</SubTitle>
-          <Button
-            label={t('overview.complete')}
-            extraRight={
-              <Chip
-                theme="primary"
-                size="tiny"
-              >{`${documentsCompleted}/${documentsTotal}`}</Chip>
-            }
-            onClick={() => this.navigateTo('documents')}
-            theme="ghost"
-            extension="full"
-            size="large"
-            icon="pen"
-          />
+          {documentsCompleted !== documentsTotal && (
+            <DocumentsNotFullyCompleted
+              documentsCompleted={documentsCompleted}
+              documentsTotal={documentsTotal}
+              navigateTo={this.navigateTo}
+            />
+          )}
+          {documentsCompleted === documentsTotal && (
+            <DocumentsFullyCompleted
+              documents={data.documentsData}
+              navigateTo={this.navigateTo}
+            />
+          )}
         </section>
         <section className="u-mb-2">
           <SubTitle className="u-mb-1">{t('overview.personalData')}</SubTitle>

--- a/packages/cozy-procedures/src/containers/Overview.jsx
+++ b/packages/cozy-procedures/src/containers/Overview.jsx
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux'
 import context from '../redux/context'
-import Overview from '../components/Overview'
+import Overview from '../components/overview/Overview'
 import {
   getCompletedFields,
   getTotalFields,


### PR DESCRIPTION
When we have the right numbers of linked documents, we change the display 

<img width="506" alt="Capture d’écran 2019-07-09 à 09 21 06" src="https://user-images.githubusercontent.com/1107936/60867507-51bac980-a22b-11e9-92a7-bd5ca4f89c1e.png">
