### PR TITLE
chore: Switch to cozy-libs renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,3 @@
 {
-  "extends": [
-    "cozy"
-  ]
+  "extends": ["cozy-libs"]
 }


### PR DESCRIPTION
Switch to a configuration where we don't pin our dependencies in this repo. i'm not sure if renovate will automatically unpin everything, if not I'll do it manually later.