### PR TITLE
[Harvest] Directly redirect to form if there is no ciphers for t…

### DIFF
--- a/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
@@ -130,7 +130,6 @@ export class EditAccountModal extends Component {
               konnector={konnector}
               initialTrigger={trigger}
               onSuccess={this.redirectToAccount}
-              onVaultDismiss={this.redirectToAccount}
               showError={true}
             />
           )}

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -49,13 +49,15 @@ export class TriggerManager extends Component {
     this.handleError = this.handleError.bind(this)
     this.handleCipherSelect = this.handleCipherSelect.bind(this)
     this.showCiphersList = this.showCiphersList.bind(this)
+    this.handleNoCiphers = this.handleNoCiphers.bind(this)
 
     this.state = {
       account,
       error: null,
       status: IDLE,
       step: account ? 'accountForm' : 'ciphersList',
-      selectedCipher: null
+      selectedCipher: null,
+      showBackButton: false
     }
   }
 
@@ -348,7 +350,8 @@ export class TriggerManager extends Component {
       this.setState(
         {
           step: 'accountForm',
-          selectedCipher
+          selectedCipher,
+          showBackButton: true
         },
         () => {
           this.handleSubmit(values)
@@ -357,7 +360,8 @@ export class TriggerManager extends Component {
     } else {
       this.setState({
         step: 'accountForm',
-        selectedCipher
+        selectedCipher,
+        showBackButton: true
       })
     }
   }
@@ -365,6 +369,13 @@ export class TriggerManager extends Component {
   showCiphersList() {
     this.setState({
       step: 'ciphersList'
+    })
+  }
+
+  handleNoCiphers() {
+    this.setState({
+      step: 'accountForm',
+      showBackButton: false
     })
   }
 
@@ -386,10 +397,16 @@ export class TriggerManager extends Component {
       t,
       onVaultDismiss
     } = this.props
-    const { account, error, status, step, selectedCipher } = this.state
+    const {
+      account,
+      error,
+      status,
+      step,
+      selectedCipher,
+      showBackButton
+    } = this.state
     const submitting = !!(status === RUNNING || triggerRunning)
     const modalInto = modalContainerId || MODAL_PLACE_ID
-    const isUpdate = !account
 
     const { oauth } = konnector
 
@@ -412,11 +429,12 @@ export class TriggerManager extends Component {
             <VaultCiphersList
               konnector={konnector}
               onSelect={this.handleCipherSelect}
+              onNoCiphers={this.handleNoCiphers}
             />
           )}
           {step === 'accountForm' && (
             <>
-              {isUpdate && (
+              {showBackButton && (
                 <BackButton onClick={this.showCiphersList}>
                   {t('triggerManager.backToCiphersList')}
                 </BackButton>

--- a/packages/cozy-harvest-lib/src/components/VaultCiphersList/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/VaultCiphersList/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import get from 'lodash/get'
 import { withVaultClient, CipherType } from 'cozy-keys-lib'
 import { Title } from 'cozy-ui/transpiled/react/Text'
@@ -11,6 +12,14 @@ import CiphersListItem from './CiphersListItem'
 import OtherAccountListItem from './OtherAccountListItem'
 
 class VaultCiphersList extends React.Component {
+  static propTypes = {
+    konnector: PropTypes.object.isRequired,
+    onNoCiphers: PropTypes.func,
+    onSelect: PropTypes.func.isRequired,
+    t: PropTypes.func.isRequired,
+    vaultClient: PropTypes.object.isRequired
+  }
+
   state = {
     loading: false,
     ciphers: []

--- a/packages/cozy-harvest-lib/src/components/VaultCiphersList/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/VaultCiphersList/index.jsx
@@ -30,14 +30,21 @@ class VaultCiphersList extends React.Component {
         type: CipherType.Login,
         uri: konnectorURI
       })
-      this.setState({
-        ciphers
-      })
+
+      if (ciphers.length > 0) {
+        this.setState({
+          ciphers,
+          loading: false
+        })
+      } else {
+        if (this.props.onNoCiphers) {
+          this.props.onNoCiphers()
+        }
+      }
     } catch (error) {
       //TODO: do something
       // eslint-disable-next-line no-console
       console.warn(error)
-    } finally {
       this.setState({ loading: false })
     }
   }

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
@@ -115,6 +115,7 @@ exports[`TriggerManager should render without account 1`] = `
           "slug": "konnectest",
         }
       }
+      onNoCiphers={[Function]}
       onSelect={[Function]}
     />
   </Wrapper>


### PR DESCRIPTION
When the user wants to add an account for a konnector, if we have no ciphers, we would show a list with just "From another account" choice. This is an useless click, so we don't show the list and directly show the form in that case.

Also fixing a bug preventing the user from editing an account.

#802 was another attempt at doing the same thing, but with a refactor. But it was causing too many problems so I decided to focus on the feature.