### PR TITLE
Harvest/UI Tweaks

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -46,7 +46,7 @@
     "cozy-client": "7.4.1",
     "cozy-device-helper": "^1.8.0",
     "cozy-realtime": "3.1.0",
-    "cozy-ui": "22.12.0",
+    "cozy-ui": "25.10.0",
     "enzyme": "3.10.0",
     "enzyme-adapter-react-16": "1.14.0",
     "identity-obj-proxy": "3.0.0",
@@ -61,7 +61,7 @@
     "cozy-client": "7.4.1",
     "cozy-device-helper": "1.7.1",
     "cozy-realtime": "^3.1.0",
-    "cozy-ui": "^22.12.0"
+    "cozy-ui": "^25.10.0"
   },
   "sideEffects": false
 }

--- a/packages/cozy-harvest-lib/src/components/AccountsListModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountsListModal.jsx
@@ -11,15 +11,15 @@ const AccountsListModal = ({ konnector, accounts, t }) => {
   const { pushHistory } = useContext(MountPointContext)
   return (
     <>
-      <Stack className="u-mb-3">
-        <div className="u-w-3 u-h-3 u-mh-auto">
-          <KonnectorIcon konnector={konnector} />
-        </div>
-        <h3 className="u-title-h3 u-ta-center">
-          {t('modal.accounts.title', { name: konnector.name })}
-        </h3>
-      </Stack>
       <ModalContent>
+        <Stack className="u-mb-3">
+          <div className="u-w-3 u-h-3 u-mh-auto">
+            <KonnectorIcon konnector={konnector} />
+          </div>
+          <h3 className="u-title-h3 u-ta-center">
+            {t('modal.accounts.title', { name: konnector.name })}
+          </h3>
+        </Stack>
         <AccountsList
           accounts={accounts}
           konnector={konnector}

--- a/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
@@ -4,16 +4,12 @@ import PropTypes from 'prop-types'
 import get from 'lodash/get'
 import flow from 'lodash/flow'
 import { withMutations } from 'cozy-client'
-import { translate } from 'cozy-ui/transpiled/react/I18n'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Modal, {
   ModalContent,
   ModalHeader
 } from 'cozy-ui/transpiled/react/Modal'
-import Button from 'cozy-ui/transpiled/react/Button'
-import { Text } from 'cozy-ui/transpiled/react/Text'
-import { withBreakpoints } from 'cozy-ui/transpiled/react'
-import palette from 'cozy-ui/transpiled/react/palette'
+import CipherIcon from 'cozy-ui/transpiled/react/CipherIcon'
 
 import accountMutations from '../connections/accounts'
 import triggersMutations from '../connections/triggers'
@@ -79,43 +75,23 @@ export class EditAccountModal extends Component {
      * When we are on mobile, we display a back button
      * On desktop we display a cross
      */
-    const {
-      konnector,
-      t,
-      breakpoints: { isMobile },
-      pushHistory
-    } = this.props
+    const { konnector, pushHistory } = this.props
     const { trigger, account, fetching } = this.state
     return (
       <Modal
         dismissAction={() => pushHistory(`/accounts/${account._id}`)}
         mobileFullscreen
         size="small"
-        closable={isMobile ? false : true}
-        closeBtnColor={palette.white}
-        className="u-bg-dodgerBlue"
       >
-        {/** TODO Should be moved to UI when this design is stablized  */}
-        <ModalHeader className="u-mb-0 u-p-0 u-h-3 u-flex u-flex-items-center">
-          {isMobile && (
-            <Button
-              onClick={() => pushHistory(`/accounts/${account._id}`)}
-              icon="previous"
-              label={t('back')}
-              iconOnly
-              extension="narrow"
-              className="u-m-0 u-p-1 u-pos-absolute u-h-3"
-              style={{
-                left: 0,
-                top: 0
-              }}
-            />
-          )}
-          <div className="u-flex-grow-1 u-ta-center">
-            <Text className="u-white">{konnector.name}</Text>
-          </div>
-        </ModalHeader>
-        <ModalContent className="u-pt-1-half">
+        <ModalHeader
+          title={
+            <div className="u-flex u-flex-items-center">
+              <CipherIcon konnector={konnector.slug} className="u-mr-1" />
+              {konnector.name}
+            </div>
+          }
+        />
+        <ModalContent>
           {fetching ? (
             <div className="u-pv-2 u-ta-center">
               <Spinner size="xxlarge" />
@@ -137,8 +113,6 @@ export class EditAccountModal extends Component {
 
 EditAccountModal.propTypes = {
   konnector: PropTypes.object.isRequired,
-  t: PropTypes.func.isRequired,
-  breakpoints: PropTypes.object.isRequired,
   accountId: PropTypes.string.isRequired,
   accounts: PropTypes.array.isRequired,
   findAccount: PropTypes.func.isRequired,
@@ -147,7 +121,5 @@ EditAccountModal.propTypes = {
 
 export default flow(
   withMutations(accountMutations, triggersMutations),
-  withBreakpoints(),
-  translate(),
   withMountPointPushHistory
 )(EditAccountModal)

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
@@ -153,7 +153,7 @@ const KonnectorAccountTabs = ({
                     </Card>
                   </div>
                 ) : null}
-                <div>
+                <div className="u-flex u-flex-row">
                   <DeleteAccountButton
                     account={account}
                     disabled={running}

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountField.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountField.spec.js.snap
@@ -22,7 +22,6 @@ exports[`AccountField render a date field 1`] = `
     placeholder="fields.date.placeholder"
     size="medium"
     type="date"
-    value=""
   />
 </div>
 `;
@@ -145,10 +144,8 @@ exports[`AccountField render a password field 1`] = `
     name="passphrase"
     placeholder="fields.passphrase.placeholder"
     showLabel="accountForm.password.show"
-    showVisibilityButton={true}
     size="medium"
     type="password"
-    value=""
   />
 </div>
 `;
@@ -175,7 +172,6 @@ exports[`AccountField should render 1`] = `
     placeholder="fields.username.placeholder"
     size="medium"
     type="text"
-    value=""
   />
 </div>
 `;

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TwoFAForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TwoFAForm.spec.js.snap
@@ -16,6 +16,7 @@ exports[`TwoFAForm should render correctly with value change 1`] = `
   className="u-mt-3"
   closable={true}
   containerClassName="u-pos-absolute"
+  into="body"
   mobileFullscreen={true}
   overflowHidden={false}
   primaryType="regular"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5823,6 +5823,23 @@ cozy-ui@24.3.0:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
+cozy-ui@25.10.0:
+  version "25.10.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-25.10.0.tgz#05094390fba5195544064f1d733bce9d182d092d"
+  integrity sha512-4PfKQMIdOUT51vacYOwakPE4YBCt6JO8dxFJb7yGGm7QcbHa9pX2vC3LethjuG6d5L+r9b8ctJpdd0RPu9yuaw==
+  dependencies:
+    "@babel/runtime" "^7.3.4"
+    body-scroll-lock "^2.5.8"
+    classnames "^2.2.5"
+    date-fns "^1.28.5"
+    hammerjs "^2.0.8"
+    node-polyglot "^2.2.2"
+    normalize.css "^7.0.0"
+    react-hot-loader "^4.3.11"
+    react-markdown "^4.0.8"
+    react-pdf "^4.0.5"
+    react-select "2.2.0"
+
 create-ecdh@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"


### PR DESCRIPTION
Some UI tweaks with @joel-costa 👍 

- The modal header on the account modification view is back to a standard header
<img width="583" alt="Capture d'écran 2019-10-22 17 35 30" src="https://user-images.githubusercontent.com/2261445/67303185-5cefe780-f4f2-11e9-999c-69bd28133e1a.png">

- The buttons inside the configuration tab stay next to each other onmobile
<img width="317" alt="Capture d'écran 2019-10-22 17 39 42" src="https://user-images.githubusercontent.com/2261445/67303714-1f3f8e80-f4f3-11e9-9f5b-20d4d18834ae.png">
