### PR TITLE
fix(cozy-authentication): Force apply the back button styles

### DIFF
--- a/packages/cozy-authentication/src/styles.styl
+++ b/packages/cozy-authentication/src/styles.styl
@@ -47,7 +47,9 @@
 .wizard-header-fixed
     @extend $wizard-header-fixed
 
-.wizard-previous
+// TODO deduplicate when the cozy-bar bundles its own cozy-ui
+// (see https://github.com/cozy/cozy-bar/pull/608)
+.wizard-previous.wizard-previous
     @extend $wizard-previous
 
 .wizard-brand


### PR DESCRIPTION
On mobile app, the cozy-bar's cozy-ui styles are overriding the custom
button's styles. So they are not applied and the back button is
misplaced.