### PR TITLE
feat(cozy-doctypes): Add a generic filename generation on conflict

### DIFF
--- a/packages/cozy-doctypes/src/File.js
+++ b/packages/cozy-doctypes/src/File.js
@@ -125,6 +125,29 @@ class CozyFile extends Document {
       throw error
     }
   }
+  /**
+   * Method to generate a new filename if there is a conflict
+   *
+   * @param {String} filenameWithoutExtension A filename without the extension
+   * @return {String} A filename with the right suffix
+   */
+  static generateNewFileNameOnConflict(filenameWithoutExtension) {
+    //Check if the string ends by _1
+    const regex = new RegExp('(_)([0-9]+)$')
+    const matches = filenameWithoutExtension.match(regex)
+    if (matches) {
+      let versionNumber = parseInt(matches[2])
+      //increment versionNumber
+      versionNumber++
+      const newFilenameWithoutExtension = filenameWithoutExtension.replace(
+        new RegExp('(_)([0-9]+)$'),
+        `_${versionNumber}`
+      )
+      return newFilenameWithoutExtension
+    } else {
+      return `${filenameWithoutExtension}_1`
+    }
+  }
 }
 
 CozyFile.doctype = 'io.cozy.files'

--- a/packages/cozy-doctypes/src/File.spec.js
+++ b/packages/cozy-doctypes/src/File.spec.js
@@ -215,4 +215,17 @@ describe('File model', () => {
       })
     })
   })
+
+  describe('generateNewFileNameOnConflict', () => {
+    it('should generate the right file name with _X', () => {
+      const filename1 = CozyFile.generateNewFileNameOnConflict('test')
+      expect(filename1).toEqual('test_1')
+      const filename2 = CozyFile.generateNewFileNameOnConflict('test_1')
+      expect(filename2).toEqual('test_2')
+      const filename3 = CozyFile.generateNewFileNameOnConflict('test_1_1_test')
+      expect(filename3).toEqual('test_1_1_test_1')
+      const filename4 = CozyFile.generateNewFileNameOnConflict('test_')
+      expect(filename4).toEqual('test__1')
+    })
+  })
 })


### PR DESCRIPTION
Sometimes, we need to erase on conflict, but sometimes we need to rename. 

This is the method we will use on rename. 