### PR TITLE
test: Check FlowProvider state prop

### DIFF
--- a/packages/cozy-harvest-lib/test/components/__snapshots__/FlowProvider.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/FlowProvider.spec.js.snap
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`FlowProvider should render 1`] = `
-<React.Fragment>
-  <Child />
-</React.Fragment>
-`;


### PR DESCRIPTION
This is a follow up on #961… but I found it hard to add a lot of new tests. Actually `FlowProvider` and `ConnectionFlow` have both a decent test coverage already. I ended up reworking the current tests so that they are more sensible and added one that explicitly tests the error case fixed in the previous PR.