### PR TITLE
Doctypes: Add Folder class

### DIFF
--- a/packages/cozy-doctypes/src/Application.js
+++ b/packages/cozy-doctypes/src/Application.js
@@ -1,10 +1,14 @@
 const Document = require('./Document')
 
+const APP_DOCTYPE = 'io.cozy.apps'
+
 class Application extends Document {}
 
 Application.schema = {
-  doctype: 'io.cozy.apps',
+  doctype: APP_DOCTYPE,
   attributes: {}
 }
+
+Application.doctype = APP_DOCTYPE
 
 module.exports = Application

--- a/packages/cozy-doctypes/src/Folder.js
+++ b/packages/cozy-doctypes/src/Folder.js
@@ -1,0 +1,88 @@
+const Application = require('./Application')
+const CozyFile = require('./File')
+
+/**
+ * Class representing the folder model.
+ * @extends CozyFile
+ */
+class CozyFolder extends CozyFile {
+  /**
+   * Create a folder with a reference to the given document
+   * @param  {String}  path     Folder path
+   * @param  {Object}  document Document to make reference to. Any doctype.
+   * @return {Object}  Folder document
+   */
+  static async createFolderWithReference(path, document) {
+    const collection = this.cozyClient.collection(CozyFile.doctype)
+    const dirId = await collection.ensureDirectoryExists(path)
+    await collection.addReferencesTo(document, [
+      {
+        _id: dirId
+      }
+    ])
+
+    const { data: dirInfos } = await collection.get(dirId)
+
+    return dirInfos
+  }
+
+  /**
+   * Returns an array of folder referenced by the given document
+   * @param  {Object}  document  Document to get references from
+   * @return {Array}             Array of folders referenced with the given
+   * document
+   */
+  static async getReferencedFolders(document) {
+    const { included } = await this.cozyClient
+      .collection(CozyFile.doctype)
+      .findReferencedBy(document)
+    return included.filter(folder => !CozyFolder.isTrashed(folder))
+  }
+
+  /**
+   * Returns an unique folder referenced with the given reference. Creates it
+   * if it does not exist.
+   * @param  {String}  path      Path used to create folder if the referenced
+   * folder does not exist.
+   * @param  {Object}  document  Document to create references from
+   * @return {Objet}             Folder referenced with the give reference
+   */
+  static async ensureFolderWithReference(path, document) {
+    const existingFolders = await CozyFolder.getReferencedFolders(document)
+    if (existingFolders.length) return existingFolders[0]
+
+    const collection = this.cozyClient.collection(CozyFile.doctype)
+    const dirId = await collection.ensureDirectoryExists(path)
+    await collection.addReferencesTo(document, [
+      {
+        _id: dirId
+      }
+    ])
+
+    const { data: dirInfos } = await collection.get(dirId)
+
+    return dirInfos
+  }
+
+  /**
+   * Indicates if a folder is in trash
+   * @param  {Object}  folder `io.cozy.files` document
+   * @return {Boolean}        `true` if the folder is in trash, `false`
+   * otherwise.
+   */
+  static isTrashed(folder) {
+    return /^\/\.cozy_trash/.test(folder.attributes.path)
+  }
+}
+
+/**
+ * References used by the Cozy platform and apps for specific folders.
+ */
+CozyFolder.refs = {
+  ADMINISTRATIVE: `${Application.doctype}/administrative`,
+  PHOTOS: `${Application.doctype}/photos`,
+  PHOTOS_BACKUP: `${Application.doctype}/photos/mobile`,
+  PHOTOS_UPLOAD: `${Application.doctype}/photos/upload`
+}
+
+module.exports = CozyFolder

--- a/packages/cozy-doctypes/src/Folder.js
+++ b/packages/cozy-doctypes/src/Folder.js
@@ -27,6 +27,39 @@ class CozyFolder extends CozyFile {
   }
 
   /**
+   * Returns a "Magic Folder", given its id
+   * @param  {String} id Magic Folder id. `CozyFolder.magicFolders` contains the
+   * ids of folders that can be magic folders.
+   * @param {String} path Default path to use if magic folder does not exist
+   * @return {Object} Folder document
+   */
+  static async ensureMagicFolder(id, path) {
+    const magicFolderDocument = {
+      _type: Application.doctype,
+      _id: id
+    }
+    const folders = await CozyFolder.getReferencedFolders(magicFolderDocument)
+    const existingMagicFolder = folders.length ? folders[0] : null
+
+    if (existingMagicFolder) return existingMagicFolder
+
+    const magicFoldersValues = Object.values(CozyFolder.magicFolders)
+    if (!magicFoldersValues.includes(id)) {
+      throw new Error(
+        `Cannot create Magic folder with id ${id}. Allowed values are ${magicFoldersValues.join(
+          ', '
+        )}.`
+      )
+    }
+
+    if (!path) {
+      throw new Error('Magic folder default path must be defined')
+    }
+
+    return CozyFolder.createFolderWithReference(path, magicFolderDocument)
+  }
+
+  /**
    * Returns an array of folder referenced by the given document
    * @param  {Object}  document  Document to get references from
    * @return {Array}             Array of folders referenced with the given
@@ -78,7 +111,7 @@ class CozyFolder extends CozyFile {
 /**
  * References used by the Cozy platform and apps for specific folders.
  */
