### PR TITLE
feat: Create or update can handle duplicates via strategies

### DIFF
--- a/packages/cozy-doctypes/__mocks__/cozy-logger/index.js
+++ b/packages/cozy-doctypes/__mocks__/cozy-logger/index.js
@@ -1,0 +1,4 @@
+const logger = jest.fn()
+logger.namespace = () => logger
+
+module.exports = logger

--- a/packages/cozy-doctypes/src/Document.spec.js
+++ b/packages/cozy-doctypes/src/Document.spec.js
@@ -1,12 +1,17 @@
 const MockDate = require('mockdate')
 const Document = require('./Document')
 const { cozyClientJS, cozyClient } = require('./testUtils')
+const logger = require('cozy-logger')
 
 class Simpson extends Document {}
 Simpson.doctype = 'io.cozy.simpsons'
 Simpson.idAttributes = ['name']
 
 const MOCKED_DATE = '2019-05-14T12:00:00.210Z'
+
+beforeEach(() => {
+  logger.mockReset()
+})
 
 beforeAll(() => {
   MockDate.set(MOCKED_DATE)
@@ -421,22 +426,64 @@ describe('Document used with CozyClient', () => {
   })
 
   describe('createOrUpdate', () => {
-    afterEach(() => {
-      Simpson.queryAll.mockReset()
-    })
-
-    it('should throw an error if there are more than one corresponding documents', async () => {
-      jest
-        .spyOn(Simpson, 'queryAll')
-        .mockReturnValueOnce([
-          { _id: 1, name: 'Marge' },
-          { _id: 2, name: 'Marge' }
+    describe('duplicate strategies', () => {
+      beforeEach(() => {
+        jest.spyOn(Simpson, 'queryAll').mockReturnValueOnce([
+          {
+            _id: 1,
+            name: 'Marge',
+            cozyMetadata: { updatedAt: new Date('2019-11-19') }
+          },
+          {
+            _id: 2,
+            name: 'Marge',
+            cozyMetadata: { updatedAt: new Date('2019-11-20') }
+          }
         ])
+        jest.spyOn(cozyClient, 'save').mockReturnValueOnce()
+        jest.spyOn(Simpson, 'deleteAll').mockReturnValueOnce()
+      })
 
-      await expect(Simpson.createOrUpdate({ name: 'Marge' })).rejects
-        .toThrow(`Create or update with selectors that returns more than 1 result
-{\"name\":\"Marge\"}
-[{\"_id\":1,\"name\":\"Marge\"},{\"_id\":2,\"name\":\"Marge\"}]`)
+      afterEach(() => {
+        Simpson.queryAll.mockReset()
+        Simpson.deleteAll.mockReset()
+      })
+
+      it('should throw if there is more than one corresponding documents (default throw strategy)', async () => {
+        await expect(Simpson.createOrUpdate({ name: 'Marge' })).rejects
+          .toThrow(`Create or update with selectors that returns more than 1 result
+{"name":"Marge"}
+[{"_id":2,"name":"Marge","cozyMetadata":{"updatedAt":"2019-11-20T00:00:00.000Z"}},{"_id":1,"name":"Marge","cozyMetadata":{"updatedAt":"2019-11-19T00:00:00.000Z"}}]`)
+      })
+
+      it('should throw there is more than one corresponding documents (throw strategy)', async () => {
+        await expect(
+          Simpson.createOrUpdate(
+            { name: 'Marge' },
+            { handleDuplicates: 'throw' }
+          )
+        ).rejects
+          .toThrow(`Create or update with selectors that returns more than 1 result
+{"name":"Marge"}
+[{"_id":2,"name":"Marge","cozyMetadata":{"updatedAt":"2019-11-20T00:00:00.000Z"}},{"_id":1,"name":"Marge","cozyMetadata":{"updatedAt":"2019-11-19T00:00:00.000Z"}}]`)
+      })
+
+      it('should update 1 doc and delete duplicates if there is more than one corresponding documents (remove strategy)', async () => {
+        await Simpson.createOrUpdate(
+          { name: 'Marge' },
+          { handleDuplicates: 'remove' }
+        )
+        expect(cozyClient.save).toHaveBeenCalledWith(
+          Simpson.addCozyMetadata({ _id: 2, name: 'Marge' })
+        )
+        expect(logger).toHaveBeenCalledWith(
+          'warn',
+          'Cleaning duplicates for doctype io.cozy.simpsons (kept: 2, removed: 1)'
+        )
+        expect(Simpson.deleteAll).toHaveBeenCalledWith([
+          { _id: 1, name: 'Marge', cozyMetadata: expect.any(Object) }
+        ])
+      })
     })
 
     it('should create the document if it does not exist', async () => {

--- a/packages/cozy-doctypes/src/Document.spec.js
+++ b/packages/cozy-doctypes/src/Document.spec.js
@@ -428,9 +428,15 @@ describe('Document used with CozyClient', () => {
     it('should throw an error if there are more than one corresponding documents', async () => {
       jest
         .spyOn(Simpson, 'queryAll')
-        .mockReturnValueOnce([{ name: 'Marge' }, { name: 'Marge' }])
+        .mockReturnValueOnce([
+          { _id: 1, name: 'Marge' },
+          { _id: 2, name: 'Marge' }
+        ])
 
-      await expect(Simpson.createOrUpdate({ name: 'Marge' })).rejects.toThrow()
+      await expect(Simpson.createOrUpdate({ name: 'Marge' })).rejects
+        .toThrow(`Create or update with selectors that returns more than 1 result
+{\"name\":\"Marge\"}
+[{\"_id\":1,\"name\":\"Marge\"},{\"_id\":2,\"name\":\"Marge\"}]`)
     })
 
     it('should create the document if it does not exist', async () => {

--- a/packages/cozy-doctypes/src/banking/BankingReconciliator.js
+++ b/packages/cozy-doctypes/src/banking/BankingReconciliator.js
@@ -75,11 +75,10 @@ class BankingReconciliator {
     const logProgress = doc => {
       log('debug', `[bulkSave] ${i++} Saving ${doc.date} ${doc.label}`)
     }
-    const savedTransactions = await BankTransaction.bulkSave(
-      transactions,
-      30,
+    const savedTransactions = await BankTransaction.bulkSave(transactions, {
+      concurrency: 30,
       logProgress
-    )
+    })
     return {
       accounts: savedAccounts,
       transactions: savedTransactions

--- a/packages/cozy-doctypes/src/banking/BankingReconciliator.js
+++ b/packages/cozy-doctypes/src/banking/BankingReconciliator.js
@@ -18,7 +18,9 @@ class BankingReconciliator {
     )
 
     log('info', 'Saving accounts...')
-    const savedAccounts = await BankAccount.bulkSave(reconciliatedAccounts)
+    const savedAccounts = await BankAccount.bulkSave(reconciliatedAccounts, {
+      handleDuplicates: 'remove'
+    })
     if (options.onAccountsSaved) {
       options.onAccountsSaved(savedAccounts)
     }
@@ -77,7 +79,8 @@ class BankingReconciliator {
     }
     const savedTransactions = await BankTransaction.bulkSave(transactions, {
       concurrency: 30,
-      logProgress
+      logProgress,
+      handleDuplicates: 'remove'
     })
     return {
       accounts: savedAccounts,

--- a/packages/cozy-scanner/CHANGELOG.md
+++ b/packages/cozy-scanner/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.1](https://github.com/cozy/cozy-libs/compare/cozy-scanner@0.1.0...cozy-scanner@0.1.1) (2019-11-12)
+
+
+### Bug Fixes
+
+* **scanner:** Fix publish lang ([13e3375](https://github.com/cozy/cozy-libs/commit/13e3375))
+
+
+
+
+
 # 0.1.0 (2019-11-06)
 
 

--- a/packages/cozy-scanner/package.json
+++ b/packages/cozy-scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-scanner",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Cozy-Scanner provides a component to take a picture of a document and describe it",
   "main": "dist/index.js",
   "license": "MIT",


### PR DESCRIPTION
Before, create or update would throw if more than 1 existing document was
found through the idAttributes selector. It results in errors for konnectors
for which 2 documents have been inserted by error (for example if the vendor returned two documents with the same vendorId).

After discussion with @edas, we resolved to removing those duplicates. To kept backward compatibility and to explicit this behavior, I went with user configurable strategies in case of duplicates.

- The default strategy is to throw an error when a duplicate is found (same behavior as before)
- The "remove" strategy `createOrUpdate(doc, { handleDuplicate: "remove" })` will remove the most ancient duplicate documents and will keep only the most recent