### PR TITLE
fix(cozy-realtime): Don't crash if no event exist

### DIFF
--- a/packages/cozy-realtime/src/CozyRealtime.js
+++ b/packages/cozy-realtime/src/CozyRealtime.js
@@ -117,6 +117,13 @@ class CozyRealtime {
   _retryLimit = 60
 
   /**
+   * Mapping between events and associated callbacks
+   *
+   * @type {Object}
+   */
+  _events = {}
+
+  /**
    * Constructor of CozyRealtime:
    * - Save cozyClient
    * - create socket
@@ -206,9 +213,8 @@ class CozyRealtime {
   _resubscribe() {
     this._retryLimit--
 
-    const subscribeList = Object.keys(this._events)
+    const subscribeList = this._getEventKeys(this._events)
       .map(key => {
-        if (!key.includes(INDEX_KEY_SEPARATOR)) return
         if (this._events[key].length === 0) return
         let [, type, id] = key.split(INDEX_KEY_SEPARATOR)
         if (id === 'undefined') id = undefined


### PR DESCRIPTION
Doing `Object.keys(this._events)` thrown an error when `this._events`
was undefined. We already had a `_getEventKeys` method that handles
this. So I just used it.