### PR TITLE
feat(cozy-procedures): Round bank account stats

### DIFF
--- a/packages/cozy-doctypes/src/banking/BankAccountStats.js
+++ b/packages/cozy-doctypes/src/banking/BankAccountStats.js
@@ -13,6 +13,8 @@ class BankAccountStats extends Document {
       return sums
     }, {})
 
+    summedStats.currency = 'EUR'
+
     return summedStats
   }
 }

--- a/packages/cozy-doctypes/src/banking/BankAccountStats.js
+++ b/packages/cozy-doctypes/src/banking/BankAccountStats.js
@@ -2,7 +2,27 @@ const Document = require('../Document')
 const sumBy = require('lodash/sumBy')
 
 class BankAccountStats extends Document {
+  static checkCurrencies(accountsStats) {
+    const currency = accountsStats[0].currency
+
+    for (const accountStats of accountsStats) {
+      if (accountStats.currency !== currency) {
+        return false
+      }
+    }
+
+    return true
+  }
+
   static sum(accountsStats) {
+    if (accountsStats.length === 0) {
+      throw new Error('You must give at least one stats object')
+    }
+
+    if (!this.checkCurrencies(accountsStats)) {
+      throw new Error('Currency of all stats object must be the same.')
+    }
+
     const properties = ['income', 'additionalIncome', 'mortgage', 'loans']
     const summedStats = properties.reduce((sums, property) => {
       sums[property] = sumBy(
@@ -13,7 +33,7 @@ class BankAccountStats extends Document {
       return sums
     }, {})
 
-    summedStats.currency = 'EUR'
+    summedStats.currency = accountsStats[0].currency
 
     return summedStats
   }

--- a/packages/cozy-doctypes/src/banking/BankAccountStats.spec.js
+++ b/packages/cozy-doctypes/src/banking/BankAccountStats.spec.js
@@ -1,5 +1,48 @@
 const BankAccountStats = require('./BankAccountStats')
 
+describe('BankAccountStats::checkCurrencies', () => {
+  it('should return true if the currencies are the same', () => {
+    const accountsStats = [
+      {
+        income: 2000,
+        additionalIncome: 400,
+        mortgage: 650,
+        loans: 800,
+        currency: 'EUR'
+      },
+      {
+        income: 1500,
+        additionalIncome: 0,
+        mortgage: 0,
+        loans: 0,
+        currency: 'EUR'
+      }
+    ]
+
+    expect(BankAccountStats.checkCurrencies(accountsStats)).toBe(true)
+  })
+
+  it('should return false if the currencies are not the same', () => {
+    const accountsStats = [
+      {
+        income: 2000,
+        additionalIncome: 400,
+        mortgage: 650,
+        loans: 800,
+        currency: 'EUR'
+      },
+      {
+        income: 1500,
+        additionalIncome: 0,
+        mortgage: 0,
+        loans: 0,
+        currency: 'USD'
+      }
+    ]
+
+    expect(BankAccountStats.checkCurrencies(accountsStats)).toBe(false)
+  })
+})
 describe('BankAccountStats::sum', () => {
   it('should return the sum of many stats objects', () => {
     const accountsStats = [
@@ -7,13 +50,15 @@ describe('BankAccountStats::sum', () => {
         income: 2000,
         additionalIncome: 400,
         mortgage: 650,
-        loans: 800
+        loans: 800,
+        currency: 'EUR'
       },
       {
         income: 1500,
         additionalIncome: 0,
         mortgage: 0,
-        loans: 0
+        loans: 0,
+        currency: 'EUR'
       }
     ]
 
@@ -24,5 +69,30 @@ describe('BankAccountStats::sum', () => {
       loans: 800,
       currency: 'EUR'
     })
+  })
+
+  it('should throw an error if the stats currencies are not the same', () => {
+    const accountsStats = [
+      {
+        income: 2000,
+        additionalIncome: 400,
+        mortgage: 650,
+        loans: 800,
+        currency: 'EUR'
+      },
+      {
+        income: 1500,
+        additionalIncome: 0,
+        mortgage: 0,
+        loans: 0,
+        currency: 'USD'
+      }
+    ]
+
+    expect(() => BankAccountStats.sum(accountsStats)).toThrow()
+  })
+
+  it('should throw an error if the given array is empty', () => {
+    expect(() => BankAccountStats.sum([])).toThrow()
   })
 })

--- a/packages/cozy-doctypes/src/banking/BankAccountStats.spec.js
+++ b/packages/cozy-doctypes/src/banking/BankAccountStats.spec.js
@@ -21,7 +21,8 @@ describe('BankAccountStats::sum', () => {
       income: 3500,
       additionalIncome: 400,
       mortgage: 650,
-      loans: 800
+      loans: 800,
+      currency: 'EUR'
     })
   })
 })

