### PR TITLE
cozy-logger — web edition 

### DIFF
--- a/packages/cozy-logger/babel.config.js
+++ b/packages/cozy-logger/babel.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  presets: ['cozy-app'],
+  ignore: ['*.spec.js'],
+  plugins: [
+    [
+      'import-redirect',
+      {
+        root: './src',
+        redirect: {
+          './dev-format': './prod-format'
+        }
+      }
+    ]
+  ]
+}

--- a/packages/cozy-logger/package.json
+++ b/packages/cozy-logger/package.json
@@ -3,16 +3,21 @@
   "version": "1.4.0",
   "description": "Logger for Cozy konnector and services",
   "main": "src/index.js",
+  "browser": "dist/index.js",
   "license": "MIT",
   "dependencies": {
     "chalk": "^2.4.2",
     "json-stringify-safe": "5.0.1"
   },
   "scripts": {
-    "test": "yarn jest"
+    "test": "yarn jest",
+    "build": "babel src/ --out-dir dist"
   },
   "prettier": {
     "semi": false,
     "singleQuote": true
+  },
+  "devDependencies": {
+    "babel-plugin-import-redirect": "^1.1.1"
   }
 }

--- a/packages/cozy-logger/package.json
+++ b/packages/cozy-logger/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.js",
   "license": "MIT",
   "dependencies": {
+    "chalk": "^2.4.2",
     "json-stringify-safe": "5.0.1"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3811,6 +3811,14 @@ babel-plugin-dynamic-import-node@^2.3.0:
   dependencies:
     object.assign "^4.1.0"
 
+babel-plugin-import-redirect@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-import-redirect/-/babel-plugin-import-redirect-1.1.1.tgz#a5d72828f0ca87469f8c35b2792e6a527157bfc9"
+  integrity sha512-VBbt2UXq3jenD6CEAZulZEKhvGW8MNhoTP7rhqfe8L0GfzVGCXdS5Xlu7NXHqzleiZewANRCG6O+C+cWn8jbdw==
+  dependencies:
+    babylon "^6.17.4"
+    resolve "^1.3.2"
+
 babel-plugin-inline-react-svg@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-inline-react-svg/-/babel-plugin-inline-react-svg-1.1.0.tgz#b39519c78249b3fcf895b541c38b485a2b11b0be"
@@ -3901,6 +3909,11 @@ babylon-walk@^1.0.2:
     babel-runtime "^6.11.6"
     babel-types "^6.15.0"
     lodash.clone "^4.5.0"
+
+babylon@^6.17.4:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
+  integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
 bail@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
At the moment, cozy-logger will break builds when included in a non-node project, mainly because it requires `chalk` which is node-only. This breakage happens more and more because cozy-logger is used in cozy-doctypes.

This PR creates adds a built step for the cozy-logger package, which uses babel to create a web-friendly version of cozy-logger, where the file using chalk is by-passed.
Webpack web builds should automatically use this. I also had the problem in a jest env, where I needed to tell jest to use `cozy-logger/dist/index.js` using the `moduleNameMapper` option.

The node version is identical.