### PR TITLE
fix: Removed outdated style

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -190,10 +190,6 @@ export class AccountForm extends PureComponent {
             ref={element => {
               container = element
             }}
-            // Hacking manually the style here, waiting for Cozy-UI to remove
-            // top margin on Field's label elements.
-            // See https://github.com/cozy/cozy-libs/issues/629
-            style={{ marginTop: '-1rem' }}
           >
             {error && showError && (
               <TriggerErrorInfo

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
@@ -4,11 +4,6 @@ exports[`AccountForm should not render error 1`] = `
 <div
   onFocusCapture={[Function]}
   onKeyUp={[Function]}
-  style={
-    Object {
-      "marginTop": "-1rem",
-    }
-  }
 >
   <AccountFields
     container={null}
@@ -60,11 +55,6 @@ exports[`AccountForm should render 1`] = `
 <div
   onFocusCapture={[Function]}
   onKeyUp={[Function]}
-  style={
-    Object {
-      "marginTop": "-1rem",
-    }
-  }
 >
   <AccountFields
     container={null}
@@ -115,11 +105,6 @@ exports[`AccountForm should render error 1`] = `
 <div
   onFocusCapture={[Function]}
   onKeyUp={[Function]}
-  style={
-    Object {
-      "marginTop": "-1rem",
-    }
-  }
 >
   <Wrapper
     className="u-mb-1"


### PR DESCRIPTION
We're using an up-to-date version of cozy-ui now, so this hack isn't necessary anymore as far as I can tell.