### PR TITLE
fix(cozy-doctypes): Fix splitFilename() edge cases

### DIFF
--- a/packages/cozy-doctypes/src/File.js
+++ b/packages/cozy-doctypes/src/File.js
@@ -2,6 +2,8 @@ const trimEnd = require('lodash/trimEnd')
 
 const Document = require('./Document')
 
+const FILENAME_WITH_EXTENSION_REGEX = /(.+)(\..*)$/
+
 /**
  * Class representing the file model.
  * @extends Document
@@ -80,12 +82,14 @@ class CozyFile extends Document {
    */
   static splitFilename(file) {
     if (!file.name) throw new Error('file should have a name property ')
-    return file.type === 'directory'
-      ? { filename: file.name, extension: '' }
-      : {
-          extension: file.name.slice(file.name.lastIndexOf('.')),
-          filename: file.name.slice(0, file.name.lastIndexOf('.'))
-        }
+
+    if (file.type === 'file') {
+      const match = file.name.match(FILENAME_WITH_EXTENSION_REGEX)
+      if (match) {
+        return { filename: match[1], extension: match[2] }
+      }
+    }
+    return { filename: file.name, extension: '' }
   }
   /**
    *

--- a/packages/cozy-doctypes/src/File.spec.js
+++ b/packages/cozy-doctypes/src/File.spec.js
@@ -181,12 +181,12 @@ describe('File model', () => {
 
     const scenarios = [
       { filename: 'file', extension: '.ext' },
-      // FIXME: { filename: 'file', extension: '' },
+      { filename: 'file', extension: '' },
       { filename: 'file.html', extension: '.ejs' },
       { filename: 'file', extension: '.' },
       { filename: 'file.', extension: '.' },
       { filename: 'file.', extension: '.ext' },
-      // FIXME: { filename: '.file', extension: '' },
+      { filename: '.file', extension: '' },
       { filename: '.file', extension: '.ext' }
     ]
 

--- a/packages/cozy-doctypes/src/File.spec.js
+++ b/packages/cozy-doctypes/src/File.spec.js
@@ -175,16 +175,29 @@ describe('File model', () => {
   })
 
   describe('splitFilename', () => {
-    it('should return an extension and a filename from a file', () => {
-      const file = {
-        name: 'foo.bar'
-      }
-      const result = CozyFile.splitFilename(file)
-      expect(result).toEqual({
-        filename: 'foo',
-        extension: '.bar'
+    const name = ({ filename, extension }) => filename + extension
+    const file = expectation => ({ type: 'file', name: name(expectation) })
+    const { stringify } = JSON
+
+    const scenarios = [
+      { filename: 'file', extension: '.ext' },
+      // FIXME: { filename: 'file', extension: '' },
+      { filename: 'file.html', extension: '.ejs' },
+      { filename: 'file', extension: '.' },
+      { filename: 'file.', extension: '.' },
+      { filename: 'file.', extension: '.ext' },
+      // FIXME: { filename: '.file', extension: '' },
+      { filename: '.file', extension: '.ext' }
+    ]
+
+    for (const expectation of scenarios) {
+      it(`splits ${stringify(name(expectation))} into ${stringify(
+        expectation
+      )}`, () => {
+        expect(CozyFile.splitFilename(file(expectation))).toEqual(expectation)
       })
-    })
+    }
+
     it('should throw an error if the file is not correct', () => {
       const file = {}
 


### PR DESCRIPTION
- Don't assume extension-less filename last char is extension
- Don't confuse hidden file with extension