### PR TITLE
chore(eslint-config-cozy-app): Update package.json fields

### DIFF
--- a/packages/eslint-config-cozy-app/package.json
+++ b/packages/eslint-config-cozy-app/package.json
@@ -5,12 +5,12 @@
   "author": "CPatchane <code@patchane.com>",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/CPatchane/create-cozy-app.git"
+    "url": "git+https://github.com/cozy/cozy-libs.git"
   },
-  "homepage": "https://github.com/CPatchane/create-cozy-app/tree/master/packages/eslint-config-cozy-app",
+  "homepage": "https://github.com/cozy/cozy-libs/tree/master/packages/eslint-config-cozy-app",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/CPatchane/create-cozy-app/issues"
+    "url": "https://github.com/cozy/cozy-libs/issues"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
The package has been moved from CPatchane/create-cozy-app to
cozy/cozy-libs but we didn't update the corresponding fields in the
package.json. So renovate PRs links were not correct anymore.