### PR TITLE
fix: Folder doctypes keeps the same class

### DIFF
--- a/packages/cozy-doctypes/src/Folder.js
+++ b/packages/cozy-doctypes/src/Folder.js
@@ -38,12 +38,12 @@ class CozyFolder extends CozyFile {
       _type: Application.doctype,
       _id: id
     }
-    const folders = await CozyFolder.getReferencedFolders(magicFolderDocument)
+    const folders = await this.getReferencedFolders(magicFolderDocument)
     const existingMagicFolder = folders.length ? folders[0] : null
 
     if (existingMagicFolder) return existingMagicFolder
 
-    const magicFoldersValues = Object.values(CozyFolder.magicFolders)
+    const magicFoldersValues = Object.values(this.magicFolders)
     if (!magicFoldersValues.includes(id)) {
       throw new Error(
         `Cannot create Magic folder with id ${id}. Allowed values are ${magicFoldersValues.join(
@@ -56,7 +56,7 @@ class CozyFolder extends CozyFile {
       throw new Error('Magic folder default path must be defined')
     }
 
-    return CozyFolder.createFolderWithReference(path, magicFolderDocument)
+    return this.createFolderWithReference(path, magicFolderDocument)
   }
 
   /**
@@ -69,7 +69,7 @@ class CozyFolder extends CozyFile {
     const { included } = await this.cozyClient
       .collection(CozyFile.doctype)
       .findReferencedBy(document)
-    return included.filter(folder => !CozyFolder.isTrashed(folder))
+    return included.filter(folder => !this.isTrashed(folder))
   }
 
   /**
@@ -81,7 +81,7 @@ class CozyFolder extends CozyFile {
    * @return {Objet}             Folder referenced with the give reference
    */
   static async ensureFolderWithReference(path, document) {
-    const existingFolders = await CozyFolder.getReferencedFolders(document)
+    const existingFolders = await this.getReferencedFolders(document)
     if (existingFolders.length) return existingFolders[0]
 
     const collection = this.cozyClient.collection(CozyFile.doctype)

--- a/packages/cozy-doctypes/src/Folder.spec.js
+++ b/packages/cozy-doctypes/src/Folder.spec.js
@@ -187,3 +187,27 @@ describe('Folder model', () => {
     })
   })
 })
+
+describe('Using copyWithClient', () => {
+  let MyCozyFolder
+  beforeEach(() => {
+    const newClient = {}
+    MyCozyFolder = CozyFolder.copyWithClient(newClient)
+  })
+
+  afterEach(() => {
+    CozyFolder.cozyClient = null
+  })
+
+  it('should call subfunctions using the same class', () => {
+    jest
+      .spyOn(MyCozyFolder, 'getReferencedFolders')
+      .mockImplementation(() => [])
+    jest.spyOn(MyCozyFolder, 'createFolderWithReference').mockImplementation()
+    MyCozyFolder.ensureMagicFolder(
+      MyCozyFolder.magicFolders.ADMINISTRATIVE,
+      '/Administrative'
+    )
+    expect(MyCozyFolder.getReferencedFolders).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
When using `copyWithClient `, we can't use the classname to call other static methods, otherwise the client's binding is lost (whereas it's kept with `registerClient`). I had a quick look and apparently only CozyFolder did that.

Using `this` works in both cases, but it shows that `copyWithClient` is just a stopgap solution and #696 might be more urgent than expected.