### PR TITLE
feat: Support SCA_REQUIRED and WEBAUTH_REQUIRED

### DIFF
--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -104,9 +104,17 @@
         "title": "New permissions needed",
         "description": "You connector was updated and the permissions changed. Please validate them before launching the connector again."
       },
+      "USER_ACTION_NEEDED.SCA_REQUIRED": {
+        "title": "Authentication on vendor required",
+        "description": "It seems that [%{name}](%{link}) requires you to log in on their app/website for the synchronisation to work. Please re-run the connector once you have settled the issue on the app/website."
+      },
       "USER_ACTION_NEEDED.TWOFA_EXPIRED": {
         "title": "Authentication renewal required",
         "description": "The last connexion to the service failed; please launch it again. You may have to provide a validation code."
+      },
+      "USER_ACTION_NEEDED.WEBAUTH_REQUIRED": {
+        "title": "Authentication on vendor website required",
+        "description": "It seems that [%{name}](%{link}) requires you to log in on their website for the synchronisation to work. Please re-run the connector once you have settled the issue on the website."
       },
       "USER_ACTION_NEEDED.WRONG_TWOFA_CODE": {
         "title": "Incorrect strong authentication code",

--- a/packages/cozy-harvest-lib/test/helpers/konnectors.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/konnectors.spec.js
@@ -198,6 +198,7 @@ describe('Konnectors Helpers', () => {
       'USER_ACTION_NEEDED.ACCOUNT_REMOVED',
       'USER_ACTION_NEEDED.CHANGE_PASSWORD',
       'USER_ACTION_NEEDED.PERMISSIONS_CHANGED',
+      'USER_ACTION_NEEDED.SCA_REQUIRED',
       'VENDOR_DOWN',
       'VENDOR_DOWN.BANK_DOWN',
       'VENDOR_DOWN.LINXO_DOWN'
@@ -224,7 +225,8 @@ describe('Konnectors Helpers', () => {
             'USER_ACTION_NEEDED.OAUTH_OUTDATED',
             'USER_ACTION_NEEDED.ACCOUNT_REMOVED',
             'USER_ACTION_NEEDED.CHANGE_PASSWORD',
-            'USER_ACTION_NEEDED.PERMISSIONS_CHANGED'
+            'USER_ACTION_NEEDED.PERMISSIONS_CHANGED',
+            'USER_ACTION_NEEDED.SCA_REQUIRED'
           ].includes(message)
         )
         expect(error.isTermsVersionMismatchError()).toBe(


### PR DESCRIPTION
Add two errors originating from banking connectors.

- SCA_REQUIRED: the vendor demands a new authentification on its app or website

- WEBAUTH_REQUIRED: the vendors demands a new authentification on its website

- [x] : [Transifex mis à jour](https://www.transifex.com/cozy/cozy-harvest-lib/translate/#fr/client/191464383?q=reviewed%3Ano+translated_after%3A2020-01-13)
- [x] : Transifex revu