### PR TITLE
WIP feat: Validation button re-render

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerLauncher.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerLauncher.jsx
@@ -131,7 +131,7 @@ export class TriggerLauncher extends Component {
     const { error, running, showTwoFAModal, trigger } = this.state
     const { children, submitting } = this.props
     return (
-      <div>
+      <>
         {children({
           error,
           launch: this.launch,
@@ -145,7 +145,7 @@ export class TriggerLauncher extends Component {
             konnectorJob={this.konnectorJob}
           />
         )}
-      </div>
+      </>
     )
   }
 }

--- a/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
@@ -65,6 +65,7 @@ export class TwoFAModal extends PureComponent {
     const { isMobile } = breakpoints
     const { twoFACode } = this.state
 
+    const isJobRunning = konnectorJob.isTwoFARunning()
     return (
       <Modal
         dismissAction={dismissAction}
@@ -100,8 +101,8 @@ export class TwoFAModal extends PureComponent {
             <Button
               className="u-mt-1"
               label={t('twoFAForm.CTA')}
-              busy={konnectorJob.isTwoFARunning()}
-              disabled={konnectorJob.isTwoFARunning() || !twoFACode}
+              busy={isJobRunning}
+              disabled={isJobRunning || !twoFACode}
               extension="full"
             />
           </form>

--- a/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
@@ -13,7 +13,7 @@ import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
 import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
 import PropTypes from 'prop-types'
 
-import { TWO_FA_MISMATCH_EVENT } from '../models/KonnectorJob'
+import { TWO_FA_MISMATCH_EVENT, STATUS_CHANGE } from '../models/KonnectorJob'
 
 export class TwoFAModal extends PureComponent {
   constructor(props) {
@@ -22,13 +22,19 @@ export class TwoFAModal extends PureComponent {
     this.handleChange = this.handleChange.bind(this)
     this.handleTwoFAMismatch = this.handleTwoFAMismatch.bind(this)
     this.handleSubmit = this.handleSubmit.bind(this)
+    this.handleStatusChange = this.handleStatusChange.bind(this)
     this.fetchIcon = this.fetchIcon.bind(this)
   }
 
   componentDidMount() {
-    this.props.konnectorJob.on(TWO_FA_MISMATCH_EVENT, this.handleTwoFAMismatch)
+    this.props.konnectorJob
+      .on(TWO_FA_MISMATCH_EVENT, this.handleTwoFAMismatch)
+      .on(STATUS_CHANGE, this.handleStatusChange)
   }
 
+  handleStatusChange() {
+    this.forceUpdate()
+  }
   handleChange(e) {
     this.setState({ twoFACode: e.currentTarget.value })
   }

--- a/packages/cozy-harvest-lib/src/connections/accounts.js
+++ b/packages/cozy-harvest-lib/src/connections/accounts.js
@@ -26,11 +26,9 @@ const createAccount = async (client, konnector, attributes) => {
 const findAccount = async (client, id) => {
   try {
     const { data } = await client.query(
-      client.find(ACCOUNTS_DOCTYPE).where({
-        _id: id
-      })
+      client.all(ACCOUNTS_DOCTYPE).getById(id)
     )
-    return (data && data[0]) || null
+    return data
   } catch (error) {
     if (error.status === 404) {
       return null

--- a/packages/cozy-harvest-lib/src/models/KonnectorJob.js
+++ b/packages/cozy-harvest-lib/src/models/KonnectorJob.js
@@ -22,6 +22,7 @@ export const SUCCESS = 'SUCCESS'
 export const RUNNING_TWOFA = 'RUNNING_TWOFA'
 export const TWO_FA_MISMATCH = 'TWO_FA_MISMATCH'
 export const TWO_FA_REQUEST = 'TWO_FA_REQUEST'
+export const STATUS_CHANGE = 'STATUS_CHANGE'
 
 // helpers
 export const prepareTriggerAccount = async (trigger, accountsMutations) => {
@@ -61,6 +62,7 @@ export class KonnectorJob {
 
   setStatus(status) {
     this._status = status
+    this.emit(STATUS_CHANGE)
   }
 
   getStatus() {


### PR DESCRIPTION
It took sometime for the 2FA validation button to change state from idle
to spinning. This is because the component did not re-render in response
to the change of status of the konnector job.

Need testing.