### PR TITLE
chore(cozy-app-publish): Add repository, homepage, bugs to package.json

### DIFF
--- a/packages/cozy-app-publish/package.json
+++ b/packages/cozy-app-publish/package.json
@@ -4,6 +4,14 @@
   "main": "index.js",
   "author": "Cozy",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cozy/cozy-libs.git"
+  },
+  "homepage": "https://github.com/cozy/cozy-libs/tree/master/packages/cozy-app-publish",
+  "bugs": {
+    "url": "https://github.com/cozy/cozy-libs/issues"
+  },
   "scripts": {
     "test": "jest --verbose --coverage",
     "test:integration": "env TEST_INTEGRATION=1 jest"


### PR DESCRIPTION
These fields are useful in various situations: renovate PRs, `npm docs`, `npm bugs` and so on.