### PR TITLE
fix(cozy-doctypes): Handle missing properties in account stats

### DIFF
--- a/packages/cozy-doctypes/src/banking/BankAccountStats.js
+++ b/packages/cozy-doctypes/src/banking/BankAccountStats.js
@@ -34,7 +34,7 @@ class BankAccountStats extends Document {
     const summedStats = properties.reduce((sums, property) => {
       sums[property] = sumBy(
         accountsStats,
-        accountStats => accountStats[property]
+        accountStats => accountStats[property] || 0
       )
 
       return sums

--- a/packages/cozy-doctypes/src/banking/BankAccountStats.spec.js
+++ b/packages/cozy-doctypes/src/banking/BankAccountStats.spec.js
@@ -74,6 +74,29 @@ describe('BankAccountStats::sum', () => {
     })
   })
 
+  it('should return 0 for a missing property', () => {
+    const accountsStats = [
+      {
+        income: 2000,
+        additionalIncome: 400,
+        mortgage: 650,
+        loans: 800,
+        currency: 'EUR'
+      },
+      {
+        income: 1500,
+        additionalIncome: 0,
+        mortgage: 0,
+        loans: 0,
+        currency: 'EUR'
+      }
+    ]
+
+    const sum = BankAccountStats.sum(accountsStats)
+
+    expect(sum.fixedCharges).toBe(0)
+  })
+
   it('should throw an error if the stats currencies are not the same', () => {
     const accountsStats = [
       {


### PR DESCRIPTION
We previously returned `undefined` if a property was missing in a bank
account stats object. This led to getting some `NaN` when doing
computations on this result. Now we return `0` so we can safely
manipulate the result.