### PR TITLE
fix(cozy-doctypes): Don't use arrow functions in Account model

### DIFF
--- a/packages/cozy-doctypes/src/Account.js
+++ b/packages/cozy-doctypes/src/Account.js
@@ -11,7 +11,7 @@ export const probableLoginFieldNames = [
 ]
 
 class Account extends Document {
-  static getAccountName = account => {
+  static getAccountName(account) {
     if (!account) return null
     if (account.auth) {
       return (
@@ -22,7 +22,7 @@ class Account extends Document {
     }
   }
 
-  static getAccountLogin = account => {
+  static getAccountLogin(account) {
     if (account && account.auth) {
       for (const fieldName of probableLoginFieldNames) {
         if (account.auth[fieldName]) return account.auth[fieldName]


### PR DESCRIPTION
This syntax is only available since node 12. Since we mainly use node
10, this is causing some errors. In banks' services build for example:

```
ERROR in ./node_modules/cozy-doctypes/src/Account.js 14:24
Module parse failed: Unexpected token (14:24)
You may need an appropriate loader to handle this file type, currently
no loaders are configured to process this file. See
https://webpack.js.org/concepts#loaders
|
| class Account extends Document {
  >   static getAccountName = account => {
  |     if (!account) return null
    |     if (account.auth) {
     @ ./node_modules/cozy-doctypes/src/index.js 1:16-36
      @ ./src/targets/services/stats.js
    }
  }
}
```

This is somehow the same problem as we had in
https://github.com/cozy/cozy-libs/pull/557