### PR TITLE
feat: Add custom konnector policy

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -30,6 +30,7 @@
     "@material-ui/core": "3",
     "cozy-bi-auth": "^0.0.1",
     "cozy-doctypes": "^1.72.0",
+    "cozy-flags": "^2.1.0",
     "date-fns": "^1.30.1",
     "final-form": "4.18.5",
     "lodash": "4.17.15",

--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.2",
     "@material-ui/core": "3",
+    "cozy-bi-auth": "^0.0.1",
     "cozy-doctypes": "^1.72.0",
     "date-fns": "^1.30.1",
     "final-form": "4.18.5",

--- a/packages/cozy-harvest-lib/src/assert.js
+++ b/packages/cozy-harvest-lib/src/assert.js
@@ -1,0 +1,7 @@
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+export default assert

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -31,6 +31,7 @@ import clone from 'lodash/clone'
 import flag from 'cozy-flags'
 
 import { createOrUpdateCipher } from '../models/cipherUtils'
+import { konnectorPolicy as biKonnectorPolicy } from '../services/budget-insight'
 
 const defaultKonnectorPolicy = {
   accountContainsAuth: true,
@@ -39,7 +40,10 @@ const defaultKonnectorPolicy = {
   match: () => true
 }
 
-const policies = [defaultKonnectorPolicy]
+const policies = [
+  flag('bi-konnector-policy') ? biKonnectorPolicy : null,
+  defaultKonnectorPolicy
+].filter(Boolean)
 
 const IDLE = 'IDLE'
 const RUNNING = 'RUNNING'

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -27,6 +27,7 @@ import TriggerLauncher from './TriggerLauncher'
 import VaultCiphersList from './VaultCiphersList'
 import manifest from '../helpers/manifest'
 import HarvestVaultProvider from './HarvestVaultProvider'
+import clone from 'lodash/clone'
 
 import { createOrUpdateCipher } from '../models/cipherUtils'
 
@@ -44,10 +45,10 @@ const createOrUpdateAccount = async ({
 }) => {
   const isUpdate = !!account
 
-  let accountToSave
+  let accountToSave = clone(account)
 
   accountToSave = accounts.setSessionResetIfNecessary(
-    accounts.resetState(account),
+    accounts.resetState(accountToSave),
     userData
   )
 

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -60,6 +60,10 @@ const createOrUpdateAccount = async ({
       accountToSave,
       cipher.id
     )
+  } else {
+    console.warn(
+      'No cipher passed when creating/updating account, account will not be linked to cipher'
+    )
   }
 
   return await saveAccount(konnector, accountToSave)
@@ -201,23 +205,12 @@ export class DumbTriggerManager extends Component {
     })
 
     try {
-      let cipher
-
-      const isVaultLocked = await vaultClient.isLocked()
-
-      if (isVaultLocked) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          'Impossible to manage ciphers since vault is locked. The created io.cozy.accounts will not be linked to an com.bitwarden.ciphers'
-        )
-      } else {
-        let cipherId = this.getSelectedCipherId()
-        cipher = await createOrUpdateCipher(vaultClient, cipherId, {
-          account,
-          konnector,
-          userData: data
-        })
-      }
+      const cipherId = this.getSelectedCipherId()
+      const cipher = await createOrUpdateCipher(vaultClient, cipherId, {
+        account,
+        konnector,
+        userData: data
+      })
 
       const savedAccount = await createOrUpdateAccount({
         account,

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -241,7 +241,7 @@ export class DumbTriggerManager extends Component {
    */
   handleError(error) {
     const { onError } = this.props
-    this.setState({ error })
+    this.setState({ error, state: IDLE })
     if (typeof onError === 'function') onError(error)
   }
 

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -35,7 +35,13 @@ const RUNNING = 'RUNNING'
 
 const MODAL_PLACE_ID = 'coz-harvest-modal-place'
 
-const buildOrUpdateAccount = ({ account, userData, cipher, konnector }) => {
+const createOrUpdateAccount = async ({
+  account,
+  cipher,
+  konnector,
+  saveAccount,
+  userData
+}) => {
   const isUpdate = !!account
 
   let accountToSave
@@ -56,7 +62,7 @@ const buildOrUpdateAccount = ({ account, userData, cipher, konnector }) => {
     )
   }
 
-  return accountToSave
+  return await saveAccount(konnector, accountToSave)
 }
 
 /**
@@ -213,18 +219,15 @@ export class DumbTriggerManager extends Component {
         })
       }
 
-      const accountToSave = buildOrUpdateAccount({
+      const savedAccount = await createOrUpdateAccount({
         account,
         cipher,
         konnector,
+        saveAccount,
         userData: data
       })
 
-      const savedAccount = accounts.mergeAuth(
-        await saveAccount(konnector, accountToSave),
-        data
-      )
-      return await this.handleNewAccount(savedAccount)
+      return await this.handleNewAccount(accounts.mergeAuth(savedAccount, data))
     } catch (error) {
       return this.handleError(error)
     }

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -431,9 +431,9 @@ export class DumbTriggerManager extends Component {
             )}
             <AccountForm
               account={
-                !this.hasCipherSelected()
-                  ? account
-                  : this.cipherToAccount(selectedCipher)
+                this.hasCipherSelected()
+                  ? this.cipherToAccount(selectedCipher)
+                  : account
               }
               error={error || triggerError}
               konnector={konnector}

--- a/packages/cozy-harvest-lib/src/components/VaultCiphersList/VaultCiphersList.jsx
+++ b/packages/cozy-harvest-lib/src/components/VaultCiphersList/VaultCiphersList.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Title } from 'cozy-ui/transpiled/react/Text'
+import I18n from 'cozy-ui/transpiled/react/I18n'
 
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/RaisedList'
 
@@ -10,7 +11,7 @@ import OtherAccountListItem from './OtherAccountListItem'
 
 export const DumbVaultCiphersList = ({ konnector, onSelect, ciphers, t }) => {
   return (
-    <>
+    <I18n lang="en" dictRequire={() => {}}>
       <Title className="u-ta-center u-mb-2">
         {t('vaultCiphersList.title')}
       </Title>
@@ -26,7 +27,7 @@ export const DumbVaultCiphersList = ({ konnector, onSelect, ciphers, t }) => {
 
         <OtherAccountListItem onClick={() => onSelect(null)} />
       </List>
-    </>
+    </I18n>
   )
 }
 

--- a/packages/cozy-harvest-lib/src/components/VaultCiphersList/VaultCiphersList.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/VaultCiphersList/VaultCiphersList.spec.jsx
@@ -2,6 +2,8 @@ import { DumbVaultCiphersList } from './VaultCiphersList'
 import { render, waitForElement, fireEvent } from '@testing-library/react'
 import React from 'react'
 
+jest.mock('cozy-ui/transpiled/react/AppIcon', () => () => null)
+
 describe('when there is some ciphers', () => {
   it('should handler cipher select', async () => {
     const onSelect = jest.fn()

--- a/packages/cozy-harvest-lib/src/components/hooks/useMaintenanceStatus.jsx
+++ b/packages/cozy-harvest-lib/src/components/hooks/useMaintenanceStatus.jsx
@@ -35,7 +35,7 @@ const useMaintenanceStatus = (client, konnector) => {
       }
     }
     fetchData()
-  }, [slug, source])
+  }, [registry, slug, source])
 
   return {
     data: {

--- a/packages/cozy-harvest-lib/src/helpers/accounts.js
+++ b/packages/cozy-harvest-lib/src/helpers/accounts.js
@@ -104,7 +104,7 @@ export const build = (konnector, authData) => {
  */
 export const mergeAuth = (account, authData) => ({
   ...account,
-  auth: merge(account.auth, authData)
+  auth: merge({}, account.auth, authData)
 })
 
 /**

--- a/packages/cozy-harvest-lib/src/models/KonnectorJob.spec.js
+++ b/packages/cozy-harvest-lib/src/models/KonnectorJob.spec.js
@@ -11,6 +11,9 @@ describe('watchKonnectorJob', () => {
     }
 
     const client = {
+      stackClient: {
+        uri: 'http://cozy.tools:8080'
+      },
       on: jest.fn()
     }
     const result = await watchKonnectorJob(client, job)

--- a/packages/cozy-harvest-lib/src/models/cipherUtils.js
+++ b/packages/cozy-harvest-lib/src/models/cipherUtils.js
@@ -86,11 +86,11 @@ export const updateCipher = async (vaultClient, cipherId, data) => {
 export const createOrUpdateCipher = async (
   vaultClient,
   cipherId,
-  { userData, account, konnector }
+  { userCredentials, account, konnector }
 ) => {
   const identifierProperty = manifest.getIdentifier(konnector.fields)
-  const login = userData[identifierProperty]
-  const password = userData.password
+  const login = userCredentials[identifierProperty]
+  const password = userCredentials.password
 
   let cipher
   if (!cipherId) {

--- a/packages/cozy-harvest-lib/src/models/cipherUtils.js
+++ b/packages/cozy-harvest-lib/src/models/cipherUtils.js
@@ -13,6 +13,12 @@ import { CipherType, UriMatchType } from 'cozy-keys-lib'
  * @returns {string} the cipher ID
  */
 export const createCipher = async (vaultClient, createOptions) => {
+  if (vaultClient.isLocked()) {
+    // eslint-disable-next-line no-console
+    console.warn('Impossible to create cipher since vault is locked')
+    return null
+  }
+
   const { konnector, login, password } = createOptions
   const konnectorURI = get(konnector, 'vendor_link')
   const konnectorName = get(konnector, 'name') || get(konnector, 'slug')

--- a/packages/cozy-harvest-lib/src/services/bi-public-key-prod.json
+++ b/packages/cozy-harvest-lib/src/services/bi-public-key-prod.json
@@ -1,0 +1,8 @@
+{
+  "use": "enc",
+  "e": "AQAB",
+  "kty": "RSA",
+  "n":
+    "ok-OJ_etl42QX9tnOgk3su7lel5UtsxE0Wuu_VGokvYvhFesszvZtJ3pfZUdslw7-kt_-VAlFgwioL8l9440CjarXBTjHo1nOEq7eDNk4nnemYBV6tG15rAwrhj9xfXY-0bU_RNufdtXz7OXQf7gJfWfUimGCXLRWvIWjM83oq8bMDH9-3YDiJsF4fRb9o9YJt6mCH9HJ_Xx1N6IzkKdymOaiv5JcmsvPE91cJRkCvYNd6Ag4yZRvbiVoyyz7EtpqgJ0dzmlkJiHQzNj40Q8oefsoRQfH-S4GUadPO2JVRGXkylIR0kY-GEE7eaj7wAyZm6VDvLcYHHKQg3U1tki_Q",
+  "kid": "rsa--b1fxmZ8vdBRF-pd89iG3kZy3ELSuZNySIH0WgVZ0dA"
+}

--- a/packages/cozy-harvest-lib/src/services/biUtils.js
+++ b/packages/cozy-harvest-lib/src/services/biUtils.js
@@ -15,24 +15,24 @@ import biPublicKeyProd from './bi-public-key-prod.json'
 const biURLProd = 'https://cozy.biapi.pro/2.0'
 const biURLDev = 'https://cozytest-sandbox.biapi.pro/2.0'
 
-export const getBIModeFromCurrentLocation = (wdw = window) => {
-  if (!wdw || !wdw.location || !wdw.location.host) {
+export const getBIModeFromCozyURL = rawCozyURL => {
+  if (!rawCozyURL) {
     return 'dev'
-  } else {
-    const domain = wdw.location.host
-      .split('.')
-      .slice(-2)
-      .join('.')
-    switch (domain) {
-      case 'cozy.rocks':
-      case 'mycozy.cloud':
-        return 'prod'
-      case 'cozy.works':
-      case 'cozy.dev':
-        return 'dev'
-      default:
-        return 'dev'
-    }
+  }
+  const cozyURL = new URL(rawCozyURL)
+  const domain = cozyURL.host
+    .split('.')
+    .slice(-2)
+    .join('.')
+  switch (domain) {
+    case 'cozy.rocks':
+    case 'mycozy.cloud':
+      return 'prod'
+    case 'cozy.works':
+    case 'cozy.dev':
+      return 'dev'
+    default:
+      return 'dev'
   }
 }
 

--- a/packages/cozy-harvest-lib/src/services/biUtils.js
+++ b/packages/cozy-harvest-lib/src/services/biUtils.js
@@ -1,3 +1,14 @@
+/**
+ * This is meant to be a subset of low level functions that are needed
+ * to talk with Budget-Insight when adding a budget-insight connection.
+ *
+ * Much more of the API is supported in the banking konnector and it
+ * might make sense to mutualize the code under a bi-sdk package if
+ * we ever need more of it here.
+ *
+ * See https://github.com/cozy/cozy-libs/pull/929#discussion_r372238690
+ */
+
 import assert from '../assert'
 import biPublicKeyProd from './bi-public-key-prod.json'
 

--- a/packages/cozy-harvest-lib/src/services/biUtils.js
+++ b/packages/cozy-harvest-lib/src/services/biUtils.js
@@ -68,6 +68,7 @@ const biRequest = async (method, path, config, rawForm, bearer) => {
     })
     return await resp.json()
   } catch (originalError) {
+    // eslint-disable-next-line no-console
     console.error(originalError)
     const err = new Error('biRequest failed')
     err.original = originalError

--- a/packages/cozy-harvest-lib/src/services/biUtils.spec.js
+++ b/packages/cozy-harvest-lib/src/services/biUtils.spec.js
@@ -1,25 +1,12 @@
-import { getBIModeFromCurrentLocation, updateBIConnection } from './biUtils'
+import { getBIModeFromCozyURL, updateBIConnection } from './biUtils'
 
 describe('getBIModeFromCurrentLocation', () => {
   it('should correctly work', () => {
-    const makeWindowWithLocation = host => ({
-      location: {
-        host
-      }
-    })
-    expect(getBIModeFromCurrentLocation(makeWindowWithLocation())).toBe('dev')
-    expect(
-      getBIModeFromCurrentLocation(makeWindowWithLocation('cozy.tools:8080'))
-    ).toBe('dev')
-    expect(
-      getBIModeFromCurrentLocation(makeWindowWithLocation('test.cozy.works'))
-    ).toBe('dev')
-    expect(
-      getBIModeFromCurrentLocation(makeWindowWithLocation('test.cozy.rocks'))
-    ).toBe('prod')
-    expect(
-      getBIModeFromCurrentLocation(makeWindowWithLocation('test.mycozy.cloud'))
-    ).toBe('prod')
+    expect(getBIModeFromCozyURL()).toBe('dev')
+    expect(getBIModeFromCozyURL('http://cozy.tools:8080')).toBe('dev')
+    expect(getBIModeFromCozyURL('https://test.cozy.works')).toBe('dev')
+    expect(getBIModeFromCozyURL('https://test.cozy.rocks')).toBe('prod')
+    expect(getBIModeFromCozyURL('https://test.mycozy.cloud')).toBe('prod')
   })
 })
 

--- a/packages/cozy-harvest-lib/src/services/biUtils.spec.js
+++ b/packages/cozy-harvest-lib/src/services/biUtils.spec.js
@@ -1,0 +1,56 @@
+import { getBIModeFromCurrentLocation, updateBIConnection } from './biUtils'
+
+describe('getBIModeFromCurrentLocation', () => {
+  it('should correctly work', () => {
+    const makeWindowWithLocation = host => ({
+      location: {
+        host
+      }
+    })
+    expect(getBIModeFromCurrentLocation(makeWindowWithLocation())).toBe('dev')
+    expect(
+      getBIModeFromCurrentLocation(makeWindowWithLocation('cozy.tools:8080'))
+    ).toBe('dev')
+    expect(
+      getBIModeFromCurrentLocation(makeWindowWithLocation('test.cozy.works'))
+    ).toBe('dev')
+    expect(
+      getBIModeFromCurrentLocation(makeWindowWithLocation('test.cozy.rocks'))
+    ).toBe('prod')
+    expect(
+      getBIModeFromCurrentLocation(makeWindowWithLocation('test.mycozy.cloud'))
+    ).toBe('prod')
+  })
+})
+
+describe('bi request', () => {
+  beforeEach(() => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ json: () => Promise.resolve({}) })
+  })
+
+  afterEach(() => {
+    global.fetch = null
+  })
+
+  it('should send the correct data', async () => {
+    await updateBIConnection(
+      { mode: 'dev', url: 'https://bi-sandox.test' },
+      1337,
+      { login: 'encrypted-login' },
+      'bi-access-token'
+    )
+    expect(fetch).toHaveBeenCalledWith(
+      'https://bi-sandox.test/users/me/connections/1337',
+      {
+        body: expect.any(Object),
+        headers: {
+          Authorization: 'Bearer bi-access-token',
+          'User-Agent': 'cozy.bi-harvest'
+        },
+        method: 'PUT'
+      }
+    )
+  })
+})

--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -9,7 +9,7 @@ import {
   createBIConnection,
   updateBIConnection,
   getBIConfig,
-  getBIModeFromCurrentLocation,
+  getBIModeFromCozyURL,
   isBudgetInsightConnector
 } from './biUtils'
 import assert from '../assert'
@@ -68,7 +68,7 @@ export const createOrUpdateBIConnection = async ({
   konnector
 }) => {
   try {
-    const mode = getBIModeFromCurrentLocation()
+    const mode = getBIModeFromCozyURL(client.stackClient.uri)
     const config = getBIConfig(mode)
     const connId = getBIConnectionIdFromAccount(account)
     const tempToken = await createTemporaryToken({

--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -1,0 +1,129 @@
+import get from 'lodash/get'
+import omit from 'lodash/omit'
+import merge from 'lodash/merge'
+import clone from 'lodash/clone'
+import defaults from 'lodash/defaults'
+
+import { waitForRealtimeResult } from './jobUtils'
+import {
+  createBIConnection,
+  updateBIConnection,
+  getBIConfig,
+  getBIModeFromCurrentLocation,
+  isBudgetInsightConnector
+} from './biUtils'
+import assert from '../assert'
+import { mkConnAuth } from 'cozy-bi-auth'
+
+const getBIConnectionIdFromAccount = account =>
+  get(account, 'data.auth.bi.connId')
+
+const throwWrappedError = (originalError, namespace) => {
+  const error = new Error(`${namespace} failed (${originalError.message})`)
+  error.original = originalError
+  throw error
+}
+
+const createTemporaryToken = async ({ client, account, konnector }) => {
+  try {
+    assert(
+      account && account._id,
+      'createTemporaryToken: Invalid account for createTemporaryToken'
+    )
+    assert(konnector.slug, 'createTemporaryToken: No konnector slug')
+    const jobResponse = await client.stackClient.jobs.create('konnector', {
+      mode: 'getTemporaryToken',
+      konnector: konnector.slug,
+      account: account._id
+    })
+    const event = await waitForRealtimeResult(
+      client,
+      jobResponse.data.attributes
+    )
+    return event.data.code
+  } catch (e) {
+    throwWrappedError(e, 'createTemporaryToken')
+  }
+}
+
+/**
+ * Ensures a BI connection is ready
+ *
+ *  - Calls the getBITemporaryToken mode of the konnector
+ *
+ * Then:
+ * If no BI connection is present in the io.cozy.accounts:
+ *  - Creates the BI connection using user supplied data
+ * If a BI connection exists:
+ *  - Updates the BI connection using user supplied data
+ *
+ * @param  {Client} options.client
+ * @param  {io.cozy.accounts} options.account
+ * @param  {io.cozy.konnectors} options.konnector
+ * @return {BIConnection}
+ */
+export const createOrUpdateBIConnection = async ({
+  account,
+  client,
+  konnector
+}) => {
+  try {
+    const mode = getBIModeFromCurrentLocation()
+    const config = getBIConfig(mode)
+    const connId = getBIConnectionIdFromAccount(account)
+    const tempToken = await createTemporaryToken({
+      account,
+      client,
+      konnector
+    })
+    assert(tempToken, 'No temporary token')
+    const credentials = { ...account.auth }
+    // The konnector can have "baked-in" parameters that need to be passed in the
+    // auth. This is the case for example for some konnectors for the bankId
+    // parameter
+    defaults(credentials, konnector.parameters)
+    const credsToSend = await mkConnAuth(config, credentials)
+    const connection = await (connId
+      ? updateBIConnection(config, connId, credsToSend, tempToken)
+      : createBIConnection(config, credsToSend, tempToken))
+    return connection
+  } catch (e) {
+    throwWrappedError(e, 'createOrUpdateBIConnection')
+  }
+}
+
+const SENSIBLE_FIELDS = ['password', 'secret', 'code', 'dob']
+const removeSensibleDataFromAccount = fullAccount => {
+  const account = clone(fullAccount)
+  account.auth = omit(account.auth, SENSIBLE_FIELDS)
+  return account
+}
+
+export const onBIAccountCreation = async ({
+  account,
+  client,
+  konnector,
+  saveAccount,
+  createOrUpdateBIConnectionFn = createOrUpdateBIConnection
+}) => {
+  const fullAccount = account
+  account = removeSensibleDataFromAccount(account)
+  account = await saveAccount(konnector, account)
+
+  const biConnection = await createOrUpdateBIConnectionFn({
+    account: {
+      ...fullAccount,
+      _id: account._id
+    },
+    client,
+    konnector
+  })
+
+  return merge(account, { data: { auth: { bi: { connId: biConnection.id } } } })
+}
+
+export const konnectorPolicy = {
+  match: isBudgetInsightConnector,
+  saveInVault: false,
+  onAccountCreation: onBIAccountCreation
+}

--- a/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
@@ -17,7 +17,7 @@ jest.mock('./biUtils', () => {
     createBIConnection: jest.fn(),
     updateBIConnection: jest.fn(),
     getBIConfig: originalBIUtils.getBIConfig,
-    getBIModeFromCurrentLocation: jest.fn().mockReturnValue('prod'),
+    getBIModeFromCozyURL: originalBIUtils.getBIModeFromCozyURL,
     isBudgetInsightConnector: originalBIUtils.isBudgetInsightConnector
   }
 })
@@ -50,7 +50,9 @@ const sleep = duration => new Promise(resolve => setTimeout(resolve, duration))
 
 describe('createOrUpdateBIConnection', () => {
   const setup = () => {
-    const client = new CozyClient({})
+    const client = new CozyClient({
+      uri: 'http://testcozy.mycozy.cloud'
+    })
     client.stackClient.jobs.create = jest.fn().mockReturnValue({
       data: {
         attributes: {

--- a/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
@@ -1,0 +1,217 @@
+import CozyClient from 'cozy-client'
+import {
+  createOrUpdateBIConnection,
+  onBIAccountCreation
+} from './budget-insight'
+import { waitForRealtimeResult } from './jobUtils'
+import { createBIConnection, updateBIConnection } from './biUtils'
+import merge from 'lodash/merge'
+
+jest.mock('./jobUtils', () => ({
+  waitForRealtimeResult: jest.fn()
+}))
+
+jest.mock('./biUtils', () => {
+  const originalBIUtils = jest.requireActual('./biUtils')
+  return {
+    createBIConnection: jest.fn(),
+    updateBIConnection: jest.fn(),
+    getBIConfig: originalBIUtils.getBIConfig,
+    getBIModeFromCurrentLocation: jest.fn().mockReturnValue('prod'),
+    isBudgetInsightConnector: originalBIUtils.isBudgetInsightConnector
+  }
+})
+
+const TEST_BANK_COZY_ID = '100000'
+const TEST_BANK_BI_ID = 59
+
+expect.extend({
+  toBeJWEValue(received) {
+    // Crude check for a JSON Web Encryption value
+    // https://tools.ietf.org/html/rfc7516 for the JWE RFC
+    const pass =
+      received.startsWith('eyJlbmM') && received.split('.').length == 5
+
+    if (pass) {
+      return {
+        message: () => `expected ${received} not to be a JWE value`,
+        pass: true
+      }
+    } else {
+      return {
+        message: () => `expected ${received} to be a JWE value`,
+        pass: false
+      }
+    }
+  }
+})
+
+const sleep = duration => new Promise(resolve => setTimeout(resolve, duration))
+
+describe('createOrUpdateBIConnection', () => {
+  const setup = () => {
+    const client = new CozyClient({})
+    client.stackClient.jobs.create = jest.fn().mockReturnValue({
+      data: {
+        attributes: {
+          _id: 'job-id-1337'
+        }
+      }
+    })
+    waitForRealtimeResult.mockImplementation(async () => {
+      sleep(2)
+      return {
+        data: {
+          code: 'bi-temporary-access-token-145613'
+        }
+      }
+    })
+
+    createBIConnection
+      .mockReset()
+      .mockResolvedValue({ id: 'created-bi-connection-id-789' })
+    updateBIConnection
+      .mockReset()
+      .mockResolvedValue({ id: 'updated-bi-connection-id-789' })
+    return { client }
+  }
+
+  const konnector = {
+    slug: 'boursorama83',
+    parameters: {
+      bankId: TEST_BANK_COZY_ID
+    }
+  }
+  const account = {
+    _id: '1337',
+    auth: {
+      login: '80546578',
+      secret: 'secretsecret'
+    }
+  }
+
+  it('should create a BI connection if no connection id in account', async () => {
+    const { client } = setup()
+    const connection = await createOrUpdateBIConnection({
+      client,
+      account,
+      konnector
+    })
+    expect(waitForRealtimeResult).toHaveBeenCalledWith(client, {
+      _id: 'job-id-1337'
+    })
+    expect(createBIConnection).toHaveBeenCalledWith(
+      expect.any(Object),
+      {
+        id_bank: TEST_BANK_BI_ID,
+        login: expect.toBeJWEValue(),
+        password: expect.toBeJWEValue()
+      },
+      'bi-temporary-access-token-145613'
+    )
+    expect(updateBIConnection).not.toHaveBeenCalled()
+    expect(connection).toEqual({ id: 'created-bi-connection-id-789' })
+  })
+
+  it('should update the BI connection if connection id in account', async () => {
+    const { client } = setup()
+    const connection = await createOrUpdateBIConnection({
+      client,
+      account: merge(account, {
+        data: {
+          auth: {
+            bi: {
+              connId: 1337
+            }
+          }
+        }
+      }),
+      konnector
+    })
+    expect(waitForRealtimeResult).toHaveBeenCalledWith(client, {
+      _id: 'job-id-1337'
+    })
+    expect(createBIConnection).not.toHaveBeenCalled()
+    expect(updateBIConnection).toHaveBeenCalledWith(
+      expect.any(Object),
+      1337,
+      {
+        id_bank: TEST_BANK_BI_ID,
+        login: expect.toBeJWEValue(),
+        password: expect.toBeJWEValue()
+      },
+      'bi-temporary-access-token-145613'
+    )
+    expect(connection).toEqual({ id: 'updated-bi-connection-id-789' })
+  })
+
+  it('should remove sensible data from account and create bi connection', async () => {
+    const { client } = setup()
+
+    const account = {
+      auth: {
+        login: '1234',
+        password: '4567',
+        dob: '20/12/1890',
+        bankId: '100000'
+      }
+    }
+
+    const konnector = {
+      slug: 'bankingconnectortest'
+    }
+
+    const saveAccount = jest.fn().mockImplementation((konnector, account) => ({
+      _id: 'created-account-id',
+      ...account
+    }))
+
+    const createOrUpdateBIConnection = jest
+      .fn()
+      .mockResolvedValue({ id: 'created-bi-connection-id' })
+
+    const accountToSave = await onBIAccountCreation({
+      client,
+      account,
+      konnector,
+      saveAccount,
+      createOrUpdateBIConnectionFn: createOrUpdateBIConnection
+    })
+
+    expect(saveAccount).toHaveBeenCalledWith(konnector, {
+      auth: {
+        login: '1234',
+        bankId: '100000'
+      }
+    })
+
+    expect(createOrUpdateBIConnection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: {
+          _id: 'created-account-id',
+          auth: {
+            bankId: '100000',
+            login: '1234',
+            password: '4567',
+            dob: '20/12/1890'
+          }
+        }
+      })
+    )
+
+    expect(accountToSave).toEqual({
+      _id: 'created-account-id',
+      auth: {
+        login: '1234',
+        bankId: '100000'
+      },
+      data: {
+        auth: {
+          bi: {
+            connId: 'created-bi-connection-id'
+          }
+        }
+      }
+    })
+  })
+})

--- a/packages/cozy-harvest-lib/src/services/jobUtils.js
+++ b/packages/cozy-harvest-lib/src/services/jobUtils.js
@@ -1,0 +1,25 @@
+import CozyRealtime from 'cozy-realtime'
+
+const JOBS_DOCTYPE = 'io.cozy.jobs'
+
+export const waitForRealtimeResult = (client, job) =>
+  new Promise((resolve, reject) => {
+    const rt = new CozyRealtime({ client })
+
+    const handleUpdate = jobAttributes => {
+      if (jobAttributes.state == 'errored') {
+        reject(`Job finished with error : ${jobAttributes.error}`)
+      }
+    }
+    const id = job._id
+    const handleNotification = event => {
+      rt.unsubscribe('notified', JOBS_DOCTYPE, id, handleNotification)
+      resolve(event)
+    }
+
+    rt.subscribe('updated', JOBS_DOCTYPE, id, handleUpdate)
+    rt.subscribe('notified', JOBS_DOCTYPE, id, handleNotification)
+    setTimeout(() => {
+      reject(new Error('Timeout for waitForRealtimeResult'))
+    }, 15 * 1000)
+  })

--- a/packages/cozy-harvest-lib/test/components/TriggerLauncher.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerLauncher.spec.js
@@ -3,7 +3,12 @@ import { shallow } from 'enzyme'
 import { TriggerLauncher } from 'components/TriggerLauncher'
 import KonnectorJob from 'models/KonnectorJob'
 
-const client = { on: jest.fn() }
+const client = {
+  on: jest.fn(),
+  stackClient: {
+    uri: 'https://cozy.tools:8080'
+  }
+}
 const trigger = {
   _id: '65c347d1ef144288a64105702cc36e59'
 }

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -380,6 +380,21 @@ describe('TriggerManager', () => {
   })
 
   describe('handleSubmit', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'log').mockImplementation(() => {})
+      jest.spyOn(console, 'info').mockImplementation(() => {})
+      jest.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      // eslint-disable-next-line no-console
+      console.log.mockRestore()
+      // eslint-disable-next-line no-console
+      console.info.mockRestore()
+      // eslint-disable-next-line no-console
+      console.warn.mockRestore()
+    })
+
     it('should render as submitting when there is no account', async () => {
       const wrapper = shallowWithoutAccount()
       const submitPromise = wrapper.instance().handleSubmit()

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -220,13 +220,31 @@ const propsWithAccount = {
   trigger: fixtures.existingTrigger
 }
 
-const shallowWithoutAccount = konnector =>
-  shallow(
-    <TriggerManager {...props} konnector={konnector || fixtures.konnector} />
+const setup = ({ konnector = fixtures.konnector, account, trigger } = {}) => {
+  const root = shallow(
+    <TriggerManager
+      {...props}
+      konnector={konnector}
+      trigger={trigger}
+      account={account}
+    />
   )
+  return { root }
+}
 
-const shallowWithAccount = () =>
-  shallow(<TriggerManager {...propsWithAccount} />)
+const shallowWithoutAccount = konnector => {
+  const { root } = setup({ konnector })
+  return root
+}
+
+const shallowWithAccount = options => {
+  const { root } = setup({
+    account: fixtures.existingAccount,
+    trigger: fixtures.existingTrigger,
+    ...options
+  })
+  return root
+}
 
 describe('TriggerManager', () => {
   beforeEach(() => {
@@ -312,7 +330,7 @@ describe('TriggerManager', () => {
     })
 
     it('should render error', async () => {
-      const wrapper = shallowWithAccount()
+      const wrapper = shallowWithAccount({ onError: null })
       await wrapper.instance().handleError(new Error('Test error'))
       expect(wrapper.getElement()).toMatchSnapshot()
     })

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -401,7 +401,7 @@ describe('TriggerManager', () => {
         }
       })
 
-      await wrapper.instance().handleSubmit({ login: 'test' })
+      await wrapper.instance().handleSubmit({ username: 'foo' })
       expect(saveAccountMock).toHaveBeenCalledWith(
         fixtures.konnector,
         expect.objectContaining(fixtures.existingAccount)

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -220,13 +220,23 @@ const propsWithAccount = {
   trigger: fixtures.existingTrigger
 }
 
-const setup = ({ konnector = fixtures.konnector, account, trigger } = {}) => {
+const defaultOnError = error => {
+  throw error
+}
+
+const setup = ({
+  konnector = fixtures.konnector,
+  account,
+  trigger,
+  onError = defaultOnError
+} = {}) => {
   const root = shallow(
     <TriggerManager
       {...props}
       konnector={konnector}
       trigger={trigger}
       account={account}
+      onError={onError}
     />
   )
   return { root }
@@ -370,16 +380,18 @@ describe('TriggerManager', () => {
   })
 
   describe('handleSubmit', () => {
-    it('should render as submitting when there is no account', () => {
+    it('should render as submitting when there is no account', async () => {
       const wrapper = shallowWithoutAccount()
-      wrapper.instance().handleSubmit()
+      const submitPromise = wrapper.instance().handleSubmit()
       expect(wrapper.state().status).toEqual('RUNNING') // TODO: test disabled prop of submit button instead of the internal state
+      await submitPromise
     })
 
-    it('should render as submitting when there is an account', () => {
+    it('should render as submitting when there is an account', async () => {
       const wrapper = shallowWithAccount()
-      wrapper.instance().handleSubmit()
+      const submitPromise = wrapper.instance().handleSubmit()
       expect(wrapper.state().status).toEqual('RUNNING')
+      await submitPromise
     })
 
     it('should call saveAccount without account', async () => {

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -71,7 +71,7 @@ const fixtures = {
     type: '@cron',
     worker: 'konnector',
     message: {
-      account: 'a87f9a8bd3884479a48811e7b7deec75',
+      account: 'created-account-id',
       konnector: 'konnectest'
     }
   },
@@ -84,7 +84,7 @@ const fixtures = {
     identifier: 'username'
   },
   createdAccount: {
-    _id: 'a87f9a8bd3884479a48811e7b7deec75',
+    _id: 'created-account-id',
     account_type: 'konnectest',
     auth: {
       username: 'foo',
@@ -93,7 +93,7 @@ const fixtures = {
     identifier: 'username'
   },
   updatedAccount: {
-    _id: 'a87f9a8bd3884479a48811e7b7deec75',
+    _id: 'updated-account-id',
     account_type: 'konnectest',
     auth: {
       username: 'foo',
@@ -101,7 +101,7 @@ const fixtures = {
     }
   },
   existingAccount: {
-    _id: '61c683295560485db0f34b859197c581',
+    _id: 'existing-account-id',
     account_type: 'konnectest',
     auth: {
       username: 'foo',
@@ -110,34 +110,34 @@ const fixtures = {
     identifier: 'username'
   },
   existingTrigger: {
-    id: '4b67e0bedd464704a6a995f5c2070ccf',
+    id: 'existing-trigger-id',
     _type: 'io.cozy.triggers',
     attributes: {
       arguments: '0 0 0 * * 0',
       type: '@cron',
       worker: 'konnector',
       message: {
-        account: '61c683295560485db0f34b859197c581',
+        account: 'existing-account-id',
         konnector: 'konnectest'
       }
     }
   },
   createdTrigger: {
-    id: '669e9a7cc3064a97bc0aa20feef71cb2',
+    id: 'created-trigger-id',
     _type: 'io.cozy.triggers',
     attributes: {
       arguments: '0 0 0 * * 0',
       type: '@cron',
       worker: 'konnector',
       message: {
-        account: 'a87f9a8bd3884479a48811e7b7deec75',
+        account: 'updated-account-id',
         konnector: 'konnectest'
       }
     }
   },
   launchedJob: {
     type: 'io.cozy.jobs',
-    id: 'ac09e6f4473f4b6fbb83c9d2f532504e',
+    id: 'lauched-job-id',
     domain: 'cozy.tools:8080',
     worker: 'konnector',
     state: 'running',
@@ -145,12 +145,12 @@ const fixtures = {
     started_at: '2016-09-19T12:35:08Z',
     error: '',
     links: {
-      self: '/jobs/ac09e6f4473f4b6fbb83c9d2f532504e'
+      self: '/jobs/lauched-job-id'
     }
   },
   runningJob: {
     type: 'io.cozy.jobs',
-    id: 'ac09e6f4473f4b6fbb83c9d2f532504e',
+    id: 'running-job-id',
     domain: 'cozy.tools:8080',
     worker: 'konnector',
     state: 'running',
@@ -158,12 +158,12 @@ const fixtures = {
     started_at: '2016-09-19T12:35:08Z',
     error: '',
     links: {
-      self: '/jobs/ac09e6f4473f4b6fbb83c9d2f532504e'
+      self: '/jobs/running-job-id'
     }
   },
   doneJob: {
     type: 'io.cozy.jobs',
-    id: 'ac09e6f4473f4b6fbb83c9d2f532504e',
+    id: 'done-job-id',
     domain: 'cozy.tools:8080',
     worker: 'konnector',
     state: 'done',
@@ -171,7 +171,7 @@ const fixtures = {
     started_at: '2016-09-19T12:35:08Z',
     error: '',
     links: {
-      self: '/jobs/ac09e6f4473f4b6fbb83c9d2f532504e'
+      self: '/jobs/done-job-id'
     }
   }
 }

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
@@ -12,7 +12,7 @@ exports[`TriggerManager handleError should render error 1`] = `
     <withI18n(withLocales(withKonnectorLocales(AccountForm))
       account={
         Object {
-          "_id": "61c683295560485db0f34b859197c581",
+          "_id": "existing-account-id",
           "account_type": "konnectest",
           "auth": Object {
             "passphrase": "bar",
@@ -56,7 +56,7 @@ exports[`TriggerManager when given an account should render correctly 1`] = `
     <withI18n(withLocales(withKonnectorLocales(AccountForm))
       account={
         Object {
-          "_id": "61c683295560485db0f34b859197c581",
+          "_id": "existing-account-id",
           "account_type": "konnectest",
           "auth": Object {
             "passphrase": "bar",

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
@@ -1,7 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TriggerManager handleError should render error 1`] = `
-<withI18n(withLocales(withClient(VaultUnlocker)))
+<KonnectorVaultUnlocker
+  konnector={
+    Object {
+      "fields": Object {
+        "passphrase": Object {
+          "type": "password",
+        },
+        "username": Object {
+          "type": "text",
+        },
+      },
+      "slug": "konnectest",
+    }
+  }
   onDismiss={[MockFunction]}
   onUnlock={[Function]}
 >
@@ -41,11 +54,24 @@ exports[`TriggerManager handleError should render error 1`] = `
       submitting={false}
     />
   </React.Fragment>
-</withI18n(withLocales(withClient(VaultUnlocker)))>
+</KonnectorVaultUnlocker>
 `;
 
 exports[`TriggerManager when given an account should render correctly 1`] = `
-<withI18n(withLocales(withClient(VaultUnlocker)))
+<KonnectorVaultUnlocker
+  konnector={
+    Object {
+      "fields": Object {
+        "passphrase": Object {
+          "type": "password",
+        },
+        "username": Object {
+          "type": "text",
+        },
+      },
+      "slug": "konnectest",
+    }
+  }
   onDismiss={[MockFunction]}
   onUnlock={[Function]}
 >
@@ -84,7 +110,7 @@ exports[`TriggerManager when given an account should render correctly 1`] = `
       submitting={false}
     />
   </React.Fragment>
-</withI18n(withLocales(withClient(VaultUnlocker)))>
+</KonnectorVaultUnlocker>
 `;
 
 exports[`TriggerManager when given an oauth konnector should redirect to OAuthForm 1`] = `
@@ -102,12 +128,25 @@ exports[`TriggerManager when given an oauth konnector should redirect to OAuthFo
 `;
 
 exports[`TriggerManager when given no account should render correctly 1`] = `
-<withI18n(withLocales(withClient(VaultUnlocker)))
+<KonnectorVaultUnlocker
+  konnector={
+    Object {
+      "fields": Object {
+        "passphrase": Object {
+          "type": "password",
+        },
+        "username": Object {
+          "type": "text",
+        },
+      },
+      "slug": "konnectest",
+    }
+  }
   onDismiss={[MockFunction]}
   onUnlock={[Function]}
 >
   <div
     id="coz-harvest-modal-place"
   />
-</withI18n(withLocales(withClient(VaultUnlocker)))>
+</KonnectorVaultUnlocker>
 `;

--- a/packages/playgrounds/src/sharing.jsx
+++ b/packages/playgrounds/src/sharing.jsx
@@ -35,7 +35,7 @@ const SharingExample = props => {
   const file = props.file
   const docId = file.id
   const [showModal, setShowModal] = useState(false)
-  const onClick = useCallback(() => setShowModal(!showModal), [])
+  const onClick = useCallback(() => setShowModal(!showModal), [showModal])
   const onClose = useCallback(() => setShowModal(false), [])
   return (
     <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,6 +83,22 @@
   optionalDependencies:
     chokidar "^2.1.8"
 
+"@babel/cli@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.8.3.tgz#121beb7c273e0521eb2feeb3883a2b7435d12328"
+  integrity sha512-K2UXPZCKMv7KwWy9Bl4sa6+jTNP7JyDiHKzoOiUUygaEDbC60vaargZDnO9oFMvlq8pIKOOyUUgeMYrsaN9djA==
+  dependencies:
+    commander "^4.0.1"
+    convert-source-map "^1.1.0"
+    fs-readdir-recursive "^1.1.0"
+    glob "^7.0.0"
+    lodash "^4.17.13"
+    make-dir "^2.1.0"
+    slash "^2.0.0"
+    source-map "^0.5.0"
+  optionalDependencies:
+    chokidar "^2.1.8"
+
 "@babel/code-frame@7.5.5", "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
@@ -95,6 +111,13 @@
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
   dependencies:
     "@babel/highlight" "^7.0.0"
+
+"@babel/code-frame@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
+  integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
+  dependencies:
+    "@babel/highlight" "^7.8.3"
 
 "@babel/core@7.2.2":
   version "7.2.2"
@@ -154,6 +177,27 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.8.3.tgz#30b0ebb4dd1585de6923a0b4d179e0b9f5d82941"
+  integrity sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.8.3"
+    "@babel/helpers" "^7.8.3"
+    "@babel/parser" "^7.8.3"
+    "@babel/template" "^7.8.3"
+    "@babel/traverse" "^7.8.3"
+    "@babel/types" "^7.8.3"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.0"
+    lodash "^4.17.13"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.0.0 <7.4.0":
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.3.4.tgz#9aa48c1989257877a9d971296e5b73bfe72e446e"
@@ -174,6 +218,16 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
     trim-right "^1.0.1"
+
+"@babel/generator@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.8.3.tgz#0e22c005b0a94c1c74eafe19ef78ce53a4d45c03"
+  integrity sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==
+  dependencies:
+    "@babel/types" "^7.8.3"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
 
 "@babel/helper-annotate-as-pure@^7.0.0":
   version "7.0.0"
@@ -239,11 +293,27 @@
     "@babel/template" "^7.1.0"
     "@babel/types" "^7.0.0"
 
+"@babel/helper-function-name@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz#eeeb665a01b1f11068e9fb86ad56a1cb1a824cca"
+  integrity sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.8.3"
+    "@babel/template" "^7.8.3"
+    "@babel/types" "^7.8.3"
+
 "@babel/helper-get-function-arity@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
   dependencies:
     "@babel/types" "^7.0.0"
+
+"@babel/helper-get-function-arity@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz#b894b947bd004381ce63ea1db9f08547e920abd5"
+  integrity sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==
+  dependencies:
+    "@babel/types" "^7.8.3"
 
 "@babel/helper-hoist-variables@^7.4.4":
   version "7.4.4"
@@ -326,6 +396,13 @@
   dependencies:
     "@babel/types" "^7.4.4"
 
+"@babel/helper-split-export-declaration@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
+  integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
+  dependencies:
+    "@babel/types" "^7.8.3"
+
 "@babel/helper-wrap-function@^7.1.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz#c4e0012445769e2815b55296ead43a958549f6fa"
@@ -344,10 +421,28 @@
     "@babel/traverse" "^7.6.0"
     "@babel/types" "^7.6.0"
 
+"@babel/helpers@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.8.3.tgz#382fbb0382ce7c4ce905945ab9641d688336ce85"
+  integrity sha512-LmU3q9Pah/XyZU89QvBgGt+BCsTPoQa+73RxAQh8fb8qkDyIfeQnmgs+hvzhTCKTzqOyk7JTkS3MS1S8Mq5yrQ==
+  dependencies:
+    "@babel/template" "^7.8.3"
+    "@babel/traverse" "^7.8.3"
+    "@babel/types" "^7.8.3"
+
 "@babel/highlight@^7.0.0":
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.5.0.tgz#56d11312bd9248fa619591d02472be6e8cb32540"
   integrity sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.8.3.tgz#28f173d04223eaaa59bc1d439a3836e6d1265797"
+  integrity sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
@@ -361,6 +456,11 @@
 "@babel/parser@^7.0.0 <7.4.0":
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.4.tgz#a43357e4bbf4b92a437fb9e465c192848287f27c"
+
+"@babel/parser@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.3.tgz#790874091d2001c9be6ec426c2eed47bc7679081"
+  integrity sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==
 
 "@babel/plugin-proposal-async-generator-functions@^7.2.0":
   version "7.2.0"
@@ -1032,6 +1132,15 @@
     "@babel/parser" "^7.6.0"
     "@babel/types" "^7.6.0"
 
+"@babel/template@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.3.tgz#e02ad04fe262a657809327f578056ca15fd4d1b8"
+  integrity sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/parser" "^7.8.3"
+    "@babel/types" "^7.8.3"
+
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.2.2", "@babel/traverse@^7.3.4", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.4", "@babel/traverse@^7.5.5", "@babel/traverse@^7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.6.0.tgz#389391d510f79be7ce2ddd6717be66d3fed4b516"
@@ -1061,6 +1170,21 @@
     globals "^11.1.0"
     lodash "^4.17.11"
 
+"@babel/traverse@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.8.3.tgz#a826215b011c9b4f73f3a893afbc05151358bf9a"
+  integrity sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.8.3"
+    "@babel/helper-function-name" "^7.8.3"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/parser" "^7.8.3"
+    "@babel/types" "^7.8.3"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.2.2", "@babel/types@^7.3.0", "@babel/types@^7.3.4", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5", "@babel/types@^7.6.0":
   version "7.6.1"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
@@ -1076,6 +1200,15 @@
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.11"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.3.tgz#5a383dffa5416db1b73dedffd311ffd0788fb31c"
+  integrity sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
 "@cnakazawa/watch@^1.0.3":
@@ -3339,6 +3472,11 @@ base64-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
+base64url@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
+  integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -4282,6 +4420,11 @@ commander@^2.11.0, commander@^2.15.1, commander@^2.19.0, commander@^2.20.0, comm
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
 
+commander@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.0.tgz#545983a0603fe425bc672d66c9e3c89c42121a83"
+  integrity sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==
+
 commander@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.1.0.tgz#d121bbae860d9992a3d517ba96f56588e47c6781"
@@ -4525,6 +4668,13 @@ convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.1:
   dependencies:
     safe-buffer "~5.1.1"
 
+convert-source-map@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
+  integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
+  dependencies:
+    safe-buffer "~5.1.1"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
@@ -4600,6 +4750,19 @@ cosmiconfig@^5.0.0, cosmiconfig@^5.0.7, cosmiconfig@^5.1.0, cosmiconfig@^5.2.0:
     is-directory "^0.3.1"
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
+
+cozy-bi-auth@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.1.tgz#79d79934e66affbd455a9dd191cac5571e183503"
+  integrity sha512-oRymdAd0A6S4InsWLusuPocZpWyu5gku5FUXFY1r9SGEJEW8FLg4ul67uxqR5SZrsO4jXFkzljUsOLJTNnWklg==
+  dependencies:
+    "@babel/cli" "^7.8.3"
+    "@babel/core" "^7.8.3"
+    babel-preset-cozy-app "^1.7.0"
+    cozy-logger "^1.3.0"
+    eslint-config-cozy-app "^1.4.0"
+    lodash "^4.17.15"
+    node-jose "^1.1.0"
 
 cozy-client-js@0.16.4:
   version "0.16.4"
@@ -6864,6 +7027,11 @@ generic-names@^1.0.1:
 genfun@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/genfun/-/genfun-5.0.0.tgz#9dd9710a06900a5c4a5bf57aca5da4e52fe76537"
+
+gensync@^1.0.0-beta.1:
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
+  integrity sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==
 
 get-caller-file@^1.0.1:
   version "1.0.3"
@@ -9519,6 +9687,11 @@ loglevel@^1.4.1, loglevel@^1.6.3:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.4.tgz#f408f4f006db8354d0577dcf6d33485b3cb90d56"
   integrity sha512-p0b6mOGKcGa+7nnmKbpzR6qloPbrgLcnio++E+14Vo/XffOGwZtRpUhr8dTH/x2oCMmEoIU0Zwm3ZauhvYD17g==
 
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
 longest-streak@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.3.tgz#3de7a3f47ee18e9074ded8575b5c091f5d0a4105"
@@ -10586,6 +10759,11 @@ node-forge@^0.7.1:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.6.tgz#fdf3b418aee1f94f0ef642cd63486c77ca9724ac"
 
+node-forge@^0.8.1:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.8.5.tgz#57906f07614dc72762c84cef442f427c0e1b86ee"
+  integrity sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==
+
 node-forge@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"
@@ -10610,6 +10788,18 @@ node-gyp@^5.0.2:
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
+
+node-jose@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/node-jose/-/node-jose-1.1.3.tgz#26e6bc563101a356c06fb254c7ef0078e8b49670"
+  integrity sha512-kupfi4uGWhRjnOmtie2T64cLge5a1TZyalEa8uWWWBgtKBcu41A4IGKpI9twZAxRnmviamEUQRK7LSyfFb2w8A==
+  dependencies:
+    base64url "^3.0.1"
+    es6-promise "^4.2.6"
+    lodash "^4.17.11"
+    long "^4.0.0"
+    node-forge "^0.8.1"
+    uuid "^3.3.2"
 
 node-libs-browser@^2.0.0, node-libs-browser@^2.2.1:
   version "2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4870,6 +4870,13 @@ cozy-doctypes@1.67.0:
     lodash "4.17.15"
     prop-types "^15.7.2"
 
+cozy-flags@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.1.0.tgz#46eda64317da44f357d37241cc160189b83878c9"
+  integrity sha512-oESKiuBzcJxrnH4Md/qWoeo3oteZNIjPzzugYU8OG6lXtbxcP5fvoFe26M2B7YAw3PDIIQuLicukao8g+yc+0g==
+  dependencies:
+    microee "^0.0.6"
+
 cozy-keys-lib@2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/cozy-keys-lib/-/cozy-keys-lib-2.5.2.tgz#b1ca7d1838613d5996313cd14e877c56acbf1136"


### PR DESCRIPTION
For the needs of the banking konnectors, a konnector must be able to insert itself
inside the connection process. A konnectorPolicy is introduced that can :

- insert custom behavior before account saving
- control whether credentials are saved into the vault