-CozyFolder.refs = {
+CozyFolder.magicFolders = {
   ADMINISTRATIVE: `${Application.doctype}/administrative`,
   PHOTOS: `${Application.doctype}/photos`,
   PHOTOS_BACKUP: `${Application.doctype}/photos/mobile`,

--- a/packages/cozy-doctypes/src/Folder.spec.js
+++ b/packages/cozy-doctypes/src/Folder.spec.js
@@ -1,0 +1,123 @@
+import { cozyClient } from './testUtils'
+
+import CozyFolder from './Folder'
+
+describe('Folder model', () => {
+  beforeAll(() => {
+    CozyFolder.registerClient(cozyClient)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should expose reference folders', () => {
+    expect(CozyFolder.refs).toBeDefined()
+    expect(CozyFolder.refs.ADMINISTRATIVE).toBeDefined()
+    expect(CozyFolder.refs.PHOTOS).toBeDefined()
+    expect(CozyFolder.refs.PHOTOS_UPLOAD).toBeDefined()
+    expect(CozyFolder.refs.PHOTOS_BACKUP).toBeDefined()
+  })
+
+  describe('getReferencedFolders', () => {
+    it('should filter trashed folders', async () => {
+      const referencedFolder = {
+        attributes: {
+          path: '/Reference/Folder'
+        }
+      }
+
+      const trashFolder = {
+        attributes: {
+          path: '/.cozy_trash/Old/Reference/Folder'
+        }
+      }
+
+      cozyClient.stackClient.collection.mockReturnValue({
+        findReferencedBy: jest
+          .fn()
+          .mockResolvedValue({ included: [referencedFolder, trashFolder] })
+      })
+
+      const result = await CozyFolder.getReferencedFolders('ref')
+
+      expect(result).toContain(referencedFolder)
+      expect(result).not.toContain(trashFolder)
+    })
+  })
+
+  describe('ensureFolderWithReference', () => {
+    it('should return first folder from returned list', async () => {
+      const existingReferencedFolders = [
+        {
+          attributes: {
+            path: '/Reference/Folder'
+          }
+        },
+        {
+          attributes: {
+            path: '/Another/Reference'
+          }
+        }
+      ]
+
+      jest
+        .spyOn(CozyFolder, 'getReferencedFolders')
+        .mockResolvedValue(existingReferencedFolders)
+
+      const result = await CozyFolder.ensureFolderWithReference(
+        '/Created/Folder',
+        {
+          _id: '31dd57ab0b154ccc8d0d6cba576c0ef0',
+          _type: 'io.cozy.examples'
+        }
+      )
+
+      expect(result).toEqual(existingReferencedFolders[0])
+    })
+
+    it('should create referenced folder', async () => {
+      const createdFolderId = '6d8cf41a358c4147bf977e34c476131e'
+      const createdFolderInfos = {
+        _id: createdFolderId,
+        _type: 'io.cozy.files',
+        attributes: {
+          path: '/Created/Folder'
+        }
+      }
+      const createdFolderResponse = {
+        data: createdFolderInfos
+      }
+
+      jest.spyOn(CozyFolder, 'getReferencedFolders').mockResolvedValue([])
+
+      jest.spyOn(cozyClient, 'collection').mockReturnValue({
+        addReferencesTo: jest.fn(),
+        ensureDirectoryExists: jest.fn().mockResolvedValue(createdFolderId),
+        get: jest.fn().mockResolvedValue(createdFolderResponse)
+      })
+
+      const result = await CozyFolder.ensureFolderWithReference(
+        '/Created/Folder',
+        {
+          _id: '31dd57ab0b154ccc8d0d6cba576c0ef0',
+          _type: 'io.cozy.examples'
+        }
+      )
+
+      expect(
+        cozyClient.collection().ensureDirectoryExists
+      ).toHaveBeenCalledWith('/Created/Folder')
+
+      expect(cozyClient.collection().addReferencesTo).toHaveBeenCalledWith(
+        {
+          _id: '31dd57ab0b154ccc8d0d6cba576c0ef0',
+          _type: 'io.cozy.examples'
+        },
+        [{ _id: createdFolderId }]
+      )
+
+      expect(result).toEqual(createdFolderInfos)
+    })
+  })
+})

--- a/packages/cozy-doctypes/src/index.js
+++ b/packages/cozy-doctypes/src/index.js
@@ -8,9 +8,10 @@ const BankingReconciliator = require('./banking/BankingReconciliator')
 const BankTransaction = require('./banking/BankTransaction')
 const BankAccountStats = require('./banking/BankAccountStats')
 const Contact = require('./contacts/Contact')
+const CozyFile = require('./File')
+const CozyFolder = require('./Folder')
 const Group = require('./contacts/Group')
 const Permission = require('./Permission')
-const CozyFile = require('./File')
 
 module.exports = {
   Account,
@@ -23,8 +24,9 @@ module.exports = {
   BankTransaction,
   BankAccountStats,
   Contact,
+  CozyFile,
+  CozyFolder,
   Group,
   registerClient: Document.registerClient,
-  Permission,
-  CozyFile
+  Permission
 }


### PR DESCRIPTION
The Folder class mutualize our logic related to folder.

The first two methods added in this PR allow to retrieve referenced folders.

It's based and the code from Drive (https://github.com/cozy/cozy-drive/pull/1243/files#diff-8f9d41bc1595335b09bde52219ed7844R7)

We would need to use it in Harvest to deal with baseDir declared in konnector manifests, for example to retrieve the `$photo` folder even if its path has changed. See https://github.com/cozy/cozy-libs/pull/638

UPDATE: After discussion, it appears that we could expose the concept of magic folders directly in the API, and create a method `ensureMagicFolder`