### PR TITLE
fix(cozy-harvest-lib): Go back when dismissing the vault unlocker

### DIFF
--- a/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
@@ -88,12 +88,13 @@ export class EditAccountModal extends Component {
       konnector,
       t,
       history,
-      breakpoints: { isMobile }
+      breakpoints: { isMobile },
+      onDismiss
     } = this.props
     const { trigger, account, fetching } = this.state
     return (
       <Modal
-        dismissAction={() => history.push('../')}
+        dismissAction={onDismiss}
         mobileFullscreen
         size="small"
         closable={isMobile ? false : true}
@@ -131,6 +132,7 @@ export class EditAccountModal extends Component {
               initialTrigger={trigger}
               onSuccess={this.redirectToAccount}
               showError={true}
+              onVaultDismiss={onDismiss}
             />
           )}
         </ModalContent>

--- a/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
@@ -52,6 +52,7 @@ const NewAccountModal = ({
               const accountId = triggersModel.getAccountId(trigger)
               history.push(`../accounts/${accountId}/success`)
             }}
+            onVaultDismiss={() => history.push('..')}
           />
         )}
       </ModalContent>

--- a/packages/cozy-harvest-lib/src/components/Routes.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes.jsx
@@ -66,13 +66,27 @@ const Routes = ({ konnectorRoot, konnector, location, history, onDismiss }) => {
                       konnector={konnector}
                       accountId={match.params.accountId}
                       accounts={accounts}
+                      onDismiss={() =>
+                        history.push(
+                          `${konnectorRoot}/accounts/${match.params.accountId}`
+                        )
+                      }
                     />
                   )}
                 />
                 <Route
                   path={`${konnectorRoot}/new`}
                   exact
-                  render={() => <NewAccountModal konnector={konnector} />}
+                  render={({ match }) => (
+                    <NewAccountModal
+                      konnector={konnector}
+                      onDismiss={() =>
+                        history.push(
+                          `${konnectorRoot}/accounts/${match.params.accountId}`
+                        )
+                      }
+                    />
+                  )}
                 />
                 <Route
                   path={`${konnectorRoot}/accounts/:accountId/success`}


### PR DESCRIPTION
We passed nothing to the `TriggerManager`'s `onVaultDismiss` prop, so nothing happened when we tried to close the `VaultUnlocker` without unlocking it.