### PR TITLE
(Procedures) Get transactions category

### DIFF
--- a/packages/playgrounds/src/common/client.js
+++ b/packages/playgrounds/src/common/client.js
@@ -16,7 +16,8 @@ const getClient = customOptions => {
           'io.cozy.jobs:POST:zip:worker',
           'io.cozy.bank.accounts.stats',
           'io.cozy.bank.accounts',
-          'io.cozy.bank.operations'
+          'io.cozy.bank.operations',
+          'io.cozy.bank.settings'
         ],
         schema: {
           apps: {


### PR DESCRIPTION
In the transactions history JSON file, we want to add the category of each transaction. We don't want to put all the categories of a given transaction (`automaticCategoryId`, `manualCategoryId`, `cozyCategoryId`, `localCategoryId`) but only the one we would show in banks. That's why I extracted the [`getCategoryId`](https://github.com/cozy/cozy-banks/blob/master/src/ducks/categories/helpers.js#L30-L62) helper from banks.