### PR TITLE
fix: Do not set lang inside templateData if it does not exist

### DIFF
--- a/packages/cozy-notifications/src/notifications.js
+++ b/packages/cozy-notifications/src/notifications.js
@@ -39,11 +39,15 @@ const getBuiltInHelpersForView = notifView => {
 
 export const buildAttributes = async (notifView, options = {}) => {
   const templateData = await notifView.buildData()
-  templateData.lang = options.lang
 
-  if (notifView.shouldSend && !notifView.shouldSend(templateData)) {
+  if (
+    !templateData ||
+    (notifView.shouldSend && !notifView.shouldSend(templateData))
+  ) {
     return
   }
+
+  templateData.lang = options.lang
 
   const partials = result(notifView.getPartials, {})
 

--- a/packages/cozy-notifications/src/notifications.spec.js
+++ b/packages/cozy-notifications/src/notifications.spec.js
@@ -74,6 +74,13 @@ describe('notifications', () => {
     expect(client.stackClient.fetchJSON).toMatchSnapshot()
   })
 
+  it('should not send if buildData returns false', async () => {
+    const { notificationView, client } = setup()
+    notificationView.buildData = jest.fn().mockReturnValue(false)
+    await sendNotification(client, notificationView)
+    expect(client.stackClient.fetchJSON).not.toHaveBeenCalled()
+  })
+
   it('should not send if shouldSend returns false', async () => {
     const { notificationView, client } = setup()
     notificationView.shouldSend = jest.fn().mockReturnValue(false)


### PR DESCRIPTION
This error would be thrown if a notification would not return
data inside buildData, this is a convention so that the notification
is not sent.