### PR TITLE
fix(cozy-harvest-lib): Remove cozy-realtime from dependencies

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -26,7 +26,6 @@
     "watch:doc:react": "(cd ../.. && TARGET=cozy-harvest-lib yarn watch:doc:react)"
   },
   "dependencies": {
-    "cozy-realtime": "^3.1.1",
     "date-fns": "^1.30.1",
     "final-form": "4.11.1",
     "lodash": "4.17.13",
@@ -42,7 +41,7 @@
     "babel-preset-cozy-app": "^1.5.2",
     "cozy-client": "6.46.0",
     "cozy-device-helper": "^1.7.3",
-    "cozy-realtime": "3.0.0",
+    "cozy-realtime": "3.1.0",
     "cozy-ui": "21.2.3",
     "enzyme": "3.9.0",
     "enzyme-adapter-react-16": "1.11.2",
@@ -57,7 +56,7 @@
   "peerDependencies": {
     "cozy-client": "6.46.0",
     "cozy-device-helper": "1.7.1",
-    "cozy-realtime": "3.0.0",
+    "cozy-realtime": "^3.1.0",
     "cozy-ui": "^21.2.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5415,6 +5415,13 @@ cozy-logger@1.3.1:
   dependencies:
     json-stringify-safe "5.0.1"
 
+cozy-realtime@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-3.1.0.tgz#ae06ef1c8174408aae70f5171820275880a4a587"
+  integrity sha512-4rLsIFAGlUQWSiMm1jgkzoPqnbH4iSDndeNLFCLhVmM93eJBztWIfXSwFQ2utvOuIvMjHeT5iw7v6GQvwzfBFA==
+  dependencies:
+    minilog "3.1.0"
+
 cozy-stack-client@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-6.25.0.tgz#4fc50087d900be4b0976ceca3606c77703cf5f52"


### PR DESCRIPTION
cozy-realtime was present in dependencies, devDependencies and
peerDependencies with different version. Keeping only the highest
version in dependencies should by sufficient

This fixes the following warning: https://travis-ci.org/cozy/cozy-libs/builds/556705656#L793