### PR TITLE
[Harvest] Update identifier overwrite prevention mechanism

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -166,9 +166,9 @@ export class AccountForm extends PureComponent {
     const initialValues = account && account.auth
     const values = manifest.getFieldsValues(konnector, account)
 
-    const isReadOnlyIdentifier = Boolean(
-      get(account, 'relationships.vaultCipher')
-    )
+    const isReadOnlyIdentifier =
+      Boolean(get(account, 'relationships.vaultCipher')) &&
+      this.props.readOnlyIdentifier
 
     if (isReadOnlyIdentifier) {
       const identifier = manifest.getIdentifier(fields)

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -486,6 +486,7 @@ export class TriggerManager extends Component {
                 showError={showError}
                 submitting={submitting}
                 onBack={this.showCiphersList}
+                readOnlyIdentifier={this.hasCipherSelected()}
               />
             </>
           )}

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -323,6 +323,12 @@
     "otherAccount": "From another account…"
   },
   "triggerManager": {
-    "connecting": "Connecting your account..."
+    "connecting": "Connecting your account...",
+    "confirmationModal": {
+      "title": "Update credentials?",
+      "description": "Your previous credentials will be definitively lost. Add a new account to keep them.",
+      "primaryText": "Update",
+      "secondaryText": "Cancel"
+    }
   }
 }

--- a/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
+++ b/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
@@ -413,7 +413,7 @@ describe('AccountForm', () => {
   })
 
   describe('with read-only identifier', () => {
-    it('should render a read-only identifier field if the account has a relationship with a vault cipher', () => {
+    it('should render a read-only identifier field if the account has a relationship with a vault cipher and props.readOnlyIdentifier is true', () => {
       const wrapper = mount(
         <AccountForm
           konnector={fixtures.konnector}
@@ -429,6 +429,7 @@ describe('AccountForm', () => {
               }
             }
           }}
+          readOnlyIdentifier={true}
         />,
         {
           context: { t },

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
@@ -35,6 +35,7 @@ exports[`TriggerManager handleError should render error 1`] = `
         }
         onBack={[Function]}
         onSubmit={[Function]}
+        readOnlyIdentifier={false}
         submitting={false}
       />
     </React.Fragment>
@@ -90,6 +91,7 @@ exports[`TriggerManager should render with account 1`] = `
         }
         onBack={[Function]}
         onSubmit={[Function]}
+        readOnlyIdentifier={false}
         submitting={false}
       />
     </React.Fragment>


### PR DESCRIPTION
Currently, we used a read-only identifier field to prevent the user from overwriting its identifier and losing some credentials. This was causing problems in some situations. For example, when the user entered a bad identifier, he couldn't update it afterwards.

To fix this issue, we decided to show a read-only identifier only when the user selected a cipher in which all required fields are not present.

It means that :

* on account creation
  * if the user selects "from another account" : we never show a read-only field during the creation process
  * if the user selected a cipher that contains all required fields : we don't show the form, so no problem
  * if the user selected an incomplete cipher : we show the form with a read-only identifier
* on account update
  * we never show a read-only field, but if the user updates an identifier, we show a warning modal with confirmation when the form is submitted

There's something missing to have the complete feature in this PR : we should have a link to the account creation form in the warning modal's text.

![image](https://user-images.githubusercontent.com/1606068/67011380-c38a9500-f0ef-11e9-849c-647fd410f4c5.png)