### PR TITLE
Show a read-only field for identifier when a cipher has been selected

### DIFF
--- a/packages/cozy-doctypes/src/Account.js
+++ b/packages/cozy-doctypes/src/Account.js
@@ -35,12 +35,19 @@ class Account extends Document {
    * Create an account document from a vault cipher
    *
    * @param {Object} cipher
+   * @param {Object} [options={}]
+   * @param {string} [options.identifierProperty=login] - The name of the identifier property to use for this account
    *
    * @returns {Object}
    */
-  static fromCipher(cipher) {
+  static fromCipher(cipher, options = {}) {
     if (!cipher) {
       throw new Error('Cipher is required')
+    }
+
+    const opts = {
+      identifierProperty: 'login',
+      ...options
     }
 
     const customFields = (cipher.fields || []).reduce((fields, field) => {
@@ -52,7 +59,7 @@ class Account extends Document {
     return {
       auth: pickBy(
         {
-          login: cipher.login.username,
+          [opts.identifierProperty]: cipher.login.username,
           password: cipher.login.password,
           ...customFields
         },

--- a/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
@@ -1,6 +1,7 @@
 import Field from 'cozy-ui/transpiled/react/Field'
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
+import pick from 'lodash/pick'
 
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 
@@ -123,6 +124,10 @@ export class AccountField extends PureComponent {
             secondaryLabels={passwordLabels}
           />
         )
+      case 'hidden':
+        return (
+          <input {...pick(fieldProps, ['value', 'type', 'name', 'role'])} />
+        )
       default:
         return <Field {...fieldProps} type="text" />
     }
@@ -171,7 +176,14 @@ AccountField.propTypes = {
    * Field type, passed to <Field /> component. Except for "dropdown" which
    * will be mapped to "select"
    */
-  type: PropTypes.oneOf(['date', 'dropdown', 'email', 'password', 'text']),
+  type: PropTypes.oneOf([
+    'date',
+    'dropdown',
+    'email',
+    'password',
+    'text',
+    'hidden'
+  ]),
   /**
    * Translation function
    */

--- a/packages/cozy-harvest-lib/src/components/AccountForm/ReadOnlyIdentifier.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/ReadOnlyIdentifier.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import cx from 'classnames'
+
+import Card from 'cozy-ui/transpiled/react/Card'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import { Media, Img, Bd } from 'cozy-ui/transpiled/react/Media'
+
+import KonnectorIcon from '../KonnectorIcon'
+
+const ReadOnlyIdentifier = props => {
+  const { className, onClick, konnector, identifier, ...rest } = props
+
+  return (
+    <Card
+      className={cx({ 'u-c-pointer': onClick }, className)}
+      onClick={onClick}
+      {...rest}
+    >
+      <Media>
+        <Img>
+          <KonnectorIcon konnector={konnector} className="u-w-1-half u-mr-1" />
+        </Img>
+        <Bd>{identifier}</Bd>
+        <Img>
+          <Icon icon="bottom-select" />
+        </Img>
+      </Media>
+    </Card>
+  )
+}
+
+ReadOnlyIdentifier.propTypes = {
+  konnector: PropTypes.object.isRequired,
+  identifier: PropTypes.string.isRequired
+}
+
+export default ReadOnlyIdentifier

--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -2,46 +2,20 @@ import React, { PureComponent } from 'react'
 import { Form } from 'react-final-form'
 import PropTypes from 'prop-types'
 import get from 'lodash/get'
-import cx from 'classnames'
 
 import { isMobile } from 'cozy-device-helper'
 import Button from 'cozy-ui/transpiled/react/Button'
-import Card from 'cozy-ui/transpiled/react/Card'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import { Media, Img, Bd } from 'cozy-ui/transpiled/react/Media'
 import withLocales from '../hoc/withLocales'
 
 import AccountFields from './AccountFields'
+import ReadOnlyIdentifier from './ReadOnlyIdentifier'
 import TriggerErrorInfo from '../infos/TriggerErrorInfo'
 import { getEncryptedFieldName } from '../../helpers/fields'
 import { KonnectorJobError } from '../../helpers/konnectors'
 import manifest from '../../helpers/manifest'
 import withKonnectorLocales from '../hoc/withKonnectorLocales'
-import KonnectorIcon from '../KonnectorIcon'
 
 const VALIDATION_ERROR_REQUIRED_FIELD = 'VALIDATION_ERROR_REQUIRED_FIELD'
-
-const ReadOnlyIdentifier = props => {
-  const { className, onClick, konnector, identifier, ...rest } = props
-
-  return (
-    <Card
-      className={cx({ 'u-c-pointer': onClick }, className)}
-      onClick={onClick}
-      {...rest}
-    >
-      <Media>
-        <Img>
-          <KonnectorIcon konnector={konnector} className="u-w-1-half u-mr-1" />
-        </Img>
-        <Bd>{identifier}</Bd>
-        <Img>
-          <Icon icon="bottom-select" />
-        </Img>
-      </Media>
-    </Card>
-  )
-}
 
 /**
  * AccountForm is reponsible of generating a form which will allow user to

--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -239,7 +239,10 @@ export class AccountForm extends PureComponent {
                 className="u-mb-1"
                 onClick={onBack}
                 konnector={konnector}
-                identifier={get(account, 'auth.login')}
+                identifier={get(
+                  account,
+                  `auth.${manifest.getIdentifier(konnector.fields)}`
+                )}
               />
             )}
             <AccountFields

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -342,7 +342,7 @@ export class TriggerManager extends Component {
       this.setState({
         step: 'accountForm',
         selectedCipher,
-        showBackButton: true
+        showBackButton: !selectedCipher
       })
     }
   }
@@ -446,6 +446,7 @@ export class TriggerManager extends Component {
                 onSubmit={this.handleSubmit}
                 showError={showError}
                 submitting={submitting}
+                onBack={this.showCiphersList}
               />
             </>
           )}

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -266,16 +266,22 @@ export class TriggerManager extends Component {
       status: RUNNING
     })
 
+    const identifierProperty = manifest.getIdentifier(konnector.fields)
+
     try {
-      const { login, password } = data
+      const identifier = data[identifierProperty]
+      const password = data.password
       let cipherId = this.getSelectedCipherId()
 
       if (cipherId) {
-        await this.updateSelectedCipher(login, password)
+        await this.updateSelectedCipher(identifier, password)
       } else if (!cipherId && account) {
-        cipherId = await this.getExistingCipherIdForAccount(login, password)
+        cipherId = await this.getExistingCipherIdForAccount(
+          identifier,
+          password
+        )
       } else if (!cipherId && !account) {
-        cipherId = await this.createNewCipherId(login, password)
+        cipherId = await this.createNewCipherId(identifier, password)
       }
       await this.shareCipherWithCozy(cipherId)
 
@@ -321,7 +327,10 @@ export class TriggerManager extends Component {
 
   handleCipherSelect(selectedCipher) {
     const { konnector } = this.props
-    const account = this.cipherToAccount(selectedCipher)
+    const account = this.cipherToAccount(
+      selectedCipher,
+      manifest.getIdentifier(konnector.fields)
+    )
     const values = manifest.getFieldsValues(konnector, account)
 
     const hasValuesForRequiredFields = manifest.hasValuesForRequiredFields(
@@ -365,7 +374,13 @@ export class TriggerManager extends Component {
       return null
     }
 
-    return Account.fromCipher(cipher)
+    const identifierProperty = manifest.getIdentifier(
+      this.props.konnector.fields
+    )
+
+    return Account.fromCipher(cipher, {
+      identifierProperty
+    })
   }
 
   componentDidUpdate(prevProps) {

--- a/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
+++ b/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 import React from 'react'
-import { shallow } from 'enzyme'
+import PropTypes from 'prop-types'
+import { shallow, mount } from 'enzyme'
 
 import { isMobile } from 'cozy-device-helper'
 
@@ -41,6 +42,12 @@ jest.mock('cozy-device-helper', () => ({
   ...require.requireActual('cozy-device-helper'),
   isMobile: jest.fn()
 }))
+
+jest.mock('components/KonnectorIcon', () => {
+  const KonnectorIcon = () => <div>KonnectorIcon</div>
+
+  return KonnectorIcon
+})
 
 describe('AccountForm', () => {
   beforeEach(() => {
@@ -402,6 +409,38 @@ describe('AccountForm', () => {
       wrapper.instance().handleKeyUp({ key: 'Enter' }, {})
       expect(wrapper.instance().focusNext).toHaveBeenCalled()
       expect(wrapper.instance().handleSubmit).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('with read-only identifier', () => {
+    it('should render a read-only identifier field if the account has a relationship with a vault cipher', () => {
+      const wrapper = mount(
+        <AccountForm
+          konnector={fixtures.konnector}
+          onSubmit={onSubmit}
+          t={t}
+          account={{
+            ...fixtures.account,
+            relationships: {
+              vaultCipher: {
+                _id: 'fake-cipher-id',
+                _type: 'com.bitwarden.ciphers',
+                _protocol: 'bitwarden'
+              }
+            }
+          }}
+        />,
+        {
+          context: { t },
+          childContextTypes: {
+            t: PropTypes.func
+          }
+        }
+      )
+
+      const hiddenInput = wrapper.find('input[type="hidden"][name="username"]')
+
+      expect(hiddenInput).toHaveLength(1)
     })
   })
 })

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
@@ -33,6 +33,7 @@ exports[`TriggerManager handleError should render error 1`] = `
             "slug": "konnectest",
           }
         }
+        onBack={[Function]}
         onSubmit={[Function]}
         submitting={false}
       />
@@ -87,6 +88,7 @@ exports[`TriggerManager should render with account 1`] = `
             "slug": "konnectest",
           }
         }
+        onBack={[Function]}
         onSubmit={[Function]}
         submitting={false}
       />


### PR DESCRIPTION
When a cipher has been selected, if the user updates the identifier field, we can't be sure if it's a correction on the identifier or if the user wants to use a totally different account.

To avoid errors, we prevent the user from updating the identifier by showing a read-only field. When the user clicks on this fields, we go back to the ciphers list.

![image](https://user-images.githubusercontent.com/1606068/65883473-6674ac80-e397-11e9-980c-2ef72ed7f250.png)
