### PR TITLE
fix: Account correctly created with the account_type property

### DIFF
--- a/packages/cozy-harvest-lib/src/cli/cli.js
+++ b/packages/cozy-harvest-lib/src/cli/cli.js
@@ -98,9 +98,11 @@ const createOrUpdateMain = async (args, client) => {
       lastState = newState
     })
 
-  const account = args.account ? await fetchAccount(client, args.account) : {}
+  const account = args.account ? await fetchAccount(client, args.account) : null
 
-  assert(account, `Could not find account ${args.account}`)
+  if (args.account) {
+    assert(account, `Could not find account ${args.account}`)
+  }
 
   logger.info(`${args.account ? 'Updating' : 'Creating'} account`)
 

--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -119,6 +119,8 @@ export class AccountForm extends PureComponent {
 
   /**
    * Submit handler
+   * Will ask for confirmation if identifier changes
+   *
    * @param  {Object} values        Actual form values data
    * @param  {Object} form          The form object injected by ReactFinalForm.
    */
@@ -126,7 +128,6 @@ export class AccountForm extends PureComponent {
     const { account, konnector } = this.props
 
     const identifier = manifest.getIdentifier(konnector.fields)
-
     if (
       account &&
       account.auth[identifier] &&

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -132,7 +132,7 @@ export class DumbTriggerManager extends Component {
       const cipherId = this.getSelectedCipherId()
       await flow.handleFormSubmit({
         client,
-        account: account || {},
+        account,
         cipherId,
         konnector,
         trigger: flow.trigger,

--- a/packages/cozy-harvest-lib/src/helpers/accounts.js
+++ b/packages/cozy-harvest-lib/src/helpers/accounts.js
@@ -2,6 +2,7 @@ import get from 'lodash/get'
 import merge from 'lodash/merge'
 import clone from 'lodash/clone'
 
+import assert from '../assert'
 import manifest from './manifest'
 
 const DEFAULT_TWOFA_CODE_PROVIDER_TYPE = 'default'
@@ -100,6 +101,10 @@ export const getLabel = account =>
  * @return {object}           io.cozy.accounts attributes
  */
 export const build = (konnector, authData) => {
+  assert(
+    konnector.slug,
+    'Cannot build an account when the konnector has no slug'
+  )
   // We are not at the final target for io.cozy.accounts.
   // For now we are just ensuring legacy
   return {

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -73,6 +73,13 @@ export const createOrUpdateAccount = async ({
   assert(flow, 'No flow')
   assert(userCredentials, 'No user credentials')
   const isUpdate = !!account
+
+  if (isUpdate) {
+    logger.debug('Updating the account...')
+  } else {
+    logger.debug('Creating the account...')
+  }
+
   const { onAccountCreation, saveInVault } = konnectorPolicy
 
   let accountToSave = clone(account) || {}
@@ -360,7 +367,7 @@ export class ConnectionFlow {
         )
       }
 
-      logger.debug('Creating/updating account...')
+      logger.debug('Creating/updating account...', account)
 
       account = await createOrUpdateAccount({
         account,

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -120,7 +120,9 @@ describe('TriggerManager', () => {
 
         await expect(findByLabelText('username')).resolves.toBeDefined()
         await expect(findByLabelText('passphrase')).resolves.toBeDefined()
-        await expect(findByTitle('back', null, { timeout: 500 })).rejects.toThrow()
+        await expect(
+          findByTitle('back', null, { timeout: 500 })
+        ).rejects.toThrow()
       })
     })
 
@@ -172,7 +174,9 @@ describe('TriggerManager', () => {
           const passwordField = await findByLabelText('passphrase')
           const backButton = await findByTitle('back')
 
-          await expect(findByLabelText('username', null, { timeout: 500 })).rejects.toThrow()
+          await expect(
+            findByLabelText('username', null, { timeout: 500 })
+          ).rejects.toThrow()
           expect(passwordField).toBeDefined()
           expect(backButton).toBeDefined()
 
@@ -305,8 +309,7 @@ describe('TriggerManager', () => {
           flow,
           identifierInput,
           passphraseInput,
-          submitButton,
-          debug
+          submitButton
         } = await setupForm({ account })
         fireEvent.change(identifierInput, {
           target: { value: 'my-identifier' }

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -118,9 +118,9 @@ describe('TriggerManager', () => {
           <TriggerManager {...props} />
         )
 
-        expect(findByLabelText('username')).resolves.toBeDefined()
-        expect(findByLabelText('passphrase')).resolves.toBeDefined()
-        expect(findByTitle('back')).rejects.toThrow()
+        await expect(findByLabelText('username')).resolves.toBeDefined()
+        await expect(findByLabelText('passphrase')).resolves.toBeDefined()
+        await expect(findByTitle('back', null, { timeout: 500 })).rejects.toThrow()
       })
     })
 
@@ -172,13 +172,13 @@ describe('TriggerManager', () => {
           const passwordField = await findByLabelText('passphrase')
           const backButton = await findByTitle('back')
 
-          expect(findByLabelText('username')).rejects.toThrow()
+          await expect(findByLabelText('username', null, { timeout: 500 })).rejects.toThrow()
           expect(passwordField).toBeDefined()
           expect(backButton).toBeDefined()
 
           fireEvent.click(backButton)
 
-          expect(findByText('Isabelle')).resolves.toBeDefined()
+          await expect(findByText('Isabelle')).resolves.toBeDefined()
         })
       })
     })


### PR DESCRIPTION
Since the TriggerManger would pass an empty object as account, the
ConnectionFlow executed the update path, that would not put the
account_type property inside the io.cozy.accounts

Without an account_type, the stack would not trigger the on_deletion
mechanism which is particularly important for banking connectors.