### PR TITLE
fix: Translating components

### DIFF
--- a/packages/cozy-harvest-lib/README.md
+++ b/packages/cozy-harvest-lib/README.md
@@ -21,16 +21,36 @@ Just run
 yarn add cozy-harvest-lib
 ```
 
+# Importing
+
+Components imported from cozy-harvest-lib **must** be imported from the root of the package, and not from specific files:
+
+```
+// imported from the root of the package 👍
+import { TriggerManager } from 'cozy-harvest-lib'
+
+// imported from another file or folder 👎
+import TriggerManager from 'cozy-harvest-lib/TriggerManager'
+```
+
+This is because all harvest components come with their own translation context. If you really do need to import a component straight from the shipped file, there is a `withLocales` HOC that is available, so something like this would work as a fallback:
+
+```
+import TriggerManager from 'cozy-harvest-lib/TriggerManager'
+import { withLocales } from 'cozy-harvest-lib'
+
+const MyTriggerManager = withLocales(TriggerManager)
+```
+
 # Getting Started
 
 For now it is possible to instanciate a `<TriggerManager />` which will allow to edit an account and launch the trigger.
 
-As this component uses CozyClient, it must be wrapped at some point into a [`<CozyProvider />`](https://github.com/cozy/cozy-client/blob/master/docs/getting-started.md#wrapping-the-app-in-a-cozyprovider) and a [`<I18n>`](https://github.com/cozy/cozy-ui/tree/master/react#i18n-translate) components.
+As this component uses CozyClient, it must be wrapped at some point into a [`<CozyProvider />`](https://github.com/cozy/cozy-client/blob/master/docs/getting-started.md#wrapping-the-app-in-a-cozyprovider).
 
 ```js
 import CozyClient, { CozyProvider } from 'cozy-client'
 import { TriggerManager } from 'cozy-harvest-lib'
