### PR TITLE
feat: URL polyfill is useless

### DIFF
--- a/packages/cozy-sharing/src/components/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal.jsx
@@ -10,8 +10,6 @@ import { default as DumbShareByLink } from './ShareByLink'
 import { default as DumbShareByEmail } from './ShareByEmail'
 import WhoHasAccess from './WhoHasAccess'
 
-require('url-polyfill')
-
 export default class ShareModal extends Component {
   static contextTypes = {
     t: PropTypes.func.isRequired


### PR DESCRIPTION
It was required for drive in order to use searchParams in Edge
because of https://github.com/y-lohse/cozy-drive/blob/845c483e9be791544e44fa4c02037f4fc8ff9619/src/sharing/ShareModal.jsx#L41
but has no use in cozy-sharing anymore