### PR TITLE
fix: Use initial trigger running status

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerLauncher.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerLauncher.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import get from 'lodash/get'
 import { withClient, withMutations } from 'cozy-client'
 import CozyRealtime from 'cozy-realtime'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
@@ -44,7 +45,8 @@ export class TriggerLauncher extends Component {
     this.state = {
       showTwoFAModal: false,
       trigger: initialTrigger,
-      error: triggersModel.getKonnectorJobError(initialTrigger)
+      error: triggersModel.getKonnectorJobError(initialTrigger),
+      running: get(initialTrigger, 'current_state.status') === 'running'
     }
 
     this.dismissTwoFAModal = this.dismissTwoFAModal.bind(this)

--- a/packages/cozy-harvest-lib/test/components/TriggerLauncher.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerLauncher.spec.js
@@ -68,20 +68,39 @@ describe('TriggerLauncher', () => {
     )
 
     const childWrapper = wrapper.find(Child)
-    const childProps = childWrapper.props()
-    expect(typeof childProps.launch).toBe('function')
+    const launchProp = childWrapper.prop('launch')
+    expect(typeof launchProp).toBe('function')
   })
 
-  it('should inject running prop', () => {
-    const wrapper = shallow(
-      <TriggerLauncher {...props}>
-        {({ running }) => <Child running={running} />}
-      </TriggerLauncher>
-    )
+  describe('running prop', () => {
+    it('should inject running prop', () => {
+      const wrapper = shallow(
+        <TriggerLauncher {...props}>
+          {({ running }) => <Child running={running} />}
+        </TriggerLauncher>
+      )
 
-    const childWrapper = wrapper.find(Child)
-    const childProps = childWrapper.props()
-    expect(typeof childProps.running).toBe('boolean')
+      const childWrapper = wrapper.find(Child)
+      const runningProp = childWrapper.prop('running')
+      expect(typeof runningProp).toBe('boolean')
+      expect(runningProp).toBe(false)
+    })
+
+    it('should get the initial running status', () => {
+      const initialTrigger = {
+        _id: 123,
+        current_state: { status: 'running' }
+      }
+      const wrapper = shallow(
+        <TriggerLauncher {...props} initialTrigger={initialTrigger}>
+          {({ running }) => <Child running={running} />}
+        </TriggerLauncher>
+      )
+
+      const childWrapper = wrapper.find(Child)
+      const runningProp = childWrapper.prop('running')
+      expect(runningProp).toBe(true)
+    })
   })
 
   describe('launch', () => {


### PR DESCRIPTION
Until a trigger is launched, the `TriggerLauncher` component uses the `initialTrigger` prop to pass down the correct information. However we were ignoring the current status, so if the `initialTrigger` said that the job was running, we were suppressing this information.