### PR TITLE
[cozy-harvest-lib]: Fixes and basic tests on TriggerManager

### DIFF
--- a/packages/cozy-harvest-lib/__mocks__/cozy-keys-lib/index.js
+++ b/packages/cozy-harvest-lib/__mocks__/cozy-keys-lib/index.js
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+
+const VaultUnlocker = ({ children, onUnlock }) => {
+  useEffect(() => {
+    onUnlock()
+  }, [onUnlock])
+
+  return children
+}
+
+VaultUnlocker.displayName = 'withI18n(withLocales(withClient(VaultUnlocker)))'
+
+const CipherType = {
+  Login: 'Login'
+}
+
+const withVaultClient = Component => Component
+
+export { VaultUnlocker, CipherType, withVaultClient }

--- a/packages/cozy-harvest-lib/src/components/AccountForm/Field.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/Field.jsx
@@ -33,7 +33,9 @@ export const Field = ({ label, type, ...props }) => {
     <Component
       {...props}
       label={<ObfuscatedLabel label={label} />}
-      aria-label={label}
+      labelProps={{
+        'aria-label': label
+      }}
       type={type}
     />
   )

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -81,7 +81,7 @@ export class DumbTriggerManager extends Component {
       account,
       error: null,
       status: IDLE,
-      step: account ? 'accountForm' : 'ciphersList',
+      step: account ? 'accountForm' : null,
       selectedCipher: undefined,
       showBackButton: false,
       ciphers: []
@@ -277,12 +277,6 @@ export class DumbTriggerManager extends Component {
     }
   }
 
