### PR TITLE
feat: Export get error locale

### DIFF
--- a/packages/cozy-harvest-lib/src/index.js
+++ b/packages/cozy-harvest-lib/src/index.js
@@ -9,5 +9,5 @@ export { default as TriggerManager } from './components/TriggerManager'
 export { default as TriggerLauncher } from './components/TriggerLauncher'
 export { default as Routes } from './components/Routes'
 
-export { KonnectorJobError } from './helpers/konnectors'
+export { KonnectorJobError, getErrorLocale } from './helpers/konnectors'
 export { handleOAuthResponse } from './helpers/oauth'


### PR DESCRIPTION
getErrorLocale will be part of the public API of cozy-harvest-lib.