### PR TITLE
(Procedures) Automatically fill banking data

### DIFF
--- a/packages/cozy-doctypes/src/banking/BankAccountStats.js
+++ b/packages/cozy-doctypes/src/banking/BankAccountStats.js
@@ -1,6 +1,21 @@
 const Document = require('../Document')
+const sumBy = require('lodash/sumBy')
 
-class BankAccountStats extends Document {}
+class BankAccountStats extends Document {
+  static sum(accountsStats) {
+    const properties = ['income', 'additionalIncome', 'mortgage', 'loans']
+    const summedStats = properties.reduce((sums, property) => {
+      sums[property] = sumBy(
+        accountsStats,
+        accountStats => accountStats[property]
+      )
+
+      return sums
+    }, {})
+
+    return summedStats
+  }
+}
 
 BankAccountStats.doctype = 'io.cozy.bank.accounts.stats'
 BankAccountStats.idAttributes = ['_id']

--- a/packages/cozy-doctypes/src/banking/BankAccountStats.spec.js
+++ b/packages/cozy-doctypes/src/banking/BankAccountStats.spec.js
@@ -1,0 +1,27 @@
+const BankAccountStats = require('./BankAccountStats')
+
+describe('BankAccountStats::sum', () => {
+  it('should return the sum of many stats objects', () => {
+    const accountsStats = [
+      {
+        income: 2000,
+        additionalIncome: 400,
+        mortgage: 650,
+        loans: 800
+      },
+      {
+        income: 1500,
+        additionalIncome: 0,
+        mortgage: 0,
+        loans: 0
+      }
+    ]
+
+    expect(BankAccountStats.sum(accountsStats)).toEqual({
+      income: 3500,
+      additionalIncome: 400,
+      mortgage: 650,
+      loans: 800
+    })
+  })
+})

