### PR TITLE
fix(cozy-app-publish): Handle explicit default space

### DIFF
--- a/packages/cozy-app-publish/lib/constants.js
+++ b/packages/cozy-app-publish/lib/constants.js
@@ -1,4 +1,5 @@
 module.exports = {
   DEFAULT_REGISTRY_URL: 'https://apps-registry.cozycloud.cc',
-  DEFAULT_BUILD_DIR: 'build'
+  DEFAULT_BUILD_DIR: 'build',
+  DEFAULT_SPACE_NAME: 'default'
 }

--- a/packages/cozy-app-publish/lib/publish.js
+++ b/packages/cozy-app-publish/lib/publish.js
@@ -1,4 +1,14 @@
 const fetch = require('node-fetch')
+const { DEFAULT_SPACE_NAME } = require('./constants')
+
+const getFullRegistryUrl = (baseRegistryUrl, spaceName, appSlug) => {
+  const spaceNameFragment =
+    spaceName && spaceName !== DEFAULT_SPACE_NAME ? `${spaceName}/` : ''
+
+  const url = `${baseRegistryUrl}/${spaceNameFragment}registry/${appSlug}`
+
+  return url
+}
 
 module.exports = async ({
   registryUrl,
@@ -11,9 +21,7 @@ module.exports = async ({
   sha256Sum,
   appType
 }) => {
-  const url = `${registryUrl}/${
-    spaceName ? spaceName + '/' : ''
-  }registry/${appSlug}`
+  const url = getFullRegistryUrl(registryUrl, spaceName, appSlug)
   const response = await fetch(url, {
     method: 'POST',
     headers: {

--- a/packages/cozy-app-publish/lib/publisher.js
+++ b/packages/cozy-app-publish/lib/publisher.js
@@ -6,7 +6,11 @@ const constants = require('./constants')
 const promptConfirm = require('./confirm')
 const defaults = require('lodash/defaults')
 
-const { DEFAULT_REGISTRY_URL, DEFAULT_BUILD_DIR } = constants
+const {
+  DEFAULT_REGISTRY_URL,
+  DEFAULT_BUILD_DIR,
+  DEFAULT_SPACE_NAME
+} = constants
 
 const publisher = ({
   getManifest,
@@ -20,7 +24,8 @@ const publisher = ({
   defaults(ctx, {
     buildDir: DEFAULT_BUILD_DIR,
     registryUrl: DEFAULT_REGISTRY_URL,
-    registryToken: getRegistryToken ? getRegistryToken() : undefined
+    registryToken: getRegistryToken ? getRegistryToken() : undefined,
+    spaceName: DEFAULT_SPACE_NAME
   })
 
   const {

--- a/packages/cozy-app-publish/test/__snapshots__/manual.spec.js.snap
+++ b/packages/cozy-app-publish/test/__snapshots__/manual.spec.js.snap
@@ -66,7 +66,7 @@ Object {
   "registryToken": "registryTokenForTest123",
   "registryUrl": "https://mock.registry.cc",
   "sha256Sum": "fakeshasum5644545",
-  "spaceName": undefined,
+  "spaceName": "default",
 }
 `;
 

--- a/packages/cozy-app-publish/test/__snapshots__/travis.spec.js.snap
+++ b/packages/cozy-app-publish/test/__snapshots__/travis.spec.js.snap
@@ -91,7 +91,7 @@ Object {
   "registryToken": "registryTokenForTest123",
   "registryUrl": "https://apps-registry.cozycloud.cc",
   "sha256Sum": "fakeshasum5644545",
-  "spaceName": undefined,
+  "spaceName": "default",
 }
 `;
 

--- a/packages/cozy-app-publish/test/publish.spec.js
+++ b/packages/cozy-app-publish/test/publish.spec.js
@@ -69,4 +69,21 @@ describe('Publish script (helper)', () => {
     expect(publish(getOptions())).rejects.toThrowErrorMatchingSnapshot()
     expect(fetch).toHaveBeenCalledTimes(1)
   })
+
+  describe('when provided space if the default one', () => {
+    it('should not put the space name in the requested URL', async () => {
+      fetch.mockResponseOnce('', {
+        status: 201
+      })
+
+      const options = getOptions()
+      options.spaceName = 'default'
+
+      await publish(options)
+
+      expect(fetch.mock.calls[0][0]).toBe(
+        options.registryUrl + '/registry/' + options.appSlug
+      )
+    })
+  })
 })


### PR DESCRIPTION
When the --space option is not provided, then it's undefined and not
used in the resulting registry url being fetched. But when we usee
--space default, then "default" was added to the URL, causing an error.
Both implicit and explicit default space options should work. This fixes
the explicit one.