### PR TITLE
fix: Drive link from harvest

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/appLinksProps.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/appLinksProps.jsx
@@ -3,7 +3,7 @@ import get from 'lodash/get'
 const appLinksProps = {
   drive: ({ trigger }) => ({
     slug: 'drive',
-    path: `/files/${get(trigger, 'message.folder_to_save')}`,
+    path: `#/files/${get(trigger, 'message.folder_to_save')}`,
     icon: 'file',
     iconColor: 'puertoRico'
   }),

--- a/packages/cozy-harvest-lib/test/components/KonnectorConfiguration/DataTab.spec.jsx
+++ b/packages/cozy-harvest-lib/test/components/KonnectorConfiguration/DataTab.spec.jsx
@@ -43,6 +43,7 @@ describe('DataTab', () => {
       })
       expect(withFolder.find(AppLinkCard).length).toEqual(1)
       expect(withFolder.find(AppLinkCard).prop('slug')).toEqual('drive')
+      expect(withFolder.find(AppLinkCard).prop('path')).toEqual('#/files/123')
     })
 
     it('should show the link to banks', () => {


### PR DESCRIPTION
The link to drive was missing a `#` at the start of the path.