### PR TITLE
(wip) feat(renovate-config-cozy): Automerge patch /minor versions of cozy libs

### DIFF
--- a/packages/renovate-config-cozy/package.json
+++ b/packages/renovate-config-cozy/package.json
@@ -16,6 +16,23 @@
           "extends": [
             "schedule:nonOfficeHours"
           ]
+        },
+        {
+          "packagePatterns": [
+            "^cozy-"
+          ],
+          "minor": {
+            "automerge": true
+          },
+          "patch": {
+            "automerge": true
+          },
+          "pin": {
+            "automerge": true
+          },
+          "lockFileMaintenance": {
+            "automerge": true
+          }
         }
       ],
       "timezone": "Europe/Paris",


### PR DESCRIPTION
Just a try to have feedbacks.

What do you think of automerging all our new patch / minor versions of our cozy-* packages when their status check are green? 