### PR TITLE
fix(cozy-harvest-lib): Fix OAuth login 

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -91,7 +91,6 @@ export class TriggerManager extends Component {
     } = this.props
 
     const { account, trigger } = this.state
-
     if (trigger) {
       return trigger
     }
@@ -230,7 +229,7 @@ export class TriggerManager extends Component {
     const trigger = await this.refetchTrigger()
     this.setState({ status: IDLE, trigger })
     if (typeof successCallback !== 'function') return
-    successCallback(triggers)
+    successCallback(trigger)
   }
 
   /**

--- a/packages/cozy-harvest-lib/src/connections/accounts.js
+++ b/packages/cozy-harvest-lib/src/connections/accounts.js
@@ -25,8 +25,12 @@ const createAccount = async (client, konnector, attributes) => {
  */
 const findAccount = async (client, id) => {
   try {
-    const { data } = await client.collection(ACCOUNTS_DOCTYPE).get(id)
-    return data
+    const { data } = await client.query(
+      client.find(ACCOUNTS_DOCTYPE).where({
+        _id: id
+      })
+    )
+    return (data && data[0]) || null
   } catch (error) {
     if (error.status === 404) {
       return null

--- a/packages/cozy-harvest-lib/test/connections/__snapshots__/accounts.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/connections/__snapshots__/accounts.spec.js.snap
@@ -18,6 +18,7 @@ KonnectorAccountWatcher {
       "collection": [MockFunction],
       "create": [MockFunction],
       "destroy": [MockFunction],
+      "find": [MockFunction],
       "on": [Function],
       "options": Object {
         "uri": "cozy.tools:8080",

--- a/packages/cozy-harvest-lib/test/connections/accounts.spec.js
+++ b/packages/cozy-harvest-lib/test/connections/accounts.spec.js
@@ -18,6 +18,9 @@ const client = {
       token: '1234abcd'
     }
   },
+  find: jest.fn().mockReturnValue({
+    where: jest.fn()
+  }),
   options: {
     uri: 'cozy.tools:8080'
   },
@@ -113,8 +116,7 @@ describe('Account mutations', () => {
     }
 
     beforeEach(() => {
-      client.collection().get.mockReset()
-      client.collection().get.mockResolvedValue({
+      client.query.mockResolvedValue({
         data: simpleAccountFixtureWithMasterRelation
       })
     })
@@ -175,8 +177,8 @@ describe('Account mutations', () => {
       })
 
       it('throws error if get fails', async () => {
-        client.collection().get.mockReset()
-        client.collection().get.mockRejectedValue(new Error('Mocked error'))
+        client.query.mockReset()
+        client.query.mockRejectedValue(new Error('Mocked error'))
 
         await expect(
           createAccount(
@@ -301,8 +303,8 @@ describe('Account mutations', () => {
       })
 
       it('throws error if get fails', async () => {
-        client.collection().get.mockReset()
-        client.collection().get.mockRejectedValue(new Error('Mocked error'))
+        client.query.mockReset()
+        client.query.mockRejectedValue(new Error('Mocked error'))
 
         await expect(
           createAccount(


### PR DESCRIPTION
We had a few issues with Oauth konnector : 

- Collection.get do not use as wanted for Trigger since the stack doesn't return `data: {} ` for this end point (PR not finished yet here : https://github.com/cozy/cozy-client/compare/fix/get?expand=1) 
- We should avoid `client.collection` and use `client.query` instead 
- We had a typo in the successCallback 