### PR TITLE
fix(cozy-procedures): Default options handling

### DIFF
--- a/packages/cozy-procedures/package.json
+++ b/packages/cozy-procedures/package.json
@@ -37,7 +37,8 @@
     "babel-plugin-inline-react-svg": "^1.1.0",
     "cozy-ui": "22.4.0",
     "enzyme-to-json": "3.3.5",
-    "jest": "24.8.0"
+    "jest": "24.8.0",
+    "react": "^16.8.3"
   },
   "peerDependencies": {
     "@material-ui/core": "3.9.3",

--- a/packages/cozy-procedures/src/ProcedureOptions.jsx
+++ b/packages/cozy-procedures/src/ProcedureOptions.jsx
@@ -11,13 +11,11 @@ const DEFAULT_OPTIONS = {
   }
 }
 
-export const optionsProvider = (
-  Component,
-  procedureOptions = DEFAULT_OPTIONS
-) => {
+export const optionsProvider = (Component, procedureOptions) => {
+  const options = { ...DEFAULT_OPTIONS, ...procedureOptions }
   const Wrapped = props => {
     return (
-      <ProcedureOptionsContext.Provider value={procedureOptions}>
+      <ProcedureOptionsContext.Provider value={options}>
         <Component {...props} />
       </ProcedureOptionsContext.Provider>
     )

--- a/packages/cozy-procedures/src/ProcedureOptions.spec.jsx
+++ b/packages/cozy-procedures/src/ProcedureOptions.spec.jsx
@@ -1,0 +1,37 @@
+import { PageFooter } from 'cozy-ui/transpiled/react'
+import { optionsProvider, optionsConsumer } from './ProcedureOptions'
+import React from 'react'
+
+describe('options', () => {
+  const DumbWrapper = ({ children }) => <div>{children}</div>
+  const DumbItem = ({ children }) => <div>{children}</div>
+  const Item = optionsConsumer(DumbItem)
+
+  it('should work with default options', () => {
+    const Wrapper = optionsProvider(DumbWrapper)
+    const root = mount(
+      <Wrapper>
+        <Item />
+      </Wrapper>
+    )
+    expect(root.find(DumbItem).props().components.PageFooter).toBe(PageFooter)
+  })
+
+  it('should work with passed options', () => {
+    const CustomPageFooter = () => <div />
+    const Wrapper = optionsProvider(DumbWrapper, {
+      components: { PageFooter: CustomPageFooter }
+    })
+    const DumbItem = ({ children }) => <div>{children}</div>
+    const Item = optionsConsumer(DumbItem)
+
+    const root = mount(
+      <Wrapper>
+        <Item />
+      </Wrapper>
+    )
+    expect(root.find(DumbItem).props().components.PageFooter).toBe(
+      CustomPageFooter
+    )
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5539,13 +5539,6 @@ cozy-device-helper@1.7.3:
   dependencies:
     lodash "4.17.13"
 
-cozy-logger@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/cozy-logger/-/cozy-logger-1.3.1.tgz#27d9578756b318b1460a135cda94475c734b9f39"
-  integrity sha512-oa2h6wkLuCTucUeeFQKOYE0hGtP6VZ+tRMxV/MKqIRKMq8xngareUusQX03jXP3C+O1GeaEhSmaboHlIDJnH7A==
-  dependencies:
-    json-stringify-safe "5.0.1"
-
 cozy-realtime@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-3.1.0.tgz#ae06ef1c8174408aae70f5171820275880a4a587"


### PR DESCRIPTION
Since `injectProcedureRoutes` gets a `...rest` from an object for the
options, it's always an object. So, when passing this to
`optionsProvider`, the default value was never used since
`procedureOptions` was never `undefined`