### PR TITLE
refactor: Extract saveAccounts part

### DIFF
--- a/packages/cozy-doctypes/src/banking/BankingReconciliator.js
+++ b/packages/cozy-doctypes/src/banking/BankingReconciliator.js
@@ -6,8 +6,8 @@ class BankingReconciliator {
     this.options = options
   }
 
-  async save(fetchedAccounts, fetchedTransactions, options = {}) {
-    const { BankAccount, BankTransaction } = this.options
+  async saveAccounts(fetchedAccounts, options) {
+    const { BankAccount } = this.options
 
     const stackAccounts = await BankAccount.fetchAll()
 
@@ -22,6 +22,17 @@ class BankingReconciliator {
     if (options.onAccountsSaved) {
       options.onAccountsSaved(savedAccounts)
     }
+
+    return { savedAccounts, reconciliatedAccounts }
+  }
+
+  async save(fetchedAccounts, fetchedTransactions, options = {}) {
+    const { BankAccount, BankTransaction } = this.options
+
+    const { reconciliatedAccounts, savedAccounts } = await this.saveAccounts(
+      fetchedAccounts,
+      options
+    )
 
     // Bank accounts saved in Cozy, we can now link transactions to accounts
     // via their cozy id


### PR DESCRIPTION
We want in the near future to be able to saveAccounts as soon as possible, without waiting
for all the transactions to come back. This will help us do that as it splits the saveAccounts
from the saveTransactions so that we can do only the saveAccounts part.