-  showCiphersList() {
-    this.setState({
-      step: 'ciphersList'
-    })
-  }
-
   cipherToAccount(cipher) {
     if (cipher === undefined) {
       return null
@@ -319,6 +313,16 @@ export class DumbTriggerManager extends Component {
     this.setState({ step: 'accountForm', showBackButton: false })
   }
 
+  showCiphersList(ciphers) {
+    const newState = { step: 'ciphersList' }
+
+    if (ciphers) {
+      newState.ciphers = ciphers
+    }
+
+    this.setState(newState)
+  }
+
   async handleVaultUnlock() {
     const { vaultClient, konnector } = this.props
 
@@ -339,9 +343,9 @@ export class DumbTriggerManager extends Component {
 
       if (ciphers.length === 0) {
         this.showAccountForm()
+      } else {
+        this.showCiphersList(ciphers)
       }
-
-      this.setState({ ciphers })
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error(
@@ -421,7 +425,7 @@ export class DumbTriggerManager extends Component {
           <>
             {showBackButton && (
               <ModalBackButton
-                onClick={this.showCiphersList}
+                onClick={() => this.showCiphersList()}
                 label={t('back')}
               />
             )}
@@ -436,7 +440,7 @@ export class DumbTriggerManager extends Component {
               onSubmit={this.handleSubmit}
               showError={showError}
               submitting={submitting}
-              onBack={this.showCiphersList}
+              onBack={() => this.showCiphersList()}
               readOnlyIdentifier={this.hasCipherSelected()}
             />
           </>

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -249,26 +249,32 @@ describe('TriggerManager', () => {
     jest.resetAllMocks()
   })
 
-  it('should redirect to OAuthForm', () => {
-    const konnector = {
-      oauth: {
-        scope: 'test'
+  describe('when given an oauth konnector', () => {
+    it('should redirect to OAuthForm', () => {
+      const konnector = {
+        oauth: {
+          scope: 'test'
+        }
       }
-    }
-    const component = shallow(
-      <TriggerManager {...props} konnector={konnector} />
-    ).getElement()
-    expect(component).toMatchSnapshot()
+      const component = shallow(
+        <TriggerManager {...props} konnector={konnector} />
+      ).getElement()
+      expect(component).toMatchSnapshot()
+    })
   })
 
-  it('should render without account', () => {
-    const component = shallowWithoutAccount().getElement()
-    expect(component).toMatchSnapshot()
+  describe('when given no account', () => {
+    it('should render correctly', () => {
+      const component = shallowWithoutAccount().getElement()
+      expect(component).toMatchSnapshot()
+    })
   })
 
-  it('should render with account', () => {
-    const component = shallowWithAccount().getElement()
-    expect(component).toMatchSnapshot()
+  describe('when given an account', () => {
+    it('should render correctly', () => {
+      const component = shallowWithAccount().getElement()
+      expect(component).toMatchSnapshot()
+    })
   })
 
   describe('handleError', () => {

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -1,22 +1,12 @@
 /* eslint-env jest */
 import React from 'react'
 import { shallow } from 'enzyme'
+import { render } from '@testing-library/react'
 
 import { DumbTriggerManager as TriggerManager } from 'components/TriggerManager'
 import cronHelpers from 'helpers/cron'
 
-jest.mock('cozy-keys-lib', () => {
-  const FakeVaultUnlocker = ({ children }) => children
-  FakeVaultUnlocker.displayName =
-    'withI18n(withLocales(withClient(VaultUnlocker)))'
-  return {
-    CipherType: {
-      Login: 'Login'
-    },
-    VaultUnlocker: FakeVaultUnlocker,
-    withVaultClient: Component => Component
-  }
-})
+jest.mock('cozy-keys-lib')
 
 jest.mock('cozy-doctypes', () => {
   const doctypes = jest.requireActual('cozy-doctypes')
@@ -193,6 +183,8 @@ const mockVaultClient = {
   decrypt: jest.fn(),
   createNewCozySharedCipher: jest.fn(),
   get: jest.fn(),
+  getAll: jest.fn(),
+  getAllDecrypted: jest.fn(),
   shareWithCozy: jest.fn(),
   isLocked: jest.fn().mockResolvedValue(false)
 }
@@ -267,6 +259,42 @@ describe('TriggerManager', () => {
     it('should render correctly', () => {
       const component = shallowWithoutAccount().getElement()
       expect(component).toMatchSnapshot()
+    })
+
+    describe('when the vault does not contain ciphers', () => {
+      it('should show the new account form', async () => {
+        mockVaultClient.getAll.mockResolvedValue([])
+        mockVaultClient.getAllDecrypted.mockResolvedValue([])
+
+        const { findByLabelText } = render(<TriggerManager {...props} />)
+
+        const usernameField = await findByLabelText('username')
+        const passwordField = await findByLabelText('passphrase')
+
+        expect(usernameField).toBeDefined()
+        expect(passwordField).toBeDefined()
+      })
+    })
+
+    describe('when the vault contains ciphers', () => {
+      it('should show the ciphers list', async () => {
+        mockVaultClient.getAll.mockResolvedValue([{ id: 'cipher1' }])
+        mockVaultClient.getAllDecrypted.mockResolvedValue([
+          {
+            id: 'cipher1',
+            name: fixtures.konnector.name,
+            login: {
+              username: 'Isabelle'
+            }
+          }
+        ])
+
+        const { findByText } = render(<TriggerManager {...props} />)
+
+        const cipherItem = await findByText('Isabelle')
+
+        expect(cipherItem).toBeDefined()
+      })
     })
   })
 

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/AccountField.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/AccountField.spec.js.snap
@@ -2,7 +2,6 @@
 
 exports[`AccountField render a date field 1`] = `
 <Field
-  aria-label="fields.date.label"
   autoComplete="off"
   className="u-m-0"
   error={false}
@@ -15,7 +14,11 @@ exports[`AccountField render a date field 1`] = `
       label="fields.date.label"
     />
   }
-  labelProps={Object {}}
+  labelProps={
+    Object {
+      "aria-label": "fields.date.label",
+    }
+  }
   name="date"
   placeholder="fields.date.placeholder"
   required={true}
@@ -97,7 +100,6 @@ exports[`AccountField render a date field 1`] = `
 
 exports[`AccountField render a dropdown field 1`] = `
 <Field
-  aria-label="fields.multiple.label"
   className="u-m-0"
   error={false}
   fieldProps={Object {}}
@@ -109,7 +111,11 @@ exports[`AccountField render a dropdown field 1`] = `
       label="fields.multiple.label"
     />
   }
-  labelProps={Object {}}
+  labelProps={
+    Object {
+      "aria-label": "fields.multiple.label",
+    }
+  }
   name="multiple"
   options={
     Array [
@@ -186,7 +192,6 @@ exports[`AccountField render a dropdown field 1`] = `
 
 exports[`AccountField render a password field 1`] = `
 <PasswordField
-  aria-label="fields.passphrase.label"
   autoComplete="off"
   className="u-m-0"
   encrypted={true}
@@ -197,6 +202,11 @@ exports[`AccountField render a password field 1`] = `
     <ObfuscatedLabel
       label="fields.passphrase.label"
     />
+  }
+  labelProps={
+    Object {
+      "aria-label": "fields.passphrase.label",
+    }
   }
   name="passphrase"
   placeholder="fields.passphrase.placeholder"
@@ -267,7 +277,6 @@ exports[`AccountField render a password field 1`] = `
 
 exports[`AccountField should render 1`] = `
 <Field
-  aria-label="fields.username.label"
   autoComplete="off"
   className="u-m-0"
   encrypted={false}
@@ -281,7 +290,11 @@ exports[`AccountField should render 1`] = `
       label="fields.username.label"
     />
   }
-  labelProps={Object {}}
+  labelProps={
+    Object {
+      "aria-label": "fields.username.label",
+    }
+  }
   name="username"
   placeholder="fields.username.placeholder"
   required={true}

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
@@ -109,22 +109,5 @@ exports[`TriggerManager when given no account should render correctly 1`] = `
   <div
     id="coz-harvest-modal-place"
   />
-  <withI18n(withLocales(DumbVaultCiphersList))
-    ciphers={Array []}
-    konnector={
-      Object {
-        "fields": Object {
-          "passphrase": Object {
-            "type": "password",
-          },
-          "username": Object {
-            "type": "text",
-          },
-        },
-        "slug": "konnectest",
-      }
-    }
-    onSelect={[Function]}
-  />
 </withI18n(withLocales(withClient(VaultUnlocker)))>
 `;

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
@@ -44,21 +44,7 @@ exports[`TriggerManager handleError should render error 1`] = `
 </withI18n(withLocales(withClient(VaultUnlocker)))>
 `;
 
-exports[`TriggerManager should redirect to OAuthForm 1`] = `
-<withI18n(OAuthForm)
-  konnector={
-    Object {
-      "oauth": Object {
-        "scope": "test",
-      },
-    }
-  }
-  onSuccess={[Function]}
-  submitting={false}
-/>
-`;
-
-exports[`TriggerManager should render with account 1`] = `
+exports[`TriggerManager when given an account should render correctly 1`] = `
 <withI18n(withLocales(withClient(VaultUnlocker)))
   onDismiss={[MockFunction]}
   onUnlock={[Function]}
@@ -101,7 +87,21 @@ exports[`TriggerManager should render with account 1`] = `
 </withI18n(withLocales(withClient(VaultUnlocker)))>
 `;
 
-exports[`TriggerManager should render without account 1`] = `
+exports[`TriggerManager when given an oauth konnector should redirect to OAuthForm 1`] = `
+<withI18n(OAuthForm)
+  konnector={
+    Object {
+      "oauth": Object {
+        "scope": "test",
+      },
+    }
+  }
+  onSuccess={[Function]}
+  submitting={false}
+/>
+`;
+
+exports[`TriggerManager when given no account should render correctly 1`] = `
 <withI18n(withLocales(withClient(VaultUnlocker)))
   onDismiss={[MockFunction]}
   onUnlock={[Function]}


### PR DESCRIPTION
This fixes two things on TriggerManager:

* Don't show an empty ciphers list briefly before showing the new account form when there is no ciphers
* Correctly pass the aria-label to the obfuscated labels

It also contains basic tests.

In a next PR, I am going to:

* Add other tests
* Clean warnings in tests