### PR TITLE
feat: Allow multiple Document classes

### DIFF
--- a/packages/cozy-doctypes/src/Document.js
+++ b/packages/cozy-doctypes/src/Document.js
@@ -82,6 +82,19 @@ class Document {
   }
 
   /**
+   * @static copyWithClient - Returns a new class bound to a client
+   *
+   * @param  {type} client Client instance
+   * @returns {type}        A new class, with the client registered
+   */
+  static copyWithClient(client) {
+    class NewDocument extends Document {}
+    NewDocument.cozyClient = null
+    NewDocument.registerClient(client)
+    return NewDocument
+  }
+
+  /**
    * Returns true if Document uses a CozyClient (from cozy-client package)
    *
    * @returns {boolean} true if Document uses a CozyClient

--- a/packages/cozy-doctypes/src/Document.spec.js
+++ b/packages/cozy-doctypes/src/Document.spec.js
@@ -663,3 +663,36 @@ describe('Document used with CozyClient', () => {
     })
   })
 })
+
+describe('copyWithClient', () => {
+  afterEach(() => {
+    Document.cozyClient = null
+  })
+
+  it('should return a class bound to a new client', () => {
+    const newClient = {}
+    const MyDocument = Document.copyWithClient(newClient)
+
+    expect(MyDocument.cozyClient).toBe(newClient)
+    expect(Document.cozyClient).toBe(null)
+  })
+
+  it('should not interfere with an existing Document class', () => {
+    const newClient = {}
+    const MyDocument = Document.copyWithClient(newClient)
+    Document.registerClient(cozyClient)
+
+    expect(MyDocument.cozyClient).toBe(newClient)
+    expect(Document.cozyClient).toBe(cozyClient)
+  })
+
+  it('should work even if Document had a registered client', () => {
+    Document.registerClient(cozyClient)
+
+    const newClient = {}
+    const MyDocument = Document.copyWithClient(newClient)
+
+    expect(MyDocument.cozyClient).toBe(newClient)
+    expect(Document.cozyClient).toBe(cozyClient)
+  })
+})


### PR DESCRIPTION
Related to https://github.com/cozy/cozy-libs/pull/690/files#r308832827 and after discussion with @ptbrowne : at the moment the Documents class is a singleton, and it's only possible to register the client once and for all. This is an issue when we use the class in libraries where we are not sure what other pieces of code might use the singleton, if there is a registered client or not, if it's cozy-client or cozy-client-js…

The proposed fix is a new static method that returns a new, independent class, to which we can bind a client, without affecting any other `Document` classes that might be used elsewhere. 