### PR TITLE
feat(AccountField): Make it non recognizable by browser extensio…

### DIFF
--- a/packages/cozy-harvest-lib/jest.config.js
+++ b/packages/cozy-harvest-lib/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  browser: true,
   collectCoverageFrom: [
     'src/**/*.{js,jsx}',
     '!**/node_modules/**',

--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -49,7 +49,7 @@
     "cozy-device-helper": "^1.8.0",
     "cozy-keys-lib": "1.10.0",
     "cozy-realtime": "3.1.0",
-    "cozy-ui": "27.11.2",
+    "cozy-ui": "29.2.1",
     "enzyme": "3.10.0",
     "enzyme-adapter-react-16": "1.15.1",
     "identity-obj-proxy": "3.0.0",
@@ -63,7 +63,7 @@
     "cozy-device-helper": "1.7.1",
     "cozy-keys-lib": "^1.10.0",
     "cozy-realtime": "^3.1.0",
-    "cozy-ui": "^27.11.2"
+    "cozy-ui": "^29.2.1"
   },
   "sideEffects": false
 }

--- a/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
@@ -1,4 +1,4 @@
-import Field from 'cozy-ui/transpiled/react/Field'
+import { Field } from './Field'
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import pick from 'lodash/pick'
@@ -21,6 +21,20 @@ const canAutofocus = () => {
     return false
   }
   return true
