### PR TITLE
Harvest/404

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModal.jsx
@@ -46,7 +46,7 @@ export class AccountModal extends Component {
     trigger: null,
     account: null,
     fetching: true,
-    error: false
+    error: null
   }
   async componentDidMount() {
     await this.loadSelectedAccountId()
@@ -65,6 +65,11 @@ export class AccountModal extends Component {
       'trigger'
     )
     if (matchingTrigger) await this.fetchAccount(matchingTrigger)
+    else
+      this.setState({
+        error: new Error('No matching trigger found'),
+        fetching: false
+      })
   }
 
   async fetchAccount(trigger) {

--- a/packages/cozy-harvest-lib/src/components/AccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModal.jsx
@@ -8,7 +8,6 @@ import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import { ModalContent } from 'cozy-ui/transpiled/react/Modal'
 import Infos from 'cozy-ui/transpiled/react/Infos'
 import Button from 'cozy-ui/transpiled/react/Button'
-import { translate } from 'cozy-ui/transpiled/react/I18n'
 
 import accountMutations from '../connections/accounts'
 import triggersMutations from '../connections/triggers'
@@ -16,6 +15,7 @@ import * as triggersModel from '../helpers/triggers'
 import KonnectorAccountTabs from './KonnectorConfiguration/KonnectorAccountTabs'
 import AccountSelectBox from './AccountSelectBox/AccountSelectBox'
 import KonnectorModalHeader from './KonnectorModalHeader'
+import withLocales from './hoc/withLocales'
 
 /**
  * AccountModal take an accountId and a list of accounts containing their
@@ -161,5 +161,5 @@ AccountModal.propTypes = {
   accountId: PropTypes.string.isRequired
 }
 export default withMutations(accountMutations, triggersMutations)(
-  withRouter(translate()(AccountModal))
+  withRouter(withLocales(AccountModal))
 )

--- a/packages/cozy-harvest-lib/src/components/KonnectorAccounts.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorAccounts.jsx
@@ -16,7 +16,7 @@ import KonnectorModalHeader from './KonnectorModalHeader'
 
 class KonnectorAccounts extends React.Component {
   state = {
-    fetchingAccounts: false,
+    fetchingAccounts: true,
     error: null,
     accounts: []
   }

--- a/packages/cozy-harvest-lib/src/components/Routes.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Route, Redirect, withRouter } from 'react-router'
+import { Route, withRouter } from 'react-router'
 import trimEnd from 'lodash/trimEnd'
 import Modal from 'cozy-ui/transpiled/react/Modal'
 
@@ -10,83 +10,85 @@ import NewAccountModal from './NewAccountModal'
 import EditAccountModal from './EditAccountModal'
 import KonnectorSuccess from './KonnectorSuccess'
 
-const Routes = ({ konnectorRoot, konnector, location, history, onDismiss }) => (
-  <Modal dismissAction={onDismiss} mobileFullscreen size="small">
-    <KonnectorAccounts konnector={konnector}>
-      {accounts => (
-        <>
-          <Route
-            path={`${konnectorRoot}/`}
-            exact
-            render={() => {
-              if (accounts.length === 0) {
-                history.push('./new')
-                return null
-              } else if (accounts.length === 1) {
-                history.push(`./accounts/${accounts[0].account._id}`)
-                return null
-              } else {
-                return (
-                  <AccountsListModal
-                    konnector={konnector}
-                    accounts={accounts}
-                  />
-                )
-              }
-            }}
-          />
-          <Route
-            path={`${konnectorRoot}/accounts/:accountId`}
-            exact
-            render={({ match }) => (
-              <AccountModal
-                konnector={konnector}
-                accountId={match.params.accountId}
-                accounts={accounts}
-                onDismiss={onDismiss}
-              />
-            )}
-          />
-          <Route
-            path={`${konnectorRoot}/accounts/:accountId/edit`}
-            exact
-            render={({ match }) => (
-              <EditAccountModal
-                konnector={konnector}
-                accountId={match.params.accountId}
-                accounts={accounts}
-              />
-            )}
-          />
-          <Route
-            path={`${konnectorRoot}/new`}
-            exact
-            render={() => <NewAccountModal konnector={konnector} />}
-          />
-          <Route
-            path={`${konnectorRoot}/accounts/:accountId/success`}
-            exact
-            render={({ match }) => {
-              return (
-                <KonnectorSuccess
+const Routes = ({ konnectorRoot, konnector, location, history, onDismiss }) => {
+  // we need to make sure the path ends with a / for relative links to work
+  if (/\/$/.test(location.pathname) === false) {
+    history.replace(trimEnd(location.pathname, '/') + '/')
+    return null
+  }
+
+  return (
+    <Modal dismissAction={onDismiss} mobileFullscreen size="small">
+      <KonnectorAccounts konnector={konnector}>
+        {accounts => (
+          <>
+            <Route
+              path={`${konnectorRoot}/`}
+              exact
+              render={() => {
+                if (accounts.length === 0) {
+                  history.push('./new')
+                  return null
+                } else if (accounts.length === 1) {
+                  history.push(`./accounts/${accounts[0].account._id}`)
+                  return null
+                } else {
+                  return (
+                    <AccountsListModal
+                      konnector={konnector}
+                      accounts={accounts}
+                    />
+                  )
+                }
+              }}
+            />
+            <Route
+              path={`${konnectorRoot}/accounts/:accountId`}
+              exact
+              render={({ match }) => (
+                <AccountModal
                   konnector={konnector}
                   accountId={match.params.accountId}
                   accounts={accounts}
                   onDismiss={onDismiss}
                 />
-              )
-            }}
-          />
-          {/* TODO redirect render twice the component */}
-          <Redirect
-            from={konnectorRoot}
-            to={trimEnd(location.pathname, '/') + '/'}
-            exact
-          />
-        </>
-      )}
-    </KonnectorAccounts>
-  </Modal>
-)
+              )}
+            />
+            <Route
+              path={`${konnectorRoot}/accounts/:accountId/edit`}
+              exact
+              render={({ match }) => (
+                <EditAccountModal
+                  konnector={konnector}
+                  accountId={match.params.accountId}
+                  accounts={accounts}
+                />
+              )}
+            />
+            <Route
+              path={`${konnectorRoot}/new`}
+              exact
+              render={() => <NewAccountModal konnector={konnector} />}
+            />
+            <Route
+              path={`${konnectorRoot}/accounts/:accountId/success`}
+              exact
+              render={({ match }) => {
+                return (
+                  <KonnectorSuccess
+                    konnector={konnector}
+                    accountId={match.params.accountId}
+                    accounts={accounts}
+                    onDismiss={onDismiss}
+                  />
+                )
+              }}
+            />
+          </>
+        )}
+      </KonnectorAccounts>
+    </Modal>
+  )
+}
 
 export default withRouter(Routes)

