### PR TITLE
feat(cozy-doctypes): Add generateFileName for a version

### DIFF
--- a/packages/cozy-doctypes/src/File.js
+++ b/packages/cozy-doctypes/src/File.js
@@ -149,6 +149,16 @@ class CozyFile extends Document {
     }
   }
 
+  static generateFileNameForRevision(file, revision, f) {
+    const { filename, extension } = CozyFile.splitFilename({
+      name: file.name,
+      type: 'file'
+    })
+    return `${filename}_${f(
+      revision.updated_at,
+      'DD MMMM - HH[h]mm'
+    )}${extension}`
+  }
   /**
    * The goal of this method is to upload a file based on a conflict strategy.
    * Be careful: We need to check if the file exists by doing a statByPath query

--- a/packages/cozy-doctypes/src/File.spec.js
+++ b/packages/cozy-doctypes/src/File.spec.js
@@ -233,6 +233,20 @@ describe('File model', () => {
     })
   })
 
+  describe('generateFileNameForRevision', () => {
+    it('should generate the right file name for a revision', () => {
+      const MOCKED_DATE = '2018-01-01T12:00:00.210Z'
+      const expectedFilename = 'test_01 January - 12h00.pdf'
+      const date = new Date(MOCKED_DATE)
+      const result = CozyFile.generateFileNameForRevision(
+        { name: 'test.pdf' },
+        { updated_at: date },
+        () => '01 January - 12h00'
+      )
+      expect(result).toEqual(expectedFilename)
+    })
+  })
+
   describe('uploadFileWithConflictStrategy', () => {
     beforeEach(() => {
       getSpy.mockImplementation(() =>


### PR DESCRIPTION
cozy-stack now handles file's version. 
cozy-client adds now the ability to download a specific version (https://github.com/cozy/cozy-client/pull/564) 

This PR add a new helper to generate the default Filename for a specific version aka : 
`filename-revisionDate.extension`