### PR TITLE
(Authentication) Execute `onAuthenticated` before redirecting

### DIFF
--- a/packages/cozy-authentication/src/MobileRouter.jsx
+++ b/packages/cozy-authentication/src/MobileRouter.jsx
@@ -71,7 +71,7 @@ export class MobileRouter extends Component {
     try {
       if (saved && saved.oauthOptions) {
         client.stackClient.setOAuthOptions(saved.oauthOptions)
-        client.login({ uri: saved.uri, token: saved.token })
+        await client.login({ uri: saved.uri, token: saved.token })
       }
     } finally {
       this.setState({ triedToReconnect: true })

--- a/packages/cozy-authentication/src/MobileRouter.jsx
+++ b/packages/cozy-authentication/src/MobileRouter.jsx
@@ -281,11 +281,14 @@ export class MobileRouter extends Component {
 
   async afterAuthentication() {
     this.setState({ isLoggingIn: false })
-    this.props.history.replace(this.props.loginPath)
-    await credentials.saveFromClient(this.props.client)
+
     if (this.props.onAuthenticated) {
-      this.props.onAuthenticated()
+      await this.props.onAuthenticated()
     }
+
+    this.props.history.replace(this.props.loginPath)
+
+    await credentials.saveFromClient(this.props.client)
   }
 
   handleBeforeLogout() {

--- a/packages/cozy-authentication/src/MobileRouter.spec.jsx
+++ b/packages/cozy-authentication/src/MobileRouter.spec.jsx
@@ -90,10 +90,23 @@ describe('MobileRouter', () => {
     expect(instance.forceUpdate).toHaveBeenCalled()
   })
 
-  it('should go to loginPath after login', () => {
+  it('should call onAuthenticated prop if defined', () => {
     setup()
     client.emit('login')
-    expect(history.replace).toHaveBeenCalledWith('/afterLogin')
+    expect(onAuthenticated).toHaveBeenCalled()
+  })
+
+  it('should go to loginPath after login', done => {
+    setup()
+    client.emit('login')
+
+    // Without this setTimeout, history.replace is reported as not called,
+    // but it's because the expectation seems to be executed before the code
+    // itself.
+    setTimeout(() => {
+      expect(history.replace).toHaveBeenCalledWith('/afterLogin')
+      done()
+    }, 0)
   })
 
   it('should go to logoutPath after logout', () => {


### PR DESCRIPTION
In banks, we want to do some things when the user is successfuly logged in, but before redirecting him to `loginPath` (initialize the cozy-bar, actually). I moved `onAuthenticated` before the redirection. I think this is the right place for doing this: if something needs to be done just before redirecting, this looks like the best place to do it; and if something needs to be done after redirecting, it can be done via the component that will be rendered on the `loginPath`.

I had to use a dirty `setTimeout` to make tests pass. Without it, `history.replace` is reported as not called, but it's because the expectation seems to be executed before the code itself.

Any thoughts?