### PR TITLE
fix(cozy-harvest-lib): KonnectorSuggestionModal actions alignement

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorSuggestionModal/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorSuggestionModal/index.jsx
@@ -71,7 +71,7 @@ const KonnectorSuggestionModal = ({
           </div>
         </DialogContent>
         <DialogActions>
-          <div className="u-flex u-flex-column u-flex-items-center">
+          <div className="u-flex u-flex-column u-flex-items-center u-w-100">
             {reason === 'FOUND_TRANSACTION' && (
               <Caption className="u-mb-1">
                 {t('suggestions.why', { name })}


### PR DESCRIPTION
When there was no element to explain the reason why a suggestion has
been made, the container of the actions was not taking the entire
available width. So the actions were not properly aligned. Forcing it to
take the full width fixes this issue.

Before:

![image](https://user-images.githubusercontent.com/1606068/71179476-874eee80-2270-11ea-9c43-05e3fd0ab21f.png)

After:
![image](https://user-images.githubusercontent.com/1606068/71179503-96ce3780-2270-11ea-8f95-a534fd8d7bf0.png)
