### PR TITLE
fix: Translation key for notes

### DIFF
--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -121,7 +121,7 @@
       }
     }
   },
-  "Files": {
+  "Notes": {
     "share": {
       "cta": "Partager",
       "title": "Partager",


### PR DESCRIPTION
We were missing the `Notes` key in the translations, so i18n was falling back on the english version.