### PR TITLE
fix: Missing translations

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 
 import { isMobile } from 'cozy-device-helper'
 import Button from 'cozy-ui/transpiled/react/Button'
-import { translate } from 'cozy-ui/transpiled/react/I18n'
+import withLocales from '../hoc/withLocales'
 
 import AccountFields from './AccountFields'
 import TriggerErrorInfo from '../infos/TriggerErrorInfo'
@@ -270,4 +270,4 @@ AccountForm.defaultProps = {
   showError: true
 }
 
-export default translate()(withKonnectorLocales(AccountForm))
+export default withLocales(withKonnectorLocales(AccountForm))

--- a/packages/cozy-harvest-lib/src/components/AccountSelectBox/CreateAccountButton.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountSelectBox/CreateAccountButton.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { translate, Button } from 'cozy-ui/transpiled/react/'
+import { Button } from 'cozy-ui/transpiled/react/'
+import withLocales from '../hoc/withLocales'
 
 /**
  * onClick is not called when we are on mobile device.
@@ -8,7 +9,7 @@ import { translate, Button } from 'cozy-ui/transpiled/react/'
  *
  * Using touchEnd, seems to fix the issue on mobile device (Android & iOS)
  */
-const CreateAccount = translate()(({ createAction, t }) => {
+const CreateAccount = withLocales(({ createAction, t }) => {
   return (
     <Button
       subtle


### PR DESCRIPTION
Not all components are in the right translation context at the moment, so using the `translate` HOC doesn't always work.