### PR TITLE
Cozy logger in cozy-libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Cozy Commitlint Config](./packages/commitlint-config-cozy): Commitlint config enforcing the cozy commit convention
 - [Cozy Browserslist Config](./packages/browserslist-config-cozy): Browserslist config enforcing the official Cozy supported browsers
 - [ESLint Config Cozy App](./packages/eslint-config-cozy-app): Config for eslint using prettier (for applications and libraries)
+- [Cozy Logger](./packages/cozy-logger): Logs message in a human friendly way while developing and logs in JSON when in production. It can be used by konnectors, services alike, and web apps.
 
 ## CLI
 

--- a/packages/cozy-logger/README.md
+++ b/packages/cozy-logger/README.md
@@ -1,0 +1,12 @@
+# Cozy logger
+
+Logger used by connectors.
+
+It is starting to be usable by apps but the code is still in NodeJS (with requires).
+
+Depending on NODE_ENV, it will either :
+
+- log with colors in a human friendly way switch (`NODE_ENV` == "developement" || "standalone" || "test")
+- log in JSON for logs to be picked up by the [stack] (`NODE_ENV` == "production")
+
+[stack]: https://github.com/cozy/cozy-stack

--- a/packages/cozy-logger/package.json
+++ b/packages/cozy-logger/package.json
@@ -7,6 +7,9 @@
   "dependencies": {
     "chalk": "2.4.2"
   },
+  "scripts": {
+    "test": "yarn jest"
+  },
   "prettier": {
     "semi": false,
     "singleQuote": true

--- a/packages/cozy-logger/package.json
+++ b/packages/cozy-logger/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "cozy-logger",
+  "version": "1.3.1",
+  "description": "Logger for Cozy konnector and services",
+  "main": "src/index.js",
+  "license": "MIT",
+  "dependencies": {
+    "chalk": "2.4.2"
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true
+  },
+  "dependencies": {
+    "json-stringify-safe": "5.0.1"
+  }
+}

--- a/packages/cozy-logger/src/Secret.js
+++ b/packages/cozy-logger/src/Secret.js
@@ -1,0 +1,10 @@
+const Secret = function(data) {
+  Object.assign(this, data)
+  return this
+}
+
+Secret.prototype.toString = function() {
+  throw new Error('Cannot convert Secret to string')
+}
+
+module.exports = Secret

--- a/packages/cozy-logger/src/dev-format.js
+++ b/packages/cozy-logger/src/dev-format.js
@@ -1,0 +1,36 @@
+const util = require('util')
+const chalk = require('chalk')
+
+if (util && util.inspect && util.inspect.defaultOptions) {
+  util.inspect.defaultOptions.maxArrayLength = null
+  util.inspect.defaultOptions.depth = 2
+  util.inspect.defaultOptions.colors = true
+}
+
+const type2color = {
+  debug: 'cyan',
+  warn: 'yellow',
+  info: 'blue',
+  error: 'red',
+  ok: 'green',
+  secret: 'red',
+  critical: 'red'
+}
+
+function devFormat(type, message, label, namespace) {
+  let formatmessage = message
+
+  if (typeof formatmessage !== 'string') {
+    formatmessage = util.inspect(formatmessage)
+  }
+
+  let formatlabel = label ? ` : "${label}" ` : ''
+  let formatnamespace = namespace ? chalk.magenta(`${namespace}: `) : ''
+
+  let color = type2color[type]
+  let formattype = color ? chalk[color](type) : type
+
+  return `${formatnamespace}${formattype}${formatlabel} : ${formatmessage}`
+}
+
+module.exports = devFormat

