### PR TITLE
feat(cozy-app-publish): Make mattermost channel optional

### DIFF
--- a/packages/cozy-app-publish/README.md
+++ b/packages/cozy-app-publish/README.md
@@ -164,7 +164,8 @@ cozy-app-publish --postpublish mattermost
 Sends a message to a mattermost channel to notify of the app's deployment. Requires the following options:
 
 - `MATTERMOST_HOOK_URL`: You will need to set up a new [Incoming Hook](https://docs.mattermost.com/developer/webhooks-incoming.html).
-- `MATTERMOST_CHANNEL`: The name of the channel messages will be posted to.
+- `MATTERMOST_CHANNEL`: (optional) The name of the channel messages will be posted to or else the
+  default channel of the hook will be used
 
 #### `--registry-url <url>`
 

--- a/packages/cozy-app-publish/lib/hooks/post/mattermost.js
+++ b/packages/cozy-app-publish/lib/hooks/post/mattermost.js
@@ -57,10 +57,6 @@ const sendMattermostReleaseMessage = (appSlug, appVersion) => {
 module.exports = async options => {
   console.log('↳ ℹ️  Sending message to Mattermost')
 
-  if (!MATTERMOST_CHANNEL) {
-    throw new Error('No MATTERMOST_CHANNEL environment variable defined')
-  }
-
   if (!MATTERMOST_HOOK_URL) {
     throw new Error('No MATTERMOST_HOOK_URL environment variable defined')
   }


### PR DESCRIPTION
A default channel can be specified in the mattermost hook.

This is especially useful for connectors when we want to change the channel (which is the same for all connectors) and don't want to change the travis configuration file for all of them.