### PR TITLE
[Harvest] Handle cipher selection

### DIFF
--- a/packages/cozy-doctypes/src/Account.js
+++ b/packages/cozy-doctypes/src/Account.js
@@ -57,7 +57,14 @@ class Account extends Document {
           ...customFields
         },
         value => Boolean(value)
-      )
+      ),
+      relationships: {
+        vaultCipher: {
+          _id: cipher.id,
+          _type: 'com.bitwarden.ciphers',
+          _protocol: 'bitwarden'
+        }
+      }
     }
   }
 }

--- a/packages/cozy-doctypes/src/Account.js
+++ b/packages/cozy-doctypes/src/Account.js
@@ -1,4 +1,5 @@
 const Document = require('./Document')
+const pickBy = require('lodash/pickBy')
 
 const ACCOUNTS_DOCTYPE = 'io.cozy.accounts'
 
@@ -27,6 +28,36 @@ class Account extends Document {
       for (const fieldName of probableLoginFieldNames) {
         if (account.auth[fieldName]) return account.auth[fieldName]
       }
+    }
+  }
+
+  /**
+   * Create an account document from a vault cipher
+   *
+   * @param {Object} cipher
+   *
+   * @returns {Object}
+   */
+  static fromCipher(cipher) {
+    if (!cipher) {
+      throw new Error('Cipher is required')
+    }
+
+    const customFields = (cipher.fields || []).reduce((fields, field) => {
+      fields[field.name] = field.value
+
+      return fields
+    }, {})
+
+    return {
+      auth: pickBy(
+        {
+          login: cipher.login.username,
+          password: cipher.login.password,
+          ...customFields
+        },
+        value => Boolean(value)
+      )
     }
   }
 }

--- a/packages/cozy-doctypes/src/Account.spec.js
+++ b/packages/cozy-doctypes/src/Account.spec.js
@@ -52,35 +52,40 @@ describe('helpers library', () => {
   })
 
   describe('fromCipher', () => {
-    it('should return an io.cozy.accounts object with auth infos (no custom fields)', () => {
-      const cipher = {
+    let cipher
+
+    beforeEach(() => {
+      cipher = {
+        id: 'cipher-id',
         login: {
           username: 'username',
           password: 'password'
         }
       }
-
+    })
+    it('should return an io.cozy.accounts object with auth infos (no custom fields)', () => {
       const account = Account.fromCipher(cipher)
 
       expect(account).toEqual({
         auth: {
           login: 'username',
           password: 'password'
+        },
+        relationships: {
+          vaultCipher: {
+            _id: 'cipher-id',
+            _type: 'com.bitwarden.ciphers',
+            _protocol: 'bitwarden'
+          }
         }
       })
     })
 
     it('should return an io.cozy.accounts object with auth infos (with custom fields)', () => {
-      const cipher = {
-        login: {
-          username: 'username',
-          password: 'password'
-        },
-        fields: [
-          { name: 'timeout', value: '2000' },
-          { name: 'error', value: 'USER_ACTION_NEEDED' }
-        ]
-      }
+      cipher.fields = [
+        { name: 'timeout', value: '2000' },
+        { name: 'error', value: 'USER_ACTION_NEEDED' }
+      ]
 
       const account = Account.fromCipher(cipher)
 
@@ -90,6 +95,13 @@ describe('helpers library', () => {
           password: 'password',
           timeout: '2000',
           error: 'USER_ACTION_NEEDED'
+        },
+        relationships: {
+          vaultCipher: {
+            _id: 'cipher-id',
+            _type: 'com.bitwarden.ciphers',
+            _protocol: 'bitwarden'
+          }
         }
       })
     })

--- a/packages/cozy-doctypes/src/Account.spec.js
+++ b/packages/cozy-doctypes/src/Account.spec.js
@@ -50,4 +50,53 @@ describe('helpers library', () => {
       expect(Account.getAccountName(account)).toBe(account.auth.email)
     })
   })
+
+  describe('fromCipher', () => {
+    it('should return an io.cozy.accounts object with auth infos (no custom fields)', () => {
+      const cipher = {
+        login: {
+          username: 'username',
+          password: 'password'
+        }
+      }
+
+      const account = Account.fromCipher(cipher)
+
+      expect(account).toEqual({
+        auth: {
+          login: 'username',
+          password: 'password'
+        }
+      })
+    })
+
+    it('should return an io.cozy.accounts object with auth infos (with custom fields)', () => {
+      const cipher = {
+        login: {
+          username: 'username',
+          password: 'password'
+        },
+        fields: [
+          { name: 'timeout', value: '2000' },
+          { name: 'error', value: 'USER_ACTION_NEEDED' }
+        ]
+      }
+
+      const account = Account.fromCipher(cipher)
+
+      expect(account).toEqual({
+        auth: {
+          login: 'username',
+          password: 'password',
+          timeout: '2000',
+          error: 'USER_ACTION_NEEDED'
+        }
+      })
+    })
+
+    it('should throw if cipher is not passed as argument', () => {
+      expect(() => Account.fromCipher()).toThrow()
+      expect(() => Account.fromCipher(null)).toThrow()
+    })
+  })
 })