--- a/packages/cozy-procedures/src/Procedure.jsx
+++ b/packages/cozy-procedures/src/Procedure.jsx
@@ -14,7 +14,8 @@ class Procedure extends React.Component {
       fetchMyself,
       fetchDocumentsByCategory,
       client,
-      setProcedureStatus
+      setProcedureStatus,
+      fetchBankAccountsStats
     } = this.props
     //We init our Document model here to be able to use CozyFile or AdministrativeProcedure models where we want
     if (!Document.cozyClient) {
@@ -28,6 +29,8 @@ class Procedure extends React.Component {
     //Since init is done, we tell the app we can start to render thing
     setProcedureStatus({ initiated: true })
     fetchMyself(client)
+
+    fetchBankAccountsStats(client)
 
     const { documents: documentsCategory } = creditApplicationTemplate
     Object.keys(documentsCategory).map(document => {
@@ -56,6 +59,7 @@ Procedure.propTypes = {
   fetchDocumentsByCategory: PropTypes.func.isRequired,
   setProcedureStatus: PropTypes.func.isRequired,
   initiated: PropTypes.bool.isRequired,
-  client: PropTypes.object.isRequired
+  client: PropTypes.object.isRequired,
+  fetchBankAccountsStats: PropTypes.func.isRequired
 }
 export default withClient(Procedure)

--- a/packages/cozy-procedures/src/containers/Procedure.jsx
+++ b/packages/cozy-procedures/src/containers/Procedure.jsx
@@ -3,7 +3,8 @@ import { connect } from 'react-redux'
 import Context from '../redux/context'
 import {
   init as initPersonalData,
-  fetchMyself
+  fetchMyself,
+  fetchBankAccountsStats
 } from '../redux/personalDataSlice'
 import {
   init as initDocuments,
@@ -23,7 +24,8 @@ const mapDispatchToProps = {
   fetchMyself,
   initDocuments,
   fetchDocumentsByCategory,
-  setProcedureStatus
+  setProcedureStatus,
+  fetchBankAccountsStats
 }
 
 export default withLocales(

--- a/packages/cozy-procedures/src/redux/personalDataSlice.spec.js
+++ b/packages/cozy-procedures/src/redux/personalDataSlice.spec.js
@@ -9,7 +9,8 @@ import reducer, {
   getSlice,
   getCompletedFromMyself,
   getCompletedFields,
-  getTotalFields
+  getTotalFields,
+  fetchBankAccountsStats
 } from './personalDataSlice'
 
 describe('Personal data', () => {
@@ -26,7 +27,8 @@ describe('Personal data', () => {
         lastname: '',
         salary: ''
       },
-      loading: false,
+      myselfLoading: false,
+      bankAccountsStatsLoading: false,
       error: ''
     })
   })
@@ -38,7 +40,8 @@ describe('Personal data', () => {
         lastname: 'Doe'
       },
       error: '',
-      loading: false
+      myselfLoading: false,
+      bankAccountsStatsLoading: false
     }
     const action = update({
       firstname: 'Jane',
@@ -50,7 +53,8 @@ describe('Personal data', () => {
         lastname: 'Doe'
       },
       error: '',
-      loading: false
+      myselfLoading: false,
+      bankAccountsStatsLoading: false
     }
     expect(reducer(stateBefore, action)).toEqual(expectedState)
   })
@@ -62,7 +66,7 @@ describe('Personal data', () => {
         lastname: 'Doe'
       },
       error: '',
-      loading: false
+      myselfLoading: false
     }
     const action = fetchMyselfLoading({ loading: true })
     const expected = {
@@ -71,7 +75,7 @@ describe('Personal data', () => {
         lastname: 'Doe'
       },
       error: '',
-      loading: true
+      myselfLoading: true
     }
     const stateAfter = reducer(stateBefore, action)
     expect(stateAfter).toEqual(expected)
@@ -86,7 +90,7 @@ describe('Personal data', () => {
         email: ''
       },
       error: '',
-      loading: false
+      myselfLoading: false
     }
     const action = fetchMyselfSuccess({
       name: { givenName: 'John', familyName: 'Doe' },
@@ -100,7 +104,7 @@ describe('Personal data', () => {
         email: 'john.doe@me.com'
       },
       error: '',
-      loading: false
+      myselfLoading: false
     }
     const stateAfter = reducer(stateBefore, action)
     expect(stateAfter).toEqual(expected)
@@ -113,7 +117,7 @@ describe('Personal data', () => {
         lastname: 'Doe'
       },
       error: '',
-      loading: false
+      myselfLoading: false
     }
     const action = fetchMyselfError({
       error: 'Unable to get the contact'
@@ -124,7 +128,7 @@ describe('Personal data', () => {
         lastname: 'Doe'
       },
       error: 'Unable to get the contact',
-      loading: false
+      myselfLoading: false
     }
     const stateAfter = reducer(stateBefore, action)
     expect(stateAfter).toEqual(expected)
@@ -265,6 +269,51 @@ describe('fetchMyself action', () => {
         const result = getTotalFields(state)
         expect(result).toEqual(6)
       })
+    })
+  })
+})
+
+describe('fetchBankAccountsStats action', () => {
+  const findSpy = jest.fn()
+  const fakeClient = {
+    query: findSpy,
+    all: jest.fn()
+  }
+  const dispatchSpy = jest.fn()
+  const accountsStats = [
+    {
+      income: 2000,
+      additionalIncome: 400,
+      mortgage: 650,
+      loans: 800
+    },
+    {
+      income: 1500,
+      additionalIncome: 0,
+      mortgage: 0,
+      loans: 0
+    }
+  ]
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should dispatch fetchBankAccountsStatsSuccess with bank accounts stats', async () => {
+    findSpy.mockResolvedValueOnce({ data: accountsStats })
+    await fetchBankAccountsStats(fakeClient)(dispatchSpy)
+    expect(dispatchSpy).toHaveBeenCalled()
+    expect(dispatchSpy).toHaveBeenNthCalledWith(1, {
+      type: 'personalData/fetchBankAccountsStatsLoading',
+      payload: { loading: true }
+    })
+    expect(dispatchSpy).toHaveBeenNthCalledWith(2, {
+      type: 'personalData/fetchBankAccountsStatsSuccess',
+      payload: accountsStats
+    })
+    expect(dispatchSpy).toHaveBeenNthCalledWith(3, {
+      type: 'personalData/fetchBankAccountsStatsLoading',
+      payload: { loading: false }
     })
   })
 })

--- a/packages/playgrounds/src/common/client.js
+++ b/packages/playgrounds/src/common/client.js
@@ -13,7 +13,8 @@ const getClient = customOptions => {
           'io.cozy.konnectors',
           'io.cozy.procedures.administratives',
           'io.cozy.jobs:GET',
-          'io.cozy.jobs:POST:zip:worker'
+          'io.cozy.jobs:POST:zip:worker',
+          'io.cozy.bank.accounts.stats'
         ],
         schema: {
           apps: {


### PR DESCRIPTION
Fetch `io.cozy.bank.accounts.stats` documents, then sum them to automatically fill banking data fields.

`io.cozy.bank.accounts.stats` documents are created by a banks service (see https://github.com/cozy/cozy-banks/pull/1393).