-import I18n from 'cozy-ui/react/I18n'
 
 const client = new CozyClient({
   /*...*/
@@ -38,11 +58,15 @@ const client = new CozyClient({
 
 ReactDOM.render(
   <CozyProvider client={client}>
-    <I18n lang="en" dictRequire={lang => require(`../src/locales/${lang}`)}>
-      // Fetch konnector at some point
-      <TriggerManager konnector="konnector" onSuccessLogin={() => alert('logged in')} />
-      // other stuff
-    </I18n>
+    <Query query={client => client.get('io.cozy.apps', 'my-konnector-id')}>
+      {konnector => (
+        <TriggerManager
+          konnector={konnector}
+          onSuccessLogin={() => alert('logged in')}
+        />
+      )}
+    </Query>
+    // other stuff
   </CozyProvider>,
   document.getElementById('main')
 )

--- a/packages/cozy-harvest-lib/src/components/AccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModal.jsx
@@ -8,6 +8,7 @@ import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import { ModalContent } from 'cozy-ui/transpiled/react/Modal'
 import Infos from 'cozy-ui/transpiled/react/Infos'
 import Button from 'cozy-ui/transpiled/react/Button'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 
 import accountMutations from '../connections/accounts'
 import triggersMutations from '../connections/triggers'
@@ -15,7 +16,6 @@ import * as triggersModel from '../helpers/triggers'
 import KonnectorAccountTabs from './KonnectorConfiguration/KonnectorAccountTabs'
 import AccountSelectBox from './AccountSelectBox/AccountSelectBox'
 import KonnectorModalHeader from './KonnectorModalHeader'
-import withLocales from './hoc/withLocales'
 
 /**
  * AccountModal take an accountId and a list of accounts containing their
@@ -161,5 +161,5 @@ AccountModal.propTypes = {
   accountId: PropTypes.string.isRequired
 }
 export default withMutations(accountMutations, triggersMutations)(
-  withRouter(withLocales(AccountModal))
+  withRouter(translate()(AccountModal))
 )

--- a/packages/cozy-harvest-lib/src/components/AccountSelectBox/CreateAccountButton.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountSelectBox/CreateAccountButton.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Button } from 'cozy-ui/transpiled/react/'
-import withLocales from '../hoc/withLocales'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 
 /**
  * onClick is not called when we are on mobile device.
@@ -9,7 +9,7 @@ import withLocales from '../hoc/withLocales'
  *
  * Using touchEnd, seems to fix the issue on mobile device (Android & iOS)
  */
-const CreateAccount = withLocales(({ createAction, t }) => {
+const CreateAccount = translate()(({ createAction, t }) => {
   return (
     <Button
       subtle

--- a/packages/cozy-harvest-lib/src/components/AccountsList/AccountsList.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountsList/AccountsList.jsx
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types'
 
 import Card from 'cozy-ui/transpiled/react/Card'
 import Button from 'cozy-ui/transpiled/react/Button'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 
-import withLocales from '../hoc/withLocales'
 import AccountsListItem from './AccountsListItem'
 
-class AccountsList extends React.PureComponent {
+export class AccountsList extends React.PureComponent {
   render() {
     const { accounts, konnector, addAccount, onPick, t } = this.props
 
@@ -51,4 +51,4 @@ AccountsList.propTypes = {
   t: PropTypes.func.isRequired
 }
 
-export default withLocales(AccountsList)
+export default translate()(AccountsList)

--- a/packages/cozy-harvest-lib/src/components/AccountsList/Status.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountsList/Status.jsx
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import palette from 'cozy-ui/transpiled/react/palette'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 
-import withLocales from '../hoc/withLocales'
 import { getErrorLocale } from '../../helpers/konnectors'
 import TriggerLauncher from '../TriggerLauncher'
 
@@ -58,4 +58,4 @@ Status.propTypes = {
   t: PropTypes.func.isRequired
 }
 
-export default withLocales(Status)
+export default translate()(Status)

--- a/packages/cozy-harvest-lib/src/components/DeleteAccountButton.jsx
+++ b/packages/cozy-harvest-lib/src/components/DeleteAccountButton.jsx
@@ -3,10 +3,11 @@ import PropTypes from 'prop-types'
 import omit from 'lodash/omit'
 
 import { Button } from 'cozy-ui/transpiled/react/Button'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 import { withMutations } from 'cozy-client'
 
 import accountsMutations from '../connections/accounts'
-import withLocales, { i18nContextTypes } from './hoc/withLocales'
+import { i18nContextTypes } from './hoc/withLocales'
 import { getMutationsProptypes } from '../helpers/proptypes'
 
 export class DeleteAccountButton extends Component {
@@ -89,6 +90,6 @@ const excludedButtonProptypes = {
   ...i18nContextTypes
 }
 
-export default withLocales(
+export default translate()(
   withMutations(accountsMutations)(DeleteAccountButton)
 )

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
@@ -15,6 +15,7 @@ import Button from 'cozy-ui/transpiled/react/Button'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Stack from 'cozy-ui/transpiled/react/Stack'
 import palette from 'cozy-ui/transpiled/react/palette'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 import { withRouter } from 'react-router'
 import { Account } from 'cozy-doctypes'
 import get from 'lodash/get'
@@ -26,7 +27,6 @@ import TriggerErrorInfo from '../infos/TriggerErrorInfo'
 import LaunchTriggerCard from '../cards/LaunchTriggerCard'
 import DocumentsLinkCard from '../cards/DocumentsLinkCard'
 import DeleteAccountButton from '../DeleteAccountButton'
-import withLocales from '../hoc/withLocales'
 import TriggerLauncher from '../TriggerLauncher'
 
 class KonnectorAccountTabs extends React.Component {
@@ -161,4 +161,4 @@ KonnectorAccountTabs.propTypes = {
   history: PropTypes.object.isRequired
 }
 
-export default withLocales(withRouter(KonnectorAccountTabs))
+export default translate()(withRouter(KonnectorAccountTabs))

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/DriveLink.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/DriveLink.jsx
@@ -1,9 +1,8 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import { ButtonLink } from 'cozy-ui/react/Button'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 import { queryConnect } from 'cozy-client'
-
-import withLocales from '../../hoc/withLocales'
 
 export class DriveLink extends PureComponent {
   render() {
@@ -41,4 +40,4 @@ export default queryConnect({
     query: client => client.all('io.cozy.apps').where({ slug: 'drive' }),
     as: 'driveQuery'
   }
-})(withLocales(DriveLink))
+})(translate()(DriveLink))

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -11,14 +11,13 @@ import Modal, {
 } from 'cozy-ui/transpiled/react/Modal'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Icon from 'cozy-ui/transpiled/react/Icon'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 import get from 'lodash/get'
 
 import accountMutations from '../connections/accounts'
 import triggersMutations from '../connections/triggers'
 import * as konnectorsModel from '../helpers/konnectors'
 import * as triggersModel from '../helpers/triggers'
-
-import withLocales from './hoc/withLocales'
 
 import TriggerManager from './TriggerManager'
 import AccountSelectBox from './AccountSelectBox/AccountSelectBox'
@@ -332,5 +331,5 @@ KonnectorModal.contextTypes = {
 }
 
 export default withMutations(accountMutations, triggersMutations)(
-  withLocales(KonnectorModal)
+  translate()(KonnectorModal)
 )

--- a/packages/cozy-harvest-lib/src/components/KonnectorSuccess.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorSuccess.jsx
@@ -6,9 +6,9 @@ import PropTypes from 'prop-types'
 import { withRouter } from 'react-router'
 
 import { ModalContent } from 'cozy-ui/transpiled/react/Modal'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 
 import Button from 'cozy-ui/react/Button'
-import withLocales from './hoc/withLocales'
 import DriveLink from '../components/KonnectorConfiguration/Success/DriveLink'
 import BanksLink from '../components/KonnectorConfiguration/Success/BanksLink'
 import connectingIllu from '../assets/connecting-data-in-progress.svg'
@@ -138,4 +138,4 @@ KonnectorSuccess.propTypes = {
 
 export { SuccessImage, BanksLink, DriveLink }
 
-export default withRouter(withLocales(KonnectorSuccess))
+export default withRouter(translate()(KonnectorSuccess))

--- a/packages/cozy-harvest-lib/src/components/Routes.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Switch, Route, Redirect, withRouter } from 'react-router'
 import Modal from 'cozy-ui/transpiled/react/Modal'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 
 import KonnectorAccounts from './KonnectorAccounts'
 import AccountsListModal from './AccountsListModal'
@@ -91,4 +92,4 @@ const Routes = ({ konnectorRoot, konnector, location, history, onDismiss }) => {
   )
 }
 
-export default withRouter(Routes)
+export default withRouter(translate()(Routes))

--- a/packages/cozy-harvest-lib/src/components/TriggerLauncher.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerLauncher.jsx
@@ -2,11 +2,11 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { withClient, withMutations } from 'cozy-client'
 import CozyRealtime from 'cozy-realtime'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 
 import TwoFAModal from './TwoFAModal'
 import { accountsMutations } from '../connections/accounts'
 import { triggersMutations } from '../connections/triggers'
-import withLocales from './hoc/withLocales'
 import * as triggersModel from '../helpers/triggers'
 import * as jobsModel from '../helpers/jobs'
 import KonnectorJob, {
@@ -224,7 +224,7 @@ TriggerLauncher.propTypes = {
   initialTrigger: PropTypes.object
 }
 
-export default withLocales(
+export default translate()(
   withClient(
     withMutations(accountsMutations, triggersMutations)(TriggerLauncher)
   )

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 import { withMutations, withClient } from 'cozy-client'
 import { CozyFolder as CozyFolderClass } from 'cozy-doctypes'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 
 import AccountForm from './AccountForm'
 import OAuthForm from './OAuthForm'
@@ -14,7 +15,6 @@ import accounts from '../helpers/accounts'
 import cron from '../helpers/cron'
 import konnectors from '../helpers/konnectors'
 import triggers from '../helpers/triggers'
-import withLocales from './hoc/withLocales'
 import TriggerLauncher from './TriggerLauncher'
 
 const IDLE = 'IDLE'
@@ -300,7 +300,7 @@ TriggerManager.propTypes = {
   statDirectoryByPath: PropTypes.func
 }
 
-const SmartTriggerManager = withLocales(
+const SmartTriggerManager = translate()(
   withMutations(
     accountsMutations,
     filesMutations,

--- a/packages/cozy-harvest-lib/src/index.js
+++ b/packages/cozy-harvest-lib/src/index.js
@@ -1,13 +1,21 @@
-export {
-  default as DeleteAccountButton
-} from './components/DeleteAccountButton'
-export { default as KonnectorModal } from './components/KonnectorModal'
-export {
-  default as withKonnectorModal
-} from './components/hoc/withKonnectorModal'
-export { default as TriggerManager } from './components/TriggerManager'
-export { default as TriggerLauncher } from './components/TriggerLauncher'
-export { default as Routes } from './components/Routes'
+import withLocales from './components/hoc/withLocales'
+
+import DeleteAccountButtonWithoutLocales from './components/DeleteAccountButton'
+import KonnectorModalWithoutLocales from './components/KonnectorModal'
+import TriggerManagerWithoutLocales from './components/TriggerManager'
+import TriggerLauncherWithoutLocales from './components/TriggerLauncher'
+import RoutesWithoutLocales from './components/Routes'
+import withKonnectorModalWithoutLocales from './components/hoc/withKonnectorModal'
+
+// All entry point files need to be exported wrapped with the translation context of harvest
+export const DeleteAccountButton = withLocales(
+  DeleteAccountButtonWithoutLocales
+)
+export const KonnectorModal = withLocales(KonnectorModalWithoutLocales)
+export const TriggerManager = withLocales(TriggerManagerWithoutLocales)
+export const TriggerLauncher = withLocales(TriggerLauncherWithoutLocales)
+export const Routes = withLocales(RoutesWithoutLocales)
+export const withKonnectorModal = withLocales(withKonnectorModalWithoutLocales)
 
 export {
   KonnectorJobError,
@@ -15,3 +23,4 @@ export {
   getErrorLocaleBound
 } from './helpers/konnectors'
 export { handleOAuthResponse } from './helpers/oauth'
+export { withLocales }

--- a/packages/cozy-harvest-lib/test/components/AccountsList/AccountsList.spec.js
+++ b/packages/cozy-harvest-lib/test/components/AccountsList/AccountsList.spec.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import AccountsList from 'components/AccountsList/AccountsList'
+import { AccountsList } from 'components/AccountsList/AccountsList'
 
 describe('AccountsList', () => {
   it('should render', () => {
@@ -23,6 +23,7 @@ describe('AccountsList', () => {
         }}
         addAccount={jest.fn()}
         onPick={jest.fn()}
+        t={jest.fn(str => str)}
       />
     )
     const component = wrapper.shallow()

--- a/packages/cozy-harvest-lib/test/components/AccountsList/__snapshots__/AccountsList.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/AccountsList/__snapshots__/AccountsList.spec.js.snap
@@ -1,39 +1,71 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AccountsList should render 1`] = `
-<I18n
-  defaultLang="en"
-  dictRequire={[Function]}
+<ul
+  className="u-nolist u-p-0 u-m-0"
 >
-  <Wrapper
-    accounts={
-      Array [
+  <li
+    className="u-mb-half"
+  >
+    <AccountsListItem
+      account={
         Object {
-          "account": Object {
-            "_id": "account-1",
-          },
-          "trigger": Object {
-            "_id": "trigger-1",
-          },
-        },
-        Object {
-          "account": Object {
-            "_id": "account-2",
-          },
-          "trigger": Object {
-            "_id": "trigger-2",
-          },
-        },
-      ]
-    }
-    addAccount={[MockFunction]}
-    konnector={
-      Object {
-        "name": "test-konnector",
-        "vendor_link": "test konnector link",
+          "_id": "account-1",
+        }
       }
-    }
-    onPick={[MockFunction]}
-  />
-</I18n>
+      konnector={
+        Object {
+          "name": "test-konnector",
+          "vendor_link": "test konnector link",
+        }
+      }
+      onClick={[Function]}
+      trigger={
+        Object {
+          "_id": "trigger-1",
+        }
+      }
+    />
+  </li>
+  <li
+    className="u-mb-half"
+  >
+    <AccountsListItem
+      account={
+        Object {
+          "_id": "account-2",
+        }
+      }
+      konnector={
+        Object {
+          "name": "test-konnector",
+          "vendor_link": "test konnector link",
+        }
+      }
+      onClick={[Function]}
+      trigger={
+        Object {
+          "_id": "trigger-2",
+        }
+      }
+    />
+  </li>
+  <li
+    className="u-mb-half"
+  >
+    <Card
+      className="u-p-0"
+      tag="div"
+    >
+      <DefaultButton
+        className="u-bdrs-4"
+        extension="full"
+        icon="plus"
+        label="modal.addAccount.button"
+        onClick={[MockFunction]}
+        theme="text"
+      />
+    </Card>
+  </li>
+</ul>
 `;

--- a/packages/cozy-harvest-lib/test/components/KonnectorSuccess.spec.js
+++ b/packages/cozy-harvest-lib/test/components/KonnectorSuccess.spec.js
@@ -1,8 +1,9 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { shallow } from 'enzyme'
 
 import CozyClient, { CozyProvider } from 'cozy-client'
-import KonnectorSuccess, {
+import {
+  KonnectorSuccess,
   BanksLink,
   DriveLink
 } from 'components/KonnectorSuccess'
@@ -23,7 +24,7 @@ describe('KonnectorSuccess', () => {
           vendor_link: 'test konnector link'
         }
     const message = folder_to_save ? { folder_to_save: '/path' } : {}
-    root = mount(
+    root = shallow(
       <CozyProvider client={client}>
         <KonnectorSuccess
           accounts={[
@@ -45,6 +46,7 @@ describe('KonnectorSuccess', () => {
           successButtonLabel="Fake label"
           error={null}
           onDone={() => {}}
+          t={jest.fn(str => str)}
         />
       </CozyProvider>
     )
@@ -52,17 +54,37 @@ describe('KonnectorSuccess', () => {
 
   it('should not show drive if trigger has no folder_to_save', () => {
     setup()
-    expect(root.find(DriveLink).length).toBe(0)
+    expect(
+      root
+        .find(KonnectorSuccess)
+        .dive()
+        .find(DriveLink).length
+    ).toBe(0)
   })
 
   it('should show drive if trigger has a folder_to_save', () => {
     setup({ folder_to_save: 'jjj' })
-    expect(root.find(DriveLink).length).toBe(1)
+    expect(
+      root
+        .find(KonnectorSuccess)
+        .dive()
+        .find(DriveLink).length
+    ).toBe(1)
   })
 
   it('should show banks if connector has datatypes with bankAccounts', () => {
     setup({ isBankingKonnector: true })
-    expect(root.find(DriveLink).length).toBe(0)
-    expect(root.find(BanksLink).length).toBe(1)
+    expect(
+      root
+        .find(KonnectorSuccess)
+        .dive()
+        .find(DriveLink).length
+    ).toBe(0)
+    expect(
+      root
+        .find(KonnectorSuccess)
+        .dive()
+        .find(BanksLink).length
+    ).toBe(1)
   })
 })


### PR DESCRIPTION
There was some confusion going on regarding translations in harvest, where we would use `translate` and `withLocales`.

- `translate` only works if there is a `withLocales` further up the tree
- `withLocales` loads the translation strings, so it should only be needed once
- however harvest exposes multiple components — in order for the to work standalone, they need to use `withLocales`

So now, every component exporter by harvest is wrapped in `withLocales`, and all the others are wrapped in `translate`. I left 2 or 3 exceptions because they are components that I'm not sure how they are used and where, so we'll have to get back to them later.  