### PR TITLE
chore: Remove preact

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -47,7 +47,7 @@
     "cozy-client": "7.13.0",
     "cozy-device-helper": "^1.8.0",
     "cozy-realtime": "3.1.0",
-    "cozy-ui": "27.6.2",
+    "cozy-ui": "27.11.2",
     "enzyme": "3.10.0",
     "enzyme-adapter-react-16": "1.15.1",
     "identity-obj-proxy": "3.0.0",
@@ -60,7 +60,7 @@
     "cozy-client": "7.13.0",
     "cozy-device-helper": "1.7.1",
     "cozy-realtime": "^3.1.0",
-    "cozy-ui": "^27.6.2"
+    "cozy-ui": "^27.11.2"
   },
   "sideEffects": false
 }

--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -34,7 +34,6 @@
     "lodash": "4.17.15",
     "microee": "^0.0.6",
     "node-polyglot": "^2.4.0",
-    "preact-portal": "^1.1.3",
     "react-final-form": "3.7.0",
     "react-markdown": "4.2.2",
     "react-router-dom": "^5.0.1",
@@ -53,8 +52,6 @@
     "enzyme-adapter-react-16": "1.15.1",
     "identity-obj-proxy": "3.0.0",
     "jest": "24.1.0",
-    "preact": "^8.4.2",
-    "preact-portal": "^1.1.3",
     "prop-types": "15.7.2",
     "react": "16.11.0",
     "react-dom": "16.11.0"

