### PR TITLE
fix(scanner): Fix publish lang

### DIFF
--- a/packages/cozy-scanner/package.json
+++ b/packages/cozy-scanner/package.json
@@ -13,12 +13,11 @@
     "url": "https://github.com/cozy/cozy-libs/issues"
   },
   "scripts": {
-    "build": "yarn run copy-files && env BABEL_ENV=transpilation yarn babel src/ --out-dir dist",
+    "prepare": "yarn build; yarn copy-files",
+    "build": "env BABEL_ENV=transpilation yarn babel src/ --out-dir dist && yarn run copy-files",
     "copy-files": "cp -rf src/locales dist/",
-    "prepublishOnly": "yarn build",
     "test": "jest src/ --verbose",
     "lint": "cd .. && yarn lint packages/cozy-scanner",
-    "tx": "tx pull --all",
     "watch": "yarn build --watch"
   },
   "dependencies": {


### PR DESCRIPTION
The current published version of Cozy-Scanner doesn't have both en and fr.json files (https://unpkg.com/browse/cozy-scanner@0.1.0/dist/locales/) 

I'm wondering if this is not because of the prepublish command. Let's use the same thing as `cozy-procedure` to see if it works. 