### PR TITLE
feat: Add RefreshableSharings to expose a way to refresh sharings

### DIFF
--- a/packages/cozy-sharing/src/components/ContactSuggestion.spec.jsx
+++ b/packages/cozy-sharing/src/components/ContactSuggestion.spec.jsx
@@ -85,7 +85,7 @@ describe('ContactSuggestion component', () => {
       _type: 'io.cozy.contacts',
       relationships: {
         groups: {
-          data: [{ _id: '610718e6-2d7a' }]
+          data: [{ _id: '610718e6-2d7a', _type: 'io.cozy.contacts.groups' }]
         }
       }
     }
@@ -121,7 +121,7 @@ describe('ContactSuggestion component', () => {
       _type: 'io.cozy.contacts',
       relationships: {
         groups: {
-          data: [{ _id: '610718e6-2d7a' }]
+          data: [{ _id: '610718e6-2d7a', _type: 'io.cozy.contacts.groups' }]
         }
       }
     }

--- a/packages/cozy-sharing/src/components/Recipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient.jsx
@@ -167,7 +167,7 @@ export class Status extends Component {
   }
 }
 
-const StatusWithBreakpoints = translate()(withBreakpoints()(withClient(Status)))
+const StatusWithBreakpoints = withBreakpoints()(translate()(withClient(Status)))
 
 const Recipient = (props, { client, t }) => {
   const { instance, isOwner, status, ...rest } = props

--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -58,7 +58,7 @@ const track = (document, action) => {
 const trackSharingByLink = document => track(document, 'shareByLink')
 const isFile = ({ _type }) => _type === 'io.cozy.files'
 
-class SharingProvider extends Component {
+export class SharingProvider extends Component {
   constructor(props, context) {
     super(props, context)
     const instanceUri = props.client.getStackClient().uri
@@ -377,6 +377,18 @@ export const ShareModal = ({ document, ...rest }) => (
       ) : (
         <SharingModal document={document} {...rest} />
       )
+    }
+  </SharingContext.Consumer>
+)
+/**
+ * Expose a refresh method
+ */
+export const RefreshableSharings = ({ children }) => (
+  <SharingContext.Consumer>
+    {({ refresh }) =>
+      children({
+        refresh
+      })
     }
   </SharingContext.Consumer>
 )

--- a/packages/cozy-sharing/src/index.spec.jsx
+++ b/packages/cozy-sharing/src/index.spec.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { createMockClient } from 'cozy-client'
+
+import { RefreshableSharings, SharingProvider } from './'
+import AppLike from '../test/AppLike'
+
+const DumbComponent = () => {
+  return <div>test </div>
+}
+describe('RefreshableSharings', () => {
+  it('should test', () => {
+    const client = createMockClient({})
+
+    const component = mount(
+      <AppLike client={client}>
+        <SharingProvider client={client}>
+          <RefreshableSharings>
+            {({ refresh }) => (
+              <DumbComponent
+                client={client}
+                t={x => x}
+                refreshSharings={refresh}
+              />
+            )}
+          </RefreshableSharings>
+        </SharingProvider>
+      </AppLike>
+    )
+    const refreshMethod = component.find(DumbComponent).prop('refreshSharings')
+
+    expect(typeof refreshMethod).toBe('function')
+  })
+})


### PR DESCRIPTION
In a few use case, we need to refresh the sharingProvider to update the infos about sharings. It's needed for instance when we delete a file or when we move a file. 

Since the stack does complicated stuffs for the sharings, we do not want ATM to mimic its behavior from a front point of view. So the refresh only call the fetch from the stack 