### PR TITLE
fix: Load flags from legacy DOM

### DIFF
--- a/packages/cozy-flags/src/flag.js
+++ b/packages/cozy-flags/src/flag.js
@@ -67,7 +67,7 @@ export const initializeFromRemote = async client => {
   enable(attributes)
 }
 
-const capitalize = str => str[0].toUppercase() + str.slice(1)
+const capitalize = str => str[0].toUpperCase() + str.slice(1)
 
 export const getTemplateData = attr => {
   if (typeof document === 'undefined') {

--- a/packages/cozy-flags/src/tests.js
+++ b/packages/cozy-flags/src/tests.js
@@ -117,7 +117,7 @@ export default function testFlagAPI(flag) {
         }
       })
 
-      fit('should initialize from DOM (legacy)', async () => {
+      it('should initialize from DOM (legacy)', async () => {
         jest.spyOn(console, 'warn').mockImplementation(() => {})
         let div
         try {

--- a/packages/cozy-flags/src/tests.js
+++ b/packages/cozy-flags/src/tests.js
@@ -116,6 +116,26 @@ export default function testFlagAPI(flag) {
           document.body.removeChild(div)
         }
       })
+
+      fit('should initialize from DOM (legacy)', async () => {
+        jest.spyOn(console, 'warn').mockImplementation(() => {})
+        let div
+        try {
+          div = document.createElement('div')
+          div.dataset.cozyFlags = JSON.stringify(domFlags)
+          document.body.appendChild(div)
+          await flag.initialize()
+          expect(flag('has_feature1')).toBe(true)
+          expect(flag('has_feature2')).toBe(false)
+          expect(flag('number_of_foos')).toBe(10)
+          expect(flag('bar_config')).toEqual({ qux: 'quux' })
+
+          // eslint-disable-next-line no-console
+          expect(console.warn).toHaveBeenCalled()
+        } finally {
+          document.body.removeChild(div)
+        }
+      })
     }
 
     it('should initialize from the remote stack', async () => {


### PR DESCRIPTION
There was a small typo causing a crash when we tried to load flags from the `data-cozy-flags` DOM node.