### PR TITLE
feat: Lib option to babel-preset-cozy-app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.16.0
   - export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
 script:
+  - set -e
   - yarn build
   - yarn lint
   - yarn test

--- a/packages/babel-preset-cozy-app/README.md
+++ b/packages/babel-preset-cozy-app/README.md
@@ -90,7 +90,12 @@ By default, this babel preset uses [`babel-plugin-transform-runtime`](https://ba
 }
 ```
 
-#### Preset and plugin options
+#### Lib option
+
+When the lib option is activated, `import/export` nodes are not transpiled. This gives the downstream bundler
+the ability to prune unused module away. It works by configuring babel-preset-env with `{"modules": false}`.
+
+### Advanced
 
 You can have control on the options passed to `babel-preset-env` and `babel-plugin-transform-runtime`:
 
@@ -114,7 +119,7 @@ to be replaced by imports from `babel-runtime`.
 See the options on the official docs :
 
 https://babeljs.io/docs/en/babel-preset-env#modules
-https://babeljs.io/docs/en/babel-plugin-transform-runtime#helpers 
+https://babeljs.io/docs/en/babel-plugin-transform-runtime#helpers
 
 ## Community
 

--- a/packages/babel-preset-cozy-app/index.js
+++ b/packages/babel-preset-cozy-app/index.js
@@ -69,6 +69,19 @@ const mkConfig = (api, options) => {
     throw e
   }
 
+  if (presetOptions.lib) {
+    merge(presetOptions, {
+      presetEnv: {
+        // Libraries are shipped with es6 imports for downstream bundler
+        // to be able to prune unused modules away
+        modules: false
+      },
+      transformRuntime: {
+        helpers: true
+      }
+    })
+  }
+
   const {
     node,
     react,

--- a/packages/babel-preset-cozy-app/index.js
+++ b/packages/babel-preset-cozy-app/index.js
@@ -70,13 +70,19 @@ const mkConfig = (api, options) => {
   }
 
   if (presetOptions.lib) {
-    merge(presetOptions, {
-      presetEnv: {
-        // Libraries are shipped with es6 imports for downstream bundler
-        // to be able to prune unused modules away
-        modules: false
-      }
-    })
+    const libConfigs = []
+
+    // Jest does not understand ES6 import by default
+    if (process.env.BABEL_ENV !== 'test') {
+      libConfigs.push({
+        presetEnv: {
+          // Libraries are shipped with es6 imports for downstream bundler
+          // to be able to prune unused modules away
+          modules: false
+        }
+      })
+    }
+    merge(presetOptions, ...libConfigs)
   }
 
   const {

--- a/packages/babel-preset-cozy-app/index.js
+++ b/packages/babel-preset-cozy-app/index.js
@@ -49,7 +49,7 @@ const optionConfigs = {
   },
   transformRuntime: {
     default: {
-      helpers: false,
+      helpers: true,
       regenerator: true
     },
     validator: either(isOfType('object'), isFalse)
@@ -75,9 +75,6 @@ const mkConfig = (api, options) => {
         // Libraries are shipped with es6 imports for downstream bundler
         // to be able to prune unused modules away
         modules: false
-      },
-      transformRuntime: {
-        helpers: true
       }
     })
   }

--- a/packages/cozy-authentication/babel.config.js
+++ b/packages/cozy-authentication/babel.config.js
@@ -4,7 +4,7 @@ module.exports = {
       presets: [
         [
           'cozy-app',
-          { presetEnv: { modules: false }, transformRuntime: { helpers: true } }
+          { lib: true }
         ]
       ],
       plugins: [

--- a/packages/cozy-authentication/babel.config.js
+++ b/packages/cozy-authentication/babel.config.js
@@ -20,7 +20,7 @@ module.exports = {
       ]
     },
     test: {
-      presets: [['cozy-app', { transformRuntime: { helpers: true } }]]
+      presets: ['cozy-app']
     }
   },
   ignore: ['*.spec.js', '*.spec.jsx']

--- a/packages/cozy-authentication/babel.config.js
+++ b/packages/cozy-authentication/babel.config.js
@@ -1,12 +1,7 @@
 module.exports = {
   env: {
     transpilation: {
-      presets: [
-        [
-          'cozy-app',
-          { lib: true }
-        ]
-      ],
+      presets: [['cozy-app', { lib: true }]],
       plugins: [
         [
           'css-modules-transform',

--- a/packages/cozy-procedures/babel.config.js
+++ b/packages/cozy-procedures/babel.config.js
@@ -6,7 +6,7 @@ module.exports = {
       presets: [
         [
           'cozy-app',
-          { presetEnv: { modules: false }, transformRuntime: { helpers: true } }
+          { lib: true }
         ]
       ],
       plugins: ['inline-react-svg']

--- a/packages/cozy-procedures/babel.config.js
+++ b/packages/cozy-procedures/babel.config.js
@@ -3,12 +3,7 @@ module.exports = {
   ignore: ['*.spec.js', '*.spec.jsx'],
   env: {
     transpilation: {
-      presets: [
-        [
-          'cozy-app',
-          { lib: true }
-        ]
-      ],
+      presets: [['cozy-app', { lib: true }]],
       plugins: ['inline-react-svg']
     }
   }


### PR DESCRIPTION
- No transform of imports
- Use of babel helpers (should we have that by default by the way ?)