### PR TITLE
[Harvest] feat: Update accounts service

### DIFF
--- a/packages/cozy-harvest-lib/jest.config.js
+++ b/packages/cozy-harvest-lib/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
   testURL: 'http://localhost/',
   moduleFileExtensions: ['js', 'jsx', 'json', 'styl'],
   moduleDirectories: ['src', 'node_modules'],
+  testPathIgnorePatterns: ['dist'],
   moduleNameMapper: {
     '^cozy-logger$': 'cozy-logger/dist/index.js',
     '\\.(png|gif|jpe?g|svg)$': '<rootDir>/test/__mocks__/fileMock.js',

--- a/packages/cozy-harvest-lib/src/index.js
+++ b/packages/cozy-harvest-lib/src/index.js
@@ -11,3 +11,6 @@ export { default as Routes } from './components/Routes'
 
 export { KonnectorJobError } from './helpers/konnectors'
 export { handleOAuthResponse } from './helpers/oauth'
+export {
+  default as updateAccountsPassword
+} from './services/updateAccountsPassword'

--- a/packages/cozy-harvest-lib/src/services/updateAccountsPassword.js
+++ b/packages/cozy-harvest-lib/src/services/updateAccountsPassword.js
@@ -1,4 +1,5 @@
 import SymmetricCryptoKey from 'cozy-keys-lib/transpiled/SymmetricCryptoKey'
+import EncryptionType from 'cozy-keys-lib/transpiled/EncryptionType'
 import get from 'lodash/get'
 import set from 'lodash/set'
 import unset from 'lodash/unset'
@@ -30,7 +31,7 @@ const updateAccountsPassword = async (
   const encryptedUsername = get(bitwardenCipherDocument, 'login.username')
   const bitwardenCipherId = get(bitwardenCipherDocument, '_id')
 
-  const orgKeyEncType = 2
+  const orgKeyEncType = EncryptionType.AesCbc256_HmacSha256_B64
   const orgKey = new SymmetricCryptoKey(
     vaultClient.Utils.fromB64ToArray(cozyKeys.organizationKey),
     orgKeyEncType

--- a/packages/cozy-harvest-lib/src/services/updateAccountsPassword.js
+++ b/packages/cozy-harvest-lib/src/services/updateAccountsPassword.js
@@ -1,0 +1,61 @@
+import SymmetricCryptoKey from 'cozy-keys-lib/transpiled/SymmetricCryptoKey'
+import get from 'lodash/get'
+import set from 'lodash/set'
+import unset from 'lodash/unset'
+
+const updateAccountsPassword = async (
+  cozyClient,
+  vaultClient,
+  bitwardenCipherDocument
+) => {
+  const cozyKeys = await cozyClient
+    .getStackClient()
+    .fetchJSON('GET', '/bitwarden/organizations/cozy')
+
+  const encryptedPassword = get(bitwardenCipherDocument, 'login.password')
+  const bitwardenCipherId = get(bitwardenCipherDocument, '_id')
+
+  const [encTypeAndIv, data, mac] = encryptedPassword.split('|')
+  const [encTypeString, iv] = encTypeAndIv.split('.')
+  const encType = parseInt(encTypeString, 10)
+
+  const orgKey = new SymmetricCryptoKey(
+    vaultClient.Utils.fromB64ToArray(cozyKeys.organizationKey),
+    encType
+  )
+
+  const decryptedPassword = await vaultClient.cryptoService.aesDecryptToUtf8(
+    encType,
+    data,
+    iv,
+    mac,
+    orgKey
+  )
+
+  const accounts = await cozyClient.query(
+    cozyClient
+      .find('io.cozy.accounts')
+      .where({
+        'relationships.vaultCipher': {
+          _id: bitwardenCipherId,
+          _type: 'com.bitwarden.ciphers'
+        }
+      })
+      .indexFields(['relationships.vaultCipher._id'])
+  )
+
+  await Promise.all(
+    accounts.data.map(account => {
+      set(account, 'auth.password', decryptedPassword)
+      unset(account, 'auth.credentials_encrypted')
+      const updatedAccount = {
+        ...account,
+        _type: 'io.cozy.accounts'
+      }
+
+      return cozyClient.save(updatedAccount)
+    })
+  )
+}
+
+export default updateAccountsPassword

--- a/packages/cozy-harvest-lib/src/services/updateAccountsPassword.spec.js
+++ b/packages/cozy-harvest-lib/src/services/updateAccountsPassword.spec.js
@@ -1,0 +1,123 @@
+import updateAccountsPassword from './updateAccountsPassword'
+
+jest.mock('cozy-keys-lib/transpiled/SymmetricCryptoKey', () => {
+  return class {
+    constructor(key, encType) {
+      return { key, encType }
+    }
+  }
+})
+
+describe('update accounts password function', () => {
+  const mockVaultClient = {
+    Utils: {
+      fromB64ToArray: str => str
+    },
+    cryptoService: {
+      aesDecryptToUtf8: jest.fn(str => str)
+    }
+  }
+  const mockCozyClient = {
+    getStackClient: () => mockCozyClient,
+    find: () => mockCozyClient,
+    where: () => mockCozyClient,
+    indexFields: () => mockCozyClient,
+    query: jest.fn(),
+    save: jest.fn(),
+    fetchJSON: jest.fn()
+  }
+
+  it('should fail when the stack provides no org key', async () => {
+    mockCozyClient.fetchJSON.mockRejectedValue({
+      error: 'No org key'
+    })
+    expect.assertions(1)
+    try {
+      await updateAccountsPassword(mockCozyClient, mockVaultClient, {})
+    } catch (err) {
+      expect(err).toEqual({
+        error: 'No org key'
+      })
+    }
+  })
+
+  it('should decrypt the password', async () => {
+    const encType = 2
+    const iv = 'iv123'
+    const mac = 'mac456'
+    const data = 'super_secret'
+    const orgKey = '123'
+
+    const encryptedPassword = `${encType}.${iv}|${data}|${mac}`
+    mockCozyClient.fetchJSON.mockResolvedValue({
+      organizationKey: orgKey
+    })
+    mockCozyClient.query.mockResolvedValue({
+      data: []
+    })
+    await updateAccountsPassword(mockCozyClient, mockVaultClient, {
+      login: {
+        password: encryptedPassword
+      }
+    })
+    expect(mockVaultClient.cryptoService.aesDecryptToUtf8).toHaveBeenCalledWith(
+      encType,
+      data,
+      iv,
+      mac,
+      {
+        key: orgKey,
+        encType
+      }
+    )
+  })
+
+  it('should update accounts', async () => {
+    mockCozyClient.fetchJSON.mockResolvedValue({
+      organizationKey: '123'
+    })
+    mockCozyClient.save.mockResolvedValue()
+    mockVaultClient.cryptoService.aesDecryptToUtf8.mockResolvedValue(
+      'new_password'
+    )
+    mockCozyClient.query.mockResolvedValue({
+      data: [
+        {
+          auth: {
+            credentials_encrypted: 'abc123',
+            login: 'A'
+          }
+        },
+        {
+          auth: {
+            credentials_encrypted: 'abc123',
+            login: 'B',
+            extra_field: 'stays'
+          }
+        }
+      ]
+    })
+    await updateAccountsPassword(mockCozyClient, mockVaultClient, {
+      login: {
+        password: 'yolo'
+      }
+    })
+
+    expect(mockCozyClient.save).toHaveBeenCalledTimes(2)
+    expect(mockCozyClient.save).toHaveBeenCalledWith({
+      _type: 'io.cozy.accounts',
+      auth: {
+        login: 'A',
+        password: 'new_password'
+      }
+    })
+    expect(mockCozyClient.save).toHaveBeenCalledWith({
+      _type: 'io.cozy.accounts',
+      auth: {
+        login: 'B',
+        password: 'new_password',
+        extra_field: 'stays'
+      }
+    })
+  })
+})


### PR DESCRIPTION
This is the main function for the service that will update `io.cozy.accounts` passwords when a change is detected in the vault. 

It takes a cipher document from couch, decrypts the password using the org key, and updates any `io.cozy.accounts` that use this cipher.

Requires https://github.com/pulls but can already be reviewed :)