### PR TITLE
feat: Show a spinner when selected cipher has all required values

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -398,6 +398,12 @@ export class TriggerManager extends Component {
     return Account.fromCipher(cipher)
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.error && this.props.error !== prevProps.error) {
+      this.setState({ step: 'accountForm' })
+    }
+  }
+
   render() {
     const {
       error: triggerError,
@@ -421,6 +427,10 @@ export class TriggerManager extends Component {
 
     const { oauth } = konnector
 
+    const showSpinner = submitting && selectedCipher && step === 'ciphersList'
+    const showCiphersList = step === 'ciphersList'
+    const showAccountForm = step === 'accountForm'
+
     if (oauth) {
       return (
         <OAuthForm
@@ -432,7 +442,7 @@ export class TriggerManager extends Component {
       )
     }
 
-    if (submitting && selectedCipher && step === 'ciphersList') {
+    if (showSpinner) {
       return (
         <div className="u-flex u-flex-column u-flex-items-center">
           <Spinner size="xxlarge" />
@@ -445,14 +455,14 @@ export class TriggerManager extends Component {
       <div>
         <VaultUnlocker onDismiss={onVaultDismiss}>
           <div id={modalInto} />
-          {step === 'ciphersList' && (
+          {showCiphersList && (
             <VaultCiphersList
               konnector={konnector}
               onSelect={this.handleCipherSelect}
               onNoCiphers={this.handleNoCiphers}
             />
           )}
-          {step === 'accountForm' && (
+          {showAccountForm && (
             <>
               {showBackButton && (
                 <BackButton onClick={this.showCiphersList}>

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -11,6 +11,7 @@ import {
   CipherType,
   UriMatchType
 } from 'cozy-keys-lib'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import AccountForm from './AccountForm'
 import OAuthForm from './OAuthForm'
@@ -361,9 +362,7 @@ export class TriggerManager extends Component {
     if (hasValuesForRequiredFields) {
       this.setState(
         {
-          step: 'accountForm',
-          selectedCipher,
-          showBackButton: true
+          selectedCipher
         },
         () => {
           this.handleSubmit(values)
@@ -430,6 +429,15 @@ export class TriggerManager extends Component {
           onSuccess={this.handleOAuthAccountId}
           submitting={submitting}
         />
+      )
+    }
+
+    if (submitting && selectedCipher && step === 'ciphersList') {
+      return (
+        <div className="u-flex u-flex-column u-flex-items-center">
+          <Spinner size="xxlarge" />
+          <p>{t('triggerManager.connecting')}</p>
+        </div>
       )
     }
 

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -323,6 +323,7 @@
     "otherAccount": "From another account…"
   },
   "triggerManager": {
-    "backToCiphersList": "Go back to accounts list"
+    "backToCiphersList": "Go back to accounts list",
+    "connecting": "Connecting your account..."
   }
 }


### PR DESCRIPTION
When the user selects a cipher that have all the required values to connect the account, we show a spinner instead of the account form with all fields disabled.

![image](https://user-images.githubusercontent.com/1606068/65345771-48f75400-dbdb-11e9-9da4-7b671dc60df3.png)