--- a/packages/cozy-procedures/src/redux/currency.js
+++ b/packages/cozy-procedures/src/redux/currency.js
@@ -5,7 +5,12 @@ export const roundCurrencyAmount = (amount, currency) => {
     EUR: 2
   }
 
-  const precision = currencyToRoundingPrecision[currency] || 2
+  let precision = currencyToRoundingPrecision[currency]
+
+  if (precision === undefined) {
+    console.warn('Default currency rounding precision has been used')
+    precision = 2
+  }
 
   return round(amount, precision)
 }

--- a/packages/cozy-procedures/src/redux/currency.js
+++ b/packages/cozy-procedures/src/redux/currency.js
@@ -1,0 +1,11 @@
+import round from 'lodash/round'
+
+export const roundCurrencyAmount = (amount, currency) => {
+  const currencyToRoundingPrecision = {
+    EUR: 2
+  }
+
+  const precision = currencyToRoundingPrecision[currency] || 2
+
+  return round(amount, precision)
+}

--- a/packages/cozy-procedures/src/redux/currency.spec.js
+++ b/packages/cozy-procedures/src/redux/currency.spec.js
@@ -1,0 +1,17 @@
+import { roundCurrencyAmount } from './currency'
+
+describe('roundCurrencyAmount', () => {
+  it('should return the rounded amount with a precision corresponding to the given currency', () => {
+    const amount = 1234.566666
+    const currency = 'EUR'
+
+    expect(roundCurrencyAmount(amount, currency)).toBe(1234.57)
+  })
+
+  it('should fallback on a 2 decimals precision if the currency is unknown', () => {
+    const amount = 1234.566666
+    const currency = 'BROUZOUF'
+
+    expect(roundCurrencyAmount(amount, currency)).toBe(1234.57)
+  })
+})

--- a/packages/cozy-procedures/src/redux/personalDataSlice.js
+++ b/packages/cozy-procedures/src/redux/personalDataSlice.js
@@ -3,6 +3,8 @@ import get from 'lodash/get'
 
 import { AdministrativeProcedure, BankAccountStats } from 'cozy-doctypes'
 
+import { roundCurrencyAmount } from './currency'
+
 const personalDataSlice = createSlice({
   initialState: {
     completedFromMyself: 0,
@@ -54,13 +56,17 @@ const personalDataSlice = createSlice({
     },
     fetchBankAccountsStatsSuccess: (state, action) => {
       const summedStats = BankAccountStats.sum(action.payload)
+      const { currency } = summedStats
 
       state.data = {
         ...state.data,
-        salary: summedStats.income,
-        additionalIncome: summedStats.additionalIncome,
-        propertyLoan: summedStats.mortgage,
-        creditsTotalAmount: summedStats.loans
+        salary: roundCurrencyAmount(summedStats.income, currency),
+        additionalIncome: roundCurrencyAmount(
+          summedStats.additionalIncome,
+          currency
+        ),
+        propertyLoan: roundCurrencyAmount(summedStats.mortgage, currency),
+        creditsTotalAmount: roundCurrencyAmount(summedStats.loans, currency)
       }
     }
   }


### PR DESCRIPTION
When automatically filled banking data is shown, we don't want to show more than 2 decimals. So we round it.