### PR TITLE
fix: Allow oauth without scope

### DIFF
--- a/packages/cozy-harvest-lib/src/helpers/oauth.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.js
@@ -76,6 +76,35 @@ export const handleOAuthResponse = () => {
 }
 
 /**
+ * Generate oauth popup url
+ * @param  {string} cozyUrl cozy url
+ * @param  {string} accountType connector slug
+ * @param  {string} oAuthStateKey localStorage key
+ * @param  {Object} oAuthConf connector manifest oauth configuration
+ * @param  {string} nonce unique nonce string
+ */
+export const getOAuthUrl = ({
+  cozyUrl,
+  accountType,
+  oAuthStateKey,
+  oAuthConf,
+  nonce
+}) => {
+  let oAuthUrl = `${cozyUrl}/accounts/${accountType}/start?state=${oAuthStateKey}&nonce=${nonce}`
+  if (
+    oAuthConf.scope !== undefined &&
+    oAuthConf.scope !== null &&
+    oAuthConf.scope !== false
+  ) {
+    const urlScope = Array.isArray(oAuthConf.scope)
+      ? oAuthConf.scope.join('+')
+      : oAuthConf.scope
+    oAuthUrl += `&scope=${urlScope}`
+  }
+  return oAuthUrl
+}
+
+/**
  * Initializes client OAuth workflow by storing the current information about
  * account type in localStorage. Generates the OAuth URL to stack endpoint,
  * passing the localStorage key as state in query string.
@@ -97,9 +126,13 @@ export const prepareOAuth = (client, konnector) => {
 
   const cozyUrl = client.stackClient.uri
 
-  const oAuthUrl = `${cozyUrl}/accounts/${accountType}/start?scope=${
-    oauth.scope
-  }&state=${oAuthStateKey}&nonce=${Date.now()}`
+  const oAuthUrl = getOAuthUrl({
+    cozyUrl,
+    accountType,
+    oAuthStateKey,
+    oAuthConf: oauth,
+    nonce: Date.now()
+  })
 
   return { oAuthStateKey, oAuthUrl }
 }
@@ -116,5 +149,6 @@ export default {
   checkOAuthData,
   handleOAuthResponse,
   prepareOAuth,
-  terminateOAuth
+  terminateOAuth,
+  getOAuthUrl
 }

--- a/packages/cozy-harvest-lib/test/helpers/oauth.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/oauth.spec.js
@@ -1,6 +1,55 @@
-import { handleOAuthResponse } from 'helpers/oauth'
+import { handleOAuthResponse, getOAuthUrl } from 'helpers/oauth'
 
 describe('Oauth helper', () => {
+  describe('getOAuthUrl', () => {
+    const defaultConf = {
+      cozyUrl: 'https://cozyurl',
+      accountType: 'testslug',
+      oAuthStateKey: 'statekey',
+      nonce: '1234'
+    }
+    it('should work with all params', () => {
+      const url = getOAuthUrl({
+        ...defaultConf,
+        oAuthConf: { scope: ['myscope'] }
+      })
+      expect(url).toEqual(
+        'https://cozyurl/accounts/testslug/start?state=statekey&nonce=1234&scope=myscope'
+      )
+    })
+    it('should remove scope if scope value is undefined or null or false', () => {
+      let url = getOAuthUrl({ ...defaultConf, oAuthConf: {} })
+      expect(url).toEqual(
+        'https://cozyurl/accounts/testslug/start?state=statekey&nonce=1234'
+      )
+      url = getOAuthUrl({ ...defaultConf, oAuthConf: { scope: false } })
+      expect(url).toEqual(
+        'https://cozyurl/accounts/testslug/start?state=statekey&nonce=1234'
+      )
+      url = getOAuthUrl({ ...defaultConf, oAuthConf: { scope: null } })
+      expect(url).toEqual(
+        'https://cozyurl/accounts/testslug/start?state=statekey&nonce=1234'
+      )
+    })
+    it('should accept string value', () => {
+      let url = getOAuthUrl({
+        ...defaultConf,
+        oAuthConf: { scope: 'thescope' }
+      })
+      expect(url).toEqual(
+        'https://cozyurl/accounts/testslug/start?state=statekey&nonce=1234&scope=thescope'
+      )
+    })
+    it('should should join array values with spaces', () => {
+      let url = getOAuthUrl({
+        ...defaultConf,
+        oAuthConf: { scope: ['thescope', 'thescope2'] }
+      })
+      expect(url).toEqual(
+        'https://cozyurl/accounts/testslug/start?state=statekey&nonce=1234&scope=thescope+thescope2'
+      )
+    })
+  })
   describe('handleOAuthResponse', () => {
     let originalLocation
     let originalOpener


### PR DESCRIPTION
The goal here is to avoid the generated oauth popup url to get : scope=undefined parameter, which is not supported by enedis webservice for example.