### PR TITLE
fix(cozy-harvest-lib): Correctly check vault locked state

### DIFF
--- a/packages/cozy-harvest-lib/src/models/cipherUtils.js
+++ b/packages/cozy-harvest-lib/src/models/cipherUtils.js
@@ -97,7 +97,9 @@ export const createOrUpdateCipher = async (
   cipherId,
   { userCredentials, account, konnector }
 ) => {
-  if (vaultClient.isLocked()) {
+  const isLocked = await vaultClient.isLocked()
+
+  if (isLocked) {
     logger.warn('Impossible to create cipher since vault is locked')
     return null
   }

--- a/packages/cozy-harvest-lib/src/models/cipherUtils.spec.js
+++ b/packages/cozy-harvest-lib/src/models/cipherUtils.spec.js
@@ -68,7 +68,7 @@ describe('createOrUpdateCipher', () => {
   it('should return null if vault client is locked', async () => {
     const { konnector, account, userCredentials, vaultClient } = setup({
       vaultClient: {
-        isLocked: () => true
+        isLocked: jest.fn().mockResolvedValue(true)
       }
     })
     const cipherId = null


### PR DESCRIPTION
WebVaultClient.isLocked returns a promise. So checking it's return value
without await is always true. Adding await ensures we get the real vault
locked state.