--- a/packages/cozy-harvest-lib/src/components/Routes.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Switch, Route, Redirect, withRouter } from 'react-router'
-import trimEnd from 'lodash/trimEnd'
 import Modal from 'cozy-ui/transpiled/react/Modal'
 
 import KonnectorAccounts from './KonnectorAccounts'
@@ -12,8 +11,8 @@ import KonnectorSuccess from './KonnectorSuccess'
 
 const Routes = ({ konnectorRoot, konnector, location, history, onDismiss }) => {
   // we need to make sure the path ends with a / for relative links to work
-  if (/\/$/.test(location.pathname) === false) {
-    history.replace(trimEnd(location.pathname, '/') + '/')
+  if (!location.pathname.endsWith('/')) {
+    history.replace(`${location.pathname}/`)
     return null
   }
 

--- a/packages/cozy-harvest-lib/src/components/Routes.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Route, withRouter } from 'react-router'
+import { Switch, Route, Redirect, withRouter } from 'react-router'
 import trimEnd from 'lodash/trimEnd'
 import Modal from 'cozy-ui/transpiled/react/Modal'
 
@@ -21,7 +21,7 @@ const Routes = ({ konnectorRoot, konnector, location, history, onDismiss }) => {
     <Modal dismissAction={onDismiss} mobileFullscreen size="small">
       <KonnectorAccounts konnector={konnector}>
         {accounts => (
-          <>
+          <Switch>
             <Route
               path={`${konnectorRoot}/`}
               exact
@@ -84,7 +84,8 @@ const Routes = ({ konnectorRoot, konnector, location, history, onDismiss }) => {
                 )
               }}
             />
-          </>
+            <Redirect from={`${konnectorRoot}/*`} to={`${konnectorRoot}/`} />
+          </Switch>
         )}
       </KonnectorAccounts>
     </Modal>


### PR DESCRIPTION
Following up on https://github.com/cozy/cozy-home/pull/1350, this PR catches non existing routes inside the harvest modal and redirects them to the root of the modal. To do this, I had to use a `Switch` component so that the fallback redirect is only rendered if nothing else matches. I've also made sure that an inexistent account id renders something.

Still not perfect, if the slug in the URL doesn't match a konnector at all we don't display anything nice, but that's a problem for cozy-home.