### PR TITLE
feat(cozy-harvest-lib): Add deleteAccounts service

### DIFF
--- a/packages/cozy-harvest-lib/src/connections/accounts.js
+++ b/packages/cozy-harvest-lib/src/connections/accounts.js
@@ -144,7 +144,7 @@ const saveAccount = (client, konnector, account = {}) => {
  * @param  {Object}  client  CozyClient
  * @param  {Object}  account io.cozy.accounts document
  */
-const deleteAccount = async (client, account) => {
+export const deleteAccount = async (client, account) => {
   try {
     await client.destroy(account)
   } catch (error) {

--- a/packages/cozy-harvest-lib/src/index.js
+++ b/packages/cozy-harvest-lib/src/index.js
@@ -31,3 +31,4 @@ export { withLocales }
 export {
   default as updateAccountsPassword
 } from './services/updateAccountsPassword'
+export { default as deleteAccounts } from './services/deleteAccounts'

--- a/packages/cozy-harvest-lib/src/services/deleteAccounts.js
+++ b/packages/cozy-harvest-lib/src/services/deleteAccounts.js
@@ -1,0 +1,22 @@
+import get from 'lodash/get'
+import { fetchAccountsForCipherId } from './utils'
+import logger from '../logger'
+import { deleteAccount } from '../connections/accounts.js'
+
+const deleteAccounts = async (cozyClient, bitwardenCipherDocument) => {
+  const bitwardenCipherId = get(bitwardenCipherDocument, '_id')
+
+  logger.debug(`Fetching accounts for cipher ${bitwardenCipherId}`)
+  const accounts = await fetchAccountsForCipherId(cozyClient, bitwardenCipherId)
+  logger.debug(
+    `Fetched ${accounts.length}accounts for cipher ${bitwardenCipherId}`
+  )
+
+  logger.debug('Deleting accounts')
+  await Promise.all(
+    accounts.data.map(account => deleteAccount(cozyClient, account))
+  )
+  logger.debug('Deleted accounts')
+}
+
+export default deleteAccounts

--- a/packages/cozy-harvest-lib/test/connections/accounts.spec.js
+++ b/packages/cozy-harvest-lib/test/connections/accounts.spec.js
@@ -344,6 +344,20 @@ describe('Account mutations', () => {
       await deleteAccount(fixtures.simpleAccount)
       expect(client.destroy).toHaveBeenCalledWith(fixtures.simpleAccount)
     })
+
+    describe('when there is a conflict', () => {
+      it('should re-fetch the account and retry', async () => {
+        client.destroy.mockRejectedValueOnce({ status: 409 })
+        client.query.mockResolvedValueOnce([
+          { _id: 'account1', _type: 'io.cozy.accounts' }
+        ])
+
+        await deleteAccount(fixtures.simpleAccount)
+
+        expect(client.query).toHaveBeenCalled()
+        expect(client.destroy).toHaveBeenCalledTimes(2)
+      })
+    })
   })
 
   describe('saveAccount', () => {

--- a/packages/cozy-harvest-lib/test/services/deleteAccounts.spec.js
+++ b/packages/cozy-harvest-lib/test/services/deleteAccounts.spec.js
@@ -1,0 +1,29 @@
+import deleteAccounts from 'services/deleteAccounts'
+import { fetchAccountsForCipherId } from 'services/utils'
+import { deleteAccount } from 'connections/accounts'
+
+jest.mock('services/utils')
+jest.mock('connections/accounts')
+
+describe('deleteAccounts', () => {
+  it('should delete all accounts linked to the deleted cipher', async () => {
+    const deletedCipher = { _id: 'bdf9ef21ef243af8abd57e4243010e8f' }
+    const accounts = [
+      { _id: 'account1', _type: 'io.cozy.accounts' },
+      { _id: 'account2', _type: 'io.cozy.accounts' }
+    ]
+    fetchAccountsForCipherId.mockResolvedValue({
+      data: accounts
+    })
+
+    const clientMock = {
+      destroy: jest.fn()
+    }
+
+    await deleteAccounts(clientMock, deletedCipher)
+
+    expect(deleteAccount).toHaveBeenCalledTimes(2)
+    expect(deleteAccount).toHaveBeenCalledWith(clientMock, accounts[0])
+    expect(deleteAccount).toHaveBeenCalledWith(clientMock, accounts[1])
+  })
+})


### PR DESCRIPTION
This finds the accounts that have a relationship with a given cipher,
and delete it. It will be used in a service to delete accounts when a
cipher has been deleted by the user.