### PR TITLE
feat: Use conventional display name for HOC

### DIFF
--- a/packages/cozy-flags/src/connect.jsx
+++ b/packages/cozy-flags/src/connect.jsx
@@ -24,7 +24,7 @@ const connect = Component => {
       return <Component {...this.props} />
     }
   }
-  Wrapped.displayName = 'flag_' + Component.displayName
+  Wrapped.displayName = `withFlags(${Component.displayName || Component.name})`
   return Wrapped
 }
 


### PR DESCRIPTION
Breaking change as snapshots will fail.