### PR TITLE
fix(cozy-procedures): Set loading to false after linking a document

### DIFF
--- a/packages/cozy-procedures/src/components/documents/EmptyDocumentHolder.jsx
+++ b/packages/cozy-procedures/src/components/documents/EmptyDocumentHolder.jsx
@@ -23,7 +23,8 @@ class EmptyDocumentHolder extends Component {
       t,
       index,
       setDocumentLoading,
-      fetchDocumentError
+      fetchDocumentError,
+      setLoadingFalse
     } = this.props
     setDocumentLoading({ idDoctemplate: categoryId, index })
     const dirPath = creditApplicationTemplate.pathToSave
@@ -53,6 +54,8 @@ class EmptyDocumentHolder extends Component {
       })
 
       Alerter.error(t('documents.upload.error'))
+    } finally {
+      setLoadingFalse({ idDoctemplate: categoryId, index })
     }
   }
 
@@ -70,6 +73,7 @@ class EmptyDocumentHolder extends Component {
 EmptyDocumentHolder.propTypes = {
   categoryId: PropTypes.string.isRequired,
   linkDocumentSuccess: PropTypes.func.isRequired,
+  setLoadingFalse: PropTypes.func.isRequired,
   breakpoints: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
   index: PropTypes.number.isRequired,

--- a/packages/cozy-procedures/src/containers/DocumentsDataForm.jsx
+++ b/packages/cozy-procedures/src/containers/DocumentsDataForm.jsx
@@ -6,7 +6,8 @@ import {
   linkDocumentSuccess,
   getFilesStatus,
   setDocumentLoading,
-  fetchDocumentError
+  fetchDocumentError,
+  setLoadingFalse
 } from '../redux/documentsDataSlice'
 
 const mapStateToProps = state => ({
@@ -19,7 +20,8 @@ const mapDispatchToProps = {
   unlinkDocument,
   linkDocumentSuccess,
   setDocumentLoading,
-  fetchDocumentError
+  fetchDocumentError,
+  setLoadingFalse
 }
 
 const DocumentsDataFormContainer = Component =>


### PR DESCRIPTION
We didn't set `loading` to `false` after linking a document. It results, that during the `unlink` action, our ui state was alway to `loading: true` and we got a loader after unlinking. 

