### PR TITLE
feat: Provide webpack config for users of cozy-notifications

### DIFF
--- a/packages/cozy-notifications/README.md
+++ b/packages/cozy-notifications/README.md
@@ -1,6 +1,29 @@
 `cozy-notifications` provides tools to send notifications (push or email) from a Cozy
 application or konnector.
 
+## Installation
+
+```
+yarn add cozy-notifications
+```
+
+You will most likely also need a custom webpack config if building for node (for example
+in konnectors, since mjml and its dependents are not built for node-js).
+
+`webpack.config.js`
+
+```
+const webpackMerge = require('webpack-merge')
+const cozyNotificationsWebpackConfig = require('cozy-notifications/dist/webpack/config')
+
+module.exports = webpackMerge({
+  // initialConfig
+}, cozyNotificationsWebpackConfig)
+```
+
+The custom webpack config provided by `cozy-notifications` applies aliases and resolves for
+`cozy-notifications` to be used in a build targetting node.
+
 ## `sendNotification`
 
 The main entrypoint of this library is `sendNotifification(cozyClient, notificationView)`.

--- a/packages/cozy-notifications/src/webpack/config.js
+++ b/packages/cozy-notifications/src/webpack/config.js
@@ -1,0 +1,35 @@
+import webpack from 'webpack'
+import path from 'path'
+
+export default {
+  resolve: {
+    alias: {
+      handlebars: 'handlebars/runtime.js'
+    }
+  },
+  module: {
+    // mjml-core/lib/helpers/mjmlconfig and encoding/lib/iconv-loader use
+    // expressions inside require. We do not need the functionality provided
+    // by the dynamic require
+    exprContextRegExp: /$^/,
+    exprContextCritical: false,
+
+    rules: [
+      // data-uri has a hashbang at the top of the file
+      {
+        test: /node_modules\/datauri\/index.js$/,
+        loader: 'shebang-loader'
+      }
+    ]
+  },
+  plugins: [
+    new webpack.NormalModuleReplacementPlugin(
+      /node_modules\/uglify-js\/tools\/node.js$/,
+      path.join(__dirname, './uglify-node.js')
+    ),
+    new webpack.NormalModuleReplacementPlugin(
+      /node_modules\/mimer\/lib\/data\/parser.js$/,
+      path.join('./src/hacks/mimer-parser.js')
+    )
+  ]
+}

--- a/packages/cozy-notifications/src/webpack/mimer-parser.js
+++ b/packages/cozy-notifications/src/webpack/mimer-parser.js
@@ -1,0 +1,50 @@
+// This file replaces node_modules/mimer/lib/data/parser.js, as it tries to
+// read a file at the path that is computed dynamically and this does not work
+// when bundled. I've made simple version as we don't need a lot of mime types
+// for email templating.
+
+module.exports = function() {
+  return {
+    atom: 'application/atom+xml',
+    epub: 'application/epub+zip',
+    js: 'application/javascript',
+    json: 'application/json',
+    mathml: 'application/mathml+xml',
+    bin: 'application/octet-stream',
+    pdf: 'application/pdf',
+    rss: 'application/rss+xml',
+    '7z': 'application/x-7z-compressed',
+    dmg: 'application/x-apple-diskimage',
+    torrent: 'application/x-bittorrent',
+    ttf: 'application/x-font-ttf',
+    woff: 'application/font-woff',
+    lnk: 'application/x-ms-shortcut',
+    rar: 'application/x-rar-compressed',
+    xhtml: 'application/xhtml+xml',
+    mp3: 'audio/mpeg',
+    ogg: 'audio/ogg',
+    gif: 'image/gif',
+    jpeg: 'image/jpeg',
+    jpg: 'image/jpeg',
+    png: 'image/png',
+    svg: 'image/svg+xml',
+    svgz: 'image/svg+xml',
+    webp: 'image/webp',
+    ico: 'image/x-icon',
+    eml: 'message/rfc822',
+    mime: 'message/rfc822',
+    ics: 'text/calendar',
+    css: 'text/css',
+    csv: 'text/csv',
+    html: 'text/html',
+    htm: 'text/html',
+    txt: 'text/plain',
+    rtx: 'text/richtext',
+    vcard: 'text/vcard',
+    h264: 'video/h264',
+    mp4: 'video/mp4',
+    mpeg: 'video/mpeg',
+    ogv: 'video/ogg',
+    webm: 'video/webm'
+  }
+}

--- a/packages/cozy-notifications/src/webpack/uglify-node.js
+++ b/packages/cozy-notifications/src/webpack/uglify-node.js
@@ -1,0 +1,6 @@
+// This file replaces node_modules/uglify-js/tools/node.js, as its calls to
+// require.resolve doesn't play nicely with webpack.
+
+exports.minify = function() {
+  return { error: 'no minify' }
+}


### PR DESCRIPTION
Unfortunately, `mjml` and its dependents are not supposed to be built
for nodejs, we have to apply aliases and resolves.

Configuration is provided for dependents on `cozy-notifications` not
to reimplement it themselves every time.

Took some bits from https://github.com/cozy/cozy-libs/blob/master/packages/cozy-mjml/webpack.config.js but I did not need everything there to have a functional konnector.