### PR TITLE
Fix/sharing path

### DIFF
--- a/packages/cozy-sharing/__tests__/fixtures.js
+++ b/packages/cozy-sharing/__tests__/fixtures.js
@@ -139,6 +139,50 @@ export const SHARING_3 = {
   }
 }
 
+export const SHARING_NO_ACTIVE = {
+  type: 'io.cozy.sharings',
+  id: 'sharing_4',
+  attributes: {
+    active: false,
+    owner: true,
+    description: 'Holidays',
+    app_slug: 'drive',
+    created_at: '2018-05-21T11:52:19.732097476+02:00',
+    updated_at: '2018-05-21T11:52:19.732097476+02:00',
+    rules: [
+      {
+        title: 'Holidays',
+        doctype: 'io.cozy.files',
+        values: ['folder_1'],
+        add: 'sync',
+        update: 'sync',
+        remove: 'sync'
+      }
+    ],
+    members: [
+      {
+        status: 'owner',
+        name: 'Jane Doe',
+        email: 'jane@doe.com',
+        instance: 'http://cozy.tools:8080'
+      },
+      {
+        status: 'pending',
+        name: 'Johnny Doe',
+        email: 'johnny@doe.com',
+        instance: 'http://cozy.foo:8080'
+      }
+    ]
+  },
+  relationships: {
+    shared_docs: {
+      data: [
+        { id: 'folder_1_1', type: 'io.cozy.files' },
+        { id: 'folder_1_2', type: 'io.cozy.files' }
+      ]
+    }
+  }
+}
 export const PERM_1 = {
   type: 'io.cozy.permissions',
   id: 'perm_1',

--- a/packages/cozy-sharing/src/checkIfNextPermissions.js
+++ b/packages/cozy-sharing/src/checkIfNextPermissions.js
@@ -1,0 +1,12 @@
+import { addSharingLink } from './state'
+export const loadNextPermissions = async (permissions, dispatch, client) => {
+  if (permissions.links && permissions.links.next) {
+    let resp = { links: { next: true } }
+    while (resp && resp.links.next) {
+      resp = await client
+        .getStackClient()
+        .fetchJSON('GET', permissions.links.next)
+      dispatch(addSharingLink(resp.data))
+    }
+  }
+}

--- a/packages/cozy-sharing/src/fetchNextPermissions.js
+++ b/packages/cozy-sharing/src/fetchNextPermissions.js
@@ -1,5 +1,12 @@
 import { addSharingLink } from './state'
-export const loadNextPermissions = async (permissions, dispatch, client) => {
+/**
+ * Fetch paginated permissions if needed and dispatch it to
+ * the store
+ * @param {Object} permissions
+ * @param {Function} dispatch
+ * @param {Object} client
+ */
+export const fetchNextPermissions = async (permissions, dispatch, client) => {
   if (permissions.links && permissions.links.next) {
     let resp = { links: { next: true } }
     while (resp && resp.links.next) {

--- a/packages/cozy-sharing/src/fetchNextPermissions.js
+++ b/packages/cozy-sharing/src/fetchNextPermissions.js
@@ -8,12 +8,10 @@ import { addSharingLink } from './state'
  */
 export const fetchNextPermissions = async (permissions, dispatch, client) => {
   if (permissions.links && permissions.links.next) {
-    let resp = { links: { next: true } }
-    while (resp && resp.links.next) {
-      resp = await client
-        .getStackClient()
-        .fetchJSON('GET', permissions.links.next)
-      dispatch(addSharingLink(resp.data))
-    }
+    const resp = await client
+      .getStackClient()
+      .fetchJSON('GET', permissions.links.next)
+    dispatch(addSharingLink(resp.data))
+    return fetchNextPermissions(resp, dispatch, client)
   }
 }

--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -42,6 +42,7 @@ import { withClient } from 'cozy-client'
 
 export { default as withLocales } from './withLocales'
 
+import { loadNextPermissions } from './checkIfNextPermissions'
 const track = (document, action) => {
   const tracker = getTracker()
   if (!tracker) {
@@ -102,6 +103,7 @@ class SharingProvider extends Component {
         apps: apps.data
       })
     )
+    loadNextPermissions(permissions, this.dispatch, client)
     if (doctype !== 'io.cozy.files') return
 
     const sharedDocIds = sharings.data

--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -19,7 +19,7 @@ import reducer, {
   getSharingForSelf,
   getSharingType,
   getSharingLink,
-  getSharingDocIds,
+  getSharedDocIdsBySharings,
   getDocumentSharing,
   getDocumentPermissions,
   hasSharedParent,
@@ -105,14 +105,7 @@ class SharingProvider extends Component {
     )
     fetchNextPermissions(permissions, this.dispatch, client)
     if (doctype !== 'io.cozy.files') return
-
-    const sharedDocIds = sharings.data
-      .map(s => {
-        if (s.attributes && s.attributes.active) {
-          return getSharingDocIds(s)
-        }
-      })
-      .reduce((acc, val) => acc.concat(val), [])
+    const sharedDocIds = getSharedDocIdsBySharings(sharings)
     const resp = await client.collection(doctype).all({ keys: sharedDocIds })
     const folderPaths = resp.data
       .filter(f => f.type === 'directory')

--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -105,7 +105,11 @@ class SharingProvider extends Component {
     if (doctype !== 'io.cozy.files') return
 
     const sharedDocIds = sharings.data
-      .map(s => getSharingDocIds(s))
+      .map(s => {
+        if (s.attributes && s.attributes.active) {
+          return getSharingDocIds(s)
+        }
+      })
       .reduce((acc, val) => acc.concat(val), [])
     const resp = await client.collection(doctype).all({ keys: sharedDocIds })
     const folderPaths = resp.data

--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -42,7 +42,7 @@ import { withClient } from 'cozy-client'
 
 export { default as withLocales } from './withLocales'
 
-import { loadNextPermissions } from './checkIfNextPermissions'
+import { fetchNextPermissions } from './fetchNextPermissions'
 const track = (document, action) => {
   const tracker = getTracker()
   if (!tracker) {
@@ -103,7 +103,7 @@ class SharingProvider extends Component {
         apps: apps.data
       })
     )
-    loadNextPermissions(permissions, this.dispatch, client)
+    fetchNextPermissions(permissions, this.dispatch, client)
     if (doctype !== 'io.cozy.files') return
 
     const sharedDocIds = sharings.data

--- a/packages/cozy-sharing/src/state.js
+++ b/packages/cozy-sharing/src/state.js
@@ -217,12 +217,10 @@ const sharedPaths = (state = [], action) => {
     case RECEIVE_PATHS:
       //!TODO Remove after we solved the sharedPaths bugs
       //eslint-disable-next-line
-      console.log('RECEIVE PATHS', action)
       return action.paths
     case ADD_SHARING:
       //!TODO Remove after we solved the sharedPaths bugs
       //eslint-disable-next-line
-      console.log('ADD SHARING', action)
       //eslint-disable-next-line
       const newState = [...state, action.path]
       return newState

--- a/packages/cozy-sharing/src/state.js
+++ b/packages/cozy-sharing/src/state.js
@@ -430,3 +430,19 @@ const getAppUrl = (apps, appName) => {
   }
   return app.links.related
 }
+
+/**
+ *
+ * @param {SharingCollection} sharings
+ * @return {Array} Array of docIds
+ */
+export const getSharedDocIdsBySharings = sharings => {
+  const docs = []
+  if (!sharings.data) return []
+  sharings.data.map(s => {
+    if (s.attributes && s.attributes.active) {
+      docs.push(getSharingDocIds(s))
+    }
+  })
+  return docs.reduce((acc, val) => acc.concat(val), [])
+}

--- a/packages/cozy-sharing/src/state.js
+++ b/packages/cozy-sharing/src/state.js
@@ -145,7 +145,15 @@ const byDocId = (state = {}, action) => {
       }
       return state
     case ADD_SHARING_LINK:
-      return indexPermission(state, action.data)
+      if (!Array.isArray(action.data)) {
+        return indexPermission(state, action.data)
+      } else {
+        let clonedState = { ...state }
+        action.data.map(s => {
+          clonedState = { ...indexPermission(clonedState, s) }
+        })
+        return clonedState
+      }
     case REVOKE_SELF:
       return forgetSharing(state, action.sharing)
     case REVOKE_SHARING_LINK:
@@ -163,7 +171,11 @@ const permissions = (state = [], action) => {
     case RECEIVE_SHARINGS:
       return action.data.permissions
     case ADD_SHARING_LINK:
-      return [...state, action.data]
+      if (!Array.isArray(action.data)) {
+        return [...state, action.data]
+      } else {
+        return [...state, ...action.data]
+      }
     case REVOKE_SHARING_LINK:
       // eslint-disable-next-line no-case-declarations
       const permIds = action.permissions.map(p => p.id)

--- a/packages/cozy-sharing/src/state.js
+++ b/packages/cozy-sharing/src/state.js
@@ -439,10 +439,10 @@ const getAppUrl = (apps, appName) => {
 export const getSharedDocIdsBySharings = sharings => {
   const docs = []
   if (!sharings.data) return []
-  sharings.data.map(s => {
+  sharings.data.forEach(s => {
     if (s.attributes && s.attributes.active) {
-      docs.push(getSharingDocIds(s))
+      docs.push(...getSharingDocIds(s))
     }
   })
-  return docs.reduce((acc, val) => acc.concat(val), [])
+  return docs
 }

--- a/packages/cozy-sharing/src/state.spec.js
+++ b/packages/cozy-sharing/src/state.spec.js
@@ -172,6 +172,22 @@ describe('Sharing state', () => {
     expect(newState.permissions).toEqual([PERM_1, PERM_2])
   })
 
+  it('should index an array of sharing links', () => {
+    const initialState = reducer(
+      undefined,
+      receiveSharings({
+        sharings: [SHARING_1, SHARING_2],
+        permissions: []
+      })
+    )
+    const newState = reducer(initialState, addSharingLink([PERM_1, PERM_2]))
+    expect(newState.byDocId).toEqual({
+      folder_1: { sharings: [SHARING_1.id], permissions: [PERM_1.id] },
+      folder_2: { sharings: [SHARING_2.id], permissions: [PERM_2.id] }
+    })
+    expect(newState.permissions).toEqual([PERM_1, PERM_2])
+  })
+
   it('should revoke a sharing link', () => {
     const initialState = reducer(
       undefined,

--- a/packages/cozy-sharing/src/state.spec.js
+++ b/packages/cozy-sharing/src/state.spec.js
@@ -9,7 +9,8 @@ import reducer, {
   matchingInstanceName,
   getSharingLink,
   hasSharedParent,
-  isShared
+  isShared,
+  getSharedDocIdsBySharings
 } from './state'
 
 import {
@@ -18,6 +19,7 @@ import {
   SHARING_3,
   PERM_1,
   PERM_2,
+  SHARING_NO_ACTIVE,
   APPS
 } from '../__tests__/fixtures'
 
@@ -375,5 +377,14 @@ describe('isShared helper', () => {
     }
     const result = isShared(state, document)
     expect(result).toBe(false)
+  })
+
+  describe('getSharedDocIdsBySharings method', () => {
+    it('should test getSharedDocIdsBySharings', () => {
+      const sharedDocsId = getSharedDocIdsBySharings({
+        data: [SHARING_1, SHARING_NO_ACTIVE]
+      })
+      expect(sharedDocsId).toEqual(SHARING_1.attributes.rules[0].values)
+    })
   })
 })


### PR DESCRIPTION
When we mount the component we do few requests to get the sharings. 

First : we fetch the sharings, ie cozy to cozy sharing. It returns ALL the sharings in a non paginated way.
Second we fetch permissions for io.cozy.files. This is the request to fetch the "shared-by-link" sharing. This request is paginated and we currently do not handle it. 

This fix does the following: 
- If we detect that we have a next attributes in the return from /permission/io.cozy.files then we fetch the API until we do not have next anymore and we dispatch the results. 

Also fixed a bug when we only need to work on active sharing. Not revoked one 