### PR TITLE
feat: Remove proptype in production mode

### DIFF
--- a/packages/babel-preset-cozy-app/README.md
+++ b/packages/babel-preset-cozy-app/README.md
@@ -22,7 +22,11 @@
 
 A shareable configuration for Cozy Applications or Scripts.
 
-This package is a Babel preset already used by [`create-cozy-app`](https://github.com/CPatchane/create-cozy-app).
+This package is a Babel preset used by all our applications and libs at Cozy. 
+
+### Features
+* Removal of PropTypes in production build
+* Optionally converts ES6 imports to ES5 requires (deactivated for libs, important for down the stream tree shaking)
 
 To install:
 

--- a/packages/babel-preset-cozy-app/index.js
+++ b/packages/babel-preset-cozy-app/index.js
@@ -126,6 +126,12 @@ const mkConfig = (api, options) => {
       }
     ]
   ]
+  if (
+    process.env.BABEL_ENV === 'production' ||
+    process.env.BABEL_ENV === 'transpilation'
+  ) {
+    plugins.push(['transform-react-remove-prop-types'])
+  }
   if (!node && transformRuntime !== false) {
     plugins.push(
       // Polyfills generator functions (for async/await usage)

--- a/packages/babel-preset-cozy-app/package.json
+++ b/packages/babel-preset-cozy-app/package.json
@@ -25,6 +25,7 @@
     "@babel/preset-env": "7.3.1",
     "@babel/preset-react": "7.0.0",
     "@babel/runtime": "7.2.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "browserslist-config-cozy": "^0.3.0",
     "lodash": "4.17.15"
   }

--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/cozy/cozy-libs/issues"
   },
   "scripts": {
-    "build": "babel src -d dist --copy-files --verbose",
+    "build": "env BABEL_ENV=production babel src -d dist --copy-files --verbose",
     "build:doc:react": "(cd ../.. && TARGET=cozy-harvest-lib yarn build:doc:react)",
     "deploy:doc": "(cd ../.. && yarn deploy:doc)",
     "prebuild": "yarn tx",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3267,6 +3267,11 @@ babel-plugin-rewire@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-rewire/-/babel-plugin-rewire-1.2.0.tgz#822562d72ed2c84e47c0f95ee232c920853e9d89"
 
+babel-plugin-transform-react-remove-prop-types@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
+  integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
+
 babel-polyfill@6.26.0, babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"


### PR DESCRIPTION
It's the follow up of https://github.com/cozy/cozy-libs/pull/711. Easier to create a new branch than rebasing the lock file ^^". 

On harvest: 
Before:
```
dist git:(feat/RemovePropTypes) ✗ du -h .
 40K	./locales
124K	./models
 24K	./cli
 32K	./connections
652K	./components
200K	./assets
 84K	./helpers
 76K	./services
1,2M	.
```
After: 
```
 dist git:(feat/RemovePropTypes) ✗ du -h .
 40K	./locales
124K	./models
 24K	./cli
 32K	./connections
640K	./components
200K	./assets
 84K	./helpers
 76K	./services
1,2M	.
```

We have a gain of 12K for the component folder. 


For UI: 
Before: 
```
➜  transpiled git:(tests/propTypes) ✗ du -h .
...
2,4M	.
```

After: 
```
➜  transpiled git:(tests/propTypes) ✗ du -h .
...
2,3M	.
```