### PR TITLE
[Harvest] Feat: Fallback for app links

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/BanksLink.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/BanksLink.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import AppLinker from 'cozy-ui/transpiled/react/AppLinker'
 import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
@@ -8,48 +8,46 @@ import { Application } from 'cozy-doctypes'
 
 import withLocales from '../../hoc/withLocales'
 
-class BanksLinkRedirectStore extends Component {
-  render() {
-    const { apps, t } = this.props
-    if (apps.fetchStatus === 'loaded') {
-      const banksApp = {
-        slug: 'banks'
-      }
-      let url = ''
-      const banksInstalled = Application.isInstalled(apps.data, banksApp)
-      if (banksInstalled) {
-        url = Application.getUrl(banksInstalled)
-      } else {
-        url = Application.getStoreInstallationURL(apps.data, banksApp)
-      }
-
-      return (
-        <AppLinker slug="banks" href={url}>
-          {({ href, name }) => (
-            <ButtonLink
-              icon="openwith"
-              href={href}
-              label={t('account.success.banksLinkText', {
-                appName: name
-              })}
-              subtle
-            />
-          )}
-        </AppLinker>
-      )
+const BanksLinkRedirectStore = ({ apps, t }) => {
+  if (apps.fetchStatus === 'loaded') {
+    const banksApp = {
+      slug: 'banks'
     }
+    let url = ''
+    const banksInstalled = Application.isInstalled(apps.data, banksApp)
+    if (banksInstalled) {
+      url = Application.getUrl(banksInstalled)
+    } else {
+      url = Application.getStoreInstallationURL(apps.data, banksApp)
+    }
+
     return (
-      <ButtonLink
-        icon="openwith"
-        label={t('account.success.banksLinkText', {
-          appName: name
-        })}
-        busy
-        subtle
-      />
+      <AppLinker slug="banks" href={url}>
+        {({ href, name }) => (
+          <ButtonLink
+            icon="openwith"
+            href={href}
+            label={t('account.success.banksLinkText', {
+              appName: name
+            })}
+            subtle
+          />
+        )}
+      </AppLinker>
     )
   }
+  return (
+    <ButtonLink
+      icon="openwith"
+      label={t('account.success.banksLinkText', {
+        appName: name
+      })}
+      busy
+      subtle
+    />
+  )
 }
+
 BanksLinkRedirectStore.propTypes = {
   apps: PropTypes.array.isRequired,
   t: PropTypes.func.isRequired

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/BanksLink.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/BanksLink.jsx
@@ -2,27 +2,18 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import AppLinker from 'cozy-ui/transpiled/react/AppLinker'
 import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
-import { queryConnect, Q } from 'cozy-client'
-
-import { Application } from 'cozy-doctypes'
+import { withClient } from 'cozy-client'
+import useAppLinkWithStoreFallback from '../../hooks/useAppLinkWithStoreFallback'
 
 import withLocales from '../../hoc/withLocales'
 
-const BanksLinkRedirectStore = ({ apps, t }) => {
-  if (apps.fetchStatus === 'loaded') {
-    const banksApp = {
-      slug: 'banks'
-    }
-    let url = ''
-    const banksInstalled = Application.isInstalled(apps.data, banksApp)
-    if (banksInstalled) {
-      url = Application.getUrl(banksInstalled)
-    } else {
-      url = Application.getStoreInstallationURL(apps.data, banksApp)
-    }
+const BanksLinkRedirectStore = ({ client, t }) => {
+  const slug = 'banks'
+  const { fetchStatus, url } = useAppLinkWithStoreFallback(slug, client)
 
+  if (fetchStatus === 'loaded') {
     return (
-      <AppLinker slug="banks" href={url}>
+      <AppLinker slug={slug} href={url}>
         {({ href, name }) => (
           <ButtonLink
             icon="openwith"
@@ -35,28 +26,26 @@ const BanksLinkRedirectStore = ({ apps, t }) => {
         )}
       </AppLinker>
     )
+  } else {
+    return (
+      <ButtonLink
+        icon="openwith"
+        label={t('account.success.banksLinkText', {
+          appName: name
+        })}
+        busy
+        subtle
+      />
+    )
   }
-  return (
-    <ButtonLink
-      icon="openwith"
-      label={t('account.success.banksLinkText', {
-        appName: name
-      })}
-      busy
-      subtle
-    />
-  )
 }
 
 BanksLinkRedirectStore.propTypes = {
-  apps: PropTypes.array.isRequired,
+  client: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired
 }
-const ConnectedBanksLinkRedirectStore = queryConnect({
-  apps: {
-    query: () => Q('io.cozy.apps'),
-    as: 'apps'
-  }
-})(withLocales(BanksLinkRedirectStore))
+const ConnectedBanksLinkRedirectStore = withClient(
+  withLocales(BanksLinkRedirectStore)
+)
 
 export default ConnectedBanksLinkRedirectStore

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/DriveLink.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/DriveLink.jsx
@@ -1,28 +1,43 @@
 import React, { memo } from 'react'
 import PropTypes from 'prop-types'
+import AppLinker from 'cozy-ui/transpiled/react/AppLinker'
 import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import { withClient } from 'cozy-client'
 import useAppLinkWithStoreFallback from '../../hooks/useAppLinkWithStoreFallback'
 
 const DriveLink = memo(({ folderId, client, t }) => {
-  const { fetchStatus, url, isInstalled } = useAppLinkWithStoreFallback(
-    'drive',
-    client,
-    `#/files/${folderId}`
-  )
-  const href = fetchStatus === 'loaded' && isInstalled ? url : undefined
+  const slug = 'drive'
+  const path = `#/files/${folderId}`
+  const { fetchStatus, url } = useAppLinkWithStoreFallback(slug, client, path)
 
-  return (
-    <ButtonLink
-      href={href}
-      target="_parent"
-      disabled={!isInstalled}
-      subtle
-      icon="openwith"
-      label={t('account.success.driveLinkText')}
-    />
-  )
+  if (fetchStatus === 'loaded') {
+    return (
+      <AppLinker slug={slug} href={url} nativePath={path}>
+        {({ href, name }) => (
+          <ButtonLink
+            icon="openwith"
+            href={href}
+            label={t('account.success.driveLinkText', {
+              appName: name
+            })}
+            subtle
+          />
+        )}
+      </AppLinker>
+    )
+  } else {
+    return (
+      <ButtonLink
+        icon="openwith"
+        label={t('account.success.banksLinkText', {
+          appName: name
+        })}
+        busy
+        subtle
+      />
+    )
+  }
 })
 
 DriveLink.displayName = 'DriveLink'

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/DriveLink.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/DriveLink.jsx
@@ -1,35 +1,33 @@
-import React, { PureComponent } from 'react'
+import React, { memo } from 'react'
 import PropTypes from 'prop-types'
 import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import { queryConnect, Q } from 'cozy-client'
 
-export class DriveLink extends PureComponent {
-  render() {
-    const { folderId, driveQuery, t } = this.props
-    let hasDrive = false
-    if (driveQuery.fetchStatus === 'loaded') {
-      if (driveQuery.data.length > 0) {
-        hasDrive = true
-      }
+const DriveLink = memo(({ folderId, driveQuery, t }) => {
+  let hasDrive = false
+  if (driveQuery.fetchStatus === 'loaded') {
+    if (driveQuery.data.length > 0) {
+      hasDrive = true
     }
-    const href = hasDrive
-      ? `${driveQuery.data[0].links.related}#/files/${folderId}`
-      : undefined
-
-    return (
-      <ButtonLink
-        href={href}
-        target="_parent"
-        disabled={!hasDrive}
-        subtle
-        icon="openwith"
-        label={t('account.success.driveLinkText')}
-      />
-    )
   }
-}
+  const href = hasDrive
+    ? `${driveQuery.data[0].links.related}#/files/${folderId}`
+    : undefined
 
+  return (
+    <ButtonLink
+      href={href}
+      target="_parent"
+      disabled={!hasDrive}
+      subtle
+      icon="openwith"
+      label={t('account.success.driveLinkText')}
+    />
+  )
+})
+
+DriveLink.displayName = 'DriveLink'
 DriveLink.propTypes = {
   t: PropTypes.func.isRequired,
   folderId: PropTypes.string.isRequired,

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/DriveLink.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/DriveLink.jsx
@@ -2,24 +2,22 @@ import React, { memo } from 'react'
 import PropTypes from 'prop-types'
 import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
-import { queryConnect, Q } from 'cozy-client'
+import { withClient } from 'cozy-client'
+import useAppLinkWithStoreFallback from '../../hooks/useAppLinkWithStoreFallback'
 
-const DriveLink = memo(({ folderId, driveQuery, t }) => {
-  let hasDrive = false
-  if (driveQuery.fetchStatus === 'loaded') {
-    if (driveQuery.data.length > 0) {
-      hasDrive = true
-    }
-  }
-  const href = hasDrive
-    ? `${driveQuery.data[0].links.related}#/files/${folderId}`
-    : undefined
+const DriveLink = memo(({ folderId, client, t }) => {
+  const { fetchStatus, url, isInstalled } = useAppLinkWithStoreFallback(
+    'drive',
+    client,
+    `#/files/${folderId}`
+  )
+  const href = fetchStatus === 'loaded' && isInstalled ? url : undefined
 
   return (
     <ButtonLink
       href={href}
       target="_parent"
-      disabled={!hasDrive}
+      disabled={!isInstalled}
       subtle
       icon="openwith"
       label={t('account.success.driveLinkText')}
@@ -31,11 +29,6 @@ DriveLink.displayName = 'DriveLink'
 DriveLink.propTypes = {
   t: PropTypes.func.isRequired,
   folderId: PropTypes.string.isRequired,
-  driveQuery: PropTypes.object.isRequired
+  client: PropTypes.object.isRequired
 }
-export default queryConnect({
-  driveQuery: {
-    query: () => Q('io.cozy.apps').where({ slug: 'drive' }),
-    as: 'driveQuery'
-  }
-})(translate()(DriveLink))
+export default withClient(translate()(DriveLink))

--- a/packages/cozy-harvest-lib/src/components/cards/AppLinkCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/AppLinkCard.jsx
@@ -64,7 +64,9 @@ const AppLinkCard = ({
                 )
               }
               theme="secondary"
-              label={t(`card.appLink.${slug}.button`)}
+              label={t(
+                `card.appLink.${slug}.${isInstalled ? 'button' : 'install'}`
+              )}
               className={isMobile ? 'u-w-100' : null}
             />
           )}

--- a/packages/cozy-harvest-lib/src/components/cards/AppLinkCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/AppLinkCard.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Card from 'cozy-ui/transpiled/react/Card'
 import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
-import AppLinker, { generateWebLink } from 'cozy-ui/transpiled/react/AppLinker'
+import AppLinker from 'cozy-ui/transpiled/react/AppLinker'
 import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
 import Circle from 'cozy-ui/transpiled/react/Circle'
 import Stack from 'cozy-ui/transpiled/react/Stack'
@@ -12,6 +12,7 @@ import { translate } from 'cozy-ui/transpiled/react/I18n'
 import palette from 'cozy-ui/transpiled/react/palette'
 import { withBreakpoints } from 'cozy-ui/transpiled/react'
 import { withClient } from 'cozy-client'
+import useAppLinkWithStoreFallback from '../hooks/useAppLinkWithStoreFallback'
 
 const AppLinkCard = ({
   slug,
@@ -23,7 +24,13 @@ const AppLinkCard = ({
   t
 }) => {
   const cozyURL = new URL(client.getStackClient().uri)
-  const { cozySubdomainType: subDomainType } = client.getInstanceOptions()
+  const { fetchStatus, url, isInstalled } = useAppLinkWithStoreFallback(
+    slug,
+    client,
+    path
+  )
+
+  if (fetchStatus !== 'loaded') return null
 
   return (
     <Card>
@@ -39,27 +46,22 @@ const AppLinkCard = ({
           {t(`card.appLink.${slug}.title`)}
         </SubTitle>
         <Text>{t(`card.appLink.${slug}.description`)}</Text>
-        <AppLinker
-          slug={slug}
-          nativePath={path}
-          href={generateWebLink({
-            cozyUrl: cozyURL.origin,
-            slug,
-            nativePath: path,
-            subDomainType
-          })}
-        >
+        <AppLinker slug={slug} nativePath={path} href={url}>
           {({ onClick, href }) => (
             <ButtonLink
               onClick={onClick}
               href={href}
               icon={
-                <AppIcon
-                  app={slug}
-                  domain={cozyURL.host}
-                  secure={cozyURL.protocol === 'https:'}
-                  className="u-w-1 u-h-1 u-mr-half"
-                />
+                isInstalled ? (
+                  <AppIcon
+                    app={slug}
+                    domain={cozyURL.host}
+                    secure={cozyURL.protocol === 'https:'}
+                    className="u-w-1 u-h-1 u-mr-half"
+                  />
+                ) : (
+                  'openwith'
+                )
               }
               theme="secondary"
               label={t(`card.appLink.${slug}.button`)}

--- a/packages/cozy-harvest-lib/src/components/hooks/useAppLinkWithStoreFallback.jsx
+++ b/packages/cozy-harvest-lib/src/components/hooks/useAppLinkWithStoreFallback.jsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react'
+import { Q } from 'cozy-client'
+import { Application } from 'cozy-doctypes'
+
+const useAppLinkWithStoreFallback = (slug, client, path = '') => {
+  const [fetchStatus, setFetchStatus] = useState('loading')
+  const [isInstalled, setIsInstalled] = useState(true)
+  const [url, setURL] = useState()
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const apps = await client.query(Q('io.cozy.apps'))
+        const appDocument = { slug }
+        const appInstalled = Application.isInstalled(apps.data, appDocument)
+        setIsInstalled(!!appInstalled)
+        if (appInstalled) {
+          setURL(Application.getUrl(appInstalled) + path)
+        } else {
+          setURL(Application.getStoreInstallationURL(apps.data, appDocument))
+        }
+        setFetchStatus('loaded')
+      } catch (error) {
+        setFetchStatus('errored')
+      }
+    }
+    load()
+  }, [client, slug, path])
+
+  return {
+    fetchStatus,
+    isInstalled,
+    url
+  }
+}
+
+export default useAppLinkWithStoreFallback

--- a/packages/cozy-harvest-lib/src/components/hooks/useAppLinkWithStoreFallback.jsx
+++ b/packages/cozy-harvest-lib/src/components/hooks/useAppLinkWithStoreFallback.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Q, models } from 'cozy-client'
 
-const { applications: ApplicationsModel } = models
+const { applications } = models
 
 const useAppLinkWithStoreFallback = (slug, client, path = '') => {
   const [fetchStatus, setFetchStatus] = useState('loading')
@@ -13,15 +13,12 @@ const useAppLinkWithStoreFallback = (slug, client, path = '') => {
       try {
         const apps = await client.query(Q('io.cozy.apps'))
         const appDocument = { slug }
-        const appInstalled = ApplicationsModel.isInstalled(
-          apps.data,
-          appDocument
-        )
+        const appInstalled = applications.isInstalled(apps.data, appDocument)
         setIsInstalled(!!appInstalled)
         if (appInstalled) {
-          setURL(ApplicationsModel.getUrl(appInstalled) + path)
+          setURL(applications.getUrl(appInstalled) + path)
         } else {
-          setURL(ApplicationsModel.getStoreURL(apps.data, appDocument))
+          setURL(applications.getStoreURL(apps.data, appDocument))
         }
         setFetchStatus('loaded')
       } catch (error) {

--- a/packages/cozy-harvest-lib/src/components/hooks/useAppLinkWithStoreFallback.jsx
+++ b/packages/cozy-harvest-lib/src/components/hooks/useAppLinkWithStoreFallback.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
-import { Q } from 'cozy-client'
-import { Application } from 'cozy-doctypes'
+import { Q, models } from 'cozy-client'
+
+const { applications: ApplicationsModel } = models
 
 const useAppLinkWithStoreFallback = (slug, client, path = '') => {
   const [fetchStatus, setFetchStatus] = useState('loading')
@@ -12,12 +13,17 @@ const useAppLinkWithStoreFallback = (slug, client, path = '') => {
       try {
         const apps = await client.query(Q('io.cozy.apps'))
         const appDocument = { slug }
-        const appInstalled = Application.isInstalled(apps.data, appDocument)
+        const appInstalled = ApplicationsModel.isInstalled(
+          apps.data,
+          appDocument
+        )
         setIsInstalled(!!appInstalled)
         if (appInstalled) {
-          setURL(Application.getUrl(appInstalled) + path)
+          setURL(ApplicationsModel.getUrl(appInstalled) + path)
         } else {
-          setURL(Application.getStoreInstallationURL(apps.data, appDocument))
+          setURL(
+            ApplicationsModel.getStoreInstallationURL(apps.data, appDocument)
+          )
         }
         setFetchStatus('loaded')
       } catch (error) {

--- a/packages/cozy-harvest-lib/src/components/hooks/useAppLinkWithStoreFallback.jsx
+++ b/packages/cozy-harvest-lib/src/components/hooks/useAppLinkWithStoreFallback.jsx
@@ -21,9 +21,7 @@ const useAppLinkWithStoreFallback = (slug, client, path = '') => {
         if (appInstalled) {
           setURL(ApplicationsModel.getUrl(appInstalled) + path)
         } else {
-          setURL(
-            ApplicationsModel.getStoreInstallationURL(apps.data, appDocument)
-          )
+          setURL(ApplicationsModel.getStoreURL(apps.data, appDocument))
         }
         setFetchStatus('loaded')
       } catch (error) {

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -40,17 +40,20 @@
       "drive": {
         "title": "Your documents",
         "description": "This service retrieves your latest documents and keeps a complete back-up for you.",
-        "button": "Open the documents"
+        "button": "Open the documents",
+        "install": "Discover Cozy Drive"
       },
       "contacts": {
         "title": "Your contacts",
         "description": "This service synchronizes all your contacts for you.",
-        "button": "Open contacts"
+        "button": "Open contacts",
+        "install": "Discover Cozy Contacts"
       },
       "banks": {
         "title": "Your banking data",
         "description": "This service retrieves your latest baking operations and keeps a complete record for you.",
-        "button": "Access bank accounts"
+        "button": "Access bank accounts",
+        "install": "Discover Cozy Banks"
       }
     }
   },

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/KonnectorSuccess.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/KonnectorSuccess.spec.js.snap
@@ -17,8 +17,8 @@ exports[`KonnectorSuccess should show apps in the correct order 1`] = `
   <p
     className="u-mv-half"
   >
-    <withQuery(withI18n(withLocales(BanksLinkRedirectStore))) />
-    <withQuery(withI18n(DriveLink))
+    <withClient(withI18n(withLocales(BanksLinkRedirectStore))) />
+    <withClient(withI18n(DriveLink))
       folderId="/path"
     />
   </p>

--- a/packages/cozy-harvest-lib/test/components/hooks/useAppLinkWithStoreFallback.spec.js
+++ b/packages/cozy-harvest-lib/test/components/hooks/useAppLinkWithStoreFallback.spec.js
@@ -1,0 +1,72 @@
+import { renderHook } from '@testing-library/react-hooks'
+import useAppLinkWithStoreFallback from 'components/hooks/useAppLinkWithStoreFallback'
+
+describe('useAppLinkWithStoreFallback', () => {
+  const mockClient = { query: jest.fn() }
+
+  it('should change loading status', async () => {
+    mockClient.query.mockResolvedValue({ data: [] })
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useAppLinkWithStoreFallback('test', mockClient)
+    )
+    expect(result.current.fetchStatus).toEqual('loading')
+    await waitForNextUpdate()
+    expect(result.current.fetchStatus).toEqual('loaded')
+  })
+
+  it('should inform when an error occurs', async () => {
+    mockClient.query.mockRejectedValue('error')
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useAppLinkWithStoreFallback('test', mockClient)
+    )
+    expect(result.current.fetchStatus).toEqual('loading')
+    await waitForNextUpdate()
+    expect(result.current.fetchStatus).toEqual('errored')
+  })
+
+  it('should return data for an installed app', async () => {
+    const testAppSlug = 'testapp'
+    const path = '#/path'
+    mockClient.query.mockResolvedValue({
+      data: [
+        {
+          attributes: {
+            slug: testAppSlug
+          },
+          links: { related: 'http://testapp.cozy.io' }
+        }
+      ]
+    })
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useAppLinkWithStoreFallback(testAppSlug, mockClient, path)
+    )
+
+    await waitForNextUpdate()
+    expect(result.current.isInstalled).toBe(true)
+    expect(result.current.url).toBe('http://testapp.cozy.io#/path')
+  })
+
+  it('should return a store URL when the app is not installed', async () => {
+    const testAppSlug = 'testapp'
+    const path = '#/path'
+    mockClient.query.mockResolvedValue({
+      data: [
+        {
+          attributes: {
+            slug: 'store'
+          },
+          links: { related: 'http://store.cozy.io' }
+        }
+      ]
+    })
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useAppLinkWithStoreFallback(testAppSlug, mockClient, path)
+    )
+
+    await waitForNextUpdate()
+    expect(result.current.isInstalled).toBe(false)
+    expect(result.current.url).toBe(
+      'http://store.cozy.io#/discover/testapp/install'
+    )
+  })
+})

--- a/packages/cozy-harvest-lib/test/components/hooks/useAppLinkWithStoreFallback.spec.js
+++ b/packages/cozy-harvest-lib/test/components/hooks/useAppLinkWithStoreFallback.spec.js
@@ -65,8 +65,6 @@ describe('useAppLinkWithStoreFallback', () => {
 
     await waitForNextUpdate()
     expect(result.current.isInstalled).toBe(false)
-    expect(result.current.url).toBe(
-      'http://store.cozy.io#/discover/testapp/install'
-    )
+    expect(result.current.url).toBe('http://store.cozy.io#/discover/testapp')
   })
 })


### PR DESCRIPTION
In #933 I added links to contacts and banks from the harvest modal. This PR makes sure that when the apps are not installed, a link to the store is displayed instead.