### PR TITLE
fix: Call revokeSelf if not the owner of the sharing

### DIFF
--- a/packages/cozy-sharing/src/SharingDetailsModal.jsx
+++ b/packages/cozy-sharing/src/SharingDetailsModal.jsx
@@ -22,7 +22,8 @@ export class SharingDetailsModal extends Component {
       recipients,
       document,
       documentType = 'Document',
-      onRevoke
+      onRevoke,
+      onRevokeSelf
     } = this.props
     return (
       <Modal
@@ -70,6 +71,7 @@ export class SharingDetailsModal extends Component {
             document={document}
             documentType={documentType}
             onRevoke={onRevoke}
+            onRevokeSelf={onRevokeSelf}
           />
         </ModalContent>
       </Modal>

--- a/packages/cozy-sharing/src/components/EditableSharingModal.jsx
+++ b/packages/cozy-sharing/src/components/EditableSharingModal.jsx
@@ -29,26 +29,30 @@ const EditableSharingModal = ({
           shareByLink,
           revokeSharingLink,
           hasSharedParent,
-          hasSharedChild
-        }) => (
-          <DumbShareModal
-            document={document}
-            documentType={documentType}
-            contacts={contacts}
-            createContact={contact => client.create(Contact.doctype, contact)}
-            groups={groups}
-            recipients={getRecipients(document.id)}
-            link={getSharingLink(document.id)}
-            isOwner={isOwner(document.id)}
-            hasSharedParent={hasSharedParent(document)}
-            hasSharedChild={hasSharedChild(document)}
-            onShare={share}
-            onRevoke={revoke}
-            onShareByLink={shareByLink}
-            onRevokeLink={revokeSharingLink}
-            {...rest}
-          />
-        )}
+          hasSharedChild,
+          revokeSelf
+        }) => {
+          return (
+            <DumbShareModal
+              document={document}
+              documentType={documentType}
+              contacts={contacts}
+              createContact={contact => client.create(Contact.doctype, contact)}
+              groups={groups}
+              recipients={getRecipients(document.id)}
+              link={getSharingLink(document.id)}
+              isOwner={isOwner(document.id)}
+              hasSharedParent={hasSharedParent(document)}
+              hasSharedChild={hasSharedChild(document)}
+              onShare={share}
+              onRevoke={revoke}
+              onShareByLink={shareByLink}
+              onRevokeLink={revokeSharingLink}
+              onRevokeSelf={revokeSelf}
+              {...rest}
+            />
+          )
+        }}
       </SharingContext.Consumer>
     </ContactsAndGroupsDataLoader>
   )

--- a/packages/cozy-sharing/src/components/Recipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient.jsx
@@ -81,9 +81,21 @@ export class Status extends Component {
   }
 
   onRevoke = async () => {
-    const { onRevoke, document, sharingId, index } = this.props
+    const {
+      onRevoke,
+      document,
+      sharingId,
+      index,
+      isOwner,
+      onRevokeSelf
+    } = this.props
     this.setState({ revoking: true })
-    await onRevoke(document, sharingId, index)
+    if (isOwner) {
+      await onRevoke(document, sharingId, index)
+    } else {
+      await onRevokeSelf(document)
+    }
+
     this.setState({ revoking: false })
   }
 

--- a/packages/cozy-sharing/src/components/Recipient.spec.jsx
+++ b/packages/cozy-sharing/src/components/Recipient.spec.jsx
@@ -69,4 +69,52 @@ describe('Recipient component', () => {
     )
     expect(component).toMatchSnapshot()
   })
+
+  it('should call revokeSelf is i m not the owner but try to revoke myselk', async () => {
+    const onRevoke = jest.fn()
+    const onRevokeSelf = jest.fn()
+    const component = mount(
+      <AppLike>
+        <Status
+          instance="foo.mycozy.cloud"
+          client={client}
+          t={x => x}
+          status="ready"
+          type="file"
+          onRevoke={onRevoke}
+          onRevokeSelf={onRevokeSelf}
+          isOwner={false}
+        />
+      </AppLike>
+    )
+
+    const instance = component.find(Status).instance()
+
+    await instance.onRevoke()
+    expect(onRevokeSelf).toBeCalled()
+  })
+
+  it('should call revoke if I m the owner of the sharing', async () => {
+    const onRevoke = jest.fn()
+    const onRevokeSelf = jest.fn()
+    const component = mount(
+      <AppLike>
+        <Status
+          instance="foo.mycozy.cloud"
+          client={client}
+          t={x => x}
+          status="ready"
+          type="file"
+          onRevoke={onRevoke}
+          onRevokeSelf={onRevokeSelf}
+          isOwner={true}
+        />
+      </AppLike>
+    )
+
+    const instance = component.find(Status).instance()
+
+    await instance.onRevoke()
+    expect(onRevoke).toBeCalled()
+  })
 })

--- a/packages/cozy-sharing/src/components/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal.jsx
@@ -33,7 +33,8 @@ export default class ShareModal extends Component {
       onShare,
       onRevoke,
       onShareByLink,
-      onRevokeLink
+      onRevokeLink,
+      onRevokeSelf
     } = this.props
     return (
       <Modal
@@ -103,6 +104,7 @@ export default class ShareModal extends Component {
                   document={document}
                   documentType={documentType}
                   onRevoke={onRevoke}
+                  onRevokeSelf={onRevokeSelf}
                 />
               )}
             </div>

--- a/packages/cozy-sharing/src/components/WhoHasAccess.jsx
+++ b/packages/cozy-sharing/src/components/WhoHasAccess.jsx
@@ -14,7 +14,8 @@ class WhoHasAccess extends PureComponent {
       document,
       documentType,
       onRevoke,
-      className
+      className,
+      onRevokeSelf
     } = this.props
     const { t } = this.context
 
@@ -35,6 +36,7 @@ class WhoHasAccess extends PureComponent {
             document={document}
             documentType={documentType}
             onRevoke={onRevoke}
+            onRevokeSelf={onRevokeSelf}
           />
         ))}
       </div>


### PR DESCRIPTION
Currently we're not doing the right thing when we try to remove a sharing from the ActionMenu. 

We display the "Remove action" with the right conditions aka "I'm the owner" or "I've accepted the cozy to cozy sharing", but after that, when we call the revoke() we don't make any difference between if I'm the owner or not. 

If I'm the owner, I can revoke members I want for the sharing and so, I need to call /revoke/:id. 
If I'm the "accepted sharing", I can only remove myself and then I need to call /revoke/self

