### PR TITLE
[Harvest] fix: Make account selection control larger

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountSelectBox/AccountSelectControl.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountSelectBox/AccountSelectControl.jsx
@@ -5,7 +5,7 @@ import palette from 'cozy-ui/transpiled/react/palette'
 const AccountSelectControl = ({ name }) => {
   return (
     <Text className="u-slateGrey u-flex u-flex-items-center u-c-pointer">
-      <Text className="u-maw-4 u-ellipsis">{name}</Text>
+      <Text className="u-maw-5 u-ellipsis">{name}</Text>
       <Icon
         icon="bottom"
         size="12"


### PR DESCRIPTION
Makes the account name container a bit larger, so text isn't truncated too early. Can be a bit cramped on small screens, but it still fits!

![app cozy tools_8080_(iPhone 6_7_8)](https://user-images.githubusercontent.com/2261445/66295079-cebd1400-e8ea-11e9-934e-502af9e666da.png)
