### PR TITLE
feat: Add webpack-expose-package-info-plugin

### DIFF
--- a/packages/webpack-expose-package-info-plugin/README.md
+++ b/packages/webpack-expose-package-info-plugin/README.md
@@ -1,0 +1,52 @@
+Expose package information
+======================
+
+This plugin is useful if you want to expose chosen package information to
+a bundle created via webpack.
+
+The mechanism uses the DefinePlugin to define a variable that will contain
+package informations.
+
+### Usage
+
+```
+const PackageInfoPlugin = require('webpack-expose-packages-version')
+
+new PackageInfoPlugin({
+  packages: ['cozy-bar', 'cozy-ui']
+})
+```
+
+#### Exposed variable
+
+By default the exposed variable is __PACKAGES__ but it can be customized
+via the `varName` option.
+
+```patch
+ new PackageInfoPlugin({
+   packages: ['cozy-bar', 'cozy-ui'],
++  varName: 'PACKAGES'
+ })
+```
+
+You can now access package information in your app.
+
+```
+/* global PACKAGES */
+
+console.log(PACKAGES)
+/* {"cozy-bar": {"version": "1.0.0"}, "cozy-ui": {"version": "6.26.2"}} */
+```
+
+#### Fields
+
+By default the only information retrieved from the package is the `version` but
+you can customize this with the `fields` options.
+
+```patch
+ new PackageInfoPlugin({
+   packages: ['cozy-bar', 'cozy-ui'],
+   varName: 'PACKAGES',
++  fields: ['version', 'repository']
+ })
+```

--- a/packages/webpack-expose-package-info-plugin/package.json
+++ b/packages/webpack-expose-package-info-plugin/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "webpack-expose-package-versions-plugin",
+  "version": "1.0.0",
+  "description": "Webpack plugin to expose package versions",
+  "main": "src/index.js",
+  "repository": "https://github.com/cozy/cozy-libs",
+  "author": "Cozy",
+  "license": "MIT",
+  "peerDependencies": {
+    "webpack": "^4.35.3"
+  }
+}

--- a/packages/webpack-expose-package-info-plugin/src/index.js
+++ b/packages/webpack-expose-package-info-plugin/src/index.js
@@ -1,0 +1,65 @@
+const webpack = require('webpack')
+const { CachedInputFileSystem, ResolverFactory } = require('enhanced-resolve')
+const fs = require('fs')
+
+const pluginName = 'PackageInfoPlugin'
+
+const pick = (obj, fields) => {
+  const res = {}
+  for (let field of fields) {
+    res[field] = obj[field]
+  }
+  return res
+}
+
+class PackageInfoPlugin {
+  constructor(options) {
+    this.varName = options.varName || '__PACKAGES__'
+    this.packages = options.packages
+    this.fields = options.fields || ['version']
+  }
+  async apply(compiler) {
+    // Create a resolver with the same options as the compiler
+    const resolver = ResolverFactory.createResolver({
+      fileSystem: new CachedInputFileSystem(fs, 4000),
+      extensions: ['.json'],
+      modules: compiler.options.resolve.modules
+    })
+
+    // We need to collect info before the compilation because we will use
+    // the DefinePlugin that is run at the `compilation` stage
+    compiler.hooks.beforeCompile.tapAsync(
+      pluginName,
+      async (params, callback) => {
+        // Collect info of all packages specified in options
+        const info = {}
+        for (let pkg of this.packages) {
+          const path = await resolvePromise(resolver, `${pkg}/package.json`)
+          const data = JSON.parse(fs.readFileSync(path))
+          info[pkg] = pick(data, this.fields)
+        }
+        const definitions = {}
+        definitions[this.varName] = JSON.stringify(info)
+
+        // Create a DefinePlugin and apply it to the compiler
+        const df = new webpack.DefinePlugin(definitions)
+        df.apply(compiler)
+        callback()
+      }
+    )
+  }
+}
+
+const resolvePromise = (resolver, request) =>
+  new Promise((resolve, reject) => {
+    const resolveContext = {}
+    resolver.resolve(
+      {},
+      __dirname,
+      request,
+      resolveContext,
+      (err, filepath) => (err && reject(err)) || resolve(filepath)
+    )
+  })
+
+module.exports = PackageInfoPlugin


### PR DESCRIPTION
Putting this in WIP, I have the feeling that the plugin could be a bit
more useful if it could supply to the application a bit more than the
version.

```patch
- webpack-expose-package-versions-plugin
+ webpack-expose-package-information-plugin
```

with an usage like this ?

```js
new PackageInformationPlugin({
  packages: ['cozy-bar', 'cozy-ui'],
  fields: ['version']
})
```