### PR TITLE
docs: Use client instead of cozyclient

### DIFF
--- a/packages/cozy-realtime/README.md
+++ b/packages/cozy-realtime/README.md
@@ -43,7 +43,7 @@ or
 ```js
 import CozyRealtime from 'cozy-realtime'
 
-const realtime = new CozyRealtime({ cozyClient })
+const realtime = new CozyRealtime({ client: cozyClient })
 const type = 'io.cozy.accounts'
 const id = 'document_id'
 const handlerCreate = accounts => {


### PR DESCRIPTION
cozyclient param is deprecated https://github.com/cozy/cozy-libs/blob/master/packages/cozy-realtime/src/index.js#L131, so let's recommend the good way to use the realtime