### PR TITLE
Fix harvest's updateAccountsPassword service

### DIFF
--- a/packages/cozy-harvest-lib/src/helpers/accounts.js
+++ b/packages/cozy-harvest-lib/src/helpers/accounts.js
@@ -126,13 +126,11 @@ export const setVaultCipherRelationship = (account, vaultCipherId) => ({
   relationships: {
     ...account.relationships,
     vaultCipher: {
-      data: [
-        {
-          _id: vaultCipherId,
-          _type: 'com.bitwarden.ciphers',
-          _protocol: 'bitwarden'
-        }
-      ]
+      data: {
+        _id: vaultCipherId,
+        _type: 'com.bitwarden.ciphers',
+        _protocol: 'bitwarden'
+      }
     }
   }
 })

--- a/packages/cozy-harvest-lib/src/services/utils.js
+++ b/packages/cozy-harvest-lib/src/services/utils.js
@@ -36,12 +36,12 @@ export const fetchAccountsForCipherId = async (cozyClient, cipherId) => {
     cozyClient
       .find('io.cozy.accounts')
       .where({
-        'relationships.vaultCipher': {
+        'relationships.vaultCipher.data': {
           _id: cipherId,
           _type: 'com.bitwarden.ciphers'
         }
       })
-      .indexFields(['relationships.vaultCipher._id'])
+      .indexFields(['relationships.vaultCipher.data._id'])
   )
 
   return accounts

--- a/packages/cozy-harvest-lib/test/services/utils.spec.js
+++ b/packages/cozy-harvest-lib/test/services/utils.spec.js
@@ -92,13 +92,13 @@ describe('fetchAccountsForCipherId', () => {
 
     expect(mockCozyClient.find).toHaveBeenCalledWith('io.cozy.accounts')
     expect(mockCozyClient.where).toHaveBeenCalledWith({
-      'relationships.vaultCipher': {
+      'relationships.vaultCipher.data': {
         _id: '123-456',
         _type: 'com.bitwarden.ciphers'
       }
     })
     expect(mockCozyClient.indexFields).toHaveBeenCalledWith([
-      'relationships.vaultCipher._id'
+      'relationships.vaultCipher.data._id'
     ])
   })
 })


### PR DESCRIPTION
Two things here.

The service was broken because we have updated the vaultCipher relationships format, but didn't reflect it in the query made in the service to fetch accounts from their linked ciphers.

We saw that the relationship should not be an array (see https://github.com/cozy/cozy-doctypes/pull/126), so in this PR I removed the array, and I updated the query in the service to make it work again.