### PR TITLE
fix: Correctly unmount TwoFAModal

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
@@ -37,15 +37,15 @@ export class TwoFAModal extends PureComponent {
   }
 
   componentDidMount() {
-    this.props.konnectorJob
-      .on(TWO_FA_MISMATCH_EVENT, this.handleTwoFAMismatch)
-      .on(TWO_FA_REQUEST_EVENT, this.handleTwoFARequest)
+    const konnJob = this.props.konnectorJob
+    konnJob.on(TWO_FA_MISMATCH_EVENT, this.handleTwoFAMismatch)
+    konnJob.on(TWO_FA_REQUEST_EVENT, this.handleTwoFARequest)
   }
 
   componentWillUnmount() {
-    this.props.konnectorJob
-      .removeListener(TWO_FA_MISMATCH_EVENT, this.handleTwoFAMismatch)
-      .removeListener(TWO_FA_REQUEST_EVENT, this.handleTwoFARequest)
+    const konnJob = this.props.konnectorJob
+    konnJob.removeListener(TWO_FA_MISMATCH_EVENT, this.handleTwoFAMismatch)
+    konnJob.removeListener(TWO_FA_REQUEST_EVENT, this.handleTwoFARequest)
   }
 
   handleTwoFARequest() {

--- a/packages/cozy-harvest-lib/src/components/TwoFAModal.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/TwoFAModal.spec.jsx
@@ -57,6 +57,11 @@ describe('TwoFAModal', () => {
     expect(root.text()).toContain('twoFAForm.desc')
   })
 
+  it('should correctly unmount', () => {
+    const { root } = setup({})
+    expect(() => root.instance().componentWillUnmount()).not.toThrow()
+  })
+
   it('should work for several two fa requests', () => {
     const opts = {
       account: {


### PR DESCRIPTION
removeEventListener does not return the original object contrarly to
on.