### PR TITLE
fix: Delay maintenance information

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
@@ -44,7 +44,9 @@ const KonnectorAccountTabs = ({
   client,
   t
 }) => {
-  const maintenanceStatus = useMaintenanceStatus(client, konnector.slug)
+  const {
+    data: { isInMaintenance, messages: maintenanceMessages }
+  } = useMaintenanceStatus(client, konnector.slug)
   const { pushHistory } = useContext(MountPointContext)
 
   return (
@@ -64,9 +66,6 @@ const KonnectorAccountTabs = ({
           hasError &&
           !hasLoginError &&
           !isTermsVersionMismatchErrorWithVersionAvailable
-
-        const isInMaintenance = maintenanceStatus.isInMaintenance
-        const maintenanceMessages = maintenanceStatus.messages
 
         return (
           <Tabs initialActiveTab={hasLoginError ? 'configuration' : 'data'}>

--- a/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
@@ -24,10 +24,10 @@ import { MountPointContext } from './MountPointContext'
 const NewAccountModal = ({ konnector, client, t }) => {
   const { pushHistory } = useContext(MountPointContext)
   const {
-    isMaintenanceLoaded,
-    isInMaintenance,
-    messages: maintenanceMessages
+    fetchStatus,
+    data: { isInMaintenance, messages: maintenanceMessages }
   } = useMaintenanceStatus(client, konnector.slug)
+  const isMaintenanceLoaded = fetchStatus === 'loaded'
 
   return (
     <>

--- a/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
@@ -5,6 +5,7 @@ import { withClient } from 'cozy-client'
 import { ModalContent } from 'cozy-ui/transpiled/react/Modal'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import Stack from 'cozy-ui/transpiled/react/Stack'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import flow from 'lodash/flow'
 
 import TriggerManager from '../components/TriggerManager'
@@ -22,9 +23,11 @@ import { MountPointContext } from './MountPointContext'
  */
 const NewAccountModal = ({ konnector, client, t }) => {
   const { pushHistory } = useContext(MountPointContext)
-  const maintenanceStatus = useMaintenanceStatus(client, konnector.slug)
-  const isInMaintenance = maintenanceStatus.isInMaintenance
-  const maintenanceMessages = maintenanceStatus.messages
+  const {
+    isMaintenanceLoaded,
+    isInMaintenance,
+    messages: maintenanceMessages
+  } = useMaintenanceStatus(client, konnector.slug)
 
   return (
     <>
@@ -37,9 +40,15 @@ const NewAccountModal = ({ konnector, client, t }) => {
             {t('modal.addAccount.title', { name: konnector.name })}
           </h3>
         </Stack>
-        {isInMaintenance ? (
+        {!isMaintenanceLoaded && (
+          <div className="u-ta-center">
+            <Spinner size="xxlarge" />
+          </div>
+        )}
+        {isMaintenanceLoaded && isInMaintenance && (
           <KonnectorMaintenance maintenanceMessages={maintenanceMessages} />
-        ) : (
+        )}
+        {isMaintenanceLoaded && !isInMaintenance && (
           <TriggerManager
             konnector={konnector}
             onLoginSuccess={trigger => {

--- a/packages/cozy-harvest-lib/src/components/hooks/useMaintenanceStatus.jsx
+++ b/packages/cozy-harvest-lib/src/components/hooks/useMaintenanceStatus.jsx
@@ -5,6 +5,7 @@ import get from 'lodash/get'
 const useMaintenanceStatus = (client, slug) => {
   const [maintenanceStatus, setMaintenanceStatus] = useState({
     isInMaintenance: false,
+    isMaintenanceLoaded: false,
     messages: {}
   })
   const registry = new Registry({
@@ -16,7 +17,11 @@ const useMaintenanceStatus = (client, slug) => {
       const appStatus = await registry.fetchApp(slug)
       const isInMaintenance = get(appStatus, 'maintenance_activated', false)
       const messages = get(appStatus, 'maintenance_options.messages', {})
-      setMaintenanceStatus({ isInMaintenance, messages })
+      setMaintenanceStatus({
+        isInMaintenance,
+        isMaintenanceLoaded: true,
+        messages
+      })
     }
     fetchData()
   }, [slug])


### PR DESCRIPTION
This PR prevents harvest from flashing the new account form until we are sure that the konnector is not in maintenance mode.