### PR TITLE
feat(renovate): Configuration for our libs

### DIFF
--- a/renovate-config-cozy-libs/package.json
+++ b/renovate-config-cozy-libs/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "renovate-config-cozy-libs",
+  "version": "0.1.0",
+  "description": "Renovate config for Cozy libs",
+  "renovate-config": {
+    "default": {
+      "extends": [
+        "cozy"
+      ],
+      "packageRules": [
+        {
+          "packagePatterns": [
+            "*"
+          ],
+          "rangeStrategy": "replace"
+        },
+        {
+          "depTypeList": [
+            "devDependencies"
+          ],
+          "rangeStrategy": "pin"
+        }
+      ]
+    }
+  },
+  "license": "MIT"
+}


### PR DESCRIPTION
This will create a new renovate configuration to use in our libs. It's based on our main config (so PRs won't happen during working hours etc), but:

- we use ranges for our dependencies, so that we don't end up with duplicate dependencies in our apps
- dev deps are kept pinned

Once published, we will update our `renovate.json` files in our lib repos to extend `cozy-libs` instead of `cozy`.