### PR TITLE
[Harvest] refactor: Deduplicate trigger launch logic

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -23,7 +23,8 @@ const RUNNING = 'RUNNING'
 const MODAL_PLACE_ID = 'coz-harvest-modal-place'
 
 /**
- * Displays the login form and on submission will create the account, triggers and folders. After that it calls TriggerLauncher to run the konnector.
+ * Displays the login form and on submission will create the account, triggers and folders.
+ * After that it calls TriggerLauncher to run the konnector.
  * @type {Component}
  */
 export class TriggerManager extends Component {

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
@@ -70,7 +70,7 @@ export class LaunchTriggerCard extends Component {
                     icon={<Icon focusable="false" icon="sync" spin={running} />}
                     className="u-mh-0 u-mv-0"
                     disabled={running}
-                    onClick={launch}
+                    onClick={() => launch(trigger)}
                     subtle
                     // TODO: Extract this directly in Cozy-UI
                     // (either with an utility class or a Button prop)

--- a/packages/cozy-harvest-lib/test/components/TriggerLauncher.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerLauncher.spec.js
@@ -10,7 +10,19 @@ const trigger = {
 }
 
 const triggersMutationsMock = {
-  fetchTrigger: jest.fn().mockResolvedValue(trigger)
+  fetchTrigger: jest.fn().mockResolvedValue(trigger),
+  createTrigger: jest.fn().mockResolvedValue(trigger),
+  createDocument: jest.fn(),
+  saveDocument: jest.fn(),
+  deleteDocument: jest.fn(),
+  createAccount: jest.fn(),
+  updateAccount: jest.fn(),
+  findAccount: jest.fn(),
+  deleteAccount: jest.fn(),
+  saveAccount: jest.fn(),
+  launchTrigger: jest.fn(),
+  watchKonnectorAccount: jest.fn(),
+  watchKonnectorJob: jest.fn()
 }
 
 const props = {
@@ -83,7 +95,7 @@ describe('TriggerLauncher', () => {
 
       const childWrapper = wrapper.find(Child)
       const childProps = childWrapper.props()
-      childProps.launch()
+      childProps.launch(trigger)
       expect(KonnectorJob.prototype.launch).toHaveBeenCalled()
     })
 
@@ -94,7 +106,7 @@ describe('TriggerLauncher', () => {
         </TriggerLauncher>
       )
 
-      wrapper.instance().launch()
+      wrapper.instance().launch(trigger)
       wrapper.update()
       const childWrapper = wrapper.find(Child)
       expect(childWrapper.props().running).toBe(true)
@@ -108,7 +120,7 @@ describe('TriggerLauncher', () => {
       )
 
       let childWrapper = wrapper.find(Child)
-      childWrapper.props().launch()
+      childWrapper.props().launch(trigger)
       expect(onMock).toHaveBeenCalledWith(
         'error',
         wrapper.instance().handleError
@@ -136,12 +148,12 @@ describe('TriggerLauncher', () => {
         </TriggerLauncher>
       )
 
-      wrapper.instance().launch()
+      wrapper.instance().launch(trigger)
       wrapper.update()
       wrapper.instance().handleError(new Error('Test error'))
       wrapper.update()
       // Relaunch
-      wrapper.instance().launch()
+      wrapper.instance().launch(trigger)
       wrapper.update()
       const childWrapper = wrapper.find(Child)
       expect(childWrapper.props().error).toBe(null)
@@ -158,7 +170,7 @@ describe('TriggerLauncher', () => {
         </TriggerLauncher>
       )
 
-      wrapper.instance().launch()
+      wrapper.instance().launch(trigger)
       wrapper.update()
       await wrapper.instance().handleError(new Error('Test error'))
       wrapper.update()
@@ -177,7 +189,7 @@ describe('TriggerLauncher', () => {
 
       const error = new Error('Test error')
 
-      wrapper.instance().launch()
+      wrapper.instance().launch(trigger)
       wrapper.update()
       await wrapper.instance().handleError(error)
       wrapper.update()
@@ -192,7 +204,7 @@ describe('TriggerLauncher', () => {
         </TriggerLauncher>
       )
 
-      wrapper.instance().launch()
+      wrapper.instance().launch(trigger)
       wrapper.update()
       wrapper.instance().displayTwoFAModal()
       await wrapper.instance().handleError(new Error('Test error'))
@@ -207,7 +219,7 @@ describe('TriggerLauncher', () => {
         </TriggerLauncher>
       )
 
-      wrapper.instance().launch()
+      wrapper.instance().launch(trigger)
       wrapper.update()
       wrapper.instance().displayTwoFAModal()
       await wrapper.instance().handleError(new Error('Test error'))
@@ -224,7 +236,7 @@ describe('TriggerLauncher', () => {
         </TriggerLauncher>
       )
 
-      wrapper.instance().launch()
+      wrapper.instance().launch(trigger)
       wrapper.update()
       await wrapper.instance().handleSuccess()
       wrapper.update()
@@ -239,11 +251,40 @@ describe('TriggerLauncher', () => {
         </TriggerLauncher>
       )
 
-      wrapper.instance().launch()
+      wrapper.instance().launch(trigger)
       wrapper.instance().displayTwoFAModal()
       await wrapper.instance().handleSuccess()
       wrapper.update()
       expect(wrapper.getElement()).toMatchSnapshot()
+    })
+  })
+
+  describe('handleLoginSuccess', () => {
+    it('should hide twoFA modal', async () => {
+      const wrapper = shallow(
+        <TriggerLauncher {...props}>
+          {({ launch, running }) => <Child launch={launch} running={running} />}
+        </TriggerLauncher>
+      )
+
+      wrapper.instance().launch(trigger)
+      wrapper.instance().displayTwoFAModal()
+      await wrapper.instance().handleLoginSuccess()
+      wrapper.update()
+      expect(wrapper.getElement()).toMatchSnapshot()
+    })
+
+    it('should call the onLoginSuccess callback', () => {
+      const onLoginSuccess = jest.fn()
+      const wrapper = shallow(
+        <TriggerLauncher {...props} onLoginSuccess={onLoginSuccess}>
+          {({ launch, running }) => <Child launch={launch} running={running} />}
+        </TriggerLauncher>
+      )
+
+      wrapper.instance().launch(trigger)
+      wrapper.instance().handleLoginSuccess()
+      expect(onLoginSuccess).toHaveBeenCalled()
     })
   })
 

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/KonnectorModal.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/KonnectorModal.spec.js.snap
@@ -5,7 +5,7 @@ exports[`KonnectorModal adding an account should render the form when controlled
   <div
     className="u-pt-1-half"
   >
-    <Wrapper
+    <LegacyTriggerManager
       konnector={
         Object {
           "name": "Mock",

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerLauncher.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerLauncher.spec.js.snap
@@ -18,6 +18,15 @@ exports[`TriggerLauncher handleError should unsubscribe from KonnectorJob 1`] = 
 </div>
 `;
 
+exports[`TriggerLauncher handleLoginSuccess should hide twoFA modal 1`] = `
+<div>
+  <Child
+    launch={[Function]}
+    running={true}
+  />
+</div>
+`;
+
 exports[`TriggerLauncher handleSuccess should hide twoFA modal 1`] = `
 <div>
   <Child

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
@@ -68,7 +68,6 @@ exports[`TriggerManager should render with account 1`] = `
         "identifier": "username",
       }
     }
-    error={null}
     konnector={
       Object {
         "fields": Object {
@@ -94,7 +93,6 @@ exports[`TriggerManager should render without account 1`] = `
     id="coz-harvest-modal-place"
   />
   <Wrapper
-    error={null}
     konnector={
       Object {
         "fields": Object {


### PR DESCRIPTION
The code to launch a trigger was more or less duplicated, once in TriggerManager and once in TriggerLauncher. This made the data flow in Harvest more complicated than it needed to be (a lot of prop drilling and callback chains to keep a single source of  truth).

This PR removes the duplicated code from TriggerManager and uses TriggerLauncher instead. We also added support for an `onLoginSuccess` callback in TriggerLauncher.

We tried to keep the breaking changes to a minimum, but there is one. TriggerLauncher now needs to work without an initial trigger, since it's also used when we are adding a new account. To accomodate this:

- The `trigger` prop has been renamed to `initialTrigger`
- The `launch` prop that TriggerLauncher passes to it's children must be called with a `trigger` parameter