### PR TITLE
feat: Show account name more prominently

### DIFF
--- a/packages/cozy-harvest-lib/src/components/VaultCiphersList/CiphersListItem.jsx
+++ b/packages/cozy-harvest-lib/src/components/VaultCiphersList/CiphersListItem.jsx
@@ -17,8 +17,8 @@ const CiphersListItem = props => {
         <CipherIcon konnector={konnector} />
       </ListItemIcon>
       <ListItemText
-        primaryText={cipherView.name}
-        secondaryText={get(cipherView, 'login.username')}
+        primaryText={get(cipherView, 'login.username')}
+        secondaryText={cipherView.name}
       />
     </ListItem>
   )


### PR DESCRIPTION
In the current design, the name of the service is the primary text, but it should be editable. Since this feature won't be available soon, it's better to use the login as primary text.

<img width="544" alt="Capture d'écran 2019-09-16 14 27 18" src="https://user-images.githubusercontent.com/2261445/64957871-22a97f80-d88e-11e9-860c-47c01f0dd74c.png">
