### PR TITLE
feat(cozy-harvest-lib): Make TriggerManager usable standalone

### DIFF
--- a/packages/cozy-harvest-lib/__mocks__/cozy-ui/transpiled/react/utils/color.js
+++ b/packages/cozy-harvest-lib/__mocks__/cozy-ui/transpiled/react/utils/color.js
@@ -1,0 +1,1 @@
+export const getCssVariableValue = () => '#fff'

--- a/packages/cozy-harvest-lib/src/components/MountPointContext.jsx
+++ b/packages/cozy-harvest-lib/src/components/MountPointContext.jsx
@@ -23,10 +23,6 @@ export class RawMountPointProvider extends React.Component {
       .split('/')
       .concat(route.split('/'))
       .filter(Boolean)
-    console.log({
-      baseRoute,
-      route
-    })
     history.push(`/${segments.join('/')}`)
   }
 
@@ -46,7 +42,6 @@ RawMountPointProvider.propTypes = {
 
 const withMountPointPushHistory = BaseComponent => {
   const Component = props => {
-    console.log(useContext)
     const { pushHistory } = useContext(MountPointContext)
     return <BaseComponent pushHistory={pushHistory} {...props} />
   }

--- a/packages/cozy-harvest-lib/src/components/Routes.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes.jsx
@@ -2,14 +2,12 @@ import React from 'react'
 import { Switch, Route, Redirect } from 'react-router'
 import Modal from 'cozy-ui/transpiled/react/Modal'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
-import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 
 import KonnectorAccounts from './KonnectorAccounts'
 import AccountModal from './AccountModal'
 import NewAccountModal from './NewAccountModal'
 import EditAccountModal from './EditAccountModal'
 import KonnectorSuccess from './KonnectorSuccess'
-import HarvestVaultProvider from './HarvestVaultProvider'
 import HarvestModalRoot from './HarvestModalRoot'
 import { MountPointProvider } from './MountPointContext'
 
@@ -17,77 +15,67 @@ const Routes = ({ konnectorRoot, konnector, onDismiss }) => {
   return (
     <MountPointProvider baseRoute={konnectorRoot}>
       <Modal dismissAction={onDismiss} mobileFullscreen size="small">
-        <MuiCozyTheme>
-          <HarvestVaultProvider>
-            <KonnectorAccounts konnector={konnector}>
-              {accounts => (
-                <Switch>
-                  <Route
-                    path={`${konnectorRoot}/`}
-                    exact
-                    render={() => (
-                      <HarvestModalRoot
-                        accounts={accounts}
-                        konnector={konnector}
-                      />
-                    )}
+        <KonnectorAccounts konnector={konnector}>
+          {accounts => (
+            <Switch>
+              <Route
+                path={`${konnectorRoot}/`}
+                exact
+                render={() => (
+                  <HarvestModalRoot accounts={accounts} konnector={konnector} />
+                )}
+              />
+              <Route
+                path={`${konnectorRoot}/accounts/:accountId`}
+                exact
+                render={({ match }) => (
+                  <AccountModal
+                    konnector={konnector}
+                    accountId={match.params.accountId}
+                    accounts={accounts}
+                    onDismiss={onDismiss}
                   />
-                  <Route
-                    path={`${konnectorRoot}/accounts/:accountId`}
-                    exact
-                    render={({ match }) => (
-                      <AccountModal
-                        konnector={konnector}
-                        accountId={match.params.accountId}
-                        accounts={accounts}
-                        onDismiss={onDismiss}
-                      />
-                    )}
+                )}
+              />
+              <Route
+                path={`${konnectorRoot}/accounts/:accountId/edit`}
+                exact
+                render={({ match }) => (
+                  <EditAccountModal
+                    konnector={konnector}
+                    accountId={match.params.accountId}
+                    accounts={accounts}
                   />
-                  <Route
-                    path={`${konnectorRoot}/accounts/:accountId/edit`}
-                    exact
-                    render={({ match }) => (
-                      <EditAccountModal
-                        konnector={konnector}
-                        accountId={match.params.accountId}
-                        accounts={accounts}
-                      />
-                    )}
+                )}
+              />
+              <Route
+                path={`${konnectorRoot}/new`}
+                exact
+                render={() => (
+                  <NewAccountModal
+                    konnector={konnector}
+                    onDismiss={onDismiss}
                   />
-                  <Route
-                    path={`${konnectorRoot}/new`}
-                    exact
-                    render={() => (
-                      <NewAccountModal
-                        konnector={konnector}
-                        onDismiss={onDismiss}
-                      />
-                    )}
-                  />
-                  <Route
-                    path={`${konnectorRoot}/accounts/:accountId/success`}
-                    exact
-                    render={({ match }) => {
-                      return (
-                        <KonnectorSuccess
-                          konnector={konnector}
-                          accountId={match.params.accountId}
-                          accounts={accounts}
-                          onDismiss={onDismiss}
-                        />
-                      )
-                    }}
-                  />
-                  <Redirect
-                    from={`${konnectorRoot}/*`}
-                    to={`${konnectorRoot}/`}
-                  />
-                </Switch>
-              )}
-            </KonnectorAccounts>
-          </HarvestVaultProvider>
-        </MuiCozyTheme>
+                )}
+              />
+              <Route
+                path={`${konnectorRoot}/accounts/:accountId/success`}
+                exact
+                render={({ match }) => {
+                  return (
+                    <KonnectorSuccess
+                      konnector={konnector}
+                      accountId={match.params.accountId}
+                      accounts={accounts}
+                      onDismiss={onDismiss}
+                    />
+                  )
+                }}
+              />
+              <Redirect from={`${konnectorRoot}/*`} to={`${konnectorRoot}/`} />
+            </Switch>
+          )}
+        </KonnectorAccounts>
       </Modal>
     </MountPointProvider>
   )

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import { TriggerManager } from 'components/TriggerManager'
+import { DumbTriggerManager as TriggerManager } from 'components/TriggerManager'
 import cronHelpers from 'helpers/cron'
 
 jest.mock('cozy-doctypes', () => {
@@ -18,6 +18,8 @@ jest.mock('cozy-doctypes', () => {
     CozyFolder
   }
 })
+
+jest.mock('cozy-ui/transpiled/react/utils/color')
 
 const fixtures = {
   data: {

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
@@ -1,46 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TriggerManager handleError should render error 1`] = `
-<div>
-  <Wrapper>
-    <div
-      id="coz-harvest-modal-place"
+<Wrapper>
+  <div
+    id="coz-harvest-modal-place"
+  />
+  <React.Fragment>
+    <Wrapper
+      account={
+        Object {
+          "_id": "61c683295560485db0f34b859197c581",
+          "account_type": "konnectest",
+          "auth": Object {
+            "passphrase": "bar",
+            "username": "foo",
+          },
+          "identifier": "username",
+        }
+      }
+      error={[Error: Test error]}
+      konnector={
+        Object {
+          "fields": Object {
+            "passphrase": Object {
+              "type": "password",
+            },
+            "username": Object {
+              "type": "text",
+            },
+          },
+          "slug": "konnectest",
+        }
+      }
+      onBack={[Function]}
+      onSubmit={[Function]}
+      readOnlyIdentifier={false}
+      submitting={false}
     />
-    <React.Fragment>
-      <Wrapper
-        account={
-          Object {
-            "_id": "61c683295560485db0f34b859197c581",
-            "account_type": "konnectest",
-            "auth": Object {
-              "passphrase": "bar",
-              "username": "foo",
-            },
-            "identifier": "username",
-          }
-        }
-        error={[Error: Test error]}
-        konnector={
-          Object {
-            "fields": Object {
-              "passphrase": Object {
-                "type": "password",
-              },
-              "username": Object {
-                "type": "text",
-              },
-            },
-            "slug": "konnectest",
-          }
-        }
-        onBack={[Function]}
-        onSubmit={[Function]}
-        readOnlyIdentifier={false}
-        submitting={false}
-      />
-    </React.Fragment>
-  </Wrapper>
-</div>
+  </React.Fragment>
+</Wrapper>
 `;
 
 exports[`TriggerManager should redirect to OAuthForm 1`] = `
@@ -58,54 +56,23 @@ exports[`TriggerManager should redirect to OAuthForm 1`] = `
 `;
 
 exports[`TriggerManager should render with account 1`] = `
-<div>
-  <Wrapper>
-    <div
-      id="coz-harvest-modal-place"
-    />
-    <React.Fragment>
-      <Wrapper
-        account={
-          Object {
-            "_id": "61c683295560485db0f34b859197c581",
-            "account_type": "konnectest",
-            "auth": Object {
-              "passphrase": "bar",
-              "username": "foo",
-            },
-            "identifier": "username",
-          }
-        }
-        konnector={
-          Object {
-            "fields": Object {
-              "passphrase": Object {
-                "type": "password",
-              },
-              "username": Object {
-                "type": "text",
-              },
-            },
-            "slug": "konnectest",
-          }
-        }
-        onBack={[Function]}
-        onSubmit={[Function]}
-        readOnlyIdentifier={false}
-        submitting={false}
-      />
-    </React.Fragment>
-  </Wrapper>
-</div>
-`;
-
-exports[`TriggerManager should render without account 1`] = `
-<div>
-  <Wrapper>
-    <div
-      id="coz-harvest-modal-place"
-    />
+<Wrapper>
+  <div
+    id="coz-harvest-modal-place"
+  />
+  <React.Fragment>
     <Wrapper
+      account={
+        Object {
+          "_id": "61c683295560485db0f34b859197c581",
+          "account_type": "konnectest",
+          "auth": Object {
+            "passphrase": "bar",
+            "username": "foo",
+          },
+          "identifier": "username",
+        }
+      }
       konnector={
         Object {
           "fields": Object {
@@ -119,9 +86,36 @@ exports[`TriggerManager should render without account 1`] = `
           "slug": "konnectest",
         }
       }
-      onNoCiphers={[Function]}
-      onSelect={[Function]}
+      onBack={[Function]}
+      onSubmit={[Function]}
+      readOnlyIdentifier={false}
+      submitting={false}
     />
-  </Wrapper>
-</div>
+  </React.Fragment>
+</Wrapper>
+`;
+
+exports[`TriggerManager should render without account 1`] = `
+<Wrapper>
+  <div
+    id="coz-harvest-modal-place"
+  />
+  <Wrapper
+    konnector={
+      Object {
+        "fields": Object {
+          "passphrase": Object {
+            "type": "password",
+          },
+          "username": Object {
+            "type": "text",
+          },
+        },
+        "slug": "konnectest",
+      }
+    }
+    onNoCiphers={[Function]}
+    onSelect={[Function]}
+  />
+</Wrapper>
 `;


### PR DESCRIPTION
In cozy-home intents, we use the TriggerManager in a standalone manner
(ie outside of harvest routes). So it must embed the providers (like
HarvestVaultProvider and MuiCozyTheme) that are required for it to work.