### PR TITLE
fix(cozy-authentication): Don't show icon and spinner at the same time

### DIFF
--- a/packages/cozy-authentication/src/steps/SelectServer.jsx
+++ b/packages/cozy-authentication/src/steps/SelectServer.jsx
@@ -347,7 +347,7 @@ export class SelectServer extends Component {
               label={t('mobile.onboarding.server_selection.button')}
               size={isTiny ? 'normal' : 'large'}
             >
-              <Icon icon="next" color="white" />
+              {!fetching && <Icon icon="next" color="white" />}
             </Button>
             <ButtonLinkRegistration
               className={classNames('wizard-buttonlink')}


### PR DESCRIPTION
We were showing an Icon in a busy button, so the spinner and the icon were on top of each other. We actually don't want to show the icon when the button is busy.

|Before|After|
|------|-----|
|![image](https://user-images.githubusercontent.com/1606068/61114196-1ec53f80-a490-11e9-8ed7-b69729325429.png)|![image](https://user-images.githubusercontent.com/1606068/61114649-1588a280-a491-11e9-9781-4bf87830e74d.png)|