### PR TITLE
fix: Remove extra translation context

### DIFF
--- a/packages/cozy-harvest-lib/src/components/VaultCiphersList/VaultCiphersList.jsx
+++ b/packages/cozy-harvest-lib/src/components/VaultCiphersList/VaultCiphersList.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Title } from 'cozy-ui/transpiled/react/Text'
-import I18n from 'cozy-ui/transpiled/react/I18n'
 
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/RaisedList'
 
@@ -11,7 +10,7 @@ import OtherAccountListItem from './OtherAccountListItem'
 
 export const DumbVaultCiphersList = ({ konnector, onSelect, ciphers, t }) => {
   return (
-    <I18n lang="en" dictRequire={() => {}}>
+    <>
       <Title className="u-ta-center u-mb-2">
         {t('vaultCiphersList.title')}
       </Title>
@@ -27,7 +26,7 @@ export const DumbVaultCiphersList = ({ konnector, onSelect, ciphers, t }) => {
 
         <OtherAccountListItem onClick={() => onSelect(null)} />
       </List>
-    </I18n>
+    </>
   )
 }
 

--- a/packages/cozy-harvest-lib/src/components/VaultCiphersList/VaultCiphersList.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/VaultCiphersList/VaultCiphersList.spec.jsx
@@ -1,6 +1,7 @@
 import { DumbVaultCiphersList } from './VaultCiphersList'
 import { render, waitForElement, fireEvent } from '@testing-library/react'
 import React from 'react'
+import I18n from 'cozy-ui/transpiled/react/I18n'
 
 jest.mock('cozy-ui/transpiled/react/AppIcon', () => () => null)
 
@@ -18,12 +19,14 @@ describe('when there is some ciphers', () => {
     ]
 
     const { getByText } = render(
-      <DumbVaultCiphersList
-        konnector={{ vendor_link: 'https://alan.com' }}
-        onSelect={onSelect}
-        ciphers={ciphers}
-        t={key => key}
-      />
+      <I18n lang="en" dictRequire={() => {}}>
+        <DumbVaultCiphersList
+          konnector={{ vendor_link: 'https://alan.com' }}
+          onSelect={onSelect}
+          ciphers={ciphers}
+          t={key => key}
+        />
+      </I18n>
     )
 
     const node = await waitForElement(() => getByText('isabelledurand'))
@@ -45,12 +48,14 @@ describe('when there is some ciphers', () => {
     ]
 
     const { getByText } = render(
-      <DumbVaultCiphersList
-        konnector={{ vendor_link: 'https://alan.com' }}
-        onSelect={onSelect}
-        ciphers={ciphers}
-        t={key => key}
-      />
+      <I18n lang="en" dictRequire={() => {}}>
+        <DumbVaultCiphersList
+          konnector={{ vendor_link: 'https://alan.com' }}
+          onSelect={onSelect}
+          ciphers={ciphers}
+          t={key => key}
+        />
+      </I18n>
     )
 
     const node = await waitForElement(() => getByText(/from another account/i))
@@ -65,13 +70,15 @@ describe('when there is no cipher', () => {
     const onSelect = jest.fn()
 
     const { getByText } = render(
-      <DumbVaultCiphersList
-        konnector={{ vendor_link: 'https://alan.com' }}
-        onNoCiphers={() => {}}
-        ciphers={[]}
-        onSelect={onSelect}
-        t={key => key}
-      />
+      <I18n lang="en" dictRequire={() => {}}>
+        <DumbVaultCiphersList
+          konnector={{ vendor_link: 'https://alan.com' }}
+          onNoCiphers={() => {}}
+          ciphers={[]}
+          onSelect={onSelect}
+          t={key => key}
+        />
+      </I18n>
     )
 
     const node = await waitForElement(() => getByText(/from another account/i))


### PR DESCRIPTION
The extra `I18n` was  introduced in c80e6efd45414a32f8186c41484068bc7987e7e4 and caused all child components to be in english. I assume the intention was to provide the I18n context during tests only (at least that's what my brain read during the review 😅)