### PR TITLE
fix(cozy-harvest-lib): Always show account form when editing an account

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -419,13 +419,12 @@ export class DumbTriggerManager extends Component {
   }
 
   showCiphersList(ciphers) {
-    const newState = { step: 'ciphersList' }
-
-    if (ciphers) {
-      newState.ciphers = ciphers
-    }
-
-    this.setState(newState)
+    this.setState(prevState => {
+      return {
+        step: prevState.step === 'accountForm' ? 'accountForm' : 'ciphersList',
+        ciphers: ciphers ? ciphers : prevState.ciphers
+      }
+    })
   }
 
   async handleVaultUnlock() {

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -364,6 +364,48 @@ describe('TriggerManager', () => {
       const component = shallowWithAccount().getElement()
       expect(component).toMatchSnapshot()
     })
+
+    describe('when the vault contains ciphers', () => {
+      it('should show the account form', async () => {
+        mockVaultClient.getAll.mockResolvedValue([])
+        mockVaultClient.getAllDecrypted.mockResolvedValue([])
+
+        const { findByLabelText } = render(
+          <TriggerManager {...propsWithAccount} />
+        )
+
+        const usernameField = await findByLabelText('username')
+        const passwordField = await findByLabelText('passphrase')
+
+        expect(usernameField).toBeDefined()
+        expect(passwordField).toBeDefined()
+      })
+    })
+
+    describe('when the vault does not contain ciphers', () => {
+      it('should show the account form', async () => {
+        mockVaultClient.getAll.mockResolvedValue([{ id: 'cipher1' }])
+        mockVaultClient.getAllDecrypted.mockResolvedValue([
+          {
+            id: 'cipher1',
+            name: fixtures.konnector.name,
+            login: {
+              username: 'Isabelle'
+            }
+          }
+        ])
+
+        const { findByLabelText } = render(
+          <TriggerManager {...propsWithAccount} />
+        )
+
+        const usernameField = await findByLabelText('username')
+        const passwordField = await findByLabelText('passphrase')
+
+        expect(usernameField).toBeDefined()
+        expect(passwordField).toBeDefined()
+      })
+    })
   })
 
   describe('handleError', () => {


### PR DESCRIPTION
When the user tries to edit an account, we show the form directly. But
ciphers are being fetched in background, and we were redirecting to the
ciphers list step as soon as we detect that some cipher exists.
Actually, when the user is on the account form step, we shouldn't
automatically redirect. If the user wants to see the ciphers list, he
can by clicking the "back" arrow.