### PR TITLE
fix(cozy-doctypes): Check that account number exist before matching it

### DIFF
--- a/packages/cozy-doctypes/src/banking/matching-accounts.js
+++ b/packages/cozy-doctypes/src/banking/matching-accounts.js
@@ -73,7 +73,7 @@ const approxNumberMatch = (account, existingAccount) => {
 const creditCardMatch = (account, existingAccount) => {
   let ccAccount, lastDigits
   for (let acc of [account, existingAccount]) {
-    const match = acc.number.match(redactedCreditCard)
+    const match = acc.number && acc.number.match(redactedCreditCard)
     if (match) {
       ccAccount = acc
       lastDigits = match[1]

--- a/packages/cozy-doctypes/src/banking/matching-accounts.js
+++ b/packages/cozy-doctypes/src/banking/matching-accounts.js
@@ -28,23 +28,23 @@ const normalizeAccountNumber = (number, iban) => {
   if (iban && iban.length == 27) {
     return iban.substr(14, 11)
   }
+
   if (!number) {
-    return
+    return number
   }
 
-  if (number && number.length == 23) {
+  if (number.length == 23) {
     // Must be an IBAN without the COUNTRY code
     // See support demand #9102 with BI
     // We extract the account number from the IBAN
     // COUNTRY (4) BANK (5) COUNTER (5) NUMBER (11) KEY (2)
     // FRXX 16275 10501 00300060030 00
     return number.substr(10, 11)
-  } else if (number && number.length == 16) {
+  } else if (number.length == 16) {
     // Linxo sends Bank account number that contains
     // the counter number
     return number.substr(5, 11)
   } else if (
-    number &&
     number.length > 11 &&
     (match = number.match(untrimmedAccountNumber))
   ) {

--- a/packages/cozy-doctypes/src/banking/matching-accounts.spec.js
+++ b/packages/cozy-doctypes/src/banking/matching-accounts.spec.js
@@ -91,4 +91,7 @@ describe('slug match', () => {
 it('should normalize account number', () => {
   expect(normalizeAccountNumber('LEO-385248377-EUR')).toBe('385248377')
   expect(normalizeAccountNumber('385248377EUR')).toBe('385248377')
+  expect(normalizeAccountNumber('')).toBe('')
+  expect(normalizeAccountNumber(null)).toBe(null)
+  expect(normalizeAccountNumber(undefined)).toBe(undefined)
 })


### PR DESCRIPTION
We have a case in which the account's `number` property is undefined on production, so we must handle this case.