### PR TITLE
fix: Use minilog cozy fork

### DIFF
--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -32,7 +32,7 @@
     "cozy-doctypes": "^1.71.0",
     "cozy-realtime": "^3.4.0",
     "lodash": "^4.17.15",
-    "minilog": "^3.1.0",
+    "minilog": "https://github.com/cozy/minilog.git#master",
     "react-autosuggest": "^9.4.3",
     "react-tooltip": "^3.11.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11200,7 +11200,7 @@ mini-html-webpack-plugin@^0.2.3:
   dependencies:
     webpack-sources "^1.1.0"
 
-minilog@3.1.0, minilog@^3.1.0, "minilog@https://github.com/cozy/minilog.git#master":
+minilog@3.1.0, "minilog@https://github.com/cozy/minilog.git#master":
   version "3.1.0"
   resolved "https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
   dependencies:


### PR DESCRIPTION
We use cozy's fork since we have a few issues with the official munilog repo (https://github.com/cozy/minilog/pull/1) 