### PR TITLE
feat(cozy-harvest-lib): Handle decrypt errors in service

### DIFF
--- a/packages/cozy-harvest-lib/src/services/updateAccountsPassword.js
+++ b/packages/cozy-harvest-lib/src/services/updateAccountsPassword.js
@@ -31,6 +31,10 @@ const updateAccountsPassword = async (
     orgKey
   )
 
+  if (decryptedPassword === null || decryptedUsername === null) {
+    throw new Error('DECRYPT_FAILED')
+  }
+
   const accounts = await fetchAccountsForCipherId(cozyClient, bitwardenCipherId)
 
   await updateAccounts(

--- a/packages/cozy-harvest-lib/test/services/updateAccountsPassword.spec.js
+++ b/packages/cozy-harvest-lib/test/services/updateAccountsPassword.spec.js
@@ -149,4 +149,19 @@ describe('update accounts password function', () => {
       'tri2'
     ])
   })
+
+  it('should throw an error if it can not decrypt username or password', async () => {
+    const orgKey = {}
+    getOrganizationKey.mockResolvedValue(orgKey)
+    decryptString.mockResolvedValue(null)
+
+    expect(
+      updateAccountsPassword(mockCozyClient, mockVaultClient, {
+        login: {
+          password: 'yolo',
+          username: 'yolo'
+        }
+      })
+    ).rejects.toThrow('DECRYPT_FAILED')
+  })
 })


### PR DESCRIPTION
When there is an error while decrypting username and/or password in the service, we throw an error so we stop as soon as possible and avoid useless requests.

A decrypting error can happen when the user updates a cipher which is not shared with the cozy organization, so we can't decrypt it using the organization key.

The bitwarden js lib handles errors with `console.error(message)` and `return null`. That's why we check the returned value to throw the error. It means that we can't pass a lot of context to the error, because we just know that something went wrong, but not what exactly.