### PR TITLE
feat: Checks for cordova's network info plugin

### DIFF
--- a/packages/cozy-device-helper/src/index.js
+++ b/packages/cozy-device-helper/src/index.js
@@ -13,8 +13,10 @@ export { checkApp, startApp } from './apps'
 export {
   hasDevicePlugin,
   hasInAppBrowserPlugin,
-  hasSafariPlugin
+  hasSafariPlugin,
+  hasNetworkInformationPlugin
 } from './plugins'
+export { isCordova } from './cordova'
 
 export { nativeLinkOpen } from './link'
 export { openDeeplinkOrRedirect } from './deeplink'

--- a/packages/cozy-device-helper/src/index.spec.js
+++ b/packages/cozy-device-helper/src/index.spec.js
@@ -6,7 +6,8 @@ import {
   getPlatform,
   hasDevicePlugin,
   hasInAppBrowserPlugin,
-  hasSafariPlugin
+  hasSafariPlugin,
+  hasNetworkInformationPlugin
 } from './index'
 
 describe('platforms', () => {
@@ -69,5 +70,16 @@ describe('cordova plugins', () => {
     window.SafariViewController = undefined
     hasSafari = await hasSafariPlugin()
     expect(hasSafari).toBeFalsy()
+  })
+  it('should identify has Network  Information plugin', async () => {
+    window.cordova = true
+    window.navigator.connection = { type: 3 }
+    expect(hasNetworkInformationPlugin()).toBeTruthy()
+    window.cordova = undefined
+    window.navigator.connection = { type: 3 }
+    expect(hasNetworkInformationPlugin()).toBeFalsy()
+    window.cordova = true
+    window.navigator.connection = undefined
+    expect(hasNetworkInformationPlugin()).toBeFalsy()
   })
 })

--- a/packages/cozy-device-helper/src/plugins.js
+++ b/packages/cozy-device-helper/src/plugins.js
@@ -16,3 +16,12 @@ export const hasSafariPlugin = () => {
     window.SafariViewController.isAvailable(available => resolve(available))
   })
 }
+
+/**
+ * Check if the Cordova's cordova-plugin-network-information plugin is installed
+ * @see https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-network-information/
+ * @returns {boolean}
+ */
+export const hasNetworkInformationPlugin = () => {
+  return isCordova() && window.navigator.connection !== undefined
+}


### PR DESCRIPTION
This addition is needed for cozy-realtime. It will
allow to send a warning when the plugin is not
loaded. If so, cozy-realtime won't be able to react
to online and offline events.