### PR TITLE
Harvest/fix: Avoid extra renders and fetches

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModal.jsx
@@ -2,8 +2,8 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
 import get from 'lodash/get'
+import flow from 'lodash/flow'
 import { withMutations } from 'cozy-client'
-import { withRouter } from 'react-router'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import { ModalContent } from 'cozy-ui/transpiled/react/Modal'
 import Infos from 'cozy-ui/transpiled/react/Infos'
@@ -16,6 +16,7 @@ import * as triggersModel from '../helpers/triggers'
 import KonnectorAccountTabs from './KonnectorConfiguration/KonnectorAccountTabs'
 import AccountSelectBox from './AccountSelectBox/AccountSelectBox'
 import KonnectorModalHeader from './KonnectorModalHeader'
+import { withMountPointPushHistory } from './MountPointContext'
 
 /**
  * AccountModal take an accountId and a list of accounts containing their
@@ -95,7 +96,7 @@ export class AccountModal extends Component {
   }
 
   render() {
-    const { konnector, onDismiss, history, accounts, t } = this.props
+    const { konnector, onDismiss, accounts, t, pushHistory } = this.props
     const { trigger, account, fetching, error } = this.state
     return (
       <>
@@ -105,10 +106,10 @@ export class AccountModal extends Component {
               selectedAccount={account}
               accountsList={accounts}
               onChange={option => {
-                history.push(`../${option.account._id}`)
+                pushHistory(`/accounts/${option.account._id}`)
               }}
               onCreate={() => {
-                history.push(`../../new`)
+                pushHistory('/new')
               }}
             />
           )}
@@ -140,7 +141,7 @@ export class AccountModal extends Component {
               trigger={trigger}
               account={account}
               onAccountDeleted={onDismiss}
-              addAccount={() => history.push('../../new')}
+              addAccount={() => pushHistory('/new')}
             />
           )}
         </ModalContent>
@@ -154,12 +155,15 @@ AccountModal.defaultProps = {
 AccountModal.propTypes = {
   konnector: PropTypes.object.isRequired,
   onDismiss: PropTypes.func,
-  history: PropTypes.object.isRequired,
   accounts: PropTypes.array.isRequired,
   t: PropTypes.func.isRequired,
   findAccount: PropTypes.func.isRequired,
+  pushHistory: PropTypes.func.isRequired,
   accountId: PropTypes.string.isRequired
 }
-export default withMutations(accountMutations, triggersMutations)(
-  withRouter(translate()(AccountModal))
-)
+
+export default flow(
+  withMutations(accountMutations, triggersMutations),
+  translate(),
+  withMountPointPushHistory
+)(AccountModal)

--- a/packages/cozy-harvest-lib/src/components/AccountsListModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountsListModal.jsx
@@ -1,41 +1,38 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import PropTypes from 'prop-types'
-import { withRouter } from 'react-router'
 import { ModalContent } from 'cozy-ui/transpiled/react/Modal'
 import Stack from 'cozy-ui/transpiled/react/Stack'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import AccountsList from './AccountsList/AccountsList'
 import KonnectorIcon from './KonnectorIcon'
+import { MountPointContext } from './MountPointContext'
 
-class AccountsListModal extends React.Component {
-  render() {
-    const { konnector, accounts, history, t } = this.props
-    return (
-      <>
-        <ModalContent>
-          <Stack className="u-mb-3">
-            <div className="u-w-3 u-h-3 u-mh-auto">
-              <KonnectorIcon konnector={konnector} />
-            </div>
-            <h3 className="u-title-h3 u-ta-center">
-              {t('modal.accounts.title', { name: konnector.name })}
-            </h3>
-          </Stack>
-          <AccountsList
-            accounts={accounts}
-            konnector={konnector}
-            onPick={option => history.push(`./accounts/${option.account._id}`)}
-            addAccount={() => history.push('./new')}
-          />
-        </ModalContent>
-      </>
-    )
-  }
+const AccountsListModal = ({ konnector, accounts, t }) => {
+  const { pushHistory } = useContext(MountPointContext)
+  return (
+    <>
+      <Stack className="u-mb-3">
+        <div className="u-w-3 u-h-3 u-mh-auto">
+          <KonnectorIcon konnector={konnector} />
+        </div>
+        <h3 className="u-title-h3 u-ta-center">
+          {t('modal.accounts.title', { name: konnector.name })}
+        </h3>
+      </Stack>
+      <ModalContent>
+        <AccountsList
+          accounts={accounts}
+          konnector={konnector}
+          onPick={option => pushHistory(`/accounts/${option.account._id}`)}
+          addAccount={() => pushHistory('/new')}
+        />
+      </ModalContent>
+    </>
+  )
 }
 
 AccountsListModal.propTypes = {
   konnector: PropTypes.object.isRequired,
-  accounts: PropTypes.array.isRequired,
-  history: PropTypes.object.isRequired
+  accounts: PropTypes.array.isRequired
 }
-export default withRouter(translate()(AccountsListModal))
+export default translate()(AccountsListModal)

--- a/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
@@ -2,8 +2,8 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
 import get from 'lodash/get'
+import flow from 'lodash/flow'
 import { withMutations } from 'cozy-client'
-import { withRouter } from 'react-router'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Modal, {
@@ -19,6 +19,7 @@ import accountMutations from '../connections/accounts'
 import triggersMutations from '../connections/triggers'
 import * as triggersModel from '../helpers/triggers'
 import TriggerManager from './TriggerManager'
+import { withMountPointPushHistory } from './MountPointContext'
 
 export class EditAccountModal extends Component {
   constructor(props) {
@@ -29,10 +30,6 @@ export class EditAccountModal extends Component {
       fetching: true,
       error: false
     }
-
-    this.handleAccountEditJobSuccess = this.handleAccountEditJobSuccess.bind(
-      this
-    )
   }
 
   componentDidMount() {
@@ -73,10 +70,6 @@ export class EditAccountModal extends Component {
     }
   }
 
-  handleAccountEditJobSuccess() {
-    this.props.history.push('../')
-  }
-
   render() {
     /**
      * We don't use the dismiss action pros that we can have from our
@@ -89,13 +82,13 @@ export class EditAccountModal extends Component {
     const {
       konnector,
       t,
-      history,
-      breakpoints: { isMobile }
+      breakpoints: { isMobile },
+      pushHistory
     } = this.props
     const { trigger, account, fetching } = this.state
     return (
       <Modal
-        dismissAction={() => history.push('../')}
+        dismissAction={() => pushHistory(`/accounts/${account._id}`)}
         mobileFullscreen
         size="small"
         closable={isMobile ? false : true}
@@ -105,7 +98,7 @@ export class EditAccountModal extends Component {
         <ModalHeader className="u-bg-dodgerBlue u-p-0 u-h-3 u-flex u-flex-items-center">
           {isMobile && (
             <Button
-              onClick={() => history.push('../')}
+              onClick={() => pushHistory(`/accounts/${account._id}`)}
               icon="previous"
               label={t('back')}
               iconOnly
@@ -131,7 +124,7 @@ export class EditAccountModal extends Component {
               account={account}
               konnector={konnector}
               initialTrigger={trigger}
-              onSuccess={this.handleAccountEditJobSuccess}
+              onSuccess={() => pushHistory(`/accounts/${account._id}`)}
               showError={true}
             />
           )}
@@ -144,7 +137,6 @@ export class EditAccountModal extends Component {
 EditAccountModal.propTypes = {
   konnector: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
-  history: PropTypes.object.isRequired,
   breakpoints: PropTypes.object.isRequired,
   accountId: PropTypes.string.isRequired,
   accounts: PropTypes.array.isRequired,
@@ -152,6 +144,9 @@ EditAccountModal.propTypes = {
   fetchTrigger: PropTypes.func.isRequired
 }
 
-export default withMutations(accountMutations, triggersMutations)(
-  withBreakpoints()(withRouter(translate()(EditAccountModal)))
-)
+export default flow(
+  withMutations(accountMutations, triggersMutations),
+  withBreakpoints(),
+  translate(),
+  withMountPointPushHistory
+)(EditAccountModal)

--- a/packages/cozy-harvest-lib/src/components/HarvestModalRoot.jsx
+++ b/packages/cozy-harvest-lib/src/components/HarvestModalRoot.jsx
@@ -1,0 +1,28 @@
+import React, { useContext } from 'react'
+import PropTypes from 'prop-types'
+import AccountsListModal from './AccountsListModal'
+import { MountPointContext } from './MountPointContext'
+
+const HarvestModalRoot = ({ accounts, konnector }) => {
+  const { pushHistory } = useContext(MountPointContext)
+  if (accounts.length === 0) {
+    pushHistory('/new')
+    return null
+  } else if (accounts.length === 1) {
+    pushHistory(`/accounts/${accounts[0].account._id}`)
+    return null
+  } else {
+    return <AccountsListModal konnector={konnector} accounts={accounts} />
+  }
+}
+
+HarvestModalRoot.propTypes = {
+  accounts: PropTypes.array,
+  konnector: PropTypes.object.isRequired
+}
+
+HarvestModalRoot.defaultProps = {
+  accounts: []
+}
+
+export default HarvestModalRoot

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import PropTypes from 'prop-types'
 
 import {
@@ -16,7 +16,6 @@ import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Stack from 'cozy-ui/transpiled/react/Stack'
 import palette from 'cozy-ui/transpiled/react/palette'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
-import { withRouter } from 'react-router'
 import { Account } from 'cozy-doctypes'
 import get from 'lodash/get'
 import has from 'lodash/has'
@@ -33,6 +32,7 @@ import DeleteAccountButton from '../DeleteAccountButton'
 import TriggerLauncher from '../TriggerLauncher'
 import KonnectorMaintenance from '../Maintenance'
 import useMaintenanceStatus from '../hooks/useMaintenanceStatus'
+import { MountPointContext } from '../MountPointContext'
 
 const KonnectorAccountTabs = ({
   konnector,
@@ -41,11 +41,11 @@ const KonnectorAccountTabs = ({
   onAccountDeleted,
   //TODO on``
   addAccount,
-  history,
   client,
   t
 }) => {
   const maintenanceStatus = useMaintenanceStatus(client, konnector.slug)
+  const { pushHistory } = useContext(MountPointContext)
 
   return (
     <TriggerLauncher initialTrigger={initialTrigger}>
@@ -131,7 +131,9 @@ const KonnectorAccountTabs = ({
                     </Uppercase>
                     <Card
                       className="u-flex u-flex-items-center u-c-pointer"
-                      onClick={() => history.push('./edit')}
+                      onClick={() =>
+                        pushHistory(`/accounts/${account._id}/edit`)
+                      }
                     >
                       <div className="u-w-2 u-mr-1">
                         <Icon
@@ -178,12 +180,10 @@ KonnectorAccountTabs.propTypes = {
   account: PropTypes.object.isRequired,
   onAccountDeleted: PropTypes.func.isRequired,
   addAccount: PropTypes.func.isRequired,
-  t: PropTypes.func.isRequired,
-  history: PropTypes.object.isRequired
+  t: PropTypes.func.isRequired
 }
 
 export default flow(
   translate(),
-  withRouter,
   withClient
 )(KonnectorAccountTabs)

--- a/packages/cozy-harvest-lib/src/components/MountPointContext.jsx
+++ b/packages/cozy-harvest-lib/src/components/MountPointContext.jsx
@@ -1,0 +1,56 @@
+import React, { useContext } from 'react'
+import PropTypes from 'prop-types'
+import { withRouter } from 'react-router'
+
+const MountPointContext = React.createContext()
+
+export class RawMountPointProvider extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.pushHistory = this.pushHistory.bind(this)
+
+    this.state = {
+      baseRoute: props.baseRoute || '/',
+      pushHistory: this.pushHistory
+    }
+  }
+
+  pushHistory(route) {
+    const { history } = this.props
+    const { baseRoute } = this.state
+    const segments = baseRoute
+      .split('/')
+      .concat(route.split('/'))
+      .filter(Boolean)
+    history.push(`/${segments.join('/')}`)
+  }
+
+  render() {
+    return (
+      <MountPointContext.Provider value={this.state}>
+        {this.props.children}
+      </MountPointContext.Provider>
+    )
+  }
+}
+
+RawMountPointProvider.propTypes = {
+  baseRoute: PropTypes.string,
+  history: PropTypes.object
+}
+
+const withMountPointPushHistory = BaseComponent => {
+  const Component = props => {
+    const { pushHistory } = useContext(MountPointContext)
+    return <BaseComponent pushHistory={pushHistory} {...props} />
+  }
+
+  Component.displayName = `const withMountPointPushHistory(${BaseComponent.displayName ||
+    BaseComponent.name})`
+
+  return Component
+}
+
+const MountPointProvider = withRouter(RawMountPointProvider)
+export { MountPointContext, MountPointProvider, withMountPointPushHistory }

--- a/packages/cozy-harvest-lib/src/components/MountPointContext.jsx
+++ b/packages/cozy-harvest-lib/src/components/MountPointContext.jsx
@@ -46,7 +46,7 @@ const withMountPointPushHistory = BaseComponent => {
     return <BaseComponent pushHistory={pushHistory} {...props} />
   }
 
-  Component.displayName = `const withMountPointPushHistory(${BaseComponent.displayName ||
+  Component.displayName = `withMountPointPushHistory(${BaseComponent.displayName ||
     BaseComponent.name})`
 
   return Component

--- a/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
@@ -1,6 +1,5 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import PropTypes from 'prop-types'
-import { withRouter } from 'react-router'
 import { withClient } from 'cozy-client'
 
 import { ModalContent } from 'cozy-ui/transpiled/react/Modal'
@@ -13,6 +12,7 @@ import KonnectorIcon from './KonnectorIcon'
 import * as triggersModel from '../helpers/triggers'
 import KonnectorMaintenance from './Maintenance'
 import useMaintenanceStatus from './hooks/useMaintenanceStatus'
+import { MountPointContext } from './MountPointContext'
 
 /**
  * We need to deal with `onLoginSuccess` and `onSucess` because we
@@ -20,7 +20,8 @@ import useMaintenanceStatus from './hooks/useMaintenanceStatus'
  * few konnectors know if the login is success or not.
  *
  */
