### PR TITLE
Feat/notes edition

### DIFF
--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -172,10 +172,15 @@ class SharingProvider extends Component {
   }
 
   shareByLink = async document => {
+    const { documentType } = this.state
+    // Notes should be shared with write permissions
+    // so that the recipient may edit the content of the note
+    const options =
+      documentType === 'Notes' ? { verbs: ['GET', 'POST', 'PUT'] } : {}
     trackSharingByLink(document)
     const resp = await this.props.client
       .collection('io.cozy.permissions')
-      .createSharingLink(document)
+      .createSharingLink(document, options)
     this.dispatch(addSharingLink(resp.data))
     return resp
   }

--- a/packages/cozy-sharing/src/state.js
+++ b/packages/cozy-sharing/src/state.js
@@ -386,7 +386,12 @@ const getDocumentSharingType = (sharing, docId) => {
 
 const buildSharingLink = (state, documentType, sharecode) => {
   const appUrl = getAppUrlForDoctype(state, documentType)
-  return `${appUrl}public?sharecode=${sharecode}`
+  switch (documentType) {
+    case 'Notes':
+      return `${appUrl}public/?sharecode=${sharecode}`
+    default:
+      return `${appUrl}public?sharecode=${sharecode}`
+  }
 }
 
 const getAppUrlForDoctype = (state, documentType) => {


### PR DESCRIPTION
When sharing a note with a public link, we want this link to allow collaboration (write access) to the note.

Also see https://github.com/cozy/cozy-client/pull/598