### PR TITLE
feat: Fix split date

### DIFF
--- a/packages/cozy-doctypes/src/banking/BankTransaction.js
+++ b/packages/cozy-doctypes/src/banking/BankTransaction.js
@@ -305,5 +305,6 @@ Transaction.checkedAttributes = [
 ]
 Transaction.LOCAL_MODEL_USAGE_THRESHOLD = 0.8
 Transaction.GLOBAL_MODEL_USAGE_THRESHOLD = 0.15
+Transaction.getSplitDate = getSplitDate
 
 module.exports = Transaction

--- a/packages/cozy-doctypes/src/banking/BankTransaction.js
+++ b/packages/cozy-doctypes/src/banking/BankTransaction.js
@@ -19,12 +19,20 @@ const getDate = transaction => {
 }
 
 /**
- * Get the date of the latest transaction in an array
+ * Get the date of the latest transaction in an array.
+ * Transactions in the future are ignored.
+ *
  * @param {array} stackTransactions
  * @returns {string} The date of the latest transaction (YYYY-MM-DD)
  */
 const getSplitDate = stackTransactions => {
-  return maxValue(stackTransactions, getDate)
+  const now = new Date()
+  const notFutureTransactions = stackTransactions.filter(transaction => {
+    const date = getDate(transaction)
+    return !isAfter(date, now)
+  })
+
+  return maxValue(notFutureTransactions, getDate)
 }
 
 const ensureISOString = date => {

--- a/packages/cozy-doctypes/src/banking/BankTransaction.spec.js
+++ b/packages/cozy-doctypes/src/banking/BankTransaction.spec.js
@@ -43,8 +43,23 @@ describe('getIdentifier', () => {
 })
 
 describe('split date', () => {
-  it('should be the oldest date present in the transaction', () => {
+  it('should be the most recent date present in the transaction', () => {
     expect(BankTransaction.getSplitDate(testTransactions)).toBe('2018-10-06')
+  })
+
+  it('should not consider future transactions', () => {
+    // Exceptionally, some transactions can come from the future
+    // For example in the case of planned stock sale
+    // https://trello.com/c/KK9CeQzB/
+    expect(
+      BankTransaction.getSplitDate([
+        ...testTransactions,
+        {
+          ...testTransactions[0],
+          date: '2050-10-06' // Someone planned a transaction in the future
+        }
+      ])
+    ).toBe('2018-10-06')
   })
 })
 

--- a/packages/cozy-doctypes/src/banking/BankTransaction.spec.js
+++ b/packages/cozy-doctypes/src/banking/BankTransaction.spec.js
@@ -1,5 +1,23 @@
 const BankTransaction = require('./BankTransaction')
 
+const testTransactions = [
+  {
+    amount: -10,
+    originalBankLabel: 'Test 01',
+    date: '2018-10-02'
+  },
+  {
+    amount: -20,
+    originalBankLabel: 'Test 02',
+    date: '2018-10-05'
+  },
+  {
+    amount: -30,
+    originalBankLabel: 'Test 03',
+    date: '2018-10-06'
+  }
+]
+
 describe('transaction reconciliation', () => {
   it('should be able to filter incoming linxo transactions on their date', () => {
     const filter = x => BankTransaction.prototype.isAfter.call(x, '2018-10-04')
@@ -24,24 +42,14 @@ describe('getIdentifier', () => {
   })
 })
 
+describe('split date', () => {
+  it('should be the oldest date present in the transaction', () => {
+    expect(BankTransaction.getSplitDate(testTransactions)).toBe('2018-10-06')
+  })
+})
+
 describe('reconciliation', () => {
-  const existingTransactions = [
-    {
-      amount: -10,
-      originalBankLabel: 'Test 01',
-      date: '2018-10-02'
-    },
-    {
-      amount: -20,
-      originalBankLabel: 'Test 02',
-      date: '2018-10-05'
-    },
-    {
-      amount: -30,
-      originalBankLabel: 'Test 03',
-      date: '2018-10-06'
-    }
-  ]
+  const existingTransactions = testTransactions
 
   it('should return the missed transactions when there are some', () => {
     const newTransactions = [


### PR DESCRIPTION
Transactions older than the split date are ignored as a fail safe
against duplicates when switching from Linxo to BI. Future transactions
should be ignored in the computation of this split date.