### PR TITLE
Small fixes

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
@@ -4,15 +4,15 @@ import { withClient } from 'cozy-client'
 
 import Stack from 'cozy-ui/transpiled/react/Stack'
 
-import * as konnectorsModel from 'helpers/konnectors'
-import KonnectorUpdateInfos from 'components/infos/KonnectorUpdateInfos'
-import LaunchTriggerCard from 'components/cards/LaunchTriggerCard'
-import KonnectorMaintenance from 'components/Maintenance'
-import AppLinkCard from 'components/cards/AppLinkCard'
-import TriggerErrorInfo from 'components/infos/TriggerErrorInfo'
-import useMaintenanceStatus from 'components/hooks/useMaintenanceStatus'
-import getRelatedAppsSlugs from 'models/getRelatedAppsSlugs'
-import appLinksProps from 'components/KonnectorConfiguration/DataTab/appLinksProps'
+import * as konnectorsModel from '../../../helpers/konnectors'
+import KonnectorUpdateInfos from '../../../components/infos/KonnectorUpdateInfos'
+import LaunchTriggerCard from '../../../components/cards/LaunchTriggerCard'
+import KonnectorMaintenance from '../../../components/Maintenance'
+import AppLinkCard from '../../../components/cards/AppLinkCard'
+import TriggerErrorInfo from '../../../components/infos/TriggerErrorInfo'
+import useMaintenanceStatus from '../../../components/hooks/useMaintenanceStatus'
+import getRelatedAppsSlugs from '../../../models/getRelatedAppsSlugs'
+import appLinksProps from '../../../components/KonnectorConfiguration/DataTab/appLinksProps'
 
 export const DataTab = ({
   konnector,

--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -97,7 +97,8 @@ const createTemporaryToken = async ({ client, account, konnector }) => {
   const jobResponse = await client.stackClient.jobs.create('konnector', {
     mode: 'getTemporaryToken',
     konnector: konnector.slug,
-    account: account._id
+    account: account._id,
+    bankId: account.auth.bankId
   })
   const event = await waitForRealtimeEvent(
     client,

--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -11,7 +11,7 @@ import merge from 'lodash/merge'
 import clone from 'lodash/clone'
 import defaults from 'lodash/defaults'
 
-import { waitForRealtimeResult } from './jobUtils'
+import { waitForRealtimeEvent } from './jobUtils'
 import { createBIConnection, updateBIConnection } from './bi-http'
 import assert from '../assert'
 import { mkConnAuth, biErrorMap } from 'cozy-bi-auth'
@@ -99,8 +99,12 @@ const createTemporaryToken = async ({ client, account, konnector }) => {
     konnector: konnector.slug,
     account: account._id
   })
-  const event = await waitForRealtimeResult(client, jobResponse.data.attributes)
-  return event.data.code
+  const event = await waitForRealtimeEvent(
+    client,
+    jobResponse.data.attributes,
+    'result'
+  )
+  return event.data.result.code
 }
 
 /**

--- a/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
@@ -4,12 +4,12 @@ import {
   onBIAccountCreation,
   getBIConfigForCozyURL
 } from './budget-insight'
-import { waitForRealtimeResult } from './jobUtils'
+import { waitForRealtimeEvent } from './jobUtils'
 import { createBIConnection, updateBIConnection } from './bi-http'
 import merge from 'lodash/merge'
 
 jest.mock('./jobUtils', () => ({
-  waitForRealtimeResult: jest.fn()
+  waitForRealtimeEvent: jest.fn()
 }))
 
 jest.mock('./bi-http', () => ({
@@ -67,11 +67,13 @@ describe('createOrUpdateBIConnection', () => {
         }
       }
     })
-    waitForRealtimeResult.mockImplementation(async () => {
+    waitForRealtimeEvent.mockImplementation(async () => {
       sleep(2)
       return {
         data: {
-          code: 'bi-temporary-access-token-145613'
+          result: {
+            code: 'bi-temporary-access-token-145613'
+          }
         }
       }
     })
@@ -106,9 +108,13 @@ describe('createOrUpdateBIConnection', () => {
       account,
       konnector
     })
-    expect(waitForRealtimeResult).toHaveBeenCalledWith(client, {
-      _id: 'job-id-1337'
-    })
+    expect(waitForRealtimeEvent).toHaveBeenCalledWith(
+      client,
+      {
+        _id: 'job-id-1337'
+      },
+      'result'
+    )
     expect(createBIConnection).toHaveBeenCalledWith(
       expect.any(Object),
       {
@@ -137,9 +143,13 @@ describe('createOrUpdateBIConnection', () => {
       }),
       konnector
     })
-    expect(waitForRealtimeResult).toHaveBeenCalledWith(client, {
-      _id: 'job-id-1337'
-    })
+    expect(waitForRealtimeEvent).toHaveBeenCalledWith(
+      client,
+      {
+        _id: 'job-id-1337'
+      },
+      'result'
+    )
     expect(createBIConnection).not.toHaveBeenCalled()
     expect(updateBIConnection).toHaveBeenCalledWith(
       expect.any(Object),

--- a/packages/cozy-harvest-lib/src/services/jobUtils.js
+++ b/packages/cozy-harvest-lib/src/services/jobUtils.js
@@ -2,7 +2,7 @@ import CozyRealtime from 'cozy-realtime'
 
 const JOBS_DOCTYPE = 'io.cozy.jobs'
 
-export const waitForRealtimeResult = (client, job) =>
+export const waitForRealtimeEvent = (client, job, eventType) =>
   new Promise((resolve, reject) => {
     const rt = new CozyRealtime({ client })
 
@@ -13,8 +13,10 @@ export const waitForRealtimeResult = (client, job) =>
     }
     const id = job._id
     const handleNotification = event => {
-      rt.unsubscribe('notified', JOBS_DOCTYPE, id, handleNotification)
-      resolve(event)
+      if (!eventType || event.data.type == eventType) {
+        rt.unsubscribe('notified', JOBS_DOCTYPE, id, handleNotification)
+        resolve(event)
+      }
     }
 
     rt.subscribe('updated', JOBS_DOCTYPE, id, handleUpdate)


### PR DESCRIPTION
- Consider only "result" event when waiting for temporary token.

Since we will receive other events from the konnector in the future,
for example "progress" events, we filter on the "type" attribute 
received in the "data" part of the event.

- Send the bankId as part of the temporary token job options. This is
necessary for multi branch banks, where the bankId is not baked in
the manifest.konnector.