### PR TITLE
Publication channel can depend on registry channel

### DIFF
--- a/packages/cozy-app-publish/lib/hooks/post/mattermost.js
+++ b/packages/cozy-app-publish/lib/hooks/post/mattermost.js
@@ -94,20 +94,21 @@ const sendMattermostReleaseMessage = async options => {
   console.log('↳ ℹ️  Sending message to Mattermost')
 
   const hookURL = process.env.MATTERMOST_HOOK_URL
-  const channel = process.env.MATTERMOST_CHANNEL
+  const channels = process.env.MATTERMOST_CHANNEL.split(',')
   const iconURL = 'https://travis-ci.com/images/logos/TravisCI-Mascot-1.png'
   const username = 'Travis'
   const message = getMessage(options)
 
-  return await sendMattermostMessage({
-    hookURL,
-    iconURL,
-    username,
-    channel,
-    message
-  })
+  for (const channel of channels) {
+    await sendMattermostMessage({
+      hookURL,
+      iconURL,
+      username,
+      channel,
+      message
+    })
+  }
 }
-
 
 module.exports = sendMattermostReleaseMessage
 module.exports.getMessage = getMessage

--- a/packages/cozy-app-publish/lib/hooks/post/mattermost.js
+++ b/packages/cozy-app-publish/lib/hooks/post/mattermost.js
@@ -109,7 +109,6 @@ const getMattermostChannels = ({ appVersion }) => {
 const sendMattermostReleaseMessage = async options => {
   validate()
 
-
   const hookURL = process.env.MATTERMOST_HOOK_URL
   const channels = getMattermostChannels({ appVersion: options.appVersion })
   const iconURL = 'https://travis-ci.com/images/logos/TravisCI-Mascot-1.png'

--- a/packages/cozy-app-publish/lib/hooks/post/mattermost.js
+++ b/packages/cozy-app-publish/lib/hooks/post/mattermost.js
@@ -36,35 +36,22 @@ const getMessage = options => {
   return message
 }
 
-const sendMattermostReleaseMessage = (
-  appSlug,
-  appVersion,
-  spaceName,
-  appType
-) => {
-  const { MATTERMOST_CHANNEL, MATTERMOST_HOOK_URL } = process.env
+const sendMattermostMessage = options => {
+  const { channel, iconURL, hookURL, username, message } = options
 
-  const MATTERMOST_ICON =
-    'https://travis-ci.com/images/logos/TravisCI-Mascot-1.png'
-  const MATTERMOST_USERNAME = 'Travis'
+  const mattermostHookUrl = url.parse(hookURL)
 
-  const mattermostHookUrl = url.parse(MATTERMOST_HOOK_URL)
-  const message = getMessage({
-    appSlug,
-    appVersion,
-    spaceName,
-    appType
-  })
   return new Promise((resolve, reject) => {
     console.log(
-      `↳ ℹ️  Sending to mattermost channel ${MATTERMOST_CHANNEL} the following message: "${message}"`
+      `↳ ℹ️  Sending to mattermost channel ${channel} the following message: "${message}"`
     )
     const postData = JSON.stringify({
-      channel: MATTERMOST_CHANNEL,
-      icon_url: MATTERMOST_ICON,
-      username: MATTERMOST_USERNAME,
+      channel: channel,
+      icon_url: iconURL,
+      username: username,
       text: message
     })
+
     const request = https.request(
       {
         headers: {
@@ -93,20 +80,36 @@ const sendMattermostReleaseMessage = (
   })
 }
 
-module.exports = async options => {
-  console.log('↳ ℹ️  Sending message to Mattermost')
-  const MATTERMOST_HOOK_URL = process.env.MATTERMOST_HOOK_URL
-
-  if (!MATTERMOST_HOOK_URL) {
+const validate = () => {
+  if (!process.env.MATTERMOST_HOOK_URL) {
     throw new Error('No MATTERMOST_HOOK_URL environment variable defined')
+  } else if (!process.env.MATTERMOST_CHANNEL) {
+    throw new Error('No MATTERMOST_CHANNEL environment variable defined')
   }
-
-  const { appSlug, appVersion, spaceName, appType } = options
-
-  sendMattermostReleaseMessage(appSlug, appVersion, spaceName, appType)
-
-  return options
 }
 
+const sendMattermostReleaseMessage = async options => {
+  validate()
+
+  console.log('↳ ℹ️  Sending message to Mattermost')
+
+  const hookURL = process.env.MATTERMOST_HOOK_URL
+  const channel = process.env.MATTERMOST_CHANNEL
+  const iconURL = 'https://travis-ci.com/images/logos/TravisCI-Mascot-1.png'
+  const username = 'Travis'
+  const message = getMessage(options)
+
+  return await sendMattermostMessage({
+    hookURL,
+    iconURL,
+    username,
+    channel,
+    message
+  })
+}
+
+
+module.exports = sendMattermostReleaseMessage
 module.exports.getMessage = getMessage
+module.exports.sendMattermostMessage = sendMattermostMessage
 module.exports.sendMattermostReleaseMessage = sendMattermostReleaseMessage

--- a/packages/cozy-app-publish/lib/hooks/post/mattermost.js
+++ b/packages/cozy-app-publish/lib/hooks/post/mattermost.js
@@ -113,3 +113,19 @@ module.exports = sendMattermostReleaseMessage
 module.exports.getMessage = getMessage
 module.exports.sendMattermostMessage = sendMattermostMessage
 module.exports.sendMattermostReleaseMessage = sendMattermostReleaseMessage
+
+if (require.main === module) {
+  const appSlug = 'test'
+  const appVersion = '0.0.1'
+  const spaceName = 'spacemountain'
+  const appType = 'konnector'
+  sendMattermostReleaseMessage({
+    appSlug,
+    appVersion,
+    spaceName,
+    appType
+  }).catch(e => {
+    console.error(e)
+    process.exit(1)
+  })
+}

--- a/packages/cozy-app-publish/lib/hooks/post/mattermost.spec.js
+++ b/packages/cozy-app-publish/lib/hooks/post/mattermost.spec.js
@@ -104,7 +104,7 @@ describe('sendMattermost Post', () => {
         }
       })
       try {
-         await sendMattermostReleaseMessage(commonInfo)
+        await sendMattermostReleaseMessage(commonInfo)
         expect(JSON.parse(writeSpy.mock.calls[0][0])).toEqual({
           channel: 'gh-notif-appvenger',
           icon_url: 'https://travis-ci.com/images/logos/TravisCI-Mascot-1.png',

--- a/packages/cozy-app-publish/lib/hooks/post/mattermost.spec.js
+++ b/packages/cozy-app-publish/lib/hooks/post/mattermost.spec.js
@@ -45,7 +45,6 @@ describe('get message', () => {
 })
 
 describe('sendMattermost Post', () => {
-
   beforeEach(() => {
     jest.spyOn(console, 'log').mockImplementation(() => {})
   })
@@ -105,13 +104,13 @@ describe('sendMattermost Post', () => {
         }
       })
       try {
-        const resp = await sendMattermostReleaseMessage(commonInfo)
+         await sendMattermostReleaseMessage(commonInfo)
         expect(JSON.parse(writeSpy.mock.calls[0][0])).toEqual({
-          "channel":"gh-notif-appvenger",
-          "icon_url":"https://travis-ci.com/images/logos/TravisCI-Mascot-1.png",
-          "username":"Travis",
-          "text":"Application __banks__ version `1.6.1` has been published on space __banks__.\n\n- [Last commit: Beautiful commit title & a beautiful ampersand 😍 ](https://github.com/cozy/cozy-banks/commits/sha1deadbeef)\n- [Job](https://travis.com/cozy/cozy-banks/jobs/jobId1234)"
-
+          channel: 'gh-notif-appvenger',
+          icon_url: 'https://travis-ci.com/images/logos/TravisCI-Mascot-1.png',
+          username: 'Travis',
+          text:
+            'Application __banks__ version `1.6.1` has been published on space __banks__.\n\n- [Last commit: Beautiful commit title & a beautiful ampersand 😍 ](https://github.com/cozy/cozy-banks/commits/sha1deadbeef)\n- [Job](https://travis.com/cozy/cozy-banks/jobs/jobId1234)'
         })
         expect(https.request).toHaveBeenCalledWith(
           {
@@ -125,7 +124,6 @@ describe('sendMattermost Post', () => {
           },
           expect.any(Function)
         )
-        expect(resp.statusCode).toEqual(200)
       } catch (error) {
         throw error
       }


### PR DESCRIPTION
## Need

Following a discussion on mattermost where it was reminded that publication messages should be published on the Publication channel.

For beta and stable channels, it is useful to have them published
on the publication channel. It remains useful to also have them
in the app channel (for dev and PO following the channel of the app).

Dev versions on the contrary should not be published on the publication channel as it would be too noisy.

## Implementation

The MATTERMOST_CHANNEL env variable now supports a JSON objects (additionally to a simple string), to configure different channels based on registry channel.

```
export MATTERMOST_CHANNEL='{"beta":"publication,team", "dev": "team", "stable":"publication,team"}'
```