### PR TITLE
chore: Use Node 10 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '8'
+  - '10'
 env:
   global:
 addons:


### PR DESCRIPTION
The majority of our apps and libs are using node 10.