### PR TITLE
fix: Support Budget Insight alternate schema for update connection

### DIFF
--- a/packages/cozy-harvest-lib/src/services/bi-http.js
+++ b/packages/cozy-harvest-lib/src/services/bi-http.js
@@ -97,13 +97,24 @@ export const updateBIConnection = async (
     connId,
     `Must pass connection id to updateBIConnection (${connId} was passed)`
   )
-  return await biRequest(
-    'PUT',
+  const resp = await biRequest(
+    'POST',
     `/users/me/connections/${connId}`,
     config,
     encodeToForm(data),
     biAccessToken
   )
+
+  // The doc indicates that the response should be a connection object.
+  // But, when the connection cannot be force updated, the response is
+  // in the form { connection, message }.
+  if (resp.id) {
+    return resp
+  } else if (resp.connection) {
+    return resp.connection
+  } else {
+    throw new Error('Unknown response from Budget-Insight')
+  }
 }
 
 export const resumeBIConnection = async (config, connId, biAccessToken) => {

--- a/packages/cozy-harvest-lib/src/services/bi-http.spec.js
+++ b/packages/cozy-harvest-lib/src/services/bi-http.spec.js
@@ -2,7 +2,10 @@ import { updateBIConnection } from './bi-http'
 
 describe('bi request', () => {
   beforeEach(() => {
-    global.fetch = jest.fn()
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: 1337 })
+    })
   })
 
   afterEach(() => {
@@ -30,7 +33,10 @@ describe('bi request', () => {
   it('should send the correct data', async () => {
     global.fetch.mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({})
+      json: () =>
+        Promise.resolve({
+          id: 1337
+        })
     })
     await updateBIConnection(
       { mode: 'dev', url: 'https://bi-sandox.test' },
@@ -45,8 +51,42 @@ describe('bi request', () => {
         headers: {
           Authorization: 'Bearer bi-access-token'
         },
-        method: 'PUT'
+        method: 'POST'
       }
     )
+  })
+
+  it('should return the correct data', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ id: 1337 })
+    })
+    const resp = await updateBIConnection(
+      { mode: 'dev', url: 'https://bi-sandox.test' },
+      1337,
+      { login: 'encrypted-login' },
+      'bi-access-token'
+    )
+    expect(resp.id).toBe(1337)
+  })
+
+  it('should return the correct data when connection is wrapped', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          message: 'Connection cannot be updated at the moment',
+          connection: {
+            id: 1338
+          }
+        })
+    })
+    const resp = await updateBIConnection(
+      { mode: 'dev', url: 'https://bi-sandox.test' },
+      1338,
+      { login: 'encrypted-login' },
+      'bi-access-token'
+    )
+    expect(resp.id).toBe(1338)
   })
 })


### PR DESCRIPTION
Budget Insight sometimes "errors" when it cannot force update the connection
to the banking vendor (for example if the connection has been refreshed
not too long ago). In this case, the response schema is different than the
normal Connection ressource that we expected.