### PR TITLE
feat(cozy-doctypes): Include subset of cozy-client

### DIFF
--- a/packages/cozy-doctypes/src/Document.js
+++ b/packages/cozy-doctypes/src/Document.js
@@ -10,7 +10,7 @@ const groupBy = require('lodash/groupBy')
 const sortBy = require('lodash/sortBy')
 const get = require('lodash/get')
 const { parallelMap } = require('./utils')
-const CozyClient = require('cozy-client').default
+const CozyClient = require('cozy-client/dist/CozyClient').default
 const log = require('cozy-logger').namespace('Document')
 const querystring = require('querystring')
 

--- a/packages/cozy-doctypes/src/testUtils.js
+++ b/packages/cozy-doctypes/src/testUtils.js
@@ -1,4 +1,4 @@
-const CozyClient = require('cozy-client').default
+const CozyClient = require('cozy-client/dist/CozyClient').default
 const CozyStackClient = require('cozy-stack-client').default
 
 jest.mock('cozy-stack-client')


### PR DESCRIPTION
This avoid including the react dependency from cozy-client
by only including cozy-client.