### PR TITLE
feat: Use snarkdown instead of react markdown

### DIFF
--- a/packages/cozy-authentication/package.json
+++ b/packages/cozy-authentication/package.json
@@ -45,7 +45,7 @@
     "cozy-device-helper": "^1.7.5",
     "localforage": "1.7.3",
     "prop-types": "15.7.2",
-    "react-markdown": "4.1.0",
+    "snarkdown": "1.2.2",
     "url-polyfill": "1.1.7"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17007,7 +17007,7 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-snarkdown@^1.2.2:
+snarkdown@1.2.2, snarkdown@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/snarkdown/-/snarkdown-1.2.2.tgz#0cfe2f3012b804de120fc0c9f7791e869c59cc74"
   integrity sha1-DP4vMBK4BN4SD8DJ93kehpxZzHQ=


### PR DESCRIPTION
In cozy-auth, we're using very simple known Markdown. We don't need a full parser with custom renderers and no need for sanitization. 

As a reminder: 
- react-markdown: 58kb 
- snarkdown: 2kb 

I wanted to use it also in harvest, but we can't since we've a custom renderers. 