--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -46,7 +46,7 @@
     "babel-preset-cozy-app": "^1.6.0",
     "cozy-client": "6.61.0",
     "cozy-device-helper": "^1.7.5",
-    "cozy-keys-lib": "1.2.3",
+    "cozy-keys-lib": "1.4.0",
     "cozy-realtime": "3.1.0",
     "cozy-ui": "23.3.0",
     "enzyme": "3.10.0",
@@ -62,7 +62,7 @@
   "peerDependencies": {
     "cozy-client": "6.61.0",
     "cozy-device-helper": "1.7.1",
-    "cozy-keys-lib": "^1.2.3",
+    "cozy-keys-lib": "^1.4.0",
     "cozy-realtime": "^3.1.0",
     "cozy-ui": "^23.3.0"
   }

--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -46,7 +46,7 @@
     "babel-preset-cozy-app": "^1.6.0",
     "cozy-client": "6.61.0",
     "cozy-device-helper": "^1.7.5",
-    "cozy-keys-lib": "1.4.0",
+    "cozy-keys-lib": "1.6.0",
     "cozy-realtime": "3.1.0",
     "cozy-ui": "23.3.0",
     "enzyme": "3.10.0",
@@ -62,7 +62,7 @@
   "peerDependencies": {
     "cozy-client": "6.61.0",
     "cozy-device-helper": "1.7.1",
-    "cozy-keys-lib": "^1.4.0",
+    "cozy-keys-lib": "^1.6.0",
     "cozy-realtime": "^3.1.0",
     "cozy-ui": "^23.3.0"
   }

--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -157,12 +157,11 @@ export class AccountForm extends PureComponent {
       submitting,
       t
     } = this.props
-    const { fields } = konnector
 
+    const { fields } = konnector
     const sanitizedFields = manifest.sanitizeFields(fields)
-    const defaultValues = manifest.defaultFieldsValues(sanitizedFields)
     const initialValues = account && account.auth
-    const initialAndDefaultValues = { ...defaultValues, ...initialValues }
+    const values = manifest.getDefaultedValues(konnector, account)
 
     let container = null
     const isLoginError =
