### PR TITLE
[cozy-harvest-lib] Don't duplicate ciphers when selecting an existing one

### DIFF
--- a/packages/cozy-harvest-lib/__mocks__/cozy-keys-lib/index.js
+++ b/packages/cozy-harvest-lib/__mocks__/cozy-keys-lib/index.js
@@ -14,6 +14,10 @@ const CipherType = {
   Login: 'Login'
 }
 
+const UriMatchType = {
+  Domain: 'Domain'
+}
+
 const withVaultClient = Component => Component
 
-export { VaultUnlocker, CipherType, withVaultClient }
+export { VaultUnlocker, CipherType, withVaultClient, UriMatchType }

--- a/packages/cozy-harvest-lib/src/models/cipherUtils.js
+++ b/packages/cozy-harvest-lib/src/models/cipherUtils.js
@@ -111,17 +111,21 @@ export const createOrUpdateCipher = async (
   const password = userCredentials.password
 
   let cipher
+
   if (!cipherId) {
     cipher = await searchForCipher(vaultClient, {
-      account,
       konnector,
+      account,
       login,
       password
     })
   }
 
-  if (cipher) {
-    cipher = await updateCipher(vaultClient, cipher.id, { login, password })
+  if (cipherId || cipher) {
+    cipher = await updateCipher(vaultClient, cipherId || cipher.id, {
+      login,
+      password
+    })
   } else {
     cipher = await createCipher(vaultClient, {
       konnector,

--- a/packages/cozy-harvest-lib/src/models/cipherUtils.js
+++ b/packages/cozy-harvest-lib/src/models/cipherUtils.js
@@ -100,7 +100,7 @@ export const createOrUpdateCipher = async (
   const isLocked = await vaultClient.isLocked()
 
   if (isLocked) {
-    logger.warn('Impossible to create cipher since vault is locked')
+    logger.warn('Impossible to create or update cipher since vault is locked')
     return null
   }
 

--- a/packages/cozy-harvest-lib/src/models/cipherUtils.spec.js
+++ b/packages/cozy-harvest-lib/src/models/cipherUtils.spec.js
@@ -83,7 +83,7 @@ describe('createOrUpdateCipher', () => {
   it('should pass the correct search to vault client', async () => {
     const { konnector, account, userCredentials, vaultClient } = setup({
       vaultClient: {
-        isLocked: () => false
+        isLocked: jest.fn().mockResolvedValue(false)
       }
     })
     const cipherId = null


### PR DESCRIPTION
When creating a new account with an existing cipher, it was duplicated. This PR fixes this. Now, the cipher is linked to the created account, but not duplicated.

Also added tests.