### PR TITLE
Less logs during CI

### DIFF
--- a/packages/cozy-app-publish/lib/hooks/pre/downcloud.js
+++ b/packages/cozy-app-publish/lib/hooks/pre/downcloud.js
@@ -8,10 +8,11 @@ const {
   createArchive,
   pushArchive
 } = require('./helpers')
+const logger = require('../../../utils/logger')
 
 module.exports = async options => {
   if (!fs.existsSync(options.buildDir)) {
-    console.error('↳ ❌  Build folder does not exist. Run `yarn build`.')
+    logger.error('↳ ❌  Build folder does not exist. Run `yarn build`.')
     throw new Error('Missing build folder')
   }
 

--- a/packages/cozy-app-publish/lib/prepublish.js
+++ b/packages/cozy-app-publish/lib/prepublish.js
@@ -1,6 +1,8 @@
 const runHooks = require('../utils/runhooks')
 const request = require('request')
 const crypto = require('crypto')
+const logger = require('../utils/logger')
+
 /**
  * Returns only expected value, avoid data injection by hook
  */
@@ -90,7 +92,7 @@ const shasum256FromURL = url =>
 const shasum = async options => {
   const { appBuildUrl } = options
   try {
-    console.log('Verifying shasum...')
+    logger.log('Verifying shasum...')
     const shasum = await prepublish.shasum256FromURL(appBuildUrl)
     options.sha256Sum = shasum
   } catch (e) {

--- a/packages/cozy-app-publish/lib/publisher.js
+++ b/packages/cozy-app-publish/lib/publisher.js
@@ -5,6 +5,7 @@ const colorize = require('../utils/colorize')
 const constants = require('./constants')
 const promptConfirm = require('./confirm')
 const defaults = require('lodash/defaults')
+const logger = require('../utils/logger')
 
 const {
   DEFAULT_REGISTRY_URL,
@@ -84,7 +85,7 @@ const publisher = ({
   }
 
   // ready publish the application on the registry
-  console.log(
+  logger.log(
     `Attempting to publish ${colorize.bold(
       publishOptions.appSlug
     )} (version ${colorize.bold(
@@ -95,14 +96,14 @@ const publisher = ({
       publishOptions.registryUrl
     )} (space: ${publishOptions.spaceName || 'default one'})`
   )
-  console.log()
+  logger.log()
 
   if (showConfirmation && !yes) {
     const goFurther = await promptConfirm(
       'Are you sure you want to publish this application above?'
     )
     if (!goFurther) {
-      console.log('Publishing cancelled')
+      logger.log('Publishing cancelled')
       return
     }
   }

--- a/packages/cozy-app-publish/package.json
+++ b/packages/cozy-app-publish/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/cozy/cozy-libs/issues"
   },
   "scripts": {
-    "test": "jest --verbose --coverage",
+    "test": "jest",
     "test:integration": "env TEST_INTEGRATION=1 jest"
   },
   "bin": {

--- a/packages/cozy-app-publish/test/jestLibs/setupJest.js
+++ b/packages/cozy-app-publish/test/jestLibs/setupJest.js
@@ -2,3 +2,9 @@
 
 const fetch = require('jest-fetch-mock')
 jest.doMock('node-fetch', () => fetch.mockResponse({ status: 201 }))
+
+jest.mock('../../utils/logger', () => ({
+  log: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+}))

--- a/packages/cozy-app-publish/utils/logger.js
+++ b/packages/cozy-app-publish/utils/logger.js
@@ -1,0 +1,7 @@
+const logger = {
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console)
+}
+
+module.exports = logger

--- a/packages/cozy-app-publish/utils/runhooks.js
+++ b/packages/cozy-app-publish/utils/runhooks.js
@@ -1,3 +1,5 @@
+const logger = require('./logger')
+
 const requireHook = (hook, type) => {
   try {
     return require(`${__dirname}/../lib/hooks/${type}/` + hook + '.js')
@@ -6,7 +8,7 @@ const requireHook = (hook, type) => {
       // Not builtin
       return require(process.cwd() + '/' + hook)
     } catch (err) {
-      console.error(err)
+      logger.error(err)
       throw new Error(`"${hook}" could not be loaded.`)
     }
   }
@@ -21,10 +23,10 @@ module.exports = async (hookNames, type, options) => {
     for (const hook of hooks) {
       try {
         const hookScript = requireHook(hook, type)
-        console.log(`↳ ℹ️  Running ${type}publish hook ${hook}`)
+        logger.log(`↳ ℹ️  Running ${type}publish hook ${hook}`)
         hookOptions = (await hookScript(hookOptions)) || hookOptions
       } catch (error) {
-        console.error(
+        logger.error(
           `↳ ❌  An error occured with ${type}publish hook ${hook}: ${error.message}`
         )
         throw new Error(`${type}publish hooks failed`)


### PR DESCRIPTION
Use a logger object to be able to mock out console logs during tests