### PR TITLE
fix: Last execution time is correctly refreshed

### DIFF
--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
@@ -8,13 +8,15 @@ import Icon from 'cozy-ui/transpiled/react/Icon'
 import Uppercase, { Text } from 'cozy-ui/transpiled/react/Text'
 import * as triggers from '../../helpers/triggers'
 import FlowProvider from '../FlowProvider'
+import { useFlowState } from '../../models/withConnectionFlow'
 
 export const DumbLaunchTriggerCard = ({ flow, className, f, t, disabled }) => {
-  const flowState = flow.getState()
   const launch = flow.launch
-  const trigger = flow.trigger
+  const flowState = useFlowState(flow)
+  const trigger = flowState.trigger
   const running = flowState.running
   const lastSuccessDate = triggers.getLastSuccessDate(trigger)
+
   return (
     <Card className={className}>
       <div className="u-flex u-flex-column-s">

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -501,6 +501,7 @@ export class ConnectionFlow {
       twoFARunning: status === RUNNING_TWOFA,
       twoFARetry: status == TWO_FA_MISMATCH,
       triggerError: triggerError,
+      trigger,
       accountError,
       error: accountError || triggerError,
       konnectorRunning: triggersModel.isKonnectorRunning(trigger)

--- a/packages/cozy-harvest-lib/src/models/withConnectionFlow.spec.jsx
+++ b/packages/cozy-harvest-lib/src/models/withConnectionFlow.spec.jsx
@@ -1,0 +1,25 @@
+import { mount } from 'enzyme'
+import React from 'react'
+import { act } from 'react-dom/test-utils'
+import ConnectionFlow from './ConnectionFlow'
+import CozyClient from 'cozy-client'
+import withConnectionFlow from './withConnectionFlow'
+
+const DumbTriggerStatus = ({ flowState }) => {
+  return <div>{flowState.status.toString()}</div>
+}
+
+const TriggerStatus = withConnectionFlow()(DumbTriggerStatus)
+
+describe('with connection flow', () => {
+  it('should update correctly', () => {
+    const client = new CozyClient({})
+    const flow = new ConnectionFlow(client)
+    const root = mount(<TriggerStatus flow={flow} />)
+    expect(root.find('div').text()).toBe('IDLE')
+    act(() => {
+      flow.setState({ status: 'SUCCESS' })
+    })
+    expect(root.find('div').text()).toBe('SUCCESS')
+  })
+})


### PR DESCRIPTION
LaunchTriggerCard bases its render on ConnectionFlow so it must
be explicit about that otherwise updaes from above could be 
"bailed out".