### PR TITLE
fix(playgrounds): Component instance can't be extended

### DIFF
--- a/packages/playgrounds/src/procedures.jsx
+++ b/packages/playgrounds/src/procedures.jsx
@@ -11,8 +11,8 @@ import 'cozy-ui/dist/cozy-ui.min.css'
 import injectProcedureRoutes from '../../cozy-procedures/dist'
 import { PageLayout, PageFooter, PageContent } from 'cozy-ui/transpiled/react'
 
-const padded = Component => ({ children }) => {
-  const Wrapped = (
+const padded = Component => {
+  const Wrapped = ({ children }) => (
     <Component>
       <div className="u-m-1">{children}</div>
     </Component>


### PR DESCRIPTION
When we try to add a property (here `displayName`) to a component instance, React throws the following error:

```
TypeError: Cannot add property displayName, object is not extensible
```

This refactor fixes this problem in the procedures playground.