### PR TITLE
Add konnector new version informatin in Konnector Configuration

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorConfiguration.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorConfiguration.jsx
@@ -12,12 +12,14 @@ import Icon from 'cozy-ui/transpiled/react/Icon'
 import { SubTitle, Text } from 'cozy-ui/transpiled/react/Text'
 import Button from 'cozy-ui/transpiled/react/Button'
 
+import KonnectorUpdateInfos from '../infos/KonnectorUpdateInfos'
 import TriggerErrorInfo from '../infos/TriggerErrorInfo'
 import TriggerManager from '../TriggerManager'
 import LaunchTriggerCard from '../cards/LaunchTriggerCard'
 import DeleteAccountButton from '../DeleteAccountButton'
 import withLocales from '../hoc/withLocales'
 import * as triggersModel from '../../helpers/triggers'
+import * as konnectorsModel from '../../helpers/konnectors'
 
 class KonnectorConfiguration extends React.Component {
   constructor(props) {
@@ -78,7 +80,10 @@ class KonnectorConfiguration extends React.Component {
     const hasError = !!konnectorJobError
     const shouldDisplayError = !isJobRunning && konnectorJobError
     const hasLoginError = hasError && konnectorJobError.isLoginError()
-    const hasGenericError = hasError && !hasLoginError
+    const hasTermsVersionMismatchError =
+      hasError && konnectorJobError.isTermsVersionMismatchError()
+    const hasGenericError =
+      hasError && !hasLoginError && !hasTermsVersionMismatchError
 
     return (
       <Tabs initialActiveTab={hasLoginError ? 'configuration' : 'data'}>
@@ -100,6 +105,13 @@ class KonnectorConfiguration extends React.Component {
 
         <TabPanels>
           <TabPanel name="data" className="u-pt-1-half u-pb-0">
+            {konnectorsModel.hasNewVersionAvailable(konnector) && (
+              <KonnectorUpdateInfos
+                className="u-mb-2"
+                konnector={konnector}
+                isBlocking={hasTermsVersionMismatchError}
+              />
+            )}
             {shouldDisplayError && hasGenericError && (
               <TriggerErrorInfo
                 className="u-mb-2"

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorConfiguration.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorConfiguration.jsx
@@ -75,16 +75,18 @@ class KonnectorConfiguration extends React.Component {
     } = this.props
     const { isJobRunning, konnectorJobError } = this.state
 
+    const hasError = !!konnectorJobError
     const shouldDisplayError = !isJobRunning && konnectorJobError
-    const hasLoginError = konnectorJobError && konnectorJobError.isLoginError()
-    const hasErrorExceptLogin = konnectorJobError && !hasLoginError
+    const hasLoginError = hasError && konnectorJobError.isLoginError()
+    const hasGenericError = hasError && !hasLoginError
 
     return (
       <Tabs initialActiveTab={hasLoginError ? 'configuration' : 'data'}>
         <TabList>
           <Tab name="data">
             {t('modal.tabs.data')}
-            {hasErrorExceptLogin && (
+            {// Login error should not be mentionned in data tab
+            hasError && !hasLoginError && (
               <Icon icon="warning" size={13} className="u-ml-half" />
             )}
           </Tab>
@@ -98,7 +100,7 @@ class KonnectorConfiguration extends React.Component {
 
         <TabPanels>
           <TabPanel name="data" className="u-pt-1-half u-pb-0">
-            {shouldDisplayError && hasErrorExceptLogin && (
+            {shouldDisplayError && hasGenericError && (
               <TriggerErrorInfo
                 className="u-mb-2"
                 error={konnectorJobError}

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorConfiguration.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorConfiguration.jsx
@@ -82,8 +82,15 @@ class KonnectorConfiguration extends React.Component {
     const hasLoginError = hasError && konnectorJobError.isLoginError()
     const hasTermsVersionMismatchError =
       hasError && konnectorJobError.isTermsVersionMismatchError()
+
+    const isTermsVersionMismatchErrorWithVersionAvailable =
+      hasTermsVersionMismatchError &&
+      konnectorsModel.hasNewVersionAvailable(konnector)
+
     const hasGenericError =
-      hasError && !hasLoginError && !hasTermsVersionMismatchError
+      hasError &&
+      !hasLoginError &&
+      !isTermsVersionMismatchErrorWithVersionAvailable
 
     return (
       <Tabs initialActiveTab={hasLoginError ? 'configuration' : 'data'}>

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -15,6 +15,7 @@ import get from 'lodash/get'
 
 import accountMutations from '../connections/accounts'
 import triggersMutations from '../connections/triggers'
+import * as konnectorsModel from '../helpers/konnectors'
 import * as triggersModel from '../helpers/triggers'
 
 import withLocales from './hoc/withLocales'
@@ -23,6 +24,7 @@ import TriggerManager from './TriggerManager'
 import AccountSelectBox from './AccountSelectBox/AccountSelectBox'
 import AccountsList from './AccountsList/AccountsList'
 import KonnectorConfiguration from './KonnectorConfiguration/KonnectorConfiguration'
+import KonnectorUpdateInfos from './infos/KonnectorUpdateInfos'
 
 /**
  * KonnectorModal can be completely standalone and will use it's internal state to switch between views, or it can be controlled by the parents through props (such as accountId) and callbacks (such as createAction and onAccountChange)
@@ -274,14 +276,19 @@ export class KonnectorModal extends PureComponent {
       )
     } else if (!account) {
       return (
-        <AccountsList
-          accounts={accounts}
-          konnector={konnector}
-          onPick={option => {
-            this.requestAccountChange(option.account, option.trigger)
-          }}
-          addAccount={this.requestAccountCreation}
-        />
+        <>
+          {konnectorsModel.hasNewVersionAvailable(konnector) && (
+            <KonnectorUpdateInfos className="u-mb-1" konnector={konnector} />
+          )}
+          <AccountsList
+            accounts={accounts}
+            konnector={konnector}
+            onPick={option => {
+              this.requestAccountChange(option.account, option.trigger)
+            }}
+            addAccount={this.requestAccountCreation}
+          />
+        </>
       )
     } else {
       return (

--- a/packages/cozy-harvest-lib/src/components/KonnectorUpdateLinker.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorUpdateLinker.jsx
@@ -1,0 +1,74 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+
+import { Query } from 'cozy-client'
+import AppLinker from 'cozy-ui/react/AppLinker'
+import Button from 'cozy-ui/react/Button'
+
+import { getStoreUrltoUpdateKonnector } from '../helpers/apps'
+
+const KonnectorUpdateButton = ({
+  disabled,
+  isBlocking,
+  href,
+  label,
+  onClick
+}) => (
+  <Button
+    disabled={disabled}
+    className="u-m-0"
+    href={href}
+    icon="eye"
+    label={label}
+    onClick={onClick}
+    theme={isBlocking ? 'danger' : 'secondary'}
+  />
+)
+
+export class KonnectorUpdateLinker extends PureComponent {
+  render() {
+    const { label, isBlocking, konnector } = this.props
+    return (
+      <Query query={client => client.all('io.cozy.apps')}>
+        {({ data, fetchStatus }) => {
+          const isLoaded = fetchStatus === 'loaded'
+          const konnectorUpdateUrl = getStoreUrltoUpdateKonnector(
+            data,
+            konnector
+          )
+          const isReady = isLoaded && konnectorUpdateUrl
+          if (isReady) {
+            return (
+              <AppLinker slug="store" href={konnectorUpdateUrl}>
+                {({ href, onClick }) => (
+                  <KonnectorUpdateButton
+                    href={href}
+                    isBlocking={isBlocking}
+                    label={label}
+                    onClick={onClick}
+                  />
+                )}
+              </AppLinker>
+            )
+          } else {
+            return (
+              <KonnectorUpdateButton
+                disabled={true}
+                label={label}
+                isBlocking={isBlocking}
+              />
+            )
+          }
+        }}
+      </Query>
+    )
+  }
+}
+
+KonnectorUpdateLinker.propTypes = {
+  isBlocking: PropTypes.bool,
+  konnector: PropTypes.object.isRequired,
+  label: PropTypes.string
+}
+
+export default KonnectorUpdateLinker

--- a/packages/cozy-harvest-lib/src/components/infos/KonnectorUpdateInfos.jsx
+++ b/packages/cozy-harvest-lib/src/components/infos/KonnectorUpdateInfos.jsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { translate } from 'cozy-ui/react/I18n'
+import Infos from 'cozy-ui/react/Infos'
+
+import KonnectorUpdateLinker from '../KonnectorUpdateLinker'
+
+/**
+ * Warns the user that a new version is available for the given konnector.
+ * Offer a button to redirect to an app able to update a konnector
+ * (typically the store).
+ */
+export const KonnectorUpdateInfos = props => {
+  const { className, konnector, isBlocking, t } = props
+  return (
+    <Infos
+      actionButton={
+        <KonnectorUpdateLinker
+          konnector={konnector}
+          isBlocking={isBlocking}
+          label={t('infos.konnectorUpdate.button.label')}
+        />
+      }
+      className={className}
+      isImportant={isBlocking}
+      text={
+        isBlocking
+          ? t('infos.konnectorUpdate.body.blocking')
+          : t('infos.konnectorUpdate.body.regular')
+      }
+      title={t('infos.konnectorUpdate.title')}
+    />
+  )
+}
+
+KonnectorUpdateInfos.propTypes = {
+  konnector: PropTypes.object.isRequired,
+  className: PropTypes.string,
+  isBlocking: PropTypes.bool,
+  t: PropTypes.func.isRequired
+}
+
+export default React.memo(translate()(KonnectorUpdateInfos))

--- a/packages/cozy-harvest-lib/src/helpers/apps.js
+++ b/packages/cozy-harvest-lib/src/helpers/apps.js
@@ -1,0 +1,29 @@
+const STORE_SLUG = 'store'
+
+/**
+ * Return Store URL where a konnector can be updated
+ * @param  {Array}  [appData=[]]   Apps data, as returned by endpoint /apps/ or
+ * /konnectors/
+ * @param  {Object} [konnector={}] KonnectorObject
+ * @return {String}                URL as string
+ */
+export const getStoreUrltoUpdateKonnector = (appData = [], konnector = {}) => {
+  if (!konnector.slug) {
+    throw new Error('Expected Konnector with defined slug')
+  }
+
+  const storeApp = appData.find(
+    app => app.attributes && app.attributes.slug === STORE_SLUG
+  )
+  if (!storeApp) return null
+
+  const storeUrl = storeApp.links && storeApp.links.related
+
+  if (!storeUrl) return null
+
+  return `${storeUrl}#/discover/${konnector.slug}/install`
+}
+
+export default {
+  getStoreUrltoUpdateKonnector
+}

--- a/packages/cozy-harvest-lib/src/helpers/konnectors.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectors.js
@@ -78,10 +78,19 @@ export class KonnectorJobError extends Error {
 
   /**
    * Test if the konnector error is a user error
-   * @return {Boolean} [description]
+   * @return {Boolean}
    */
   isUserError() {
     return USER_ERRORS.includes(this.type)
+  }
+
+  /**
+   * Test if the konnector error is due to a term version mismatch. Term version
+   * mismatch errors indicates that the konnector must be updated manually
+   * @return {Boolean}
+   */
+  isTermsVersionMismatchError() {
+    return this.type === TERMS_VERSION_MISMATCH
   }
 }
 

--- a/packages/cozy-harvest-lib/src/helpers/konnectors.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectors.js
@@ -145,6 +145,14 @@ export const getAccountType = konnector => {
 }
 
 /**
+ * Returns true if the konnector has a new version available and can be updated
+ * @param  {Object}  konnector
+ * @return {Boolean}
+ */
+export const hasNewVersionAvailable = (konnector = {}) =>
+  !!konnector.available_version
+
+/**
  * Indicates if the given konnector requires a folder to work properly.
  * This directly relies on the `fields.advancedFields.folderPath` from manifest for legacy Konnector.
  * Relies on `folders` for new Konnector
@@ -303,5 +311,6 @@ export default {
   buildFolderPath,
   buildFolderPermission,
   getAccountType,
+  hasNewVersionAvailable,
   needsFolder
 }

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -71,6 +71,10 @@
         "title": "Missing destination folder",
         "description": "It seems that this account's destination folder has been deleted. Please restore it by disconnecting this account and then reconnect again."
       },
+      "TERMS_VERSION_MISMATCH": {
+        "title": "Unexpected Terms Of Service version",
+        "description": "%{name} seems to have updated its Terms Of Service. Please check that the service is up to date. It this error still occurs, please contact us at <a href=\"mailto:contact@cozycloud.cc\">contact@cozycloud.cc</a>."
+      },
       "UNKNOWN_ERROR": {
         "title": "Connection error",
         "description": "An unknown error has occurred."

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -158,6 +158,18 @@
     "administrative": "Administrative",
     "photos": "Photos"
   },
+  "infos": {
+    "konnectorUpdate": {
+      "title": "An update is available for this service.",
+      "body": {
+        "regular": "Perform this update to keep fetching your data and to have the latest features:",
+        "blocking": "Update it to keep fetching your data:"
+      },
+      "button": {
+        "label": "See update"
+      }
+    }
+  },
   "legacy": {
     "fields": {
       "access_token": {

--- a/packages/cozy-harvest-lib/src/models/KonnectorJob.js
+++ b/packages/cozy-harvest-lib/src/models/KonnectorJob.js
@@ -104,7 +104,7 @@ export class KonnectorJob {
   }
 
   /**
-   * Legacy events use the KonnectorJobWatcher unstil it has been merged into
+   * Legacy events use the KonnectorJobWatcher until it has been merged into
    * KonnectorJob so we need to re-emit the events
    */
   handleLegacyEvent(event) {

--- a/packages/cozy-harvest-lib/test/components/KonnectorUpdateInfos.spec.js
+++ b/packages/cozy-harvest-lib/test/components/KonnectorUpdateInfos.spec.js
@@ -1,0 +1,34 @@
+/* eslint-env jest */
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import { KonnectorUpdateInfos } from 'components/infos/KonnectorUpdateInfos'
+
+// Default props
+const intents = {
+  redirect: jest.fn()
+}
+const konnector = {
+  slug: 'test-konnector'
+}
+const t = key => key
+
+const props = {
+  intents,
+  konnector,
+  t
+}
+
+describe('KonnectorUpdateInfos', () => {
+  it('should render', () => {
+    const component = shallow(<KonnectorUpdateInfos {...props} />).getElement()
+    expect(component).toMatchSnapshot()
+  })
+
+  it('should render as blocking', () => {
+    const component = shallow(
+      <KonnectorUpdateInfos {...props} isBlocking={true} />
+    ).getElement()
+    expect(component).toMatchSnapshot()
+  })
+})

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/KonnectorModal.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/KonnectorModal.spec.js.snap
@@ -134,52 +134,54 @@ exports[`KonnectorModal should show the configuration view of a single account 1
 
 exports[`KonnectorModal should show the list of accounts 1`] = `
 <ModalContent>
-  <Wrapper
-    accounts={
-      Array [
-        Object {
-          "account": Object {
-            "_id": "123",
-            "doctype": "io.cozy.accounts",
-          },
-          "trigger": Object {
-            "_id": "784",
-            "doctype": "io.cozy.triggers",
-          },
-        },
-        Object {
-          "account": Object {
-            "_id": "123",
-            "doctype": "io.cozy.accounts",
-          },
-          "trigger": Object {
-            "_id": "872",
-            "doctype": "io.cozy.triggers",
-          },
-        },
-      ]
-    }
-    addAccount={[Function]}
-    konnector={
-      Object {
-        "name": "Mock",
-        "slug": "mock",
-        "triggers": Object {
-          "data": Array [
-            Object {
+  <React.Fragment>
+    <Wrapper
+      accounts={
+        Array [
+          Object {
+            "account": Object {
+              "_id": "123",
+              "doctype": "io.cozy.accounts",
+            },
+            "trigger": Object {
               "_id": "784",
               "doctype": "io.cozy.triggers",
             },
-            Object {
+          },
+          Object {
+            "account": Object {
+              "_id": "123",
+              "doctype": "io.cozy.accounts",
+            },
+            "trigger": Object {
               "_id": "872",
               "doctype": "io.cozy.triggers",
             },
-          ],
-        },
+          },
+        ]
       }
-    }
-    onPick={[Function]}
-  />
+      addAccount={[Function]}
+      konnector={
+        Object {
+          "name": "Mock",
+          "slug": "mock",
+          "triggers": Object {
+            "data": Array [
+              Object {
+                "_id": "784",
+                "doctype": "io.cozy.triggers",
+              },
+              Object {
+                "_id": "872",
+                "doctype": "io.cozy.triggers",
+              },
+            ],
+          },
+        }
+      }
+      onPick={[Function]}
+    />
+  </React.Fragment>
 </ModalContent>
 `;
 

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/KonnectorUpdateInfos.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/KonnectorUpdateInfos.spec.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KonnectorUpdateInfos should render 1`] = `
+<Infos
+  actionButton={
+    <KonnectorUpdateLinker
+      konnector={
+        Object {
+          "slug": "test-konnector",
+        }
+      }
+      label="infos.konnectorUpdate.button.label"
+    />
+  }
+  icon={null}
+  text="infos.konnectorUpdate.body.regular"
+  title="infos.konnectorUpdate.title"
+/>
+`;
+
+exports[`KonnectorUpdateInfos should render as blocking 1`] = `
+<Infos
+  actionButton={
+    <KonnectorUpdateLinker
+      isBlocking={true}
+      konnector={
+        Object {
+          "slug": "test-konnector",
+        }
+      }
+      label="infos.konnectorUpdate.button.label"
+    />
+  }
+  icon={null}
+  isImportant={true}
+  text="infos.konnectorUpdate.body.blocking"
+  title="infos.konnectorUpdate.title"
+/>
+`;

--- a/packages/cozy-harvest-lib/test/helpers/konnectors.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/konnectors.spec.js
@@ -180,6 +180,7 @@ describe('Konnectors Helpers', () => {
       'LOGIN_FAILED.TOO_MANY_ATTEMPTS',
       'MAINTENANCE',
       'NOT_EXISTING_DIRECTORY',
+      'TERMS_VERSION_MISMATCH',
       'USER_ACTION_NEEDED',
       'USER_ACTION_NEEDED.OAUTH_OUTDATED',
       'USER_ACTION_NEEDED.ACCOUNT_REMOVED',
@@ -213,6 +214,9 @@ describe('Konnectors Helpers', () => {
             'USER_ACTION_NEEDED.CHANGE_PASSWORD',
             'USER_ACTION_NEEDED.PERMISSIONS_CHANGED'
           ].includes(message)
+        )
+        expect(error.isTermsVersionMismatchError()).toBe(
+          message === 'TERMS_VERSION_MISMATCH'
         )
       })
     }

--- a/packages/cozy-harvest-lib/test/helpers/konnectors.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/konnectors.spec.js
@@ -2,6 +2,7 @@ import {
   buildFolderPath,
   buildFolderPermission,
   getAccountType,
+  hasNewVersionAvailable,
   KonnectorJobError,
   needsFolder
 } from 'helpers/konnectors'
@@ -160,6 +161,15 @@ describe('Konnectors Helpers', () => {
           verbs: ['GET', 'PATCH', 'POST']
         }
       })
+    })
+  })
+
+  describe('hasNewVersionAvailable', () => {
+    it('should return true', () => {
+      expect(hasNewVersionAvailable({ available_version: true })).toBe(true)
+    })
+    it('should return false', () => {
+      expect(hasNewVersionAvailable({ available_version: false })).toBe(false)
     })
   })
 


### PR DESCRIPTION
This PR get back the information panel to update a konnector.

It's displayed when a konnector has `available_version` attribute to `true`.

I kept the behavior from Home when a `TERMS_VERSION_MISMATCH` error occurs : the Infos panel theme switch to `danger`.

![Capture d’écran 2019-08-22 à 12 56 52](https://user-images.githubusercontent.com/776764/63521852-80e57b80-c4f7-11e9-9d4e-f5901f9e3421.png)

![Capture d’écran 2019-08-22 à 12 54 37](https://user-images.githubusercontent.com/776764/63521860-85aa2f80-c4f7-11e9-9656-520f24fd28c9.png)

During tests I encountered issues when dealing with Intents mocking, so I choose to inject them with a `withIntents HOC`. If reviewers agree with its implementation we will then move it to the `cozy-interapp` package, it will just need a little babel configuration. For now it was convenient to have it directly in `cozy-harvest-lib`.

We talked about using AppLinker for redirections via intents, but actually it is `cozy-interapp` responsability so I will update directly the package with this feature.

I look after adding the "available version in account list", but it's missing from the mockup and I don't get the point with indicating in each account that the whole konnector has an available update. By the way, Home do not indicates anything. At least in it current version, I gonna checkout old ones to see if it was previously done.