+}
+
+/*
+ * Password manager extensions try to find strings like "login" and "password" in
+ * inputs name and id. We need to map these so it is not included in these
+ * attributes
+ */
+const fieldNameRemap = {
+  login: 'lgn',
+  password: 'pwd'
+}
+
+const getFieldName = originalName => {
+  return fieldNameRemap[originalName] || originalName
 }
 
 /**
@@ -73,10 +87,13 @@ export class AccountField extends PureComponent {
         ? label
         : name
 
+    const finalName = getFieldName(name)
+
     // Cozy-UI <Field /> props
     const fieldProps = {
       ...this.props,
-      id: `harvest-account-${name}`,
+      name: finalName,
+      id: `harvest-account-${finalName}`,
       autoComplete: 'off',
       className: 'u-m-0', // 0 margin
       disabled: disabled,
@@ -113,18 +130,7 @@ export class AccountField extends PureComponent {
       case 'dropdown':
         return <Field {...sanitizeSelectProps(fieldProps)} />
       case 'password':
-        return (
-          /*
-          Using the `new-password` value is the best way to avoid
-          autocomplete for password.
-          See https://stackoverflow.com/a/17721462/1135990
-           */
-          <Field
-            {...fieldProps}
-            autoComplete="new-password"
-            secondaryLabels={passwordLabels}
-          />
-        )
+        return <Field {...fieldProps} secondaryLabels={passwordLabels} />
       case 'hidden':
         return (
           <input {...pick(fieldProps, ['value', 'type', 'name', 'role'])} />

--- a/packages/cozy-harvest-lib/src/components/AccountForm/Field.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/Field.jsx
@@ -33,6 +33,7 @@ export const Field = ({ label, type, ...props }) => {
     <Component
       {...props}
       label={<ObfuscatedLabel label={label} />}
+      aria-label={label}
       type={type}
     />
   )

--- a/packages/cozy-harvest-lib/src/components/AccountForm/Field.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/Field.jsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react'
+import UIField from 'cozy-ui/transpiled/react/Field'
+
+const ObfuscateChar = () => {
+  return (
+    <span style={{ fontSize: 0 }} aria-hidden="true">
+      a
+    </span>
+  )
+}
+
+/**
+ * Obfuscate a given label by inserting chars in it.
+ * The chars inserted are not visible, but they are rendered by screen readers,
+ * which is no good for accessibility. We must find a better solution.
+ */
+const ObfuscatedLabel = ({ label }) => {
+  const chars = label.split('')
+
+  return chars.map((char, index) => (
+    <React.Fragment key={`${char}-${index}`}>
+      <ObfuscateChar />
+      {char}
+      <ObfuscateChar />
+    </React.Fragment>
+  ))
+}
+
+export const Field = ({ label, type, ...props }) => {
+  let Component = type === 'password' ? PasswordField : UIField
+
+  return (
+    <Component
+      {...props}
+      label={<ObfuscatedLabel label={label} />}
+      type={type}
+    />
+  )
+}
+
+const PasswordField = ({
+  secondaryLabels,
+  value: valueProps,
+  onChange,
+  ...props
+}) => {
+  const [hidden, setHidden] = useState(true)
+  const [value, setValue] = useState(valueProps)
+
+  const dot = '\u2022'
+  const hiddenValue = value.replace(/./g, dot)
+
+  const getNewValue = inputValue => {
+    const valueArray = Array.from(inputValue)
+
+    const newValue = valueArray.reduce((newValue, char, index) => {
+      if (char === dot) {
+        return newValue + value.charAt(index)
+      } else {
+        return newValue + char
+      }
+    }, '')
+
+    return newValue
+  }
+
+  const handleChange = e => {
+    const newValue = getNewValue(e.target.value)
+
+    onChange({
+      target: {
+        value: newValue
+      }
+    })
+
+    setValue(newValue)
+  }
+
+  /*
+    Using the `new-password` value is the best way to avoid
+    autocomplete for password.
+    See https://stackoverflow.com/a/17721462/1135990
+  */
+  return (
+    <UIField
+      {...props}
+      value={hidden ? hiddenValue : value}
+      type="text"
+      autoComplete="new-password"
+      onChange={handleChange}
+      side={
+        <span onClick={() => setHidden(!hidden)}>
+          {hidden ? secondaryLabels.showLabel : secondaryLabels.hideLabel}
+        </span>
+      }
+    />
+  )
+}

--- a/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
+++ b/packages/cozy-harvest-lib/test/components/AccountForm.spec.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { shallow, mount } from 'enzyme'
+import { I18n } from 'cozy-ui/transpiled/react'
 
 import { isMobile } from 'cozy-device-helper'
 
@@ -415,22 +416,24 @@ describe('AccountForm', () => {
   describe('with read-only identifier', () => {
     it('should render a read-only identifier field if the account has a relationship with a vault cipher and props.readOnlyIdentifier is true', () => {
       const wrapper = mount(
-        <AccountForm
-          konnector={fixtures.konnector}
-          onSubmit={onSubmit}
-          t={t}
-          account={{
-            ...fixtures.account,
-            relationships: {
-              vaultCipher: {
-                _id: 'fake-cipher-id',
-                _type: 'com.bitwarden.ciphers',
-                _protocol: 'bitwarden'
+        <I18n lang="en" dictRequire={() => {}}>
+          <AccountForm
+            konnector={fixtures.konnector}
+            onSubmit={onSubmit}
+            t={t}
+            account={{
+              ...fixtures.account,
+              relationships: {
+                vaultCipher: {
+                  _id: 'fake-cipher-id',
+                  _type: 'com.bitwarden.ciphers',
+                  _protocol: 'bitwarden'
+                }
               }
-            }
-          }}
-          readOnlyIdentifier={true}
-        />,
+            }}
+            readOnlyIdentifier={true}
+          />
+        </I18n>,
         {
           context: { t },
           childContextTypes: {

--- a/packages/cozy-harvest-lib/test/components/AccountsList/__snapshots__/AccountsListItem.spec.jsx.snap
+++ b/packages/cozy-harvest-lib/test/components/AccountsList/__snapshots__/AccountsListItem.spec.jsx.snap
@@ -8,15 +8,15 @@ exports[`AccountsListItem should not render the caption since accountLogin is un
   <div
     className="u-flex-grow-1 u-flex-shrink-1 u-ov-hidden u-mr-1"
   >
-    <Text
+    <ForwardRef
       className="u-ellipsis"
       ellipsis={false}
       tag="div"
     >
       account-1
-    </Text>
+    </ForwardRef>
   </div>
-  <Wrapper
+  <withI18n(Status)
     konnector={
       Object {
         "name": "test-konnector",
@@ -36,27 +36,27 @@ exports[`AccountsListItem should render the caption since accountName !== login 
   <div
     className="u-flex-grow-1 u-flex-shrink-1 u-ov-hidden u-mr-1"
   >
-    <Text
+    <ForwardRef
       className="u-ellipsis"
       ellipsis={false}
       tag="div"
     >
       myAccountName
-    </Text>
-    <Caption
+    </ForwardRef>
+    <ForwardRef
       ellipsis={false}
       tag="div"
     >
-      <Text
+      <ForwardRef
         className="u-ellipsis"
         ellipsis={false}
         tag="div"
       >
         mylogin
-      </Text>
-    </Caption>
+      </ForwardRef>
+    </ForwardRef>
   </div>
-  <Wrapper
+  <withI18n(Status)
     konnector={
       Object {
         "name": "test-konnector",

--- a/packages/cozy-harvest-lib/test/components/Maintenance/index.spec.jsx
+++ b/packages/cozy-harvest-lib/test/components/Maintenance/index.spec.jsx
@@ -1,18 +1,21 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import KonnectorMaintenance from 'components/Maintenance'
+import { I18n } from 'cozy-ui/transpiled/react'
 
 describe('KonnectorMaintenance', () => {
   it('should match the snapshot', () => {
     const component = mount(
-      <KonnectorMaintenance
-        maintenanceMessages={{
-          en: {
-            long_message: 'long_message',
-            short_message: 'short_message'
-          }
-        }}
-      />,
+      <I18n lang="en" dictRequire={() => {}}>
+        <KonnectorMaintenance
+          maintenanceMessages={{
+            en: {
+              long_message: 'long_message',
+              short_message: 'short_message'
+            }
+          }}
+        />
+      </I18n>,
       {
         context: { t: s => s, lang: 'en' }
       }

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -6,6 +6,8 @@ import { DumbTriggerManager as TriggerManager } from 'components/TriggerManager'
 import cronHelpers from 'helpers/cron'
 
 jest.mock('cozy-doctypes', () => {
+  const doctypes = jest.requireActual('cozy-doctypes')
+
   const CozyFolder = {
     copyWithClient: () => CozyFolder,
     ensureMagicFolder: () => ({ path: '/Administrative' }),
@@ -14,7 +16,9 @@ jest.mock('cozy-doctypes', () => {
       PHOTOS: '/photos'
     }
   }
+
   return {
+    ...doctypes,
     CozyFolder
   }
 })

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountField.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountField.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`AccountField render a date field 1`] = `
 <Field
+  aria-label="fields.date.label"
   autoComplete="off"
   className="u-m-0"
   error={false}
@@ -96,6 +97,7 @@ exports[`AccountField render a date field 1`] = `
 
 exports[`AccountField render a dropdown field 1`] = `
 <Field
+  aria-label="fields.multiple.label"
   className="u-m-0"
   error={false}
   fieldProps={Object {}}
@@ -184,6 +186,7 @@ exports[`AccountField render a dropdown field 1`] = `
 
 exports[`AccountField render a password field 1`] = `
 <PasswordField
+  aria-label="fields.passphrase.label"
   autoComplete="off"
   className="u-m-0"
   encrypted={true}
@@ -264,6 +267,7 @@ exports[`AccountField render a password field 1`] = `
 
 exports[`AccountField should render 1`] = `
 <Field
+  aria-label="fields.username.label"
   autoComplete="off"
   className="u-m-0"
   encrypted={false}

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountField.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountField.spec.js.snap
@@ -1,177 +1,341 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AccountField render a date field 1`] = `
-<div
-  className="styles__o-field___3n5HM u-m-0"
->
-  <Label
-    block={true}
-    className=""
-    error={false}
-    htmlFor="harvest-account-date"
-  >
-    fields.date.label
-  </Label>
-  <Input
-    autoComplete="off"
-    error={false}
-    fullwidth={true}
-    id="harvest-account-date"
-    inputRef={[Function]}
-    name="date"
-    placeholder="fields.date.placeholder"
-    size="medium"
-    type="date"
-  />
-</div>
+<Field
+  autoComplete="off"
+  className="u-m-0"
+  error={false}
+  fieldProps={Object {}}
+  fullwidth={true}
+  id="harvest-account-date"
+  inputRef={[Function]}
+  label={
+    <ObfuscatedLabel
+      label="fields.date.label"
+    />
+  }
+  labelProps={Object {}}
+  name="date"
+  placeholder="fields.date.placeholder"
+  required={true}
+  secondaryLabels={Object {}}
+  side={null}
+  size="medium"
+  t={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          "legacy.fields.date.label",
+          Object {
+            "_": "date",
+          },
+        ],
+        Array [
+          "fields.date.label",
+          Object {
+            "_": "legacy.fields.date.label",
+          },
+        ],
+        Array [
+          "fields.date.placeholder",
+          Object {
+            "_": "",
+          },
+        ],
+        Array [
+          "accountForm.password.hide",
+        ],
+        Array [
+          "accountForm.password.show",
+        ],
+        Array [
+          "default.dateFormat",
+        ],
+        Array [
+          "fields.date.placeholder",
+          Object {
+            "_": "default.dateformat",
+          },
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": "legacy.fields.date.label",
+        },
+        Object {
+          "type": "return",
+          "value": "fields.date.label",
+        },
+        Object {
+          "type": "return",
+          "value": "fields.date.placeholder",
+        },
+        Object {
+          "type": "return",
+          "value": "accountForm.password.hide",
+        },
+        Object {
+          "type": "return",
+          "value": "accountForm.password.show",
+        },
+        Object {
+          "type": "return",
+          "value": "default.dateFormat",
+        },
+        Object {
+          "type": "return",
+          "value": "fields.date.placeholder",
+        },
+      ],
+    }
+  }
+  type="date"
+/>
 `;
 
 exports[`AccountField render a dropdown field 1`] = `
-<div
-  className="styles__o-field___3n5HM u-m-0"
->
-  <Label
-    block={true}
-    className=""
-    error={false}
-    htmlFor="harvest-account-multiple"
-  >
-    fields.multiple.label
-  </Label>
-  <withBreakpoints(SelectBox)
-    className="u-m-0"
-    error={false}
-    fieldProps={Object {}}
-    fullwidth={true}
-    id="harvest-account-multiple"
-    inputRef={[Function]}
-    label="fields.multiple.label"
-    labelProps={Object {}}
-    name="multiple"
-    options={
-      Array [
-        Object {
-          "label": "Option 1",
-          "value": "option1",
-        },
-        Object {
-          "label": "Option 2",
-          "value": "option2",
-        },
-      ]
-    }
-    placeholder="fields.multiple.placeholder"
-    required={true}
-    secondaryLabels={Object {}}
-    side={null}
-    size="medium"
-    t={
-      [MockFunction] {
-        "calls": Array [
-          Array [
-            "legacy.fields.multiple.label",
-            Object {
-              "_": "multiple",
-            },
-          ],
-          Array [
-            "fields.multiple.label",
-            Object {
-              "_": "legacy.fields.multiple.label",
-            },
-          ],
-          Array [
-            "fields.multiple.placeholder",
-            Object {
-              "_": "",
-            },
-          ],
-          Array [
-            "accountForm.password.hide",
-          ],
-          Array [
-            "accountForm.password.show",
-          ],
-        ],
-        "results": Array [
+<Field
+  className="u-m-0"
+  error={false}
+  fieldProps={Object {}}
+  fullwidth={true}
+  id="harvest-account-multiple"
+  inputRef={[Function]}
+  label={
+    <ObfuscatedLabel
+      label="fields.multiple.label"
+    />
+  }
+  labelProps={Object {}}
+  name="multiple"
+  options={
+    Array [
+      Object {
+        "label": "Option 1",
+        "value": "option1",
+      },
+      Object {
+        "label": "Option 2",
+        "value": "option2",
+      },
+    ]
+  }
+  placeholder="fields.multiple.placeholder"
+  required={true}
+  secondaryLabels={Object {}}
+  side={null}
+  size="medium"
+  t={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          "legacy.fields.multiple.label",
           Object {
-            "type": "return",
-            "value": "legacy.fields.multiple.label",
-          },
-          Object {
-            "type": "return",
-            "value": "fields.multiple.label",
-          },
-          Object {
-            "type": "return",
-            "value": "fields.multiple.placeholder",
-          },
-          Object {
-            "type": "return",
-            "value": "accountForm.password.hide",
-          },
-          Object {
-            "type": "return",
-            "value": "accountForm.password.show",
+            "_": "multiple",
           },
         ],
-      }
+        Array [
+          "fields.multiple.label",
+          Object {
+            "_": "legacy.fields.multiple.label",
+          },
+        ],
+        Array [
+          "fields.multiple.placeholder",
+          Object {
+            "_": "",
+          },
+        ],
+        Array [
+          "accountForm.password.hide",
+        ],
+        Array [
+          "accountForm.password.show",
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": "legacy.fields.multiple.label",
+        },
+        Object {
+          "type": "return",
+          "value": "fields.multiple.label",
+        },
+        Object {
+          "type": "return",
+          "value": "fields.multiple.placeholder",
+        },
+        Object {
+          "type": "return",
+          "value": "accountForm.password.hide",
+        },
+        Object {
+          "type": "return",
+          "value": "accountForm.password.show",
+        },
+      ],
     }
-    type="select"
-  />
-</div>
+  }
+  type="select"
+/>
 `;
 
 exports[`AccountField render a password field 1`] = `
-<div
-  className="styles__o-field___3n5HM u-m-0"
->
-  <Label
-    block={true}
-    className=""
-    error={false}
-    htmlFor="harvest-account-passphrase"
-  >
-    fields.passphrase.label
-  </Label>
-  <InputPassword
-    autoComplete="new-password"
-    error={false}
-    fullwidth={true}
-    hideLabel="accountForm.password.hide"
-    id="harvest-account-passphrase"
-    inputRef={[Function]}
-    name="passphrase"
-    placeholder="fields.passphrase.placeholder"
-    showLabel="accountForm.password.show"
-    size="medium"
-    type="password"
-  />
-</div>
+<PasswordField
+  autoComplete="off"
+  className="u-m-0"
+  encrypted={true}
+  fullwidth={true}
+  id="harvest-account-passphrase"
+  inputRef={[Function]}
+  label={
+    <ObfuscatedLabel
+      label="fields.passphrase.label"
+    />
+  }
+  name="passphrase"
+  placeholder="fields.passphrase.placeholder"
+  required={true}
+  secondaryLabels={
+    Object {
+      "hideLabel": "accountForm.password.hide",
+      "showLabel": "accountForm.password.show",
+    }
+  }
+  side={null}
+  size="medium"
+  t={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          "legacy.fields.passphrase.label",
+          Object {
+            "_": "passphrase",
+          },
+        ],
+        Array [
+          "fields.passphrase.label",
+          Object {
+            "_": "legacy.fields.passphrase.label",
+          },
+        ],
+        Array [
+          "fields.passphrase.placeholder",
+          Object {
+            "_": "",
+          },
+        ],
+        Array [
+          "accountForm.password.hide",
+        ],
+        Array [
+          "accountForm.password.show",
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": "legacy.fields.passphrase.label",
+        },
+        Object {
+          "type": "return",
+          "value": "fields.passphrase.label",
+        },
+        Object {
+          "type": "return",
+          "value": "fields.passphrase.placeholder",
+        },
+        Object {
+          "type": "return",
+          "value": "accountForm.password.hide",
+        },
+        Object {
+          "type": "return",
+          "value": "accountForm.password.show",
+        },
+      ],
+    }
+  }
+  type="password"
+/>
 `;
 
 exports[`AccountField should render 1`] = `
-<div
-  className="styles__o-field___3n5HM u-m-0"
->
-  <Label
-    block={true}
-    className=""
-    error={false}
-    htmlFor="harvest-account-username"
-  >
-    fields.username.label
-  </Label>
-  <Input
-    autoComplete="off"
-    error={false}
-    fullwidth={true}
-    id="harvest-account-username"
-    inputRef={[Function]}
-    name="username"
-    placeholder="fields.username.placeholder"
-    size="medium"
-    type="text"
-  />
-</div>
+<Field
+  autoComplete="off"
+  className="u-m-0"
+  encrypted={false}
+  error={false}
+  fieldProps={Object {}}
+  fullwidth={true}
+  id="harvest-account-username"
+  inputRef={[Function]}
+  label={
+    <ObfuscatedLabel
+      label="fields.username.label"
+    />
+  }
+  labelProps={Object {}}
+  name="username"
+  placeholder="fields.username.placeholder"
+  required={true}
+  secondaryLabels={Object {}}
+  side={null}
+  size="medium"
+  t={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          "legacy.fields.username.label",
+          Object {
+            "_": "username",
+          },
+        ],
+        Array [
+          "fields.username.label",
+          Object {
+            "_": "legacy.fields.username.label",
+          },
+        ],
+        Array [
+          "fields.username.placeholder",
+          Object {
+            "_": "",
+          },
+        ],
+        Array [
+          "accountForm.password.hide",
+        ],
+        Array [
+          "accountForm.password.show",
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": "legacy.fields.username.label",
+        },
+        Object {
+          "type": "return",
+          "value": "fields.username.label",
+        },
+        Object {
+          "type": "return",
+          "value": "fields.username.placeholder",
+        },
+        Object {
+          "type": "return",
+          "value": "accountForm.password.hide",
+        },
+        Object {
+          "type": "return",
+          "value": "accountForm.password.show",
+        },
+      ],
+    }
+  }
+  type="text"
+/>
 `;

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountForm.spec.js.snap
@@ -106,7 +106,7 @@ exports[`AccountForm should render error 1`] = `
   onFocusCapture={[Function]}
   onKeyUp={[Function]}
 >
-  <Wrapper
+  <withI18n(withKonnectorLocales(TriggerErrorInfo)
     className="u-mb-1"
     error={[Error: Test error]}
     konnector={

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountModal.spec.jsx.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountModal.spec.jsx.snap
@@ -9,7 +9,7 @@ exports[`AccountModal should display the fetching state by default 1`] = `
     <div
       className="u-ta-center"
     >
-      <Wrapper
+      <withI18n(Spinner)
         size="xxlarge"
       />
     </div>
@@ -57,7 +57,7 @@ exports[`AccountModal with an account should display the AccountSelect & Content
     />
   </KonnectorModalHeader>
   <ModalContent>
-    <withClient(Wrapper)
+    <withClient(withI18n(KonnectorAccountTabs))
       account={
         Object {
           "_id": "123",
@@ -117,7 +117,7 @@ exports[`AccountModal with an account should display the AccountSelect & Content
     />
   </KonnectorModalHeader>
   <ModalContent>
-    <withClient(Wrapper)
+    <withClient(withI18n(KonnectorAccountTabs))
       account={
         Object {
           "_id": "account_2",

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/KonnectorModal.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/KonnectorModal.spec.js.snap
@@ -29,7 +29,7 @@ exports[`KonnectorModal adding an account should render the form when controlled
 
 exports[`KonnectorModal should render the selected account via a prop 1`] = `
 <ModalContent>
-  <withClient(Wrapper)
+  <withClient(withI18n(KonnectorAccountTabs))
     account={
       Object {
         "_id": "123",
@@ -80,7 +80,7 @@ exports[`KonnectorModal should show a spinner while loading 1`] = `
 
 exports[`KonnectorModal should show an error view 1`] = `
 <ModalContent>
-  <Infos
+  <Memo(InfosMigration)
     actionButton={
       <DefaultButton
         theme="danger"
@@ -88,7 +88,6 @@ exports[`KonnectorModal should show an error view 1`] = `
         modal.konnector.error.button
       </DefaultButton>
     }
-    icon={null}
     isImportant={true}
     text="modal.konnector.error.description"
     title="modal.konnector.error.title"
@@ -98,7 +97,7 @@ exports[`KonnectorModal should show an error view 1`] = `
 
 exports[`KonnectorModal should show the configuration view of a single account 1`] = `
 <ModalContent>
-  <withClient(Wrapper)
+  <withClient(withI18n(KonnectorAccountTabs))
     account={
       Object {
         "_id": "123",
@@ -135,7 +134,7 @@ exports[`KonnectorModal should show the configuration view of a single account 1
 exports[`KonnectorModal should show the list of accounts 1`] = `
 <ModalContent>
   <React.Fragment>
-    <Wrapper
+    <withI18n(AccountsList)
       accounts={
         Array [
           Object {
@@ -187,7 +186,7 @@ exports[`KonnectorModal should show the list of accounts 1`] = `
 
 exports[`KonnectorModal switching account should show the add account view when controlled by state 1`] = `
 <ModalContent>
-  <withClient(Wrapper)
+  <withClient(withI18n(KonnectorAccountTabs))
     account={
       Object {
         "_id": "123",

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/KonnectorUpdateInfos.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/KonnectorUpdateInfos.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KonnectorUpdateInfos should render 1`] = `
-<Infos
+<InfosMigration
   actionButton={
     <KonnectorUpdateLinker
       konnector={
@@ -12,14 +12,13 @@ exports[`KonnectorUpdateInfos should render 1`] = `
       label="infos.konnectorUpdate.button.label"
     />
   }
-  icon={null}
   text="infos.konnectorUpdate.body.regular"
   title="infos.konnectorUpdate.title"
 />
 `;
 
 exports[`KonnectorUpdateInfos should render as blocking 1`] = `
-<Infos
+<InfosMigration
   actionButton={
     <KonnectorUpdateLinker
       isBlocking={true}
@@ -31,7 +30,6 @@ exports[`KonnectorUpdateInfos should render as blocking 1`] = `
       label="infos.konnectorUpdate.button.label"
     />
   }
-  icon={null}
   isImportant={true}
   text="infos.konnectorUpdate.body.blocking"
   title="infos.konnectorUpdate.title"

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerLauncher.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerLauncher.spec.js.snap
@@ -42,7 +42,7 @@ exports[`TriggerLauncher handleTwoFA should display Two FA modal 1`] = `
     launch={[Function]}
     running={false}
   />
-  <Wrapper
+  <withI18n(withBreakpoints(TwoFAModal))
     dismissAction={[Function]}
     into="coz-harvest-modal-place"
   />

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
@@ -8,7 +8,7 @@ exports[`TriggerManager handleError should render error 1`] = `
     id="coz-harvest-modal-place"
   />
   <React.Fragment>
-    <Wrapper
+    <withI18n(withLocales(withKonnectorLocales(AccountForm))
       account={
         Object {
           "_id": "61c683295560485db0f34b859197c581",
@@ -44,7 +44,7 @@ exports[`TriggerManager handleError should render error 1`] = `
 `;
 
 exports[`TriggerManager should redirect to OAuthForm 1`] = `
-<Wrapper
+<withI18n(OAuthForm)
   konnector={
     Object {
       "oauth": Object {
@@ -65,7 +65,7 @@ exports[`TriggerManager should render with account 1`] = `
     id="coz-harvest-modal-place"
   />
   <React.Fragment>
-    <Wrapper
+    <withI18n(withLocales(withKonnectorLocales(AccountForm))
       account={
         Object {
           "_id": "61c683295560485db0f34b859197c581",
@@ -106,7 +106,7 @@ exports[`TriggerManager should render without account 1`] = `
   <div
     id="coz-harvest-modal-place"
   />
-  <Wrapper
+  <withI18n(withLocales(DumbVaultCiphersList))
     ciphers={Array []}
     konnector={
       Object {

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TwoFAForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TwoFAForm.spec.js.snap
@@ -33,19 +33,19 @@ exports[`TwoFAForm should render correctly with value change 1`] = `
     <form
       onSubmit={[Function]}
     >
-      <SubTitle
+      <ForwardRef
         className="u-mb-1 u-mt-half u-ta-center"
         ellipsis={false}
         tag="div"
       >
         twoFAForm.title.default
-      </SubTitle>
-      <Text
+      </ForwardRef>
+      <ForwardRef
         ellipsis={false}
         tag="div"
       >
         twoFAForm.desc
-      </Text>
+      </ForwardRef>
       <Field
         autoComplete="off"
         className="u-mt-0 u-mb-0"

--- a/packages/cozy-harvest-lib/test/components/infos/__snapshots__/TriggerErrorInfo.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/infos/__snapshots__/TriggerErrorInfo.spec.js.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TriggerErrorInfo should render 1`] = `
-<Infos
-  icon={null}
+<InfosMigration
   isImportant={true}
   text={
     <Markdown
@@ -14,8 +13,7 @@ exports[`TriggerErrorInfo should render 1`] = `
 `;
 
 exports[`TriggerErrorInfo should render regular Error 1`] = `
-<Infos
-  icon={null}
+<InfosMigration
   isImportant={true}
   text={
     <Markdown

--- a/yarn.lock
+++ b/yarn.lock
@@ -4755,6 +4755,24 @@ cozy-ui@28.4.1, cozy-ui@^28.4.1:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
+cozy-ui@29.2.1:
+  version "29.2.1"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-29.2.1.tgz#0fcafc6f62985f585dc74b2603b8885960a82737"
+  integrity sha512-VOnZT/qfBu8DdsbhyVMwwRdlDNkZqj5l802X57qnHmKo6cCsx0ORNCkuaEgH1FDc3vhGqHfbv8532Yc+/n7qrA==
+  dependencies:
+    "@babel/runtime" "^7.3.4"
+    body-scroll-lock "^2.5.8"
+    classnames "^2.2.5"
+    date-fns "^1.28.5"
+    hammerjs "^2.0.8"
+    node-polyglot "^2.2.2"
+    normalize.css "^7.0.0"
+    react-hot-loader "^4.3.11"
+    react-markdown "^4.0.8"
+    react-pdf "^4.0.5"
+    react-select "2.2.0"
+    react-swipeable-views "0.13.3"
+
 cozy-ui@^24.0.0:
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-24.3.0.tgz#fd92c11798c52f573dc614b12f2a0ba550e845ec"


### PR DESCRIPTION
We want harvest's konnector form to not be recognized by password managers browsers extensions, so they don't try to autofill it with wrong credentials guessed from the current URL (which is the cozy instance one, not the one from the vendor the user is configuring a konnector for).

To achieve this, we use several techniques:

* Don't include things like « login » or « password » in inputs `name`, `id` or `className`
* Don't use a `input type="password"`: instead we use a classic text input, but we show dots unicode characters in it
* Obfuscate the labels: this is the hacky part. Some extensions look at the label associated to the input and check if it contains something that can tell them it's a login form. To prevent them from doing this, I obfuscated the label content by adding invisible letters in the middle of the label string. This way, when checking `label.textContent`, extensions see garbage and can't compare it to known string (login, identifiant, mot de passe, password,...). Of course it totally breaks accessibility as a screen reader will not be able to read the label correctly (theorically, I still need to take some time to check it).

In the end, Bitwarden (and Cozy Extension), Lastpass and Dashlane totally ignore this form.