-const NewAccountModal = ({ konnector, history, client, t }) => {
+const NewAccountModal = ({ konnector, client, t }) => {
+  const { pushHistory } = useContext(MountPointContext)
   const maintenanceStatus = useMaintenanceStatus(client, konnector.slug)
   const isInMaintenance = maintenanceStatus.isInMaintenance
   const maintenanceMessages = maintenanceStatus.messages
@@ -43,11 +44,11 @@ const NewAccountModal = ({ konnector, history, client, t }) => {
             konnector={konnector}
             onLoginSuccess={trigger => {
               const accountId = triggersModel.getAccountId(trigger)
-              history.push(`../accounts/${accountId}/success`)
+              pushHistory(`/accounts/${accountId}/success`)
             }}
             onSuccess={trigger => {
               const accountId = triggersModel.getAccountId(trigger)
-              history.push(`../accounts/${accountId}/success`)
+              pushHistory(`/accounts/${accountId}/success`)
             }}
           />
         )}
@@ -57,12 +58,10 @@ const NewAccountModal = ({ konnector, history, client, t }) => {
 }
 
 NewAccountModal.propTypes = {
-  konnector: PropTypes.object.isRequired,
-  history: PropTypes.object.isRequired
+  konnector: PropTypes.object.isRequired
 }
 
 export default flow(
-  withRouter,
   translate(),
   withClient
 )(NewAccountModal)

--- a/packages/cozy-harvest-lib/src/components/Routes.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes.jsx
@@ -1,95 +1,80 @@
 import React from 'react'
-import { Switch, Route, Redirect, withRouter } from 'react-router'
+import { Switch, Route, Redirect } from 'react-router'
 import Modal from 'cozy-ui/transpiled/react/Modal'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 
 import KonnectorAccounts from './KonnectorAccounts'
-import AccountsListModal from './AccountsListModal'
 import AccountModal from './AccountModal'
 import NewAccountModal from './NewAccountModal'
 import EditAccountModal from './EditAccountModal'
 import KonnectorSuccess from './KonnectorSuccess'
+import HarvestModalRoot from './HarvestModalRoot'
 
-const Routes = ({ konnectorRoot, konnector, location, history, onDismiss }) => {
-  // we need to make sure the path ends with a / for relative links to work
-  if (!location.pathname.endsWith('/')) {
-    history.replace(`${location.pathname}/`)
-    return null
-  }
+import { MountPointProvider } from './MountPointContext'
 
+const Routes = ({ konnectorRoot, konnector, onDismiss }) => {
   return (
-    <Modal dismissAction={onDismiss} mobileFullscreen size="small">
-      <KonnectorAccounts konnector={konnector}>
-        {accounts => (
-          <Switch>
-            <Route
-              path={`${konnectorRoot}/`}
-              exact
-              render={() => {
-                if (accounts.length === 0) {
-                  history.push('./new')
-                  return null
-                } else if (accounts.length === 1) {
-                  history.push(`./accounts/${accounts[0].account._id}`)
-                  return null
-                } else {
-                  return (
-                    <AccountsListModal
-                      konnector={konnector}
-                      accounts={accounts}
-                    />
-                  )
-                }
-              }}
-            />
-            <Route
-              path={`${konnectorRoot}/accounts/:accountId`}
-              exact
-              render={({ match }) => (
-                <AccountModal
-                  konnector={konnector}
-                  accountId={match.params.accountId}
-                  accounts={accounts}
-                  onDismiss={onDismiss}
-                />
-              )}
-            />
-            <Route
-              path={`${konnectorRoot}/accounts/:accountId/edit`}
-              exact
-              render={({ match }) => (
-                <EditAccountModal
-                  konnector={konnector}
-                  accountId={match.params.accountId}
-                  accounts={accounts}
-                />
-              )}
-            />
-            <Route
-              path={`${konnectorRoot}/new`}
-              exact
-              render={() => <NewAccountModal konnector={konnector} />}
-            />
-            <Route
-              path={`${konnectorRoot}/accounts/:accountId/success`}
-              exact
-              render={({ match }) => {
-                return (
-                  <KonnectorSuccess
+    <MountPointProvider baseRoute={konnectorRoot}>
+      <Modal dismissAction={onDismiss} mobileFullscreen size="small">
+        <KonnectorAccounts konnector={konnector}>
+          {accounts => (
+            <Switch>
+              <Route
+                path={`${konnectorRoot}/`}
+                exact
+                render={() => (
+                  <HarvestModalRoot accounts={accounts} konnector={konnector} />
+                )}
+              />
+              <Route
+                path={`${konnectorRoot}/accounts/:accountId`}
+                exact
+                render={({ match }) => (
+                  <AccountModal
                     konnector={konnector}
                     accountId={match.params.accountId}
                     accounts={accounts}
                     onDismiss={onDismiss}
                   />
-                )
-              }}
-            />
-            <Redirect from={`${konnectorRoot}/*`} to={`${konnectorRoot}/`} />
-          </Switch>
-        )}
-      </KonnectorAccounts>
-    </Modal>
+                )}
+              />
+              <Route
+                path={`${konnectorRoot}/accounts/:accountId/edit`}
+                exact
+                render={({ match }) => (
+                  <EditAccountModal
+                    konnector={konnector}
+                    accountId={match.params.accountId}
+                    accounts={accounts}
+                  />
+                )}
+              />
+              <Route
+                path={`${konnectorRoot}/new`}
+                exact
+                render={() => <NewAccountModal konnector={konnector} />}
+              />
+              <Route
+                path={`${konnectorRoot}/accounts/:accountId/success`}
+                exact
+                render={({ match }) => {
+                  return (
+                    <KonnectorSuccess
+                      konnector={konnector}
+                      accountId={match.params.accountId}
+                      accounts={accounts}
+                      onDismiss={onDismiss}
+                    />
+                  )
+                }}
+              />
+              <Redirect from={`${konnectorRoot}/*`} to={`${konnectorRoot}/`} />
+            </Switch>
+          )}
+        </KonnectorAccounts>
+      </Modal>
+    </MountPointProvider>
   )
 }
 
-export default withRouter(translate()(Routes))
+export default translate()(Routes)

--- a/packages/cozy-harvest-lib/test/components/AccountModal.spec.jsx
+++ b/packages/cozy-harvest-lib/test/components/AccountModal.spec.jsx
@@ -35,15 +35,13 @@ describe('AccountModal', () => {
       _id: '123',
       name: 'account 1'
     })
-    const mockHistory = {
-      push: jest.fn()
-    }
+    const mockHistoryPush = jest.fn()
     const component = shallow(
       <AccountModal
         accountId={accountIdMock}
         accounts={accountsMock}
         findAccount={findAccount}
-        history={mockHistory}
+        pushHistory={mockHistoryPush}
       />
     )
 
@@ -70,14 +68,14 @@ describe('AccountModal', () => {
       component.find('AccountSelectBox').prop('onChange')({
         account: { _id: '123' }
       })
-      expect(mockHistory.push).toHaveBeenCalledWith('../123')
+      expect(mockHistoryPush).toHaveBeenCalledWith('/accounts/123')
 
       component.find('AccountSelectBox').prop('onCreate')()
-      expect(mockHistory.push).toHaveBeenCalledWith('../../new')
+      expect(mockHistoryPush).toHaveBeenCalledWith('/new')
 
       const ModalContent = component.find('ModalContent').childAt(0)
       ModalContent.prop('addAccount')()
-      expect(mockHistory.push).toHaveBeenCalledWith('../../new')
+      expect(mockHistoryPush).toHaveBeenCalledWith('/new')
     })
   })
 })

