### PR TITLE
fix(cozy-harvest-lib): Check if accountLogin is not undefined

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountsList/AccountsListItem.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountsList/AccountsListItem.jsx
@@ -11,10 +11,13 @@ import Status from './Status'
 export class AccountsListItem extends React.PureComponent {
   render() {
     const { account, onClick, konnector, trigger } = this.props
-
     const accountName = Account.getAccountName(account)
     const accountLogin = Account.getAccountLogin(account)
-    const nameAndLoginDiffer = accountName !== accountLogin
+    /**
+     * When the account is from an OAuth, we cat not have an accountLogin.
+     * So have to check if accountLogin is not undefined before doing the check
+     *  */
+    const shouldShowAccountLogin = accountLogin && accountName !== accountLogin
     return (
       <Card
         className="u-flex u-flex-justify-between u-flex-items-center u-c-pointer u-maw-100"
@@ -22,7 +25,7 @@ export class AccountsListItem extends React.PureComponent {
       >
         <div className="u-flex-grow-1 u-flex-shrink-1 u-ov-hidden u-mr-1">
           <MidEllipsis text={accountName} />
-          {nameAndLoginDiffer && (
+          {shouldShowAccountLogin && (
             <Caption>
               <MidEllipsis text={accountLogin} />
             </Caption>

--- a/packages/cozy-harvest-lib/test/components/AccountsList/AccountsListItem.spec.js
+++ b/packages/cozy-harvest-lib/test/components/AccountsList/AccountsListItem.spec.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import AccountsListItem from 'components/AccountsList/AccountsListItem'
+
+describe('AccountsListItem', () => {
+  it('should not render the caption since accountLogin is undefined', () => {
+    const wrapper = shallow(
+      <AccountsListItem
+        account={{
+          _id: 'account-1'
+        }}
+        konnector={{
+          name: 'test-konnector',
+          vendor_link: 'test konnector link'
+        }}
+        onClick={jest.fn()}
+        trigger={jest.fn()}
+      />
+    )
+    const component = wrapper.shallow()
+    expect(component.getElement()).toMatchSnapshot()
+  })
+
+  it('should render the caption since accountName !== login', () => {
+    const wrapper = shallow(
+      <AccountsListItem
+        account={{
+          _id: 'account-1',
+          auth: { login: 'mylogin', accountName: 'myAccountName' }
+        }}
+        konnector={{
+          name: 'test-konnector',
+          vendor_link: 'test konnector link'
+        }}
+        onClick={jest.fn()}
+        trigger={jest.fn()}
+      />
+    )
+    const component = wrapper.shallow()
+    expect(component.getElement()).toMatchSnapshot()
+  })
+})

--- a/packages/cozy-harvest-lib/test/components/AccountsList/__snapshots__/AccountsListItem.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/AccountsList/__snapshots__/AccountsListItem.spec.js.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AccountsListItem should not render the caption since accountLogin is undefined 1`] = `
+<div
+  className="styles__c-card___YgP7B u-flex u-flex-justify-between u-flex-items-center u-c-pointer u-maw-100"
+  onClick={[MockFunction]}
+>
+  <div
+    className="u-flex-grow-1 u-flex-shrink-1 u-ov-hidden u-mr-1"
+  >
+    <MidEllipsis
+      text="account-1"
+    />
+  </div>
+  <Wrapper
+    konnector={
+      Object {
+        "name": "test-konnector",
+        "vendor_link": "test konnector link",
+      }
+    }
+    trigger={[MockFunction]}
+  />
+</div>
+`;
+
+exports[`AccountsListItem should render the caption since accountName !== login 1`] = `
+<div
+  className="styles__c-card___YgP7B u-flex u-flex-justify-between u-flex-items-center u-c-pointer u-maw-100"
+  onClick={[MockFunction]}
+>
+  <div
+    className="u-flex-grow-1 u-flex-shrink-1 u-ov-hidden u-mr-1"
+  >
+    <MidEllipsis
+      text="myAccountName"
+    />
+    <Caption
+      ellipsis={false}
+      tag="div"
+    >
+      <MidEllipsis
+        text="mylogin"
+      />
+    </Caption>
+  </div>
+  <Wrapper
+    konnector={
+      Object {
+        "name": "test-konnector",
+        "vendor_link": "test konnector link",
+      }
+    }
+    trigger={[MockFunction]}
+  />
+</div>
+`;


### PR DESCRIPTION
Before checking if the accountName differs from the login, we have to check if the login is not undefined ;). It's the case on a few OAuth konnector 