### PR TITLE
Harvest/fix conditional folder

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
@@ -18,6 +18,7 @@ import palette from 'cozy-ui/transpiled/react/palette'
 import { withRouter } from 'react-router'
 import { Account } from 'cozy-doctypes'
 import get from 'lodash/get'
+import has from 'lodash/has'
 
 import KonnectorUpdateInfos from '../infos/KonnectorUpdateInfos'
 import * as konnectorsModel from '../../helpers/konnectors'
@@ -90,9 +91,11 @@ class KonnectorAccountTabs extends React.Component {
                       <TriggerErrorInfo error={error} konnector={konnector} />
                     )}
                     <LaunchTriggerCard initialTrigger={initialTrigger} />
-                    <DocumentsLinkCard
-                      folderId={get(initialTrigger, 'message.folder_to_save')}
-                    />
+                    {has(initialTrigger, 'message.folder_to_save') && (
+                      <DocumentsLinkCard
+                        folderId={get(initialTrigger, 'message.folder_to_save')}
+                      />
+                    )}
                   </Stack>
                 </TabPanel>
                 <TabPanel name="configuration" className="u-pt-1-half u-pb-0">

--- a/packages/cozy-harvest-lib/src/components/cards/DocumentsLinkCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/DocumentsLinkCard.jsx
@@ -60,7 +60,7 @@ const DocumentsLinkCard = ({
               }
               theme="secondary"
               label={t('card.documentsLink.button')}
-              extension={isMobile ? 'full' : false}
+              className={isMobile ? 'u-w-100' : null}
             />
           )}
         </AppLinker>


### PR DESCRIPTION
We don't want to show the folder link for konnectors that don't load files.

(PR also includes a tiny fix for the link button that had wrong margins on mobile. The `full` extension cancels out the margins from the `Stack` component, we don't want that.)