### PR TITLE
fix(TriggerManager): Bypass ciphers list when there's no choice in it

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -418,6 +418,10 @@ export class DumbTriggerManager extends Component {
     return this.state.selectedCipher !== undefined
   }
 
+  showAccountForm() {
+    this.setState({ step: 'accountForm', showBackButton: false })
+  }
+
   async handleVaultUnlock() {
     const { vaultClient, konnector } = this.props
 
@@ -426,7 +430,7 @@ export class DumbTriggerManager extends Component {
     })
 
     if (encryptedCiphers.length === 0) {
-      this.setState({ step: 'accountForm', showBackButton: false })
+      this.showAccountForm()
       return
     }
 
@@ -436,6 +440,7 @@ export class DumbTriggerManager extends Component {
         uri: get(konnector, 'vendor_link')
       })
 
+      this.showAccountForm()
       this.setState({ ciphers })
     } catch (err) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
When the user has no ciphers for a given konnector, we want to bypass
the ciphers list because there will be only one choice in it : « from
another account ». So we want to directly show the form.