### PR TITLE
fix: Submitting button returns to idle state after error

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -265,6 +265,8 @@ export class DumbTriggerManager extends Component {
       return await this.handleNewAccount(oAuthAccount)
     } catch (error) {
       this.handleError(error)
+    } finally {
+      this.setState({ status: IDLE })
     }
   }
 
@@ -294,11 +296,9 @@ export class DumbTriggerManager extends Component {
       status: RUNNING
     })
 
-    const konnectorPolicy = findKonnectorPolicy(konnector)
-
     try {
       let cipher
-
+      const konnectorPolicy = findKonnectorPolicy(konnector)
       logger.log('konnector policy', konnectorPolicy)
       if (konnectorPolicy.saveInVault) {
         const cipherId = this.getSelectedCipherId()
@@ -327,6 +327,10 @@ export class DumbTriggerManager extends Component {
       return await this.handleNewAccount(accounts.mergeAuth(savedAccount, data))
     } catch (error) {
       return this.handleError(error)
+    } finally {
+      this.setState({
+        status: IDLE
+      })
     }
   }
 
@@ -337,7 +341,7 @@ export class DumbTriggerManager extends Component {
    */
   async handleNewAccount(account) {
     const trigger = await this.ensureTrigger(account)
-    this.setState({ account, status: IDLE })
+    this.setState({ account })
     return await this.props.launch(trigger)
   }
   /**
@@ -346,7 +350,7 @@ export class DumbTriggerManager extends Component {
   handleError(error) {
     logger.error('TriggerManager handleError', error)
     const { onError } = this.props
-    this.setState({ error, state: IDLE })
+    this.setState({ error })
     if (typeof onError === 'function') onError(error)
   }
 

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -432,6 +432,22 @@ describe('TriggerManager', () => {
       await submitPromise
     })
 
+    it('should stop being rendered as submitting on error', async () => {
+      const wrapper = shallowWithAccount()
+      mockVaultClient.isLocked.mockReset().mockImplementationOnce(() => {
+        throw new Error('fakeerror')
+      })
+
+      try {
+        await wrapper.instance().handleSubmit(fixtures.data)
+        expect(mockVaultClient.isLocked).toHaveBeenCalledTimes(1)
+      } catch (e) {
+        // eslint-disable-next-line no-empty
+      }
+
+      expect(isSubmitting(wrapper)).toBe(false)
+    })
+
     it('should call saveAccount without account', async () => {
       const wrapper = shallowWithoutAccount()
       await wrapper.instance().handleSubmit(fixtures.data)

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -413,17 +413,22 @@ describe('TriggerManager', () => {
   })
 
   describe('handleSubmit', () => {
+    const isSubmitting = wrapper => {
+      // TODO: test disabled prop of submit button instead of the internal state
+      return wrapper.state().status == 'RUNNING'
+    }
+
     it('should render as submitting when there is no account', async () => {
       const wrapper = shallowWithoutAccount()
       const submitPromise = wrapper.instance().handleSubmit()
-      expect(wrapper.state().status).toEqual('RUNNING') // TODO: test disabled prop of submit button instead of the internal state
+      expect(isSubmitting(wrapper)).toBe(true)
       await submitPromise
     })
 
     it('should render as submitting when there is an account', async () => {
       const wrapper = shallowWithAccount()
       const submitPromise = wrapper.instance().handleSubmit()
-      expect(wrapper.state().status).toEqual('RUNNING')
+      expect(isSubmitting(wrapper)).toBe(true)
       await submitPromise
     })
 


### PR DESCRIPTION
The submit button for account creation  would not return to idle state
if there was an error.