### PR TITLE
fix: Sharing has side effect on css files

### DIFF
--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -52,5 +52,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.12.0"
   },
-  "sideEffects": false
+  "sideEffects": [
+    "*.css"
+  ]
 }


### PR DESCRIPTION
Since we need to import the css file provided by cozy-sharing by doing : 
`iimport 'cozy-sharing/dist/stylesheet.css'` we need to declare that the package has a side effect on this css file. If we don't, webpack will treeshake it since we "don't use the file".

For more info about side effect: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free
