### PR TITLE
[Harvest] feat: Allow editing the login, always

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
@@ -59,11 +59,9 @@ export class AccountField extends PureComponent {
       disabled,
       hasError,
       forceEncryptedPlaceholder,
-      initialValue,
       label,
       name,
       required,
-      role,
       t,
       type
     } = this.props
@@ -74,14 +72,12 @@ export class AccountField extends PureComponent {
         ? label
         : name
 
-    const isEditable = !(role === ROLE_IDENTIFIER && initialValue)
-
     // Cozy-UI <Field /> props
     const fieldProps = {
       ...this.props,
       autoComplete: 'off',
       className: 'u-m-0', // 0 margin
-      disabled: disabled || !isEditable,
+      disabled: disabled,
       error: !disabled && hasError,
       fullwidth: true,
       inputRef: this.setInputRef,

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountField.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountField.spec.js.snap
@@ -14,7 +14,6 @@ exports[`AccountField render a date field 1`] = `
   </Label>
   <Input
     autoComplete="off"
-    disabled={false}
     error={false}
     fullwidth={true}
     id=""
@@ -42,7 +41,6 @@ exports[`AccountField render a dropdown field 1`] = `
   </Label>
   <Aware
     className="u-m-0"
-    disabled={false}
     error={false}
     fieldProps={Object {}}
     fullwidth={true}
@@ -138,7 +136,6 @@ exports[`AccountField render a password field 1`] = `
   </Label>
   <InputPassword
     autoComplete="new-password"
-    disabled={false}
     error={false}
     fullwidth={true}
     hideLabel="accountForm.password.hide"
@@ -169,7 +166,6 @@ exports[`AccountField should render 1`] = `
   </Label>
   <Input
     autoComplete="off"
-    disabled={false}
     error={false}
     fullwidth={true}
     id=""


### PR DESCRIPTION
We want to be able to edit the login of a connector, even if the connector is already configured.