### PR TITLE
Refactor TriggerManager handleSubmit

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -309,7 +309,11 @@ export class DumbTriggerManager extends Component {
   }
 
   /**
-   * TODO move to AccountHelper
+   * - Ensures a cipher is created for the authentication data
+   *   Find cipher via identifier / password
+   * - Creates io.cozy.accounts
+   * - Links cipher to account
+   * - Saves account
    */
   async handleSubmit(data = {}) {
     const { konnector, saveAccount, vaultClient } = this.props

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -135,8 +135,15 @@ const updateCipher = async (vaultClient, cipherId, data) => {
   }
 }
 
-const createOrUpdateCipher = async (vaultClient, cipherId, data) => {
-  const { login, password, konnector, account } = data
+const createOrUpdateCipher = async (
+  vaultClient,
+  cipherId,
+  { userData, account, konnector }
+) => {
+  const identifierProperty = manifest.getIdentifier(konnector.fields)
+  const login = userData[identifierProperty]
+  const password = userData.password
+
   let cipher
   if (!cipherId) {
     cipher = await searchForCipher(vaultClient, {
@@ -322,23 +329,19 @@ export class DumbTriggerManager extends Component {
           'Impossible to manage ciphers since vault is locked. The created io.cozy.accounts will not be linked to an com.bitwarden.ciphers'
         )
       } else {
-        const identifierProperty = manifest.getIdentifier(konnector.fields)
-        const login = data[identifierProperty]
-        const password = data.password
         let cipherId = this.getSelectedCipherId()
         cipher = await createOrUpdateCipher(vaultClient, cipherId, {
-          konnector,
           account,
-          login,
-          password
+          konnector,
+          userData: data
         })
       }
 
       const accountToSave = buildOrUpdateAccount({
         account,
-        userData: data,
+        cipher,
         konnector,
-        cipher
+        userData: data
       })
 
       const savedAccount = accounts.mergeAuth(

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -5,15 +5,18 @@ import flow from 'lodash/flow'
 
 import { withMutations, withClient } from 'cozy-client'
 import { CozyFolder as CozyFolderClass, Account } from 'cozy-doctypes'
+
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+import { ModalBackButton } from 'cozy-ui/transpiled/react/Modal'
+
 import {
   VaultUnlocker,
   withVaultClient,
   CipherType,
   UriMatchType
 } from 'cozy-keys-lib'
-import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import AccountForm from './AccountForm'
 import OAuthForm from './OAuthForm'
@@ -28,7 +31,6 @@ import triggers from '../helpers/triggers'
 import TriggerLauncher from './TriggerLauncher'
 import VaultCiphersList from './VaultCiphersList'
 import manifest from '../helpers/manifest'
-import { ModalBackButton } from 'cozy-ui/transpiled/react/Modal'
 import HarvestVaultProvider from './HarvestVaultProvider'
 
 const IDLE = 'IDLE'

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -37,19 +37,26 @@ const MODAL_PLACE_ID = 'coz-harvest-modal-place'
 
 const buildOrUpdateAccount = ({ account, userData, cipher, konnector }) => {
   const isUpdate = !!account
-  const accountWithNewState = accounts.setSessionResetIfNecessary(
+
+  let accountToSave
+
+  accountToSave = accounts.setSessionResetIfNecessary(
     accounts.resetState(account),
     userData
   )
-  const accountDocument = isUpdate
-    ? accounts.mergeAuth(accountWithNewState, userData)
+
+  accountToSave = isUpdate
+    ? accounts.mergeAuth(accountToSave, userData)
     : accounts.build(konnector, userData)
 
   if (cipher) {
-    return accounts.setVaultCipherRelationship(accountDocument, cipher.id)
-  } else {
-    return accountDocument
+    accountToSave = accounts.setVaultCipherRelationship(
+      accountToSave,
+      cipher.id
+    )
   }
+
+  return accountToSave
 }
 
 /**

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -11,12 +11,7 @@ import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import { ModalBackButton } from 'cozy-ui/transpiled/react/Modal'
 
-import {
-  VaultUnlocker,
-  withVaultClient,
-  CipherType,
-  UriMatchType
-} from 'cozy-keys-lib'
+import { VaultUnlocker, withVaultClient, CipherType } from 'cozy-keys-lib'
 
 import AccountForm from './AccountForm'
 import OAuthForm from './OAuthForm'
@@ -33,144 +28,12 @@ import VaultCiphersList from './VaultCiphersList'
 import manifest from '../helpers/manifest'
 import HarvestVaultProvider from './HarvestVaultProvider'
 
+import { createOrUpdateCipher } from '../models/cipherUtils'
+
 const IDLE = 'IDLE'
 const RUNNING = 'RUNNING'
 
 const MODAL_PLACE_ID = 'coz-harvest-modal-place'
-
-/**
- * Finds a cipher inside vaultClient from account / konnector / login / password
- *
- * @param {string} searchOptions - Used to find the cipher
- * @param {string} searchOptions.konnector - Used for its vendor link
- * @param {string} searchOptions.account - Used for its cipherId if it exists
- * @param {string} searchOptions.login - Used to match the cipher
- * @param {string} searchOptions.password - Used to match the cipher
- *
- * @returns {Cipher} The cipher or null if no cipher was found
- */
-const searchForCipher = async (vaultClient, searchOptions) => {
-  const { konnector, account, login, password } = searchOptions
-  const konnectorURI = get(konnector, 'vendor_link')
-
-  const id = accounts.getVaultCipherId(account)
-  const search = {
-    username: login,
-    uri: konnectorURI,
-    type: CipherType.Login
-  }
-  const sort = [view => view.login.password === password, 'revisionDate']
-  const cipher = await vaultClient.getByIdOrSearch(id, search, sort)
-  return cipher || null
-}
-
-/**
- * Create a new cipher and return its ID
- *
- * @param {string} login - the login to register in the new cipher
- * @param {string} password - the password to register in the new cipher
- *
- * @returns {string} the cipher ID
- */
-const createCipher = async (vaultClient, createOptions) => {
-  const { konnector, login, password } = createOptions
-  const konnectorURI = get(konnector, 'vendor_link')
-  const konnectorName = get(konnector, 'name') || get(konnector, 'slug')
-
-  const cipherData = {
-    id: null,
-    type: CipherType.Login,
-    name: konnectorName,
-    login: {
-      username: login,
-      password,
-      uris: konnectorURI
-        ? [{ uri: konnectorURI, match: UriMatchType.Domain }]
-        : []
-    }
-  }
-
-  const cipher = await vaultClient.createNewCozySharedCipher(cipherData, null)
-  await vaultClient.saveCipher(cipher)
-
-  return cipher
-}
-
-/**
- * Share a cipher to the cozy org
- * @param {string} cipherId - uuid of a cipher
- */
-const shareCipherWithCozy = async (vaultClient, cipherId) => {
-  const cipher = await vaultClient.get(cipherId)
-  const cipherView = await vaultClient.decrypt(cipher)
-  await vaultClient.shareWithCozy(cipherView)
-}
-
-/**
- * Update a cipher with provided identifier and password
- *
- * @param {string} cipherId - uuid of a cipher
- * @param {string} data.login - the new login
- * @param {string} data.password - the new password
- */
-const updateCipher = async (vaultClient, cipherId, data) => {
-  const { login, password } = data
-
-  const originalCipher = await vaultClient.getByIdOrSearch(cipherId)
-  const cipherData = await vaultClient.decrypt(originalCipher)
-
-  if (
-    cipherData.login.username !== login ||
-    cipherData.login.password !== password
-  ) {
-    cipherData.login.username = login
-    cipherData.login.password = password
-
-    const newCipher = await vaultClient.createNewCozySharedCipher(
-      cipherData,
-      originalCipher
-    )
-    const cipher = await vaultClient.saveCipher(newCipher)
-    return cipher
-  } else {
-    return originalCipher
-  }
-}
-
-const createOrUpdateCipher = async (
-  vaultClient,
-  cipherId,
-  { userData, account, konnector }
-) => {
-  const identifierProperty = manifest.getIdentifier(konnector.fields)
-  const login = userData[identifierProperty]
-  const password = userData.password
-
-  let cipher
-  if (!cipherId) {
-    cipher = await searchForCipher(vaultClient, {
-      account,
-      konnector,
-      login,
-      password
-    })
-    cipherId = cipher ? cipher.id : null
-  }
-
-  if (cipherId) {
-    cipher = await updateCipher(vaultClient, cipherId, { login, password })
-  } else {
-    cipher = await createCipher(vaultClient, {
-      konnector,
-      login,
-      password
-    })
-  }
-
-  await shareCipherWithCozy(vaultClient, cipher.id)
-
-  return cipher
-}
 
 const buildOrUpdateAccount = ({ account, userData, cipher, konnector }) => {
   const isUpdate = !!account

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -287,23 +287,17 @@ export class DumbTriggerManager extends Component {
    */
   async handleSubmit(data = {}) {
     const { konnector, saveAccount, vaultClient } = this.props
-
     const { account } = this.state
-    const isUpdate = !!account
 
     this.setState({
       error: null,
       status: RUNNING
     })
 
-    const identifierProperty = manifest.getIdentifier(konnector.fields)
-
-    const isVaultLocked = await vaultClient.isLocked()
-
     try {
-      const identifier = data[identifierProperty]
-      const password = data.password
-      let cipherId = this.getSelectedCipherId()
+      let cipherId
+
+      const isVaultLocked = await vaultClient.isLocked()
 
       if (isVaultLocked) {
         // eslint-disable-next-line no-console
@@ -311,15 +305,20 @@ export class DumbTriggerManager extends Component {
           'Impossible to manage ciphers since vault is locked. The created io.cozy.accounts will not be linked to an com.bitwarden.ciphers'
         )
       } else {
+        const identifierProperty = manifest.getIdentifier(konnector.fields)
+        const login = data[identifierProperty]
+        const password = data.password
+        let cipherId = this.getSelectedCipherId()
         const cipher = await createOrUpdateCipher(vaultClient, cipherId, {
           konnector,
           account,
-          login: identifier,
+          login,
           password
         })
         cipherId = cipher.id
       }
 
+      const isUpdate = !!account
       const accountWithNewState = accounts.setSessionResetIfNecessary(
         accounts.resetState(account),
         data

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -95,6 +95,16 @@ const createCipher = async (vaultClient, createOptions) => {
 }
 
 /**
+ * Share a cipher to the cozy org
+ * @param {string} cipherId - uuid of a cipher
+ */
+const shareCipherWithCozy = async (vaultClient, cipherId) => {
+  const cipher = await vaultClient.get(cipherId)
+  const cipherView = await vaultClient.decrypt(cipher)
+  await vaultClient.shareWithCozy(cipherView)
+}
+
+/**
  * Update a cipher with provided identifier and password
  *
  * @param {string} cipherId - uuid of a cipher
@@ -245,17 +255,6 @@ export class DumbTriggerManager extends Component {
   }
 
   /**
-   * Share a cipher to the cozy org
-   * @param {string} cipherId - uuid of a cipher
-   */
-  async shareCipherWithCozy(cipherId) {
-    const { vaultClient } = this.props
-    const cipher = await vaultClient.get(cipherId)
-    const cipherView = await vaultClient.decrypt(cipher)
-    await vaultClient.shareWithCozy(cipherView)
-  }
-
-  /**
    * TODO move to AccountHelper
    */
   async handleSubmit(data = {}) {
@@ -306,7 +305,7 @@ export class DumbTriggerManager extends Component {
           }
         }
 
-        await this.shareCipherWithCozy(cipherId)
+        await shareCipherWithCozy(vaultClient, cipherId)
       }
 
       const accountWithNewState = accounts.setSessionResetIfNecessary(

--- a/packages/cozy-harvest-lib/src/models/cipherUtils.js
+++ b/packages/cozy-harvest-lib/src/models/cipherUtils.js
@@ -1,0 +1,139 @@
+import manifest from '../helpers/manifest'
+import accounts from '../helpers/accounts'
+import get from 'lodash/get'
+
+import { CipherType, UriMatchType } from 'cozy-keys-lib'
+
+/**
+ * Create a new cipher and return its ID
+ *
+ * @param {string} login - the login to register in the new cipher
+ * @param {string} password - the password to register in the new cipher
+ *
+ * @returns {string} the cipher ID
+ */
+export const createCipher = async (vaultClient, createOptions) => {
+  const { konnector, login, password } = createOptions
+  const konnectorURI = get(konnector, 'vendor_link')
+  const konnectorName = get(konnector, 'name') || get(konnector, 'slug')
+
+  const cipherData = {
+    id: null,
+    type: CipherType.Login,
+    name: konnectorName,
+    login: {
+      username: login,
+      password,
+      uris: konnectorURI
+        ? [{ uri: konnectorURI, match: UriMatchType.Domain }]
+        : []
+    }
+  }
+
+  const cipher = await vaultClient.createNewCozySharedCipher(cipherData, null)
+  await vaultClient.saveCipher(cipher)
+
+  return cipher
+}
+
+/**
+ * Share a cipher to the cozy org
+ * @param {string} cipherId - uuid of a cipher
+ */
+export const shareCipherWithCozy = async (vaultClient, cipherId) => {
+  const cipher = await vaultClient.get(cipherId)
+  const cipherView = await vaultClient.decrypt(cipher)
+  await vaultClient.shareWithCozy(cipherView)
+}
+
+/**
+ * Update a cipher with provided identifier and password
+ *
+ * @param {string} cipherId - uuid of a cipher
+ * @param {string} data.login - the new login
+ * @param {string} data.password - the new password
+ */
+export const updateCipher = async (vaultClient, cipherId, data) => {
+  const { login, password } = data
+
+  const originalCipher = await vaultClient.getByIdOrSearch(cipherId)
+  const cipherData = await vaultClient.decrypt(originalCipher)
+
+  if (
+    cipherData.login.username !== login ||
+    cipherData.login.password !== password
+  ) {
+    cipherData.login.username = login
+    cipherData.login.password = password
+
+    const newCipher = await vaultClient.createNewCozySharedCipher(
+      cipherData,
+      originalCipher
+    )
+    const cipher = await vaultClient.saveCipher(newCipher)
+    return cipher
+  } else {
+    return originalCipher
+  }
+}
+
+export const createOrUpdateCipher = async (
+  vaultClient,
+  cipherId,
+  { userData, account, konnector }
+) => {
+  const identifierProperty = manifest.getIdentifier(konnector.fields)
+  const login = userData[identifierProperty]
+  const password = userData.password
+
+  let cipher
+  if (!cipherId) {
+    cipher = await searchForCipher(vaultClient, {
+      account,
+      konnector,
+      login,
+      password
+    })
+    cipherId = cipher ? cipher.id : null
+  }
+
+  if (cipherId) {
+    cipher = await updateCipher(vaultClient, cipherId, { login, password })
+  } else {
+    cipher = await createCipher(vaultClient, {
+      konnector,
+      login,
+      password
+    })
+  }
+
+  await shareCipherWithCozy(vaultClient, cipher.id)
+
+  return cipher
+}
+
+/**
+ * Finds a cipher inside vaultClient from account / konnector / login / password
+ *
+ * @param {string} searchOptions - Used to find the cipher
+ * @param {string} searchOptions.konnector - Used for its vendor link
+ * @param {string} searchOptions.account - Used for its cipherId if it exists
+ * @param {string} searchOptions.login - Used to match the cipher
+ * @param {string} searchOptions.password - Used to match the cipher
+ *
+ * @returns {Cipher} The cipher or null if no cipher was found
+ */
+const searchForCipher = async (vaultClient, searchOptions) => {
+  const { konnector, account, login, password } = searchOptions
+  const konnectorURI = get(konnector, 'vendor_link')
+
+  const id = accounts.getVaultCipherId(account)
+  const search = {
+    username: login,
+    uri: konnectorURI,
+    type: CipherType.Login
+  }
+  const sort = [view => view.login.password === password, 'revisionDate']
+  const cipher = await vaultClient.getByIdOrSearch(id, search, sort)
+  return cipher || null
+}

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -5,6 +5,19 @@ import { shallow } from 'enzyme'
 import { DumbTriggerManager as TriggerManager } from 'components/TriggerManager'
 import cronHelpers from 'helpers/cron'
 
+jest.mock('cozy-keys-lib', () => {
+  const FakeVaultUnlocker = ({ children }) => children
+  FakeVaultUnlocker.displayName =
+    'withI18n(withLocales(withClient(VaultUnlocker)))'
+  return {
+    CipherType: {
+      Login: 'Login'
+    },
+    VaultUnlocker: FakeVaultUnlocker,
+    withVaultClient: Component => Component
+  }
+})
+
 jest.mock('cozy-doctypes', () => {
   const doctypes = jest.requireActual('cozy-doctypes')
 

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -218,7 +218,8 @@ const props = {
   launch: launchTriggerMock,
   t: tMock,
   vaultClient: mockVaultClient,
-  breakpoints: { isMobile: false }
+  breakpoints: { isMobile: false },
+  onVaultDismiss: jest.fn()
 }
 
 const propsWithAccount = {

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`TriggerManager handleError should render error 1`] = `
 <withI18n(withLocales(withClient(VaultUnlocker)))
+  onDismiss={[MockFunction]}
   onUnlock={[Function]}
 >
   <div
@@ -59,6 +60,7 @@ exports[`TriggerManager should redirect to OAuthForm 1`] = `
 
 exports[`TriggerManager should render with account 1`] = `
 <withI18n(withLocales(withClient(VaultUnlocker)))
+  onDismiss={[MockFunction]}
   onUnlock={[Function]}
 >
   <div
@@ -101,6 +103,7 @@ exports[`TriggerManager should render with account 1`] = `
 
 exports[`TriggerManager should render without account 1`] = `
 <withI18n(withLocales(withClient(VaultUnlocker)))
+  onDismiss={[MockFunction]}
   onUnlock={[Function]}
 >
   <div


### PR DESCRIPTION
Break functions and move them out of the component. Having them inside the components makes it
harder to reason about since every method can use the internal state of the component class.

This should also make testing easier since we od not have to instantiate a component to call
those functions.

It makes the logic inside handleSubmit more understandable IMHO. It is a first step towards 
having custom logic inside TriggerManager to support BI connection creation flow.