### PR TITLE
WIP: chore(cozy-doctypes): Don't use babel in tests

### DIFF
--- a/packages/cozy-doctypes/jest.config.js
+++ b/packages/cozy-doctypes/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  transform: {}
+}


### PR DESCRIPTION
In https://github.com/cozy/cozy-libs/pull/557 and https://github.com/cozy/cozy-libs/pull/697 our tests should failed before the fixes. It was not the case because Jest is passing the test files in Babel when it finds a `babel.config.js` file (see https://jestjs.io/docs/en/getting-started#using-babel):

> Note: babel-jest is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the transform configuration option

In this PR, I tried to add a `jest.config.js` file with `transform: {}` in it. But it makes tests fail a lot more than I planned.