### PR TITLE
feat(realtime): Subscribe to CREATED with an id

### DIFF
--- a/packages/cozy-realtime/src/index.js
+++ b/packages/cozy-realtime/src/index.js
@@ -47,10 +47,6 @@ const validateParameters = (eventName, type, id, handler) => {
     msg = `'${type}' is not a valide type, it should be a string.`
   }
 
-  if (id && eventName === 'created') {
-    msg = `The 'id' should not be specified for 'created' event.`
-  }
-
   if (typeof handler !== 'function') {
     msg = `The handler '${handler}' should be a function.`
   }

--- a/packages/cozy-realtime/src/index.spec.js
+++ b/packages/cozy-realtime/src/index.spec.js
@@ -54,10 +54,10 @@ describe('CozyRealtime', () => {
       cozyStack.emitMessage(type, fakeDoc, 'CREATED')
     })
 
-    it('should throw an error when config has id for created event', () => {
-      expect(() =>
+    it('should not throw an error when config has id for created event', () => {
+      expect(
         realtime.subscribe('created', type, 'my_id', () => {})
-      ).toThrow()
+      ).resolves.toBeDefined()
     })
 
     it('should launch handler when document is updated', async done => {


### PR DESCRIPTION
Subscribing to realtime 'CREATED' events with an id was forbidden in the previous version.
It is usually an error but is plainly acceptable for the io.cozy.notes.events