### PR TITLE
Handle trigger updates

### DIFF
--- a/packages/cozy-harvest-lib/src/components/Routes.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes.jsx
@@ -14,7 +14,12 @@ import { MountPointProvider } from './MountPointContext'
 const Routes = ({ konnectorRoot, konnector, onDismiss }) => {
   return (
     <MountPointProvider baseRoute={konnectorRoot}>
-      <Modal dismissAction={onDismiss} mobileFullscreen size="small">
+      <Modal
+        dismissAction={onDismiss}
+        mobileFullscreen
+        size="small"
+        aria-label={konnector.name}
+      >
         <KonnectorAccounts konnector={konnector}>
           {accounts => (
             <Switch>

--- a/packages/cozy-harvest-lib/test/components/KonnectorAccounts.spec.jsx
+++ b/packages/cozy-harvest-lib/test/components/KonnectorAccounts.spec.jsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { KonnectorAccounts } from 'components/KonnectorAccounts'
+
+describe('KonnectorAccounts', () => {
+  const mockClient = {
+    on: jest.fn(),
+    stackClient: { uri: 'http://coy.tools:8080' }
+  }
+
+  it('should show a spinner', () => {
+    const children = jest.fn()
+    const component = shallow(
+      <KonnectorAccounts
+        konnector={{}}
+        location={{}}
+        client={mockClient}
+        findAccount={jest.fn()}
+        fetchTrigger={jest.fn()}
+        t={jest.fn()}
+      >
+        {children}
+      </KonnectorAccounts>
+    )
+
+    expect(component.getElement()).toMatchSnapshot()
+    expect(children).not.toHaveBeenCalled()
+  })
+
+  it('should call children with the accounts and triggers list', async () => {
+    const children = jest.fn()
+    const findAccount = jest
+      .fn()
+      .mockResolvedValueOnce({ _type: 'io.cozy.accounts', _id: '123' })
+    const fetchTrigger = jest.fn()
+    const component = shallow(
+      <KonnectorAccounts
+        konnector={{ triggers: { data: [{ _id: 'abc', error: null }] } }}
+        location={{}}
+        client={mockClient}
+        findAccount={findAccount}
+        fetchTrigger={fetchTrigger}
+        t={jest.fn()}
+      >
+        {children}
+      </KonnectorAccounts>
+    )
+    await component.instance().fetchAccounts()
+    await component.update()
+
+    expect(children).toHaveBeenCalledWith([
+      {
+        account: { _type: 'io.cozy.accounts', _id: '123' },
+        trigger: { _id: 'abc', error: null }
+      }
+    ])
+
+    fetchTrigger.mockResolvedValueOnce({
+      _id: 'abc',
+      error: 'LOGIN_FAILED'
+    })
+    await component.instance().handleTriggerUpdate({ trigger_id: 'abc' })
+    await component.update()
+
+    expect(children).toHaveBeenCalledWith([
+      {
+        account: { _type: 'io.cozy.accounts', _id: '123' },
+        trigger: { _id: 'abc', error: 'LOGIN_FAILED' }
+      }
+    ])
+  })
+})

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/KonnectorAccounts.spec.jsx.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/KonnectorAccounts.spec.jsx.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KonnectorAccounts should show a spinner 1`] = `
+<React.Fragment>
+  <KonnectorModalHeader
+    konnector={Object {}}
+  />
+  <ModalContent>
+    <div
+      className="u-pv-2 u-ta-center"
+    >
+      <withI18n(Spinner)
+        size="xxlarge"
+      />
+    </div>
+  </ModalContent>
+</React.Fragment>
+`;


### PR DESCRIPTION
`KonnectorAccounts` is one of the root components of harvest, it injects a list of triggers down the tree. The problem is that this list of triggers is never updated, which means that if a konnector changes state from "error" to "ok", harvest is not aware of it (technically some components *are* aware of it because they use realtime, but they forget as soon as we chance route).

We could handle this in the (`componentDidUpdate`](https://github.com/cozy/cozy-libs/blob/master/packages/cozy-harvest-lib/src/components/KonnectorAccounts.jsx#L44-L52) but we want to get rid of it eventually. The goal is more for harvest to be standalone, so `KonnectorAccounts` now also listens to the realtime to update itself. 