### PR TITLE
fix: Load current konnector error

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountsList/Status.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountsList/Status.jsx
@@ -17,7 +17,8 @@ import FlowProvider from '../FlowProvider'
 const Status = ({ t, trigger, konnector }) => {
   return (
     <FlowProvider initialTrigger={trigger}>
-      {({ error, running }) => {
+      {({ flow }) => {
+        const { error, running } = flow.getState()
         const errorTitle = getErrorLocale(error, konnector, t, 'title')
         if (running) {
           return (

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
@@ -27,7 +27,9 @@ export const KonnectorAccountTabs = ({
 }) => {
   return (
     <FlowProvider initialTrigger={initialTrigger}>
-      {({ error, running }) => {
+      {({ flow }) => {
+        const { error, running } = flow.getState()
+
         const hasError = !!error
         const shouldDisplayError = !running && hasError
         const hasLoginError = hasError && error.isLoginError()

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -99,12 +99,12 @@ export class DumbTriggerManager extends Component {
    * @param  {string}  accountId
    */
   async handleOAuthAccountId(accountId) {
-    const { client, flow, konnector, trigger, t } = this.props
+    const { client, flow, konnector, t } = this.props
     const oAuthAccount = await findAccount(client, accountId)
     flow.ensureTriggerAndLaunch(client, {
       account: oAuthAccount,
       konnector: konnector,
-      trigger: trigger,
+      trigger: flow.trigger,
       t: t
     })
   }
@@ -120,7 +120,7 @@ export class DumbTriggerManager extends Component {
   }
 
   async handleSubmit(data = {}) {
-    const { client, flow, konnector, trigger, vaultClient, t } = this.props
+    const { client, flow, konnector, vaultClient, t } = this.props
     const { account } = this.state
 
     this.setState({
@@ -135,7 +135,7 @@ export class DumbTriggerManager extends Component {
         account: account || {},
         cipherId,
         konnector,
-        trigger,
+        trigger: flow.trigger,
         userCredentials: data,
         vaultClient,
         t
@@ -379,14 +379,6 @@ DumbTriggerManager.propTypes = {
    * @type {Boolean}
    */
   showError: PropTypes.bool,
-  /**
-   * Existing trigger document to manage.
-   * @type {Object}
-   */
-  trigger: PropTypes.object,
-  /**
-   * Translation function
-   */
   t: PropTypes.func,
   /**
    * What to do when the Vault unlock screen is dismissed without password
@@ -437,11 +429,10 @@ const LegacyTriggerManager = props => {
       onError={onError}
       initialTrigger={initialTrigger}
     >
-      {({ error, trigger, flow }) => (
+      {({ flow }) => (
         <TriggerManager
           {...otherProps}
-          error={error}
-          trigger={trigger}
+          error={flow.getState().error}
           flow={flow}
         />
       )}


### PR DESCRIPTION
Something that slipped through the big PR — `FlowProvider` no longer directly injects `error` and similar props, instead they need to be retrieved from the `flow` object.