### PR TITLE
cozy-auth: Few fixes

### DIFF
--- a/packages/cozy-authentication/src/MobileRouter.jsx
+++ b/packages/cozy-authentication/src/MobileRouter.jsx
@@ -218,7 +218,6 @@ export class MobileRouter extends Component {
       client,
       LoginInComponent,
       children,
-
       // TODO LogoutComponent should come from props.components and have
       // a default
       LogoutComponent
@@ -280,15 +279,17 @@ export class MobileRouter extends Component {
   }
 
   async afterAuthentication() {
-    this.setState({ isLoggingIn: false })
-
     if (this.props.onAuthenticated) {
       await this.props.onAuthenticated()
     }
-
     this.props.history.replace(this.props.loginPath)
 
     await credentials.saveFromClient(this.props.client)
+    //We need to set the state after all the previous actions
+    //since we can have async task in `onAuthenticated`. Setting
+    //isLoggingIn to true before result in displaying `appRoutes`
+    //too soon in this case
+    this.setState({ isLoggingIn: false })
   }
 
   handleBeforeLogout() {

--- a/packages/cozy-authentication/src/MobileRouter.jsx
+++ b/packages/cozy-authentication/src/MobileRouter.jsx
@@ -71,7 +71,10 @@ export class MobileRouter extends Component {
     try {
       if (saved && saved.oauthOptions) {
         client.stackClient.setOAuthOptions(saved.oauthOptions)
-        await client.login({ uri: saved.uri, token: saved.token })
+        await client.login({
+          uri: saved.uri,
+          token: saved.token
+        })
       }
     } finally {
       this.setState({ triedToReconnect: true })
@@ -282,7 +285,6 @@ export class MobileRouter extends Component {
     if (this.props.onAuthenticated) {
       await this.props.onAuthenticated()
     }
-    this.props.history.replace(this.props.loginPath)
 
     await credentials.saveFromClient(this.props.client)
     //We need to set the state after all the previous actions
@@ -316,7 +318,6 @@ MobileRouter.defaultProps = {
     console.error('Exception', e) //eslint-disable-line no-console
   },
 
-  loginPath: '/',
   logoutPath: '/',
 
   components: {
@@ -345,8 +346,6 @@ MobileRouter.propTypes = {
   /** CozyClient instance, should be provided via <CozyProvider /> */
   client: PropTypes.object.isRequired,
 
-  /** After login, where do we go */
-  loginPath: PropTypes.string,
   /** After logout, where do we go */
   logoutPath: PropTypes.string,
 

--- a/packages/cozy-authentication/src/MobileRouter.spec.jsx
+++ b/packages/cozy-authentication/src/MobileRouter.spec.jsx
@@ -72,7 +72,6 @@ describe('MobileRouter', () => {
         <I18n t={x => x} lang="en" dictRequire={() => ({})}>
           <MobileRouter
             {...props}
-            loginPath="/afterLogin"
             logoutPath="/afterLogout"
             initialTriedToReconnect={true}
             LogoutComponent={LogoutComponent}
@@ -94,19 +93,6 @@ describe('MobileRouter', () => {
     setup()
     client.emit('login')
     expect(onAuthenticated).toHaveBeenCalled()
-  })
-
-  it('should go to loginPath after login', done => {
-    setup()
-    client.emit('login')
-
-    // Without this setTimeout, history.replace is reported as not called,
-    // but it's because the expectation seems to be executed before the code
-    // itself.
-    setTimeout(() => {
-      expect(history.replace).toHaveBeenCalledWith('/afterLogin')
-      done()
-    }, 0)
   })
 
   it('should go to logoutPath after logout', () => {
@@ -170,13 +156,18 @@ describe('MobileRouter', () => {
   })
 
   describe('Logging in', () => {
-    it('should show LogInComponent during logout', () => {
+    it('should show LogInComponent during login', async () => {
       LogoutComponent = LoggingOut
       setup()
       client.emit('beforeLogin')
       app.update()
       expect(app.find(LoginInComponent).length).toBe(1)
-      client.emit('login')
+      // We don't emit('login') since we need to wait the end of
+      // `afterAuthentication` now to check if the login component is
+      // here or not. So we call afterAuth manually
+      const mobileRouter = app.find(DumbMobileRouter).instance()
+
+      await mobileRouter.afterAuthentication()
       app.update()
       expect(app.find(LoginInComponent).length).toBe(0)
     })


### PR DESCRIPTION
Commits should speak for themselves. 

It's a breaking change for the second one, but can be easily fixed in banks by doing the `props.router.replace('/balance')` in `onAuthenticated` callback https://github.com/cozy/cozy-banks/blob/master/src/ducks/mobile/MobileRouter.jsx#L24