### PR TITLE
Harvest/fix: Make modal top edges round

### DIFF
--- a/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
@@ -100,9 +100,10 @@ export class EditAccountModal extends Component {
         size="small"
         closable={isMobile ? false : true}
         closeBtnColor={palette.white}
+        className="u-bg-dodgerBlue"
       >
         {/** TODO Should be moved to UI when this design is stablized  */}
-        <ModalHeader className="u-bg-dodgerBlue u-p-0 u-h-3 u-flex u-flex-items-center">
+        <ModalHeader className="u-mb-0 u-p-0 u-h-3 u-flex u-flex-items-center">
           {isMobile && (
             <Button
               onClick={() => history.push('../')}
@@ -121,7 +122,7 @@ export class EditAccountModal extends Component {
             <Text className="u-white">{konnector.name}</Text>
           </div>
         </ModalHeader>
-        <ModalContent>
+        <ModalContent className="u-pt-1-half">
           {fetching ? (
             <div className="u-pv-2 u-ta-center">
               <Spinner size="xxlarge" />


### PR DESCRIPTION
Our modals have rounded edges, but they are defined on the `Modal` component. The `ModalHeader` has square edges, and giving it a background color makes them stand out. Same goes for the `BrandedModalHeader`. 

I've added this issue to our list of things-to-specify with @joel-costa for our Modal rework and found a workaround for this case (giving the whole modal a background color)