### PR TITLE
feat: Hide password toggle when field is empty

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/Field.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/Field.jsx
@@ -92,9 +92,11 @@ const PasswordField = ({
       autoComplete="new-password"
       onChange={handleChange}
       side={
-        <span onClick={() => setHidden(!hidden)}>
-          {hidden ? secondaryLabels.showLabel : secondaryLabels.hideLabel}
-        </span>
+        value ? (
+          <span onClick={() => setHidden(!hidden)}>
+            {hidden ? secondaryLabels.showLabel : secondaryLabels.hideLabel}
+          </span>
+        ) : null
       }
     />
   )

--- a/packages/cozy-harvest-lib/test/components/AccountField.spec.js
+++ b/packages/cozy-harvest-lib/test/components/AccountField.spec.js
@@ -49,6 +49,27 @@ describe('AccountField', () => {
     expect(component).toMatchSnapshot()
   })
 
+  it('hide the password toggle on empty fields', () => {
+    const wrapper = shallow(
+      <AccountField {...fixtures.passphrase} name="passphrase" t={t} value="" />
+    )
+    const component = wrapper.dive().dive()
+    expect(component.prop('side')).toBe(null)
+  })
+
+  it('show the password toggle on non-empty fields', () => {
+    const wrapper = shallow(
+      <AccountField
+        {...fixtures.passphrase}
+        name="passphrase"
+        value="123"
+        t={t}
+      />
+    )
+    const component = wrapper.dive().dive()
+    expect(component.prop('side')).not.toBe(null)
+  })
+
   it('render a dropdown field', () => {
     const options = [
       { label: 'Option 1', value: 'option1' },

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -255,7 +255,9 @@ describe('TriggerManager', () => {
       const passphraseLabel = await utils.findByLabelText('passphrase')
       const identifierInput = identifierLabel.nextElementSibling
       const passphraseInput =
-        passphraseLabel.nextElementSibling.nextElementSibling
+        passphraseLabel.nextElementSibling instanceof HTMLInputElement
+          ? passphraseLabel.nextElementSibling
+          : passphraseLabel.nextElementSibling.nextElementSibling
       const submitButton = await utils.findByText('Submit')
 
       return {


### PR DESCRIPTION
When editing an account in harvest, we show a password field that is empty (because the password is encrypted and not available to the front-end) — but that password field has a reveal/hide button along it. This seems to confuse people who don't understand why the field is empty once they click the "reveal" button.

A redesign is underway but in the meantime, this PR hides the "reveal" button until there is something in the field.

<img width="595" alt="Capture d'écran 2020-03-02 16 01 28" src="https://user-images.githubusercontent.com/2261445/75688513-e92fc980-5c9f-11ea-8a83-dcb62b6eb0cc.png">
