### PR TITLE
Fix/import

### DIFF
--- a/packages/cozy-app-publish/package.json
+++ b/packages/cozy-app-publish/package.json
@@ -32,11 +32,9 @@
   },
   "files": [
     "index.js",
-    "cozy-app-publish.js",
     "LICENSE",
     "README.md",
-    "utils",
-    "lib"
+    "src"
   ],
   "devDependencies": {
     "babel-core": "7.0.0-bridge.0",

--- a/packages/cozy-app-publish/src/cozy-app-publish.js
+++ b/packages/cozy-app-publish/src/cozy-app-publish.js
@@ -8,7 +8,7 @@ const scripts = require('./index')
 const capitalize = require('lodash/capitalize')
 const omitBy = require('lodash/omitBy')
 
-const pkg = require('./package.json')
+const pkg = require('../package.json')
 
 const MODES = {
   TRAVIS: 'travis',


### PR DESCRIPTION
- path to package.json was not right
- files object in package.json was based on the previous folder structure. Since we moved all the files in /src we need to export them. Without, we just have the index and the binary exported (https://unpkg.com/browse/cozy-app-publish@0.22.2/src/) 