@@ -171,9 +170,9 @@ export class AccountForm extends PureComponent {
     return (
       // See https://github.com/final-form/react-final-form#getting-started
       <Form
-        initialValues={initialAndDefaultValues}
+        initialValues={values}
         onSubmit={onSubmit}
-        validate={this.validate(sanitizedFields, initialAndDefaultValues)}
+        validate={this.validate(sanitizedFields, values)}
         render={({ dirty, form, values, valid }) => (
           <div
             onKeyUp={event =>
@@ -202,7 +201,7 @@ export class AccountForm extends PureComponent {
               disabled={submitting}
               fields={sanitizedFields}
               hasError={error && isLoginError}
-              initialValues={initialAndDefaultValues}
+              initialValues={values}
               inputRefByName={this.inputRefByName}
               t={t}
             />

--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -161,7 +161,7 @@ export class AccountForm extends PureComponent {
     const { fields } = konnector
     const sanitizedFields = manifest.sanitizeFields(fields)
     const initialValues = account && account.auth
-    const values = manifest.getDefaultedValues(konnector, account)
+    const values = manifest.getFieldsValues(konnector, account)
 
     let container = null
     const isLoginError =

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -136,11 +136,24 @@ export class TriggerManager extends Component {
     }
   }
 
+  /**
+   * Get the ID of the cipher selected by the user in the list
+   *
+   * @returns {string} the cipher ID
+   */
   getSelectedCipherId() {
     const { selectedCipher } = this.state
     return selectedCipher && selectedCipher.id
   }
 
+  /**
+   * Create a new cipher and return its ID
+   *
+   * @param {string} login - the login to register in the new cipher
+   * @param {string} password - the password to register in the new cipher
+   *
+   * @returns {string} the cipher ID
+   */
   async getNewCipherId(login, password) {
     const { vaultClient, konnector } = this.props
 
@@ -164,6 +177,14 @@ export class TriggerManager extends Component {
     return cipher.id
   }
 
+  /**
+   * Find an existing cipher for the account and return its ID
+   *
+   * @param {string} login - the login to set in the cipher
+   * @param {string} password - the password to set in the cipher
+   *
+   * @returns {string} the cipher ID
+   */
   async getExistingCipherIdForAccount(login, password) {
     const { account } = this.state
     const { vaultClient, konnector } = this.props

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -48,7 +48,7 @@ export class TriggerManager extends Component {
       account,
       error: null,
       status: IDLE,
-      step: 'ciphersList',
+      step: account ? 'accountForm' : 'ciphersList',
       selectedCipher: null
     }
   }
@@ -377,9 +377,11 @@ export class TriggerManager extends Component {
           )}
           {step === 'accountForm' && (
             <>
-              <BackButton onClick={this.showCiphersList}>
-                {t('triggerManager.backToCiphersList')}
-              </BackButton>
+              {!account && (
+                <BackButton onClick={this.showCiphersList}>
+                  {t('triggerManager.backToCiphersList')}
+                </BackButton>
+              )}
               <AccountForm
                 account={account || this.cipherToAccount(selectedCipher)}
                 error={error || triggerError}

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -313,7 +313,7 @@ export class TriggerManager extends Component {
     const { fields } = konnector
     const sanitizedFields = manifest.sanitizeFields(fields)
     const account = this.cipherToAccount(selectedCipher)
-    const values = manifest.getDefaultedValues(konnector, account)
+    const values = manifest.getFieldsValues(konnector, account)
 
     const requiredFields = Object.entries(sanitizedFields)
       .filter(([, value]) => value.required)

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import get from 'lodash/get'
 import flow from 'lodash/flow'
-import intersection from 'lodash/intersection'
 
 import { withMutations, withClient } from 'cozy-client'
 import { CozyFolder as CozyFolderClass, Account } from 'cozy-doctypes'
@@ -337,18 +336,13 @@ export class TriggerManager extends Component {
 
   handleCipherSelect(selectedCipher) {
     const { konnector } = this.props
-    const { fields } = konnector
-    const sanitizedFields = manifest.sanitizeFields(fields)
     const account = this.cipherToAccount(selectedCipher)
     const values = manifest.getFieldsValues(konnector, account)
 
-    const requiredFields = Object.entries(sanitizedFields)
-      .filter(([, value]) => value.required)
-      .map(([key]) => key)
-
-    const hasValuesForRequiredFields =
-      intersection(Object.keys(values), requiredFields).length ===
-      requiredFields.length
+    const hasValuesForRequiredFields = manifest.hasValuesForRequiredFields(
+      konnector,
+      values
+    )
 
     if (hasValuesForRequiredFields) {
       this.setState(

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -48,7 +48,8 @@ export class TriggerManager extends Component {
       account,
       error: null,
       status: IDLE,
-      step: 'ciphersList'
+      step: 'ciphersList',
+      selectedCipher: null
     }
   }
 
@@ -227,9 +228,10 @@ export class TriggerManager extends Component {
     if (typeof onError === 'function') onError(error)
   }
 
-  handleCipherSelect() {
+  handleCipherSelect(selectedCipher) {
     this.setState({
-      step: 'accountForm'
+      step: 'accountForm',
+      selectedCipher
     })
   }
 
@@ -237,6 +239,26 @@ export class TriggerManager extends Component {
     this.setState({
       step: 'ciphersList'
     })
+  }
+
+  cipherToAccount(cipher) {
+    if (!cipher) {
+      return null
+    }
+
+    const customFields = (cipher.fields || []).reduce((fields, field) => {
+      fields[field.name] = field.value
+
+      return fields
+    }, {})
+
+    return {
+      auth: {
+        ...cipher.login,
+        login: cipher.login.username,
+        ...customFields
+      }
+    }
   }
 
   render() {
@@ -249,7 +271,7 @@ export class TriggerManager extends Component {
       t,
       onVaultDismiss
     } = this.props
-    const { account, error, status, step } = this.state
+    const { account, error, status, step, selectedCipher } = this.state
     const submitting = !!(status === RUNNING || triggerRunning)
     const modalInto = modalContainerId || MODAL_PLACE_ID
 
@@ -282,7 +304,7 @@ export class TriggerManager extends Component {
                 {t('triggerManager.backToCiphersList')}
               </BackButton>
               <AccountForm
-                account={account}
+                account={account || this.cipherToAccount(selectedCipher)}
                 error={error || triggerError}
                 konnector={konnector}
                 onSubmit={this.handleSubmit}

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -3,10 +3,9 @@ import PropTypes from 'prop-types'
 import get from 'lodash/get'
 import flow from 'lodash/flow'
 import intersection from 'lodash/intersection'
-import pickBy from 'lodash/pickBy'
 
 import { withMutations, withClient } from 'cozy-client'
-import { CozyFolder as CozyFolderClass } from 'cozy-doctypes'
+import { CozyFolder as CozyFolderClass, Account } from 'cozy-doctypes'
 import { VaultUnlocker, withVaultClient, CipherType } from 'cozy-keys-lib'
 
 import AccountForm from './AccountForm'
@@ -373,22 +372,7 @@ export class TriggerManager extends Component {
       return null
     }
 
-    const customFields = (cipher.fields || []).reduce((fields, field) => {
-      fields[field.name] = field.value
-
-      return fields
-    }, {})
-
-    return {
-      auth: pickBy(
-        {
-          login: cipher.login.username,
-          password: cipher.login.password,
-          ...customFields
-        },
-        value => Boolean(value)
-      )
-    }
+    return Account.fromCipher(cipher)
   }
 
   render() {

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -319,12 +319,11 @@ export class TriggerManager extends Component {
       .filter(([, value]) => value.required)
       .map(([key]) => key)
 
-    const requiredFieldsInValues = intersection(
-      Object.keys(values),
-      requiredFields
-    )
+    const hasValuesForRequiredFields =
+      intersection(Object.keys(values), requiredFields).length ===
+      requiredFields.length
 
-    if (requiredFieldsInValues.length === requiredFields.length) {
+    if (hasValuesForRequiredFields) {
       this.setState(
         {
           step: 'accountForm',
@@ -384,6 +383,7 @@ export class TriggerManager extends Component {
     const { account, error, status, step, selectedCipher } = this.state
     const submitting = !!(status === RUNNING || triggerRunning)
     const modalInto = modalContainerId || MODAL_PLACE_ID
+    const isUpdate = !account
 
     const { oauth } = konnector
 
@@ -410,7 +410,7 @@ export class TriggerManager extends Component {
           )}
           {step === 'accountForm' && (
             <>
-              {!account && (
+              {isUpdate && (
                 <BackButton onClick={this.showCiphersList}>
                   {t('triggerManager.backToCiphersList')}
                 </BackButton>

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -6,7 +6,12 @@ import intersection from 'lodash/intersection'
 
 import { withMutations, withClient } from 'cozy-client'
 import { CozyFolder as CozyFolderClass, Account } from 'cozy-doctypes'
-import { VaultUnlocker, withVaultClient, CipherType } from 'cozy-keys-lib'
+import {
+  VaultUnlocker,
+  withVaultClient,
+  CipherType,
+  UriMatchType
+} from 'cozy-keys-lib'
 
 import AccountForm from './AccountForm'
 import OAuthForm from './OAuthForm'
@@ -161,12 +166,14 @@ export class TriggerManager extends Component {
 
     const cipherData = {
       id: null,
-      type: 1,
+      type: CipherType.Login,
       name: konnectorName,
       login: {
         username: login,
         password,
-        uris: konnectorURI ? [{ uri: konnectorURI, match: 0 }] : []
+        uris: konnectorURI
+          ? [{ uri: konnectorURI, match: UriMatchType.Domain }]
+          : []
       }
     }
 

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -138,7 +138,7 @@ export class TriggerManager extends Component {
   /**
    * Get the ID of the cipher selected by the user in the list
    *
-   * @returns {string} the cipher ID
+   * @returns {string|null} the cipher ID
    */
   getSelectedCipherId() {
     const { selectedCipher } = this.state

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -152,6 +152,7 @@ export class TriggerManager extends Component {
       const konnectorName = get(konnector, 'name') || get(konnector, 'slug')
 
       let originalCipher = null
+      let cipherData
       if (isUpdate) {
         const id = accounts.getVaultCipherId(account)
         const search = {
@@ -161,10 +162,7 @@ export class TriggerManager extends Component {
         }
         const sort = [view => view.login.password === password, 'revisionDate']
         originalCipher = await vaultClient.getByIdOrSearch(id, search, sort)
-      }
 
-      let cipherData
-      if (originalCipher) {
         cipherData = await vaultClient.decrypt(originalCipher)
         cipherData.login.username = login
         cipherData.login.password = password

--- a/packages/cozy-harvest-lib/src/components/VaultCiphersList/CiphersListItem.jsx
+++ b/packages/cozy-harvest-lib/src/components/VaultCiphersList/CiphersListItem.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import get from 'lodash/get'
+import cx from 'classnames'
 
 import ListItem from '@material-ui/core/ListItem'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
@@ -9,10 +10,19 @@ import ListItemIcon from '@material-ui/core/ListItemIcon'
 import CipherIcon from 'cozy-ui/transpiled/react/CipherIcon'
 
 const CiphersListItem = props => {
-  const { cipherView, konnector, ...rest } = props
+  const { cipherView, konnector, className, onClick, ...rest } = props
 
   return (
-    <ListItem {...rest}>
+    <ListItem
+      className={cx(
+        {
+          'u-c-pointer': onClick
+        },
+        className
+      )}
+      onClick={onClick}
+      {...rest}
+    >
       <ListItemIcon>
         <CipherIcon konnector={konnector} />
       </ListItemIcon>

--- a/packages/cozy-harvest-lib/src/components/VaultCiphersList/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/VaultCiphersList/index.jsx
@@ -65,10 +65,11 @@ class VaultCiphersList extends React.Component {
               key={cipherView.id}
               cipherView={cipherView}
               konnector={konnector}
+              onClick={() => onSelect(cipherView)}
             />
           ))}
 
-          <OtherAccountListItem onClick={onSelect} />
+          <OtherAccountListItem onClick={() => onSelect(null)} />
         </List>
       </>
     )

--- a/packages/cozy-harvest-lib/src/helpers/manifest.js
+++ b/packages/cozy-harvest-lib/src/helpers/manifest.js
@@ -3,6 +3,7 @@ import _cloneDeep from 'lodash/cloneDeep'
 import findKey from 'lodash/findKey'
 import _mapValues from 'lodash/mapValues'
 import _pickBy from 'lodash/pickBy'
+import intersection from 'lodash/intersection'
 
 export const ROLE_IDENTIFIER = 'identifier'
 
@@ -213,10 +214,39 @@ const getFieldsValues = (konnector, account) => {
   return initialAndDefaultValues
 }
 
+/**
+ * Get required fields names for a given konnector
+ *
+ * @param {Object} konnector - an io.cozy.konnectors document
+ *
+ * @returns {string[]} An array of all required fields names
+ */
+const getRequiredFields = konnector => {
+  const { fields } = konnector
+  const sanitizedFields = sanitizeFields(fields)
+
+  const requiredFields = Object.entries(sanitizedFields)
+    .filter(([, value]) => value.required)
+    .map(([key]) => key)
+
+  return requiredFields
+}
+
+const hasValuesForRequiredFields = (konnector, values) => {
+  const requiredFields = getRequiredFields(konnector)
+  const hasValuesForRequiredFields =
+    intersection(Object.keys(values), requiredFields).length ===
+    requiredFields.length
+
+  return hasValuesForRequiredFields
+}
+
 export default {
   defaultFieldsValues,
   getIdentifier,
   sanitize,
   sanitizeFields,
-  getFieldsValues
+  getFieldsValues,
+  getRequiredFields,
+  hasValuesForRequiredFields
 }

--- a/packages/cozy-harvest-lib/src/helpers/manifest.js
+++ b/packages/cozy-harvest-lib/src/helpers/manifest.js
@@ -193,9 +193,20 @@ export const sanitize = (manifest = {}) =>
       }
     : manifest
 
+const getDefaultedValues = (konnector, account) => {
+  const { fields } = konnector
+  const sanitizedFields = sanitizeFields(fields)
+  const defaultValues = defaultFieldsValues(sanitizedFields)
+  const initialValues = account && account.auth
+  const initialAndDefaultValues = { ...defaultValues, ...initialValues }
+
+  return initialAndDefaultValues
+}
+
 export default {
   defaultFieldsValues,
   getIdentifier,
   sanitize,
-  sanitizeFields
+  sanitizeFields,
+  getDefaultedValues
 }

--- a/packages/cozy-harvest-lib/src/helpers/manifest.js
+++ b/packages/cozy-harvest-lib/src/helpers/manifest.js
@@ -193,7 +193,17 @@ export const sanitize = (manifest = {}) =>
       }
     : manifest
 
-const getDefaultedValues = (konnector, account) => {
+/**
+ * Get fields value for a given konnector and account.
+ * Values present in the account are used and merged with default ones from the
+ * konnector's manifest
+ *
+ * @param {Object} konnector - an io.cozy.konnectors document
+ * @param {Object} account - an io.cozy.accounts document
+ *
+ * @returns {Object} An object with values for the fields
+ */
+const getFieldsValues = (konnector, account) => {
   const { fields } = konnector
   const sanitizedFields = sanitizeFields(fields)
   const defaultValues = defaultFieldsValues(sanitizedFields)
@@ -208,5 +218,5 @@ export default {
   getIdentifier,
   sanitize,
   sanitizeFields,
-  getDefaultedValues
+  getFieldsValues
 }

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -170,7 +170,8 @@ const fixtures = {
 const mockVaultClient = {
   createNewCipher: jest.fn(),
   saveCipher: jest.fn(),
-  getByIdOrSearch: jest.fn()
+  getByIdOrSearch: jest.fn(),
+  decrypt: jest.fn()
 }
 
 const addPermissionMock = jest.fn()
@@ -313,6 +314,14 @@ describe('TriggerManager', () => {
 
     it('should call saveAccount with account (no password provided)', async () => {
       const wrapper = shallowWithAccount()
+
+      mockVaultClient.decrypt.mockResolvedValueOnce({
+        login: {
+          username: 'username',
+          password: 'password'
+        }
+      })
+
       await wrapper.instance().handleSubmit({ login: 'test' })
       expect(saveAccountMock).toHaveBeenCalledWith(
         fixtures.konnector,
@@ -322,6 +331,14 @@ describe('TriggerManager', () => {
 
     it('should call saveAccount with account with RESET_SESSION state if passphrase changed', async () => {
       const wrapper = shallowWithAccount()
+
+      mockVaultClient.decrypt.mockResolvedValueOnce({
+        login: {
+          username: 'username',
+          password: 'password'
+        }
+      })
+
       await wrapper.instance().handleSubmit(fixtures.data)
       expect(saveAccountMock).toHaveBeenCalled()
       expect(saveAccountMock.mock.calls[0][1].state).toEqual('RESET_SESSION')
@@ -329,10 +346,20 @@ describe('TriggerManager', () => {
 
     it('should call saveAccount with account with RESET_SESSION state if password changed', async () => {
       const wrapper = shallowWithAccount()
-      await wrapper.instance().handleSubmit({
+      const instance = wrapper.instance()
+
+      mockVaultClient.decrypt.mockResolvedValueOnce({
+        login: {
+          username: 'username',
+          password: 'password'
+        }
+      })
+
+      await instance.handleSubmit({
         login: 'foo',
         password: 'bar'
       })
+
       expect(saveAccountMock).toHaveBeenCalled()
       expect(saveAccountMock.mock.calls[0][1].state).toEqual('RESET_SESSION')
     })
@@ -343,6 +370,13 @@ describe('TriggerManager', () => {
       jest
         .spyOn(instance, 'handleNewAccount')
         .mockResolvedValue(fixtures.launchedJob)
+
+      mockVaultClient.decrypt.mockResolvedValueOnce({
+        login: {
+          username: 'username',
+          password: 'password'
+        }
+      })
 
       await instance.handleSubmit(fixtures.data)
 

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -171,7 +171,8 @@ const mockVaultClient = {
   createNewCipher: jest.fn(),
   saveCipher: jest.fn(),
   getByIdOrSearch: jest.fn(),
-  decrypt: jest.fn()
+  decrypt: jest.fn(),
+  createNewCozySharedCipher: jest.fn()
 }
 
 const addPermissionMock = jest.fn()
@@ -215,7 +216,9 @@ describe('TriggerManager', () => {
   beforeEach(() => {
     createTriggerMock.mockResolvedValue(fixtures.createdTrigger)
     saveAccountMock.mockResolvedValue(fixtures.createdAccount)
-    mockVaultClient.createNewCipher.mockResolvedValue({ id: 'cipher-id-1' })
+    mockVaultClient.createNewCozySharedCipher.mockResolvedValue({
+      id: 'cipher-id-1'
+    })
   })
 
   afterEach(() => {

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
@@ -6,22 +6,37 @@ exports[`TriggerManager handleError should render error 1`] = `
     <div
       id="coz-harvest-modal-place"
     />
-    <Wrapper
-      konnector={
-        Object {
-          "fields": Object {
-            "passphrase": Object {
-              "type": "password",
+    <React.Fragment>
+      <Wrapper
+        account={
+          Object {
+            "_id": "61c683295560485db0f34b859197c581",
+            "account_type": "konnectest",
+            "auth": Object {
+              "passphrase": "bar",
+              "username": "foo",
             },
-            "username": Object {
-              "type": "text",
-            },
-          },
-          "slug": "konnectest",
+            "identifier": "username",
+          }
         }
-      }
-      onSelect={[Function]}
-    />
+        error={[Error: Test error]}
+        konnector={
+          Object {
+            "fields": Object {
+              "passphrase": Object {
+                "type": "password",
+              },
+              "username": Object {
+                "type": "text",
+              },
+            },
+            "slug": "konnectest",
+          }
+        }
+        onSubmit={[Function]}
+        submitting={false}
+      />
+    </React.Fragment>
   </Wrapper>
 </div>
 `;
@@ -46,22 +61,36 @@ exports[`TriggerManager should render with account 1`] = `
     <div
       id="coz-harvest-modal-place"
     />
-    <Wrapper
-      konnector={
-        Object {
-          "fields": Object {
-            "passphrase": Object {
-              "type": "password",
+    <React.Fragment>
+      <Wrapper
+        account={
+          Object {
+            "_id": "61c683295560485db0f34b859197c581",
+            "account_type": "konnectest",
+            "auth": Object {
+              "passphrase": "bar",
+              "username": "foo",
             },
-            "username": Object {
-              "type": "text",
-            },
-          },
-          "slug": "konnectest",
+            "identifier": "username",
+          }
         }
-      }
-      onSelect={[Function]}
-    />
+        konnector={
+          Object {
+            "fields": Object {
+              "passphrase": Object {
+                "type": "password",
+              },
+              "username": Object {
+                "type": "text",
+              },
+            },
+            "slug": "konnectest",
+          }
+        }
+        onSubmit={[Function]}
+        submitting={false}
+      />
+    </React.Fragment>
   </Wrapper>
 </div>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4910,10 +4910,10 @@ cozy-client@^6.58.1:
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
-cozy-keys-lib@1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/cozy-keys-lib/-/cozy-keys-lib-1.2.3.tgz#72590a093870c308967d0e624b5ee272f00d5216"
-  integrity sha512-6LgCanDiYI0w7aVqAbXILc2+cr38fsdBfObpTciXb4VW3U3jHU1FIlt34HkHR3/kL8sXqJPgeOVbHzH6+PANoA==
+cozy-keys-lib@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/cozy-keys-lib/-/cozy-keys-lib-1.4.0.tgz#6684045dd9e5758e5642e9c60608e88675944b9f"
+  integrity sha512-JZgPE0bq+30Nztu87QvlB9g57WP7M1Nuc74JPLZwwTQ4fMk3Edrjyrip6JFtscwtWpnKWO7VRHQQE+en+c5SzA==
   dependencies:
     "@aspnet/signalr" "^1.1.4"
     "@aspnet/signalr-protocol-msgpack" "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4910,10 +4910,10 @@ cozy-client@^6.58.1:
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
-cozy-keys-lib@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/cozy-keys-lib/-/cozy-keys-lib-1.4.0.tgz#6684045dd9e5758e5642e9c60608e88675944b9f"
-  integrity sha512-JZgPE0bq+30Nztu87QvlB9g57WP7M1Nuc74JPLZwwTQ4fMk3Edrjyrip6JFtscwtWpnKWO7VRHQQE+en+c5SzA==
+cozy-keys-lib@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-keys-lib/-/cozy-keys-lib-1.6.0.tgz#4e9689da5c3532701a566df8e9f34ad94464de37"
+  integrity sha512-tc2xqN3LQhb1WcN7XoWdk42cC3VE5WAvYk4CJVHjWGUl4nc1SKYc2jgNGumpZ/uhnVycoIa6mUJ0g/yiRIfDgQ==
   dependencies:
     "@aspnet/signalr" "^1.1.4"
     "@aspnet/signalr-protocol-msgpack" "^1.1.0"


### PR DESCRIPTION
When the user clicks on a cipher, it is used in the account form.

There are two cases:

* If all required fields are present in the cipher, then the account form is automatically submitted
* Otherwise, the user can edit the missing fields and submit the form manually