--- a/packages/cozy-logger/src/index.js
+++ b/packages/cozy-logger/src/index.js
@@ -1,0 +1,79 @@
+const { filterLevel, filterSecrets } = require('./log-filters')
+const Secret = require('./Secret')
+const { LOG_LEVEL } = process.env
+let level = LOG_LEVEL || 'debug'
+const format = require('./log-format')
+const filters = [filterLevel, filterSecrets]
+
+const filterOut = function() {
+  for (const filter of filters) {
+    if (filter.apply(null, arguments) === false) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Use it to log messages in your konnector. Typical types are
+ *
+ * - `debug`
+ * - `warning`
+ * - `info`
+ * - `error`
+ * - `ok`
+ *
+ *
+ * @example
+ *
+ * They will be colored in development mode. In production mode, those logs are formatted in JSON to be interpreted by the stack and possibly sent to the client. `error` will stop the konnector.
+ *
+ * ```js
+ * logger = log('my-namespace')
+ * logger('debug', '365 bills')
+ * // my-namespace : debug : 365 bills
+ * logger('info', 'Page fetched')
+ * // my-namespace : info : Page fetched
+ * ```
+ * @param  {string} type
+ * @param  {string} message
+ * @param  {string} label
+ * @param  {string} namespace
+ */
+function log(type, message, label, namespace) {
+  if (filterOut(level, type, message, label, namespace)) {
+    return
+  }
+  // eslint-disable-next-line no-console
+  console.log(format(type, message, label, namespace))
+}
+
+log.addFilter = function(filter) {
+  return filters.push(filter)
+}
+
+log.setLevel = function(lvl) {
+  level = lvl
+}
+
+// Short-hands
+const methods = ['debug', 'info', 'warn', 'error', 'ok', 'critical']
+methods.forEach(level => {
+  log[level] = function(message, label, namespace) {
+    return log(level, message, label, namespace)
+  }
+})
+
+module.exports = log
+
+log.setNoRetry = obj => {
+  if (obj) obj.no_retry = true
+  else obj = { no_retry: true }
+  return obj.no_retry
+}
+log.Secret = Secret
+log.namespace = function(namespace) {
+  return function(type, message, label, ns = namespace) {
+    log(type, message, label, ns)
+  }
+}

--- a/packages/cozy-logger/src/log-filters.js
+++ b/packages/cozy-logger/src/log-filters.js
@@ -1,0 +1,26 @@
+const levels = {
+  secret: 0,
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+  ok: 50,
+  critical: 50
+}
+
+const Secret = require('./Secret')
+
+const filterSecrets = function(level, type, message) {
+  if (type !== 'secret' && message instanceof Secret) {
+    throw new Error('You should log a secret with log.secret')
+  }
+}
+
+const filterLevel = function(level, type) {
+  return levels[type] >= levels[level]
+}
+
+module.exports = {
+  filterSecrets,
+  filterLevel
+}

--- a/packages/cozy-logger/src/log-format.js
+++ b/packages/cozy-logger/src/log-format.js
@@ -1,0 +1,17 @@
+const prodFormat = require('./prod-format')
+const devFormat = require('./dev-format')
+
+switch (process.env.NODE_ENV) {
+  case 'production':
+    module.exports = prodFormat
+    break
+  case 'development':
+    module.exports = devFormat
+    break
+  case 'standalone':
+    module.exports = devFormat
+    break
+  case 'test':
+    module.exports = devFormat
+    break
+}

--- a/packages/cozy-logger/src/log-formats.spec.js
+++ b/packages/cozy-logger/src/log-formats.spec.js
@@ -1,7 +1,6 @@
 const prodFormat = require('./prod-format')
 const devFormat = require('./dev-format')
 const { setNoRetry } = require('./')
-const chalk = require('chalk')
 
 describe('dev format', () => {
   it('should log correctly an error', () => {
@@ -11,9 +10,7 @@ describe('dev format', () => {
     const lines = formatted.split('\n')
     expect(lines[0]).toEqual(expect.stringContaining('critical'))
     expect(lines[0]).toEqual(expect.stringContaining('LOGIN_FAILED'))
-    expect(lines[lines.length - 1]).toEqual(
-      expect.stringContaining('no_retry: ' + chalk.yellow('true'))
-    )
+    expect(lines[lines.length - 1]).toEqual(expect.stringContaining('no_retry'))
   })
 })
 

--- a/packages/cozy-logger/src/log-formats.spec.js
+++ b/packages/cozy-logger/src/log-formats.spec.js
@@ -1,0 +1,41 @@
+const prodFormat = require('./prod-format')
+const devFormat = require('./dev-format')
+const { setNoRetry } = require('./')
+const chalk = require('chalk')
+
+describe('dev format', () => {
+  it('should log correctly an error', () => {
+    const err = new Error('LOGIN_FAILED')
+    setNoRetry(err)
+    const formatted = devFormat('critical', err)
+    const lines = formatted.split('\n')
+    expect(lines[0]).toEqual(expect.stringContaining('critical'))
+    expect(lines[0]).toEqual(expect.stringContaining('LOGIN_FAILED'))
+    expect(lines[lines.length - 1]).toEqual(
+      expect.stringContaining('no_retry: ' + chalk.yellow('true'))
+    )
+  })
+})
+
+describe('prod format', () => {
+  const expectation = {
+    time: expect.any(String),
+    type: 'critical',
+    no_retry: true,
+    message: 'LOGIN_FAILED'
+  }
+
+  it('should log correctly an error', () => {
+    const err = new Error('LOGIN_FAILED')
+    setNoRetry(err)
+    const formatted = prodFormat('critical', err)
+    expect(JSON.parse(formatted)).toMatchObject(expectation)
+  })
+
+  it('should log correctly an object', () => {
+    const err = { message: 'LOGIN_FAILED' }
+    setNoRetry(err)
+    const formatted = prodFormat('critical', err)
+    expect(JSON.parse(formatted)).toMatchObject(expectation)
+  })
+})

--- a/packages/cozy-logger/src/prod-format.js
+++ b/packages/cozy-logger/src/prod-format.js
@@ -1,0 +1,35 @@
+const stringify = require('json-stringify-safe')
+
+const LOG_LENGTH_LIMIT = 64 * 1024 - 1
+
+function prodFormat(type, message, label, namespace) {
+  const log = { time: new Date(), type, label, namespace }
+
+  if (typeof message === 'object') {
+    if (message && message.no_retry) {
+      log.no_retry = message.no_retry
+    }
+    if (message && message.message) {
+      log.message = message.message
+    }
+  } else {
+    log.message = message
+  }
+
+  // properly display error messages
+  if (log.message && log.message.stack) {
+    log.message = log.message.stack
+  }
+
+  // cut the string to avoid a fail in the stack
+  let result = log
+  try {
+    result = stringify(log).substr(0, LOG_LENGTH_LIMIT)
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.log(err.message, 'cozy-logger: Failed to convert message to JSON')
+  }
+  return result
+}
+
+module.exports = prodFormat


### PR DESCRIPTION
Move from cozy-konnector-libs

cozy-konnector-libs does not have automatic publication, so by moving cozy-logger we get automatic publication for free.

Since cozy-logger is used by apps, it makes more sense to move it here.