### PR TITLE
fix(cozy-harvest-lib): Show account form on account edition

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -449,7 +449,7 @@ export class DumbTriggerManager extends Component {
       if (ciphers.length === 0) {
         this.showAccountForm()
       } else {
-        if (this.step === 'accountForm') {
+        if (this.state.step === 'accountForm') {
           this.setState({ ciphers })
         } else {
           this.showCiphersList(ciphers)

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
@@ -1,5 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TriggerManager account creation should render correctly 1`] = `
+<KonnectorVaultUnlocker
+  konnector={
+    Object {
+      "fields": Object {
+        "passphrase": Object {
+          "type": "password",
+        },
+        "username": Object {
+          "type": "text",
+        },
+      },
+      "slug": "konnectest",
+    }
+  }
+  onDismiss={[MockFunction]}
+  onUnlock={[Function]}
+>
+  <div
+    id="coz-harvest-modal-place"
+  />
+</KonnectorVaultUnlocker>
+`;
+
+exports[`TriggerManager account update should render correctly 1`] = `
+<KonnectorVaultUnlocker
+  konnector={
+    Object {
+      "fields": Object {
+        "passphrase": Object {
+          "type": "password",
+        },
+        "username": Object {
+          "type": "text",
+        },
+      },
+      "slug": "konnectest",
+    }
+  }
+  onDismiss={[MockFunction]}
+  onUnlock={[Function]}
+>
+  <div
+    id="coz-harvest-modal-place"
+  />
+  <React.Fragment>
+    <withI18n(withLocales(withKonnectorLocales(AccountForm))
+      account={
+        Object {
+          "_id": "existing-account-id",
+          "account_type": "konnectest",
+          "auth": Object {
+            "passphrase": "bar",
+            "username": "foo",
+          },
+          "identifier": "username",
+        }
+      }
+      konnector={
+        Object {
+          "fields": Object {
+            "passphrase": Object {
+              "type": "password",
+            },
+            "username": Object {
+              "type": "text",
+            },
+          },
+          "slug": "konnectest",
+        }
+      }
+      onBack={[Function]}
+      onSubmit={[Function]}
+      readOnlyIdentifier={false}
+      submitting={false}
+    />
+  </React.Fragment>
+</KonnectorVaultUnlocker>
+`;
+
 exports[`TriggerManager handleError should render error 1`] = `
 <KonnectorVaultUnlocker
   konnector={
@@ -57,62 +137,6 @@ exports[`TriggerManager handleError should render error 1`] = `
 </KonnectorVaultUnlocker>
 `;
 
-exports[`TriggerManager when given an account should render correctly 1`] = `
-<KonnectorVaultUnlocker
-  konnector={
-    Object {
-      "fields": Object {
-        "passphrase": Object {
-          "type": "password",
-        },
-        "username": Object {
-          "type": "text",
-        },
-      },
-      "slug": "konnectest",
-    }
-  }
-  onDismiss={[MockFunction]}
-  onUnlock={[Function]}
->
-  <div
-    id="coz-harvest-modal-place"
-  />
-  <React.Fragment>
-    <withI18n(withLocales(withKonnectorLocales(AccountForm))
-      account={
-        Object {
-          "_id": "existing-account-id",
-          "account_type": "konnectest",
-          "auth": Object {
-            "passphrase": "bar",
-            "username": "foo",
-          },
-          "identifier": "username",
-        }
-      }
-      konnector={
-        Object {
-          "fields": Object {
-            "passphrase": Object {
-              "type": "password",
-            },
-            "username": Object {
-              "type": "text",
-            },
-          },
-          "slug": "konnectest",
-        }
-      }
-      onBack={[Function]}
-      onSubmit={[Function]}
-      readOnlyIdentifier={false}
-      submitting={false}
-    />
-  </React.Fragment>
-</KonnectorVaultUnlocker>
-`;
-
 exports[`TriggerManager when given an oauth konnector should redirect to OAuthForm 1`] = `
 <withI18n(OAuthForm)
   konnector={
@@ -125,28 +149,4 @@ exports[`TriggerManager when given an oauth konnector should redirect to OAuthFo
   onSuccess={[Function]}
   submitting={false}
 />
-`;
-
-exports[`TriggerManager when given no account should render correctly 1`] = `
-<KonnectorVaultUnlocker
-  konnector={
-    Object {
-      "fields": Object {
-        "passphrase": Object {
-          "type": "password",
-        },
-        "username": Object {
-          "type": "text",
-        },
-      },
-      "slug": "konnectest",
-    }
-  }
-  onDismiss={[MockFunction]}
-  onUnlock={[Function]}
->
-  <div
-    id="coz-harvest-modal-place"
-  />
-</KonnectorVaultUnlocker>
 `;


### PR DESCRIPTION
This is quite similar to https://github.com/cozy/cozy-libs/pull/949.
Actually I broke it in https://github.com/cozy/cozy-libs/pull/952
because I reverted a commit that contained tests. Thus the tests
disappeared, but I thought they were passing.

So here I bring back the tests from the reverted commit and really fix
the issue...