### PR TITLE
[Harvest] Use referenced folders

### DIFF
--- a/packages/cozy-harvest-lib/jest.config.js
+++ b/packages/cozy-harvest-lib/jest.config.js
@@ -9,7 +9,8 @@ module.exports = {
   moduleDirectories: ['src', 'node_modules'],
   moduleNameMapper: {
     // identity-obj-proxy module is installed by cozy-scripts
-    styles: 'identity-obj-proxy'
+    styles: 'identity-obj-proxy',
+    '^cozy-logger$': 'cozy-logger/dist/index.js'
   },
   transformIgnorePatterns: ['node_modules/(?!cozy-ui)'],
   setupFilesAfterEnv: ['<rootDir>/test/setup.js']

--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.2",
+    "cozy-doctypes": "^1.57.1",
     "date-fns": "^1.30.1",
     "final-form": "4.11.1",
     "lodash": "4.17.15",

--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.2",
-    "cozy-doctypes": "^1.57.1",
+    "cozy-doctypes": "^1.58.0",
     "date-fns": "^1.30.1",
     "final-form": "4.11.1",
     "lodash": "4.17.15",

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -108,14 +108,17 @@ export class TriggerManager extends Component {
     let folder
 
     if (konnectors.needsFolder(konnector)) {
-      const adminFolder = await CozyFolder.ensureMagicFolder(
-        CozyFolder.magicFolders.ADMINISTRATIVE,
-        `/${t('folder.administrative')}`
-      )
-      const photosFolder = await CozyFolder.ensureMagicFolder(
-        CozyFolder.magicFolders.PHOTOS,
-        `/${t('folder.photos')}`
-      )
+      const [adminFolder, photosFolder] = await Promise.all([
+        CozyFolder.ensureMagicFolder(
+          CozyFolder.magicFolders.ADMINISTRATIVE,
+          `/${t('folder.administrative')}`
+        ),
+        CozyFolder.ensureMagicFolder(
+          CozyFolder.magicFolders.PHOTOS,
+          `/${t('folder.photos')}`
+        )
+      ])
+
       const path = konnectors.buildFolderPath(konnector, account, {
         administrative: adminFolder.path,
         photos: photosFolder.path

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
 import { withMutations, withClient } from 'cozy-client'
-import { CozyFolder } from 'cozy-doctypes'
+import { CozyFolder as CozyFolderClass } from 'cozy-doctypes'
 
 import AccountForm from './AccountForm'
 import OAuthForm from './OAuthForm'
@@ -57,12 +57,7 @@ export class TriggerManager extends Component {
   }
 
   componentDidMount() {
-    try {
-      CozyFolder.registerClient(this.props.client)
-    } catch (error) {
-      if (error.message !== 'Document cannot be re-registered to a client.')
-        throw error
-    }
+    this.CozyFolder = CozyFolderClass.copyWithClient(this.props.client)
   }
 
   componentWillUnmount() {
@@ -109,12 +104,12 @@ export class TriggerManager extends Component {
 
     if (konnectors.needsFolder(konnector)) {
       const [adminFolder, photosFolder] = await Promise.all([
-        CozyFolder.ensureMagicFolder(
-          CozyFolder.magicFolders.ADMINISTRATIVE,
+        this.CozyFolder.ensureMagicFolder(
+          this.CozyFolder.magicFolders.ADMINISTRATIVE,
           `/${t('folder.administrative')}`
         ),
-        CozyFolder.ensureMagicFolder(
-          CozyFolder.magicFolders.PHOTOS,
+        this.CozyFolder.ensureMagicFolder(
+          this.CozyFolder.magicFolders.PHOTOS,
           `/${t('folder.photos')}`
         )
       ])

--- a/packages/cozy-harvest-lib/src/helpers/konnectors.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectors.js
@@ -206,12 +206,10 @@ export const buildFolderPath = (konnector, account, folders = {}) => {
     konnector,
     // For now konnectors are only defining one folder in their folders array
     'folders[0].defaultDir',
-    `$administrative/$konnector/$account`
+    '$administrative/$konnector/$account'
   )
   // Trim `/` and avoid multiple `/` characters with regexp
   let sanitizedPath = trim(fullPath.replace(/(\/+)/g, '/'), '/')
-  //We remove the first / if needed
-  if (sanitizedPath.startsWith('/')) sanitizedPath = sanitizedPath.substring(1)
   //If the konnector doesn't have any of our base dir, we set it to $administrative
   if (!hasBaseDir(sanitizedPath)) {
     sanitizedPath = '$administrative/' + sanitizedPath

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -7,6 +7,19 @@ import cronHelpers from 'helpers/cron'
 import KonnectorJobWatcher from '../../src/models/konnector/KonnectorJobWatcher'
 import { KonnectorJobError } from 'helpers/konnectors'
 
+jest.mock('cozy-doctypes', () => {
+  return {
+    CozyFolder: {
+      registerClient: () => {},
+      ensureMagicFolder: () => ({ path: '/Administrative' }),
+      magicFolders: {
+        ADMINISTRATIVE: '/adminsitrative',
+        PHOTOS: '/photos'
+      }
+    }
+  }
+})
+
 const fixtures = {
   data: {
     username: 'foo',

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -8,15 +8,16 @@ import KonnectorJobWatcher from '../../src/models/konnector/KonnectorJobWatcher'
 import { KonnectorJobError } from 'helpers/konnectors'
 
 jest.mock('cozy-doctypes', () => {
-  return {
-    CozyFolder: {
-      registerClient: () => {},
-      ensureMagicFolder: () => ({ path: '/Administrative' }),
-      magicFolders: {
-        ADMINISTRATIVE: 'io.cozy.apps/administrative',
-        PHOTOS: '/photos'
-      }
+  const CozyFolder = {
+    copyWithClient: () => CozyFolder,
+    ensureMagicFolder: () => ({ path: '/Administrative' }),
+    magicFolders: {
+      ADMINISTRATIVE: 'io.cozy.apps/administrative',
+      PHOTOS: '/photos'
     }
+  }
+  return {
+    CozyFolder
   }
 })
 

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -13,7 +13,7 @@ jest.mock('cozy-doctypes', () => {
       registerClient: () => {},
       ensureMagicFolder: () => ({ path: '/Administrative' }),
       magicFolders: {
-        ADMINISTRATIVE: '/adminsitrative',
+        ADMINISTRATIVE: 'io.cozy.apps/administrative',
         PHOTOS: '/photos'
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5559,6 +5559,17 @@ cozy-device-helper@1.7.3:
   dependencies:
     lodash "4.17.13"
 
+cozy-doctypes@^1.58.0:
+  version "1.58.0"
+  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.58.0.tgz#908ceee104072a68d624b2c159b828138fadb78e"
+  integrity sha512-cbXrRyWS2jGBlswvhQqT7r+zubBiRATFO/XFkm5upK8VJKRON8ExHpHP8+hee65wIuZ//8fs30NpEtAaAVFvYQ==
+  dependencies:
+    "@babel/runtime" "7.3.1"
+    cozy-logger "^1.5.0"
+    es6-promise-pool "2.5.0"
+    lodash "4.17.15"
+    prop-types "^15.7.2"
+
 cozy-realtime@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-3.1.0.tgz#ae06ef1c8174408aae70f5171820275880a4a587"


### PR DESCRIPTION
We want connectors to save their files in the special folders (like `Administrative`), even if these folders are moved or renamed. So this PR uses the special references they have instead hardcoding their path.

This PR will probably fail the CI because of a problem in cozy-logger, I'm looking into it.