### PR TITLE
fix: Add string to create sync folder

### DIFF
--- a/packages/cozy-authentication/src/locales/en.json
+++ b/packages/cozy-authentication/src/locales/en.json
@@ -50,6 +50,14 @@
       "description": "It appears you revoked this device from your Cozy. If you didn't, please let us know at contact@cozycloud.cc. All your local data related to your Cozy will be removed.",
       "loginagain": "Log in again",
       "logout": "Log out"
+    },
+    "settings": {
+      "media_backup": {
+        "media_folder": "Photos",
+        "backup_folder": "Backed up from my mobile",
+        "legacy_backup_folder": "Backuped from my mobile",
+        "title": "Media Backup"
+      }
     }
   }
 }

--- a/packages/cozy-authentication/src/locales/fr.json
+++ b/packages/cozy-authentication/src/locales/fr.json
@@ -49,6 +49,14 @@
       "description": "Vous semblez avoir révoqué votre périphérique depuis votre Cozy. Si ce n'est pas vous, n'hésitez pas à nous contacter à contact@cozycloud.cc. Toutes les données relatives à Cozy présentes localement vont être supprimées.",
       "loginagain": "Se réenregistrer",
       "logout": "Se déconnecter"
+    },
+    "settings": {
+      "media_backup": {
+        "media_folder": "Photos",
+        "backup_folder": "Sauvegardées depuis mon mobile",
+        "legacy_backup_folder": "Sauvegardées depuis mon mobile",
+        "title": "Sauvegarder des médias"
+      }
     }
   }
 }


### PR DESCRIPTION
We forgot to take those strings when extracting from Drive resulting of trying to create few folders without the right keys... 