--- a/packages/cozy-harvest-lib/test/components/MountPointContext.spec.jsx
+++ b/packages/cozy-harvest-lib/test/components/MountPointContext.spec.jsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { RawMountPointProvider } from 'components/MountPointContext'
+
+describe('MountPointProvider', () => {
+  const historyMock = { push: jest.fn() }
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should push to the correct route', () => {
+    const component = shallow(
+      <RawMountPointProvider baseRoute="/root" history={historyMock} />
+    )
+
+    component.instance().pushHistory('/one')
+    expect(historyMock.push).toHaveBeenCalledWith('/root/one')
+
+    component.instance().pushHistory('/one/two')
+    expect(historyMock.push).toHaveBeenCalledWith('/root/one/two')
+
+    component.instance().pushHistory('no/slash')
+    expect(historyMock.push).toHaveBeenCalledWith('/root/no/slash')
+
+    component.instance().pushHistory('too/many///slashes')
+    expect(historyMock.push).toHaveBeenCalledWith('/root/too/many/slashes')
+  })
+
+  it('should handle a trailing slash in the base route', () => {
+    const component = shallow(
+      <RawMountPointProvider baseRoute="/root/" history={historyMock} />
+    )
+
+    component.instance().pushHistory('/one')
+    expect(historyMock.push).toHaveBeenCalledWith('/root/one')
+
+    component.instance().pushHistory('no/slash')
+    expect(historyMock.push).toHaveBeenCalledWith('/root/no/slash')
+  })
+
+  it('should handle a base route with multiple segments', () => {
+    const component = shallow(
+      <RawMountPointProvider baseRoute="/base/route/" history={historyMock} />
+    )
+
+    component.instance().pushHistory('/one')
+    expect(historyMock.push).toHaveBeenCalledWith('/base/route/one')
+
+    component.instance().pushHistory('/one/two')
+    expect(historyMock.push).toHaveBeenCalledWith('/base/route/one/two')
+  })
+})

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountModal.spec.jsx.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountModal.spec.jsx.snap
@@ -53,7 +53,7 @@ exports[`AccountModal with an account should display the AccountSelect & Content
     />
   </KonnectorModalHeader>
   <ModalContent>
-    <withClient(withRouter(Wrapper))
+    <withClient(Wrapper)
       account={
         Object {
           "_id": "123",
@@ -110,7 +110,7 @@ exports[`AccountModal with an account should display the AccountSelect & Content
     />
   </KonnectorModalHeader>
   <ModalContent>
-    <withClient(withRouter(Wrapper))
+    <withClient(Wrapper)
       account={
         Object {
           "_id": "account_2",

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/KonnectorModal.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/KonnectorModal.spec.js.snap
@@ -29,7 +29,7 @@ exports[`KonnectorModal adding an account should render the form when controlled
 
 exports[`KonnectorModal should render the selected account via a prop 1`] = `
 <ModalContent>
-  <withClient(withRouter(Wrapper))
+  <withClient(Wrapper)
     account={
       Object {
         "_id": "123",
@@ -98,7 +98,7 @@ exports[`KonnectorModal should show an error view 1`] = `
 
 exports[`KonnectorModal should show the configuration view of a single account 1`] = `
 <ModalContent>
-  <withClient(withRouter(Wrapper))
+  <withClient(Wrapper)
     account={
       Object {
         "_id": "123",
@@ -187,7 +187,7 @@ exports[`KonnectorModal should show the list of accounts 1`] = `
 
 exports[`KonnectorModal switching account should show the add account view when controlled by state 1`] = `
 <ModalContent>
-  <withClient(withRouter(Wrapper))
+  <withClient(Wrapper)
     account={
       Object {
         "_id": "123",


### PR DESCRIPTION
In order for the relative routes to work properly in harvest, we had to make sure that we are always on a URL ending with a trailing slash (otherwise redirecting from `/one/to` using `history.push('./three')` ends up on `/one/three`). We had a redirect in place that handled this, but whenever it was triggered, it returned `null`. This in turn unmounted the harvest react tree, and upon being remounted, we were fetching data from the network that we already had.

Instead of further trying to work around the limitations of react-router and relative routes, I implemented a solution discussed in #832. It takes the form of a react context applied to harvest that exposes a `pushHistory` function. This function makes sure we end up on the correct route, regardless of slashes.