### PR TITLE
fix: Don't import from index

### DIFF
--- a/packages/cozy-scanner/src/Scanner.jsx
+++ b/packages/cozy-scanner/src/Scanner.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { withClient } from 'cozy-client'
 import PropTypes from 'prop-types'
 import { CozyFile } from 'cozy-doctypes'
-import { Modal } from 'cozy-ui/transpiled/react'
+import Modal from 'cozy-ui/transpiled/react/Modal'
 
 import { ModalScannerQualification } from './'
 import withOffline from 'cozy-ui/transpiled/helpers/withOffline'

--- a/packages/cozy-sharing/src/components/SharedBadge.jsx
+++ b/packages/cozy-sharing/src/components/SharedBadge.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classNames from 'classnames'
-import { Icon } from 'cozy-ui/transpiled/react'
+import Icon from 'cozy-ui/transpiled/react/Icon'
 import styles from './badge.styl'
 import palette from 'cozy-ui/transpiled/react/palette'
 


### PR DESCRIPTION
It currently brings a bug in a jest env. Plus it's more efficient to use from the full path in order to let the magic happen (tree shaking) 