### PR TITLE
[Harvest] Show an empty form when editing an account and selected "from another account"

### DIFF
--- a/packages/cozy-doctypes/src/Account.spec.js
+++ b/packages/cozy-doctypes/src/Account.spec.js
@@ -106,9 +106,12 @@ describe('helpers library', () => {
       })
     })
 
-    it('should throw if cipher is not passed as argument', () => {
-      expect(() => Account.fromCipher()).toThrow()
-      expect(() => Account.fromCipher(null)).toThrow()
+    it('should handle null cipher', () => {
+      const account = Account.fromCipher(null)
+
+      expect(account).toEqual({
+        auth: {}
+      })
     })
   })
 })

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -377,7 +377,7 @@ export class TriggerManager extends Component {
   }
 
   cipherToAccount(cipher) {
-    if (cipher === undefined) {
+    if (!this.hasCipherSelected()) {
       return null
     }
 
@@ -396,6 +396,16 @@ export class TriggerManager extends Component {
     if (this.props.error && this.props.error !== prevProps.error) {
       this.setState({ step: 'accountForm' })
     }
+  }
+
+  /**
+   * Tells whether we currently have a cipher selected or not
+   * selectedCipher === undefined means nothing has been selected
+   * selectedCipher === null means « from another account has been selected »
+   * selectedCipher === Object means a cipher has been selected
+   */
+  hasCipherSelected() {
+    return this.state.selectedCipher !== undefined
   }
 
   render() {
@@ -466,7 +476,7 @@ export class TriggerManager extends Component {
               )}
               <AccountForm
                 account={
-                  selectedCipher === undefined
+                  !this.hasCipherSelected()
                     ? account
                     : this.cipherToAccount(selectedCipher)
                 }

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -57,7 +57,7 @@ export class TriggerManager extends Component {
       error: null,
       status: IDLE,
       step: account ? 'accountForm' : 'ciphersList',
-      selectedCipher: null,
+      selectedCipher: undefined,
       showBackButton: false
     }
   }
@@ -377,7 +377,7 @@ export class TriggerManager extends Component {
   }
 
   cipherToAccount(cipher) {
-    if (!cipher) {
+    if (cipher === undefined) {
       return null
     }
 
@@ -385,9 +385,11 @@ export class TriggerManager extends Component {
       this.props.konnector.fields
     )
 
-    return Account.fromCipher(cipher, {
+    const account = Account.fromCipher(cipher, {
       identifierProperty
     })
+
+    return account
   }
 
   componentDidUpdate(prevProps) {
@@ -463,7 +465,11 @@ export class TriggerManager extends Component {
                 />
               )}
               <AccountForm
-                account={account || this.cipherToAccount(selectedCipher)}
+                account={
+                  selectedCipher === undefined
+                    ? account
+                    : this.cipherToAccount(selectedCipher)
+                }
                 error={error || triggerError}
                 konnector={konnector}
                 onSubmit={this.handleSubmit}


### PR DESCRIPTION
We had a bug when we edited an account, then go back to ciphers list and select "from another account". In that case, we showed the account form with a read-only identifier since there is an `account` prop.

This fixes this behavior so we always have an empty account form when we select "from another account".