### PR TITLE
Custom konnector maintenance

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
@@ -46,7 +46,7 @@ const KonnectorAccountTabs = ({
 }) => {
   const {
     data: { isInMaintenance, messages: maintenanceMessages }
-  } = useMaintenanceStatus(client, konnector.slug)
+  } = useMaintenanceStatus(client, konnector)
   const { pushHistory } = useContext(MountPointContext)
 
   return (

--- a/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
@@ -27,7 +27,8 @@ const NewAccountModal = ({ konnector, client, t }) => {
     fetchStatus,
     data: { isInMaintenance, messages: maintenanceMessages }
   } = useMaintenanceStatus(client, konnector.slug)
-  const isMaintenanceLoaded = fetchStatus === 'loaded'
+  const isMaintenanceLoaded =
+    fetchStatus === 'loaded' || fetchStatus === 'failed'
 
   return (
     <>

--- a/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
@@ -26,7 +26,7 @@ const NewAccountModal = ({ konnector, client, t }) => {
   const {
     fetchStatus,
     data: { isInMaintenance, messages: maintenanceMessages }
-  } = useMaintenanceStatus(client, konnector.slug)
+  } = useMaintenanceStatus(client, konnector)
   const isMaintenanceLoaded =
     fetchStatus === 'loaded' || fetchStatus === 'failed'
 

--- a/packages/cozy-harvest-lib/src/components/hooks/useMaintenanceStatus.jsx
+++ b/packages/cozy-harvest-lib/src/components/hooks/useMaintenanceStatus.jsx
@@ -2,7 +2,9 @@ import { useState, useEffect } from 'react'
 import { Registry } from 'cozy-client'
 import get from 'lodash/get'
 
-const useMaintenanceStatus = (client, slug) => {
+const useMaintenanceStatus = (client, konnector) => {
+  const { slug, source } = konnector
+
   const [isInMaintenance, setIsInMaintenance] = useState(false)
   const [messages, setMessages] = useState({})
   const [fetchStatus, setFetchStatus] = useState('idle')
@@ -14,6 +16,11 @@ const useMaintenanceStatus = (client, slug) => {
 
   useEffect(() => {
     const fetchData = async () => {
+      if (/^registry:\/\//i.test(source) === false) {
+        // Only konnectors from the registry have a maintenance status, manually installed once are always considered OK
+        setFetchStatus('loaded')
+        return
+      }
       try {
         setFetchStatus('loading')
         const appStatus = await registry.fetchApp(slug)
@@ -28,7 +35,7 @@ const useMaintenanceStatus = (client, slug) => {
       }
     }
     fetchData()
-  }, [slug])
+  }, [slug, source])
 
   return {
     data: {


### PR DESCRIPTION
We were always trying to fetch the maintenance status for konnectors, even those that aren't from the registry (eg. manually installed).
Also, if we failed to fetch the maintenance status, we would keep displaying the loading spinner instead of falling back tom some content. Now we just show the form if that happens.

Kind of urgent to get this out of the door, I'm adding tests in a separate PR.