### PR TITLE
Interapp: Fix missing _id from intent documents

### DIFF
--- a/packages/cozy-interapp/src/request.js
+++ b/packages/cozy-interapp/src/request.js
@@ -4,9 +4,11 @@ class Request {
   }
 
   get(id) {
-    return this.stackClient
-      .fetchJSON('GET', `/intents/${id}`)
-      .then(resp => resp.data)
+    return this.stackClient.fetchJSON('GET', `/intents/${id}`).then(resp => {
+      const data = resp.data
+      if (!data._id) data._id = data.id
+      return data
+    })
   }
 
   post(action, type, data, permissions) {


### PR DESCRIPTION
Since the interapp lib used to be based on `_id` attribute of documents, we add it if it's missing.
Missing `_id` here was causing `invalid event id` or `unexpected handshake message from intent service` errors
For now we don't know why this attribute is now missing or not sent by the stack anymore.
Edit: We should use `id` only for documents using jsonapi from the cozy-stack. For now we keep the both but the `_id` usage should be removed at term.