### PR TITLE
fix: Init flags when client is already logged in

### DIFF
--- a/packages/cozy-flags/src/flag.js
+++ b/packages/cozy-flags/src/flag.js
@@ -139,10 +139,17 @@ class FlagClientPlugin {
     this.handleLogout = this.handleLogout.bind(this)
     this.client.on('login', this.handleLogin)
     this.client.on('logout', this.handleLogout)
+
+    this.initializing = new Promise(resolve => {
+      this.resolveInitializing = resolve
+    })
+
+    if (client.isLogged) this.handleLogin()
   }
 
   async handleLogin() {
     await flag.initialize(this.client)
+    this.resolveInitializing()
   }
 
   async handleLogout() {

--- a/packages/cozy-flags/src/tests.js
+++ b/packages/cozy-flags/src/tests.js
@@ -89,15 +89,29 @@ export default function testFlagAPI(flag) {
       return { client }
     }
 
-    it('should have a cozy-client plugin', async () => {
-      const { client } = setup()
-      client.registerPlugin(flag.plugin)
-      await client.plugins.flags.handleLogin()
-      expect(flag('has_feature1')).toBe(true)
-      expect(flag('has_feature2')).toBe(false)
-      expect(flag('from_remote')).toBe(true)
-      expect(flag('number_of_foos')).toBe(10)
-      expect(flag('bar_config')).toEqual({ qux: 'quux' })
+    describe('cozy-client plugin', () => {
+      it('should have a cozy-client plugin', async () => {
+        const { client } = setup()
+        client.registerPlugin(flag.plugin)
+        await client.plugins.flags.handleLogin()
+        expect(flag('has_feature1')).toBe(true)
+        expect(flag('has_feature2')).toBe(false)
+        expect(flag('from_remote')).toBe(true)
+        expect(flag('number_of_foos')).toBe(10)
+        expect(flag('bar_config')).toEqual({ qux: 'quux' })
+      })
+
+      it('should initialize when already logged in', async () => {
+        const { client } = setup()
+        client.isLogged = true
+        client.registerPlugin(flag.plugin)
+        await client.plugins.flags.initializing
+        expect(flag('has_feature1')).toBe(true)
+        expect(flag('has_feature2')).toBe(false)
+        expect(flag('from_remote')).toBe(true)
+        expect(flag('number_of_foos')).toBe(10)
+        expect(flag('bar_config')).toEqual({ qux: 'quux' })
+      })
     })
 
     if (typeof document !== 'undefined') {


### PR DESCRIPTION
The flags plugin for cozy-client waits for the `login` event to load the flags. We often do something like:

```
const client = new CozyClient({ token, url })
client.registerPlugin(flag.plugin)
```

… but when the plugin is registered, the `login` event has already been fired and the flags are never loaded.

This PR solves the problem by loading the flags iff it detects that the client is already logged in. SInce loading the flags is `async`, there is now also an exposed promise on `client.plugins.flags.initializing` to know when they are ready.