### PR TITLE
fix: CopyWithClient returns the correct class

### DIFF
--- a/packages/cozy-doctypes/src/Document.js
+++ b/packages/cozy-doctypes/src/Document.js
@@ -88,10 +88,11 @@ class Document {
    * @returns {type}        A new class, with the client registered
    */
   static copyWithClient(client) {
-    class NewDocument extends Document {}
-    NewDocument.cozyClient = null
-    NewDocument.registerClient(client)
-    return NewDocument
+    const BaseClass = this
+    class ExtendedClass extends BaseClass {}
+    ExtendedClass.cozyClient = null
+    ExtendedClass.registerClient(client)
+    return ExtendedClass
   }
 
   /**

--- a/packages/cozy-doctypes/src/Document.spec.js
+++ b/packages/cozy-doctypes/src/Document.spec.js
@@ -677,6 +677,18 @@ describe('copyWithClient', () => {
     expect(Document.cozyClient).toBe(null)
   })
 
+  it('should return an extension of the base class', () => {
+    class ExtendedClass extends Document {
+      static myExtendedMethod() {
+        return 'myExtendedMethod called'
+      }
+    }
+    const newClient = {}
+
+    const MyClass = ExtendedClass.copyWithClient(newClient)
+    expect(MyClass.myExtendedMethod()).toEqual('myExtendedMethod called')
+  })
+
   it('should not interfere with an existing Document class', () => {
     const newClient = {}
     const MyDocument = Document.copyWithClient(newClient)


### PR DESCRIPTION
Using `copyWithClient` from another class than Document would return a Document class object, instead of the correct class.