### PR TITLE
Revert "feat: Share ciphers with the cozy org"

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -180,11 +180,10 @@ export class TriggerManager extends Component {
         }
       }
 
-      const cipher = await vaultClient.createNewCozySharedCipher(
+      const cipher = await vaultClient.createNewCipher(
         cipherData,
         originalCipher || null
       )
-
       await vaultClient.saveCipher(cipher)
 
       const accountWithNewState = accounts.setSessionResetIfNecessary(


### PR DESCRIPTION
This reverts commit aa0ae01e12a501e176b0f36f55e3c1a327cbbe86.

Since the `createNewCozySharedCipher` method is not yet available in
cozy-keys-lib, using it make the trigger creation process crash unless
you use a linked cozy-keys-lib on the `feat/share-cozy` branch and a
cozy-stack built on the `password-manager` branch. Also, this commit is
present in the cozy-lib's `feat/share-cozy` branch. So it seems this
commit landed in the `feat/pwmanager` by mistake. Reverting it for now,
so we can re-apply it later when everything is ready.