### PR TITLE
fix(cozy-logger): Set production mode as default mode

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,3 +12,4 @@ packages/cozy-realtime @edas @ptbrowne
 packages/cozy-release @doubleface
 packages/eslint-config-cozy-app @edas @drazik
 packages/renovate-config-cozy @y-lohse @doubleface
+packages/cozy-logger @doubleface

--- a/packages/cozy-logger/src/log-format.js
+++ b/packages/cozy-logger/src/log-format.js
@@ -14,4 +14,6 @@ switch (process.env.NODE_ENV) {
   case 'test':
     module.exports = devFormat
     break
+  default:
+    module.exports = prodFormat
 }


### PR DESCRIPTION
If NODE_ENV env var was not defined, no log formater would be defined and this could cause fatal error.

I also set myself as code owner for this package. Anybody is welcome of course :-)