--- a/packages/cozy-notifications/package.json
+++ b/packages/cozy-notifications/package.json
@@ -21,7 +21,7 @@
     "watch": "yarn build --watch"
   },
   "dependencies": {
-    "cozy-ui": "24.8.0",
+    "cozy-ui": "27.11.2",
     "handlebars": "4.1.2",
     "handlebars-layouts": "3.1.4",
     "lodash": "4.17.15",

--- a/packages/cozy-procedures/package.json
+++ b/packages/cozy-procedures/package.json
@@ -38,7 +38,7 @@
     "@material-ui/lab": "^3.0.0-alpha.30",
     "babel-plugin-inline-react-svg": "^1.1.0",
     "cozy-client": "6.66.0",
-    "cozy-ui": "22.14.1",
+    "cozy-ui": "27.11.2",
     "enzyme-to-json": "3.4.0",
     "jest": "24.8.0",
     "react": "16.11.0"
@@ -48,7 +48,7 @@
     "@material-ui/lab": "^3.0.0-alpha.30",
     "cozy-client": "6.66.0",
     "cozy-doctypes": "^1.49.3",
-    "cozy-ui": "^22.4.0"
+    "cozy-ui": "^27.11.2"
   },
   "jest": {
     "setupFiles": [

--- a/packages/cozy-procedures/src/components/form/__snapshots__/SelectBoxAdapter.spec.jsx.snap
+++ b/packages/cozy-procedures/src/components/form/__snapshots__/SelectBoxAdapter.spec.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SelectBoxAdapter component should match snapshot 1`] = `
-<Aware
+<withBreakpoints(SelectBox)
   fullwidth={true}
   isClearable={true}
   isSearchable={false}

--- a/packages/cozy-scanner/package.json
+++ b/packages/cozy-scanner/package.json
@@ -30,7 +30,7 @@
     "babel-jest": "^24.9.0",
     "babel-preset-cozy-app": "^1.7.0",
     "cozy-doctypes": "1.67.0",
-    "cozy-ui": "^25.7.0",
+    "cozy-ui": "27.11.2",
     "jest": "24.1.0",
     "jest-dom": "^4.0.0",
     "mockdate": "^2.0.5",
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "cozy-client": "7.4.1",
     "cozy-doctypes": "1.67.0",
-    "cozy-ui": "^25.7.0"
+    "cozy-ui": "^27.11.2"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5248,23 +5248,6 @@ cozy-ui@22.14.1:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@24.8.0:
-  version "24.8.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-24.8.0.tgz#0c1c0c413aabeae0a43902bde49c4981a1e078a6"
-  integrity sha512-ukW/j74XBhfazQzkLAbS/TSJVwf6UaUveARUWwbff5gZGy1JMrWCUZIo6VGOx9K4RJ1W+U3NuKI5Xx/3DBwXBw==
-  dependencies:
-    "@babel/runtime" "^7.3.4"
-    body-scroll-lock "^2.5.8"
-    classnames "^2.2.5"
-    date-fns "^1.28.5"
-    hammerjs "^2.0.8"
-    node-polyglot "^2.2.2"
-    normalize.css "^7.0.0"
-    react-hot-loader "^4.3.11"
-    react-markdown "^4.0.8"
-    react-pdf "^4.0.5"
-    react-select "2.2.0"
-
 cozy-ui@27.11.2:
   version "27.11.2"
   resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-27.11.2.tgz#4e79e25049848f3b225d36cd341a29046701b6df"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5283,23 +5283,6 @@ cozy-ui@27.11.2:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@^25.7.0:
-  version "25.13.1"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-25.13.1.tgz#fc7d2a4066c4a45c8894d1b59e7aff51dc9057a1"
-  integrity sha512-Xv7r65dj5RZKtqygSbsm07frATqJnZy4xSdD0tNoRpszHzqrqxozp0vKXlPPBM6/7J83esmGopcZXIv7+po6WA==
-  dependencies:
-    "@babel/runtime" "^7.3.4"
-    body-scroll-lock "^2.5.8"
-    classnames "^2.2.5"
-    date-fns "^1.28.5"
-    hammerjs "^2.0.8"
-    node-polyglot "^2.2.2"
-    normalize.css "^7.0.0"
-    react-hot-loader "^4.3.11"
-    react-markdown "^4.0.8"
-    react-pdf "^4.0.5"
-    react-select "2.2.0"
-
 create-ecdh@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5265,10 +5265,10 @@ cozy-ui@24.8.0:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@27.6.2:
-  version "27.6.2"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-27.6.2.tgz#d200907a6799e24f5eff867361bf25efaf74b9e1"
-  integrity sha512-t4ilyQ38/tVkw5tAuBfZt8wStq4D01yjUz9WzCPg3N9T9Kuid1a+NM7Vpa4pc2cSd1/v7e4hyHz9LthNdA4dMQ==
+cozy-ui@27.11.2:
+  version "27.11.2"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-27.11.2.tgz#4e79e25049848f3b225d36cd341a29046701b6df"
+  integrity sha512-dFQTQ5vftNXfKBdsa3gYa/3t+KCaSLk38x8w8X+KjzfMdrj2Yx2XaC2HFk5eOvVu4wj9YG0KN7aCKJepg2/SKg==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"
@@ -13481,14 +13481,6 @@ pouchdb-utils@7.0.0:
     pouchdb-errors "7.0.0"
     pouchdb-md5 "7.0.0"
     uuid "3.2.1"
-
-preact-portal@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/preact-portal/-/preact-portal-1.1.3.tgz#22cdd3ecf6ad9aaa3f830607a9c6591de90aedb7"
-
-preact@^8.4.2:
-  version "8.4.2"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-8.4.2.tgz#1263b974a17d1ea80b66590e41ef786ced5d6a23"
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Preact and preact-modal were indicated as dependencies here.

Preact and preact-modal are used by cozy-ui as peer dependencies,
so they do not need to be included here. Saw the bug in Banks
where preact-portal was installed even if it's been a long time
that we do not use preact-portal.

It would actually cause a build bug since the new version of cozy-ui that inverted the USE_REACT flag to USE_PREACT. 

1. Since process.env.USE_PREACT is not changed to
false, the require('preact-portal') was executed
2. It would be found in the node_modules but would fail on its require('preact').
3. So even a try/catch around the require('preact-portal') would not
prevent the build error (since preact-portal could be found).

So if you have preact or preact-portal in your node_modules, you MUST use USE_PREACT env var.