### PR TITLE
feat: Support 2fa flow done on mobile/app

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -19,7 +19,7 @@
     "deploy:doc": "(cd ../.. && yarn deploy:doc)",
     "prebuild": "yarn tx",
     "prepublishOnly": "yarn build",
-    "test": "jest test/ --verbose",
+    "test": "env USE_REACT=true jest test/ --verbose",
     "lint": "cd .. && yarn lint packages/cozy-harvest-lib",
     "tx": "tx pull --all",
     "watch": "yarn build --watch",

--- a/packages/cozy-harvest-lib/src/components/KonnectorIcon.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorIcon.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { withClient } from 'cozy-client'
 import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
 
+// TODO move this to cozy-ui
 class KonnectorIcon extends PureComponent {
   fetchIcon() {
     const { konnector, client } = this.props
@@ -13,7 +14,9 @@ class KonnectorIcon extends PureComponent {
   }
 
   render() {
-    return <AppIcon fetchIcon={this.fetchIcon.bind(this)} />
+    // eslint-disable-next-line no-unused-vars
+    const { client, konnector, ...restProps } = this.props
+    return <AppIcon fetchIcon={this.fetchIcon.bind(this)} {...restProps} />
   }
 }
 

--- a/packages/cozy-harvest-lib/src/components/TriggerLauncher.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerLauncher.jsx
@@ -99,12 +99,12 @@ export class TriggerLauncher extends Component {
     this.konnectorJob.launch()
   }
 
-  dismissTwoFAModal() {
-    this.setState({ showTwoFAModal: false })
+  dismissTwoFAModal(account) {
+    this.setState({ showTwoFAModal: false, account })
   }
 
-  displayTwoFAModal() {
-    this.setState({ showTwoFAModal: true })
+  displayTwoFAModal(account) {
+    this.setState({ showTwoFAModal: true, account })
   }
 
   async handleError(error) {
@@ -166,7 +166,7 @@ export class TriggerLauncher extends Component {
   }
 
   render() {
-    const { error, running, showTwoFAModal, trigger } = this.state
+    const { error, running, showTwoFAModal, trigger, account } = this.state
 
     const { children, submitting } = this.props
     return (
@@ -182,6 +182,7 @@ export class TriggerLauncher extends Component {
             dismissAction={this.dismissTwoFAModal}
             into="coz-harvest-modal-place"
             konnectorJob={this.konnectorJob}
+            account={account}
           />
         )}
       </div>

--- a/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react'
 
-import { withClient } from 'cozy-client'
 import Modal, {
   ModalDescription,
   ModalHeader
@@ -9,9 +8,9 @@ import Text, { SubTitle, Caption } from 'cozy-ui/transpiled/react/Text'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import Button from 'cozy-ui/transpiled/react/Button'
 import Field from 'cozy-ui/transpiled/react/Field'
-import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
 import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
 import PropTypes from 'prop-types'
+import KonnectorIcon from './KonnectorIcon'
 
 import { TWO_FA_MISMATCH_EVENT } from '../models/KonnectorJob'
 
@@ -22,7 +21,6 @@ export class TwoFAModal extends PureComponent {
     this.handleChange = this.handleChange.bind(this)
     this.handleTwoFAMismatch = this.handleTwoFAMismatch.bind(this)
     this.handleSubmit = this.handleSubmit.bind(this)
-    this.fetchIcon = this.fetchIcon.bind(this)
   }
 
   componentDidMount() {
@@ -45,19 +43,14 @@ export class TwoFAModal extends PureComponent {
     this.forceUpdate()
   }
 
-  fetchIcon() {
-    const { client } = this.context
-    const { konnectorJob } = this.props
-    return client.stackClient.getIconURL({
-      type: 'konnector',
-      slug: konnectorJob.getKonnectorSlug()
-    })
-  }
-
   render() {
     const { dismissAction, konnectorJob, t, breakpoints = {} } = this.props
     const { isMobile } = breakpoints
     const { twoFACode } = this.state
+
+    const konn = {
+      slug: konnectorJob.getKonnectorSlug()
+    }
 
     return (
       <Modal
@@ -66,9 +59,10 @@ export class TwoFAModal extends PureComponent {
         containerClassName="u-pos-absolute"
         className={isMobile ? '' : 'u-mt-3'}
         size="xsmall"
+        into="body"
       >
         <ModalHeader>
-          <AppIcon fetchIcon={this.fetchIcon} className="u-mah-3 u-ml-1" />
+          <KonnectorIcon konnector={konn} className="u-mah-3 u-ml-1" />
         </ModalHeader>
         <ModalDescription>
           <form onSubmit={this.handleSubmit}>
@@ -106,8 +100,7 @@ export class TwoFAModal extends PureComponent {
 }
 
 TwoFAModal.propTypes = {
-  client: PropTypes.object,
   konnectorJob: PropTypes.object.isRequired
 }
 
-export default withClient(translate()(withBreakpoints()(TwoFAModal)))
+export default translate()(withBreakpoints()(TwoFAModal))

--- a/packages/cozy-harvest-lib/src/components/TwoFAModal.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/TwoFAModal.spec.jsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { TwoFAModal } from './TwoFAModal'
+
+jest.mock('./KonnectorIcon', () => () => null)
+
+describe('TwoFAModal', () => {
+  const setup = ({ konnectorSlug, account }) => {
+    const konnJob = {
+      isTwoFARetry: jest.fn(),
+      getKonnectorSlug: () => konnectorSlug,
+      on: jest.fn(),
+      isTwoFARunning: jest.fn()
+    }
+    const client = {}
+    const root = mount(
+      <TwoFAModal
+        dismissAction={jest.fn()}
+        konnectorJob={konnJob}
+        t={x => x}
+        breakpoints={{ isMobile: true }}
+        account={account}
+        client={client}
+      />
+    )
+    return { root }
+  }
+
+  it('should work even with unknown 2FA', () => {
+    const opts = {
+      account: {
+        state: 'TWO_FA_NEEDED.UNKNOWN'
+      },
+      konnectorSlug: 'boursoma83'
+    }
+    const { root } = setup(opts)
+
+    // show an input by default
+    expect(root.find('input').length).toBe(1)
+    expect(root.text()).toContain('twoFAForm.desc')
+  })
+
+  it('should work', () => {
+    const opts = {
+      account: {
+        state: 'TWO_FA_NEEDED.APP'
+      },
+      konnectorSlug: 'boursoma83'
+    }
+    const { root } = setup(opts)
+    // no input for app two fa
+    expect(root.find('input').length).toBe(0)
+    expect(root.text()).toContain('twoFAForm.desc')
+  })
+})

--- a/packages/cozy-harvest-lib/src/helpers/accounts.js
+++ b/packages/cozy-harvest-lib/src/helpers/accounts.js
@@ -5,9 +5,22 @@ import manifest from './manifest'
 
 const DEFAULT_TWOFA_CODE_PROVIDER_TYPE = 'default'
 
-const PROVIDERS = {
+export const TWOFA_PROVIDERS = {
   EMAIL: 'email',
-  SMS: 'sms'
+  SMS: 'sms',
+  APP: 'app'
+}
+
+// For some 2FA modes, we do not need user input, this is for example the
+// case for the "app" two fa where the user will open the website/app of the
+// provider and click on a notification or a button. For those modes, we
+// does not need to show an input field with a submit button. We only have
+// to wait, the konnector should tell us when everything is OK.
+export const TWOFA_USER_INPUT = {
+  default: true,
+  [TWOFA_PROVIDERS.EMAIL]: true,
+  [TWOFA_PROVIDERS.SMS]: true,
+  [TWOFA_PROVIDERS.APP]: false
 }
 
 const TWOFA_NEEDED_STATUS = 'TWOFA_NEEDED'
@@ -49,7 +62,7 @@ export const getTwoFACodeProvider = account => {
   if (!account || !account.state) return DEFAULT_TWOFA_CODE_PROVIDER_TYPE
   const codeParts = account.state ? account.state.split('.') : []
   if (codeParts.length > 1) {
-    return PROVIDERS[codeParts[1]] || DEFAULT_TWOFA_CODE_PROVIDER_TYPE
+    return TWOFA_PROVIDERS[codeParts[1]] || DEFAULT_TWOFA_CODE_PROVIDER_TYPE
   } else {
     return DEFAULT_TWOFA_CODE_PROVIDER_TYPE
   }

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -315,9 +315,11 @@
     "providers": {
       "default": "Enter the code sent to you by e-mail or SMS",
       "email": "Enter the code sent to you by e-mail",
-      "sms": "Enter the code sent to you by SMS"
+      "sms": "Enter the code sent to you by SMS",
+      "app": "Please check your provider app to authenticate"
     },
     "desc": "This code allows you to finish your connexion.",
+    "desc-2fa": "You need to open your provider's app and/or click on a notification to confirm your authentication.",
     "code": {
       "label": "code"
     },

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerLauncher.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerLauncher.spec.js.snap
@@ -42,7 +42,7 @@ exports[`TriggerLauncher handleTwoFA should display Two FA modal 1`] = `
     launch={[Function]}
     running={false}
   />
-  <withClient(Wrapper)
+  <Wrapper
     dismissAction={[Function]}
     into="coz-harvest-modal-place"
   />


### PR DESCRIPTION
This is called the decoupled flow because the 2FA is done on another device
   than the one where the user logs in. This means that we do not need to show
   a user input and a submit button in the 2FA modal.

![Image collée à 2019-10-21 16-44](https://user-images.githubusercontent.com/465582/67229443-9ade0480-f43b-11e9-8dfb-64556a1f151e.png)


- [x] The icon is working now.
- [ ] Translations on transifex
