### PR TITLE
Change name of package PackageInfoPlugin

### DIFF
--- a/packages/webpack-expose-package-info-plugin/package.json
+++ b/packages/webpack-expose-package-info-plugin/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "webpack-expose-package-versions-plugin",
-  "version": "1.0.0",
-  "description": "Webpack plugin to expose package versions",
+  "name": "webpack-expose-package-info-plugin",
+  "version": "0.0.0",
+  "description": "Webpack plugin to expose package info as a variable",
   "main": "src/index.js",
   "repository": "https://github.com/cozy/cozy-libs",
   "author": "Cozy",

--- a/packages/webpack-expose-package-info-plugin/src/index.js
+++ b/packages/webpack-expose-package-info-plugin/src/index.js
@@ -23,7 +23,8 @@ class PackageInfoPlugin {
     const resolver = ResolverFactory.createResolver({
       fileSystem: new CachedInputFileSystem(fs, 4000),
       extensions: ['.json'],
-      modules: compiler.options.resolve.modules
+      modules: compiler.options.resolve.modules,
+      alias: compiler.options.resolve.alias
     })
 
     // We need to collect info before the compilation because we will use


### PR DESCRIPTION
I forgot to change the name of the package in the package.json.

Also includes the `alias` fix.