### PR TITLE
feat: Adds no-console as eslint errors

### DIFF
--- a/packages/eslint-config-cozy-app/basics.js
+++ b/packages/eslint-config-cozy-app/basics.js
@@ -11,6 +11,7 @@ module.exports = {
     es6: true
   },
   rules: {
+    'no-console': 'error',
     'prettier/prettier': [
       'error',
       {


### PR DESCRIPTION
We want to raise errors in case of `console.log` in our source codes.
The upgrade of eslint to 5.x to 6.x changed the default for no-console. This PR is to restore the previous behaviour.

See https://github.com/eslint/eslint/blob/24ca088fdc901feef8f10b050414fbde64b55c7d/docs/user-guide/migrating-to-6.0.0.md#eslint-recommended-changes