### PR TITLE
fix(cozy-harvest-lib): The onVaultDismiss prop is not required

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -638,7 +638,7 @@ DumbTriggerManager.propTypes = {
   /**
    * What to do when the Vault unlock screen is dismissed without password
    */
-  onVaultDismiss: PropTypes.func.isRequired,
+  onVaultDismiss: PropTypes.func,
   /**
    * Whether the vault will be closable or not.
    * @type {Boolean}


### PR DESCRIPTION
This prop is not required in all TriggerManager use cases. We don't
always want to do something when the vault is dismissed.