### PR TITLE
Feat/harvest accounts

### DIFF
--- a/packages/cozy-doctypes/src/Account.js
+++ b/packages/cozy-doctypes/src/Account.js
@@ -2,7 +2,34 @@ const Document = require('./Document')
 
 const ACCOUNTS_DOCTYPE = 'io.cozy.accounts'
 
-class Account extends Document {}
+// Order matters
+export const probableLoginFieldNames = [
+  'login',
+  'identifier',
+  'new_identifier',
+  'email'
+]
+
+class Account extends Document {
+  static getAccountName = account => {
+    if (!account) return null
+    if (account.auth) {
+      return (
+        account.auth.accountName || this.getAccountLogin(account) || account._id
+      )
+    } else {
+      return account._id
+    }
+  }
+
+  static getAccountLogin = account => {
+    if (account && account.auth) {
+      for (const fieldName of probableLoginFieldNames) {
+        if (account.auth[fieldName]) return account.auth[fieldName]
+      }
+    }
+  }
+}
 
 Account.schema = {
   doctype: ACCOUNTS_DOCTYPE,

--- a/packages/cozy-doctypes/src/Account.spec.js
+++ b/packages/cozy-doctypes/src/Account.spec.js
@@ -1,0 +1,53 @@
+/* eslint-env jest */
+import { cozyClient } from './testUtils'
+import Account from './Account'
+
+beforeAll(() => {
+  Account.registerClient(cozyClient)
+})
+describe('helpers library', () => {
+  describe('getAccountName', () => {
+    it('should return _id property by default (fallback)', () => {
+      const account = { _id: 'mock12345', auth: { token: '1234' } }
+      expect(Account.getAccountName(account)).toBe(account._id)
+    })
+    it('should return _id property by default (fallback) if no auth property', () => {
+      const account = { _id: 'mock12345' }
+      expect(Account.getAccountName(account)).toBe(account._id)
+    })
+    it('should return auth.acountName property if it exists, prior to other auth properties', () => {
+      const account = { _id: 'mock12345', auth: { accountName: 'myaccount' } }
+      expect(Account.getAccountName(account)).toBe(account.auth.accountName)
+    })
+    it('should return auth.login property if it exists, prior to auth.identifier and auth.email', () => {
+      const account = {
+        _id: 'mock12345',
+        auth: {
+          login: 'myaccountlogin',
+          identifier: 'myaccountidentifier',
+          email: 'myaccount@email.mock'
+        }
+      }
+      expect(Account.getAccountName(account)).toBe(account.auth.login)
+    })
+    it("should return auth.identifier property if it exists (prior to auth.email) and if auth.login doesn't", () => {
+      const account = {
+        _id: 'mock12345',
+        auth: {
+          identifier: 'myaccountidentifier',
+          email: 'myaccount@email.mock'
+        }
+      }
+      expect(Account.getAccountName(account)).toBe(account.auth.identifier)
+    })
+    it('should return auth.email property if it exists and if neither auth.login and neither auth.identifier exist', () => {
+      const account = {
+        _id: 'mock12345',
+        auth: {
+          email: 'myaccount@email.mock'
+        }
+      }
+      expect(Account.getAccountName(account)).toBe(account.auth.email)
+    })
+  })
+})

--- a/packages/cozy-harvest-lib/jest.config.js
+++ b/packages/cozy-harvest-lib/jest.config.js
@@ -10,7 +10,8 @@ module.exports = {
   moduleNameMapper: {
     // identity-obj-proxy module is installed by cozy-scripts
     styles: 'identity-obj-proxy',
-    '^cozy-logger$': 'cozy-logger/dist/index.js'
+    '^cozy-logger$': 'cozy-logger/dist/index.js',
+    '\\.(png|gif|jpe?g|svg)$': '<rootDir>/test/__mocks__/fileMock.js'
   },
   transformIgnorePatterns: ['node_modules/(?!cozy-ui)'],
   setupFilesAfterEnv: ['<rootDir>/test/setup.js']

--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -21,7 +21,6 @@
     "prepublishOnly": "yarn build",
     "test": "jest --verbose",
     "tx": "tx pull --all",
-    "posttx": "./scripts/check-locales.sh",
     "watch": "yarn build --watch",
     "watch:doc:react": "(cd ../.. && TARGET=cozy-harvest-lib yarn watch:doc:react)"
   },

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -29,7 +29,7 @@ import { Text } from 'cozy-ui/transpiled/react/Text'
 
 import AccountSelectControl from './KonnectorModal/AccountSelectControl'
 import CreateAccountButton from './KonnectorModal/CreateAccountButton'
-
+import { Account } from 'cozy-doctypes'
 const MenuWithFixedComponent = props => {
   const { children } = props
   const { createAction, ...selectProps } = props.selectProps
@@ -68,6 +68,8 @@ export class KonnectorModal extends PureComponent {
    * Next tasks: remove these methods and rewrite the override
    */
   componentDidMount() {
+    const { client } = this.context
+    Account.copyWithClient(client)
     this.fetchAccount(this.props.konnector.triggers.data[0])
     this.fetchAccounts()
   }
@@ -198,12 +200,16 @@ export class KonnectorModal extends PureComponent {
                     this.fetchAccount(option.trigger)
                   }}
                   createAction={createAction}
-                  getOptionLabel={option => option.account.auth.login}
+                  getOptionLabel={option =>
+                    Account.getAccountName(option.account)
+                  }
                   getOptionValue={option => option.trigger._id}
                   defaultValue={accounts[0]}
                   components={{
                     Control: reactSelectControl(
-                      <AccountSelectControl name={account.auth.login} />
+                      <AccountSelectControl
+                        name={Account.getAccountName(account)}
+                      />
                     ),
                     Menu: MenuWithFixedComponent
                   }}

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -10,7 +10,6 @@ import Modal, {
   ModalHeader
 } from 'cozy-ui/transpiled/react/Modal'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
-import { SubTitle } from 'cozy-ui/transpiled/react/Text'
 
 import accountMutations from '../connections/accounts'
 import triggersMutations from '../connections/triggers'
@@ -20,8 +19,20 @@ import DeleteAccountCard from './cards/DeleteAccountCard'
 import LaunchTriggerCard from './cards/LaunchTriggerCard'
 import TriggerErrorInfo from './infos/TriggerErrorInfo'
 import withLocales from './hoc/withLocales'
-import SelectBox from 'cozy-ui/transpiled/react/SelectBox'
+import SelectBox, {
+  reactSelectControl
+} from 'cozy-ui/transpiled/react/SelectBox'
 
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import { Text } from 'cozy-ui/transpiled/react/Text'
+
+const MyAccountComponent = ({ name }) => {
+  return (
+    <Text className="u-slateGrey u-flex u-flex-items-center u-c-pointer">
+      {name} <Icon icon={'bottom-select'} size="12" className="u-ml-half" />
+    </Text>
+  )
+}
 /**
  * KonnectorModal open a Modal related to a given konnector. It fetches the
  * first account and then include a TriggerManager component.
@@ -156,22 +167,52 @@ export class KonnectorModal extends PureComponent {
         mobileFullscreen
         size="small"
         into={into}
+        closable={false}
       >
-        <ModalHeader>
-          <AppIcon fetchIcon={this.fetchIcon} className="u-mah-3 u-ml-1" />
+        <ModalHeader className="u-pr-2">
+          <div className="u-flex u-flex-row u-w-100 u-flex-items-center">
+            <div className="u-w-3 u-h-3 u-mr-half">
+              <AppIcon fetchIcon={this.fetchIcon} />
+            </div>
+            <div className="u-flex-grow-1 u-mr-half">
+              <h3 className="u-title-h3 u-m-0">{konnector.name}</h3>
 
-          {accounts.length === 0 && <SelectBox />}
-          {accounts.length > 0 && (
-            <SelectBox
-              options={accounts}
-              onChange={option => {
-                this.fetchAccount(option.trigger)
-              }}
-              getOptionLabel={option => option.account.auth.login}
-              getOptionValue={option => option.trigger._id}
-              defaultValue={accounts[0]}
-            />
-          )}
+              {accounts.length === 0 && (
+                <Text className="u-slateGrey u-flex u-flex-items-center">
+                  Loading
+                </Text>
+              )}
+              {accounts.length > 0 && (
+                <SelectBox
+                  size="tiny"
+                  options={accounts}
+                  onChange={option => {
+                    this.fetchAccount(option.trigger)
+                  }}
+                  getOptionLabel={option => option.account.auth.login}
+                  getOptionValue={option => option.trigger._id}
+                  defaultValue={accounts[0]}
+                  components={{
+                    Control: reactSelectControl(
+                      <MyAccountComponent
+                        name={this.state.account.auth.login}
+                      />
+                    )
+                  }}
+                />
+              )}
+            </div>
+            <div className="">
+              <Button
+                icon={<Icon icon={'cross'} size={'24'} />}
+                onClick={dismissAction}
+                iconOnly
+                label={'close'}
+                subtle
+                theme={'secondary'}
+              />
+            </div>
+          </div>
         </ModalHeader>
         {fetching ? (
           <ModalContent>
@@ -182,9 +223,6 @@ export class KonnectorModal extends PureComponent {
           </ModalContent>
         ) : (
           <ModalContent className="u-pb-0">
-            <SubTitle className="u-mb-1 u-ta-center">
-              {t('modal.konnector.title', { name: konnector.name })}
-            </SubTitle>
             {error ? (
               <Infos
                 actionButton={

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -26,34 +26,17 @@ import SelectBox, {
 
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import { Text } from 'cozy-ui/transpiled/react/Text'
-import { translate } from 'cozy-ui/transpiled/react/I18n'
 
-const MyAccountComponent = ({ name }) => {
-  return (
-    <Text className="u-slateGrey u-flex u-flex-items-center u-c-pointer">
-      {name} <Icon icon={'bottom-select'} size="12" className="u-ml-half" />
-    </Text>
-  )
-}
+import AccountSelectControl from './KonnectorModal/AccountSelectControl'
+import CreateAccountButton from './KonnectorModal/CreateAccountButton'
 
-const CreateAccount = translate()(({ createAction, t }) => {
-  return (
-    <Button
-      subtle
-      size={'small'}
-      className={'u-m-half'}
-      onClick={createAction}
-      label={t('modal.konnector.create_account')}
-    />
-  )
-})
 const MenuWithFixedComponent = props => {
   const { children } = props
   const { createAction, ...selectProps } = props.selectProps
   return (
     <components.Menu {...props} selectProps={selectProps}>
       {children}
-      <CreateAccount createAction={createAction} />
+      <CreateAccountButton createAction={createAction} />
     </components.Menu>
   )
 }
@@ -205,9 +188,7 @@ export class KonnectorModal extends PureComponent {
               <h3 className="u-title-h3 u-m-0">{konnector.name}</h3>
 
               {accounts.length === 0 && (
-                <Text className="u-slateGrey u-flex u-flex-items-center">
-                  {t('loading')}
-                </Text>
+                <Text className="u-slateGrey">{t('loading')}</Text>
               )}
               {accounts.length > 0 && account && (
                 <SelectBox
@@ -222,23 +203,21 @@ export class KonnectorModal extends PureComponent {
                   defaultValue={accounts[0]}
                   components={{
                     Control: reactSelectControl(
-                      <MyAccountComponent name={account.auth.login} />
+                      <AccountSelectControl name={account.auth.login} />
                     ),
                     Menu: MenuWithFixedComponent
                   }}
                 />
               )}
             </div>
-            <div className="">
-              <Button
-                icon={<Icon icon={'cross'} size={'24'} />}
-                onClick={dismissAction}
-                iconOnly
-                label={t('close')}
-                subtle
-                theme={'secondary'}
-              />
-            </div>
+            <Button
+              icon={<Icon icon={'cross'} size={'24'} />}
+              onClick={dismissAction}
+              iconOnly
+              label={t('close')}
+              subtle
+              theme={'secondary'}
+            />
           </div>
         </ModalHeader>
         {fetching ? (

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal/AccountSelectControl.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal/AccountSelectControl.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Text, Icon } from 'cozy-ui/transpiled/react'
+
+const AccountSelectControl = ({ name }) => {
+  return (
+    <Text className="u-slateGrey u-flex u-flex-items-center u-c-pointer">
+      {name} <Icon icon={'bottom-select'} size="12" className="u-ml-half" />
+    </Text>
+  )
+}
+
+export default AccountSelectControl

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal/CreateAccountButton.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal/CreateAccountButton.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { translate, Button } from 'cozy-ui/transpiled/react/'
+
+const CreateAccount = translate()(({ createAction, t }) => {
+  return (
+    <Button
+      subtle
+      size={'small'}
+      className={'u-m-half'}
+      onClick={createAction}
+      label={t('modal.konnector.create_account')}
+    />
+  )
+})
+
+export default CreateAccount

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
@@ -6,8 +6,8 @@ import Button from 'cozy-ui/transpiled/react/Button'
 import Card from 'cozy-ui/transpiled/react/Card'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import { Uppercase, Text } from 'cozy-ui/transpiled/react/Text'
-
+import { Text } from 'cozy-ui/transpiled/react/Text'
+import Uppercase from 'cozy-ui/transpiled/react/Text'
 import * as triggers from '../../helpers/triggers'
 import TriggerLauncher, {
   TriggerLauncher as DumbTriggerLauncher

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
@@ -6,8 +6,7 @@ import Button from 'cozy-ui/transpiled/react/Button'
 import Card from 'cozy-ui/transpiled/react/Card'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import { Text } from 'cozy-ui/transpiled/react/Text'
-import Uppercase from 'cozy-ui/transpiled/react/Text'
+import Uppercase, { Text } from 'cozy-ui/transpiled/react/Text'
 import * as triggers from '../../helpers/triggers'
 import TriggerLauncher, {
   TriggerLauncher as DumbTriggerLauncher

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -1,4 +1,6 @@
 {
+  "loading": "Loading",
+  "close": "Close",
   "accountForm": {
     "submit": {
       "label": "Submit"
@@ -245,12 +247,12 @@
   },
   "modal": {
     "konnector": {
-      "title": "Edit your %{name} account",
       "error": {
         "title": "Unable to retrieve your account",
         "description": "The account cannot be retrieved (%{message}).",
         "button": "Close"
-      }
+      },
+      "create_account": "Create an account"
     }
   },
   "oauth": {

--- a/packages/cozy-harvest-lib/test/__mocks__/fileMock.js
+++ b/packages/cozy-harvest-lib/test/__mocks__/fileMock.js
@@ -1,0 +1,3 @@
+'use strict'
+
+export default 'test-file-stub'


### PR DESCRIPTION
KonnectorModal now displays also a `Select` with accounts linked to the konnector. 

I added a few functions to `cozy-doctypes/Account` and their tests from `Home`


Several things to do after : 
- Move MenuFixed to UI (we used it here, but also in `Contacts`) 
- Refactor the logic to fetch the account / triggers 


<img width="590" alt="Capture d’écran 2019-08-02 à 15 49 15" src="https://user-images.githubusercontent.com/1107936/62374831-1b781d80-b53d-11e9-9e2e-ed719bc26ddf.png">
