### PR TITLE
fix: Bad password matching would result in null fields

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -52,7 +52,7 @@
     "babel-preset-cozy-app": "^1.8.1",
     "cozy-client": "10.8.1",
     "cozy-device-helper": "^1.9.2",
-    "cozy-keys-lib": "2.6.0",
+    "cozy-keys-lib": "^3.0.0",
     "cozy-realtime": "^3.7.0",
     "cozy-ui": "30.7.0",
     "enzyme": "3.11.0",
@@ -69,7 +69,7 @@
   "peerDependencies": {
     "cozy-client": "7.14.0",
     "cozy-device-helper": "1.7.1",
-    "cozy-keys-lib": "^2.5.2",
+    "cozy-keys-lib": "^3.0.0",
     "cozy-realtime": "^3.1.0",
     "cozy-ui": "^29.2.1"
   },

--- a/packages/cozy-harvest-lib/src/models/cipherUtils.js
+++ b/packages/cozy-harvest-lib/src/models/cipherUtils.js
@@ -169,16 +169,21 @@ const searchForCipher = async (vaultClient, searchOptions) => {
 
   const cipher = await vaultClient.getByIdOrSearch(id, search, sort)
 
-  // If there is no id, we do strict password matching
-  if (!id) {
-    // Since getByIdOrSearch does not support password matching,
-    // we have to do the password matching here
+  if (id) {
+    // We know the cipher we are targetting, so we do not need to check
+    // for password equality. Checking for password inequality would
+    // prevent password update through Harvest.
+    return cipher
+  } else {
+    // If there is no id, we do strict password matching
+    // We are in a case where we add an account through Harvest
+    // There might be already a cipher that corresponds to it in the Vault
+    // (through an import for example) and we want it to be found but we
+    // do not want to match a cipher that has not exactly the same password.
     const decrypted = await vaultClient.decrypt(cipher)
     if (decrypted && decrypted.login && decrypted.login.password === password) {
       return cipher
     }
-  } else {
-    return cipher
   }
   return null
 }

--- a/packages/cozy-harvest-lib/src/models/cipherUtils.spec.js
+++ b/packages/cozy-harvest-lib/src/models/cipherUtils.spec.js
@@ -4,7 +4,8 @@ describe('createOrUpdateCipher', () => {
   const setup = ({
     konnector: konnectorAttrs,
     userCredentials: userCredentialsAttrs,
-    vaultClient: vaultClientAttrs
+    vaultClient: vaultClientAttrs,
+    account: accountAttrs
   } = {}) => {
     const konnector = {
       vendor_link: 'konnector-vendor-link',
@@ -21,6 +22,19 @@ describe('createOrUpdateCipher', () => {
 
     const sharedCipher = {
       id: 'shared-with-cozy-cipher-id'
+    }
+
+    const account = {
+      relationships: {
+        vaultCipher: {
+          data: [
+            {
+              _id: 'existing-cipher'
+            }
+          ]
+        }
+      },
+      ...accountAttrs
     }
 
     const foundCipher = { id: 'found-cipher-id' }
@@ -64,6 +78,7 @@ describe('createOrUpdateCipher', () => {
       konnector,
       userCredentials,
       vaultClient,
+      account,
       existingCipher
     }
   }
@@ -99,7 +114,7 @@ describe('createOrUpdateCipher', () => {
       })
     })
 
-    describe('when a cipher exists with the same credentials', () => {
+    describe('when a cipher exists with the same credentials (account with cipher)', () => {
       it('should update the cipher with given credentials', async () => {
         const {
           konnector,
@@ -124,6 +139,41 @@ describe('createOrUpdateCipher', () => {
         )
 
         expect(cipher.id).toBe('existing-cipher')
+        expect(cipher.login.username).toBe(userCredentials.login)
+        expect(cipher.login.password).toBe(userCredentials.password)
+        expect(cipher.organizationId).toBe('cozy-org-id')
+        expect(cipher.collectionIds).toEqual(['cozy-org-collection-id'])
+      })
+    })
+
+    describe('when a cipher exists with the same credentials (account without cipher)', () => {
+      it('should create a new cipher with given credentials', async () => {
+        const {
+          konnector,
+          account,
+          userCredentials,
+          vaultClient,
+          existingCipher
+        } = setup({
+          vaultClient: {
+            isLocked: jest.fn().mockResolvedValue(false)
+          },
+          account: {
+            relationships: {}
+          }
+        })
+
+        vaultClient.getByIdOrSearch.mockResolvedValue(existingCipher)
+
+        const cipherId = null
+
+        const cipher = await cipherUtils.createOrUpdateCipher(
+          vaultClient,
+          cipherId,
+          { userCredentials, account, konnector }
+        )
+
+        expect(cipher.id).toBe(null)
         expect(cipher.login.username).toBe(userCredentials.login)
         expect(cipher.login.password).toBe(userCredentials.password)
         expect(cipher.organizationId).toBe('cozy-org-id')

--- a/packages/cozy-harvest-lib/src/models/cipherUtils.spec.js
+++ b/packages/cozy-harvest-lib/src/models/cipherUtils.spec.js
@@ -42,29 +42,30 @@ describe('createOrUpdateCipher', () => {
       ...vaultClientAttrs
     }
 
+    const existingCipher = {
+      collectionIds: ['cozy-org-collection-id'],
+      id: 'existing-cipher',
+      login: {
+        password: 'password-to-be-updated',
+        uris: [
+          {
+            match: 'Domain',
+            uri: 'konnector-vendor-link'
+          }
+        ],
+        username: 'login-to-be-updated'
+      },
+      name: 'konnector-name',
+      organizationId: 'cozy-org-id',
+      type: 'Login'
+    }
+
     return {
       konnector,
       userCredentials,
-      vaultClient
+      vaultClient,
+      existingCipher
     }
-  }
-
-  const existingCipher = {
-    collectionIds: ['cozy-org-collection-id'],
-    id: 'existing-cipher',
-    login: {
-      password: 'password-to-be-updated',
-      uris: [
-        {
-          match: 'Domain',
-          uri: 'konnector-vendor-link'
-        }
-      ],
-      username: 'login-to-be-updated'
-    },
-    name: 'konnector-name',
-    organizationId: 'cozy-org-id',
-    type: 'Login'
   }
 
   afterEach(() => {
@@ -100,7 +101,13 @@ describe('createOrUpdateCipher', () => {
 
     describe('when a cipher exists with the same credentials', () => {
       it('should update the cipher with given credentials', async () => {
-        const { konnector, account, userCredentials, vaultClient } = setup({
+        const {
+          konnector,
+          account,
+          userCredentials,
+          vaultClient,
+          existingCipher
+        } = setup({
           vaultClient: {
             isLocked: jest.fn().mockResolvedValue(false)
           }
@@ -127,7 +134,13 @@ describe('createOrUpdateCipher', () => {
 
   describe('when given a cipherId', () => {
     it('should update the cipher with given credentials', async () => {
-      const { konnector, account, userCredentials, vaultClient } = setup({
+      const {
+        konnector,
+        account,
+        userCredentials,
+        vaultClient,
+        existingCipher
+      } = setup({
         vaultClient: {
           isLocked: jest.fn().mockResolvedValue(false)
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4715,24 +4715,23 @@ cozy-doctypes@1.67.0:
     lodash "4.17.15"
     prop-types "^15.7.2"
 
-cozy-keys-lib@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/cozy-keys-lib/-/cozy-keys-lib-2.6.0.tgz#22f548e60b2a71fc976f0f56a739fa876bff3b12"
-  integrity sha512-URaF+qSAzlLYklDJWRLwUeJMOGn0f6WibqIfzhLA3A1AzpxbEX2EzYi2GBUQZnxuTpnh4nxCboVDhkDS5Hiq9Q==
+cozy-keys-lib@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-keys-lib/-/cozy-keys-lib-3.0.0.tgz#bff5c43d380884e45dbff4e945dedd48aef24e0a"
+  integrity sha512-VNh3Odm1p13YY5rszeYk+nabNLcAh7u5VDiga4SDfUxr2R0bWxBhM03TnLNbZ4SCqXXcKt0pi0ANmW23Nu5oiA==
   dependencies:
     "@aspnet/signalr" "^1.1.4"
     "@aspnet/signalr-protocol-msgpack" "^1.1.0"
     big-integer "^1.6.44"
     classnames "^2.2.6"
     cozy-device-helper "^1.7.5"
-    cozy-ui "^29.9.1"
     lodash "^4.17.15"
     lunr "^2.3.6"
     microee "^0.0.6"
+    minilog "https://github.com/cozy/minilog.git#master"
     node-forge "^0.9.0"
+    papaparse "^5.1.1"
     prop-types "^15.7.2"
-    react "^16.8.3"
-    react-dom "^16.9.0"
     sweetalert "^2.1.2"
     tldjs "^2.3.1"
     zxcvbn "^4.4.2"
@@ -4839,24 +4838,6 @@ cozy-ui@30.7.0:
   version "30.7.0"
   resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-30.7.0.tgz#5d736c96e272a739908b1dcf7852b573c58b89ea"
   integrity sha512-aylBjrekV2eA8Sx84hY8AjFGunHkR/tVRJBGx1/CavYIffLj6DVttPwNdz/j2V1YbI1U5kgMN1MXZ7PQLZo8ng==
-  dependencies:
-    "@babel/runtime" "^7.3.4"
-    body-scroll-lock "^2.5.8"
-    classnames "^2.2.5"
-    date-fns "^1.28.5"
-    hammerjs "^2.0.8"
-    node-polyglot "^2.2.2"
-    normalize.css "^7.0.0"
-    react-hot-loader "^4.3.11"
-    react-markdown "^4.0.8"
-    react-pdf "^4.0.5"
-    react-select "2.2.0"
-    react-swipeable-views "0.13.3"
-
-cozy-ui@^29.9.1:
-  version "29.9.1"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-29.9.1.tgz#9e8d7b0a12c85166c6bf4b25a70ea6847336099f"
-  integrity sha512-xt5VDSOrm3zB7WnovMmel1fT/q52tLkEC9j12gmkkR1aEFc3c3Ced5iZu/NmuOYy2fkx0nvgazoggWrsmUZTVg==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"
@@ -10138,6 +10119,13 @@ mini-html-webpack-plugin@^0.2.3:
   dependencies:
     webpack-sources "^1.1.0"
 
+"minilog@git+https://github.com/cozy/minilog.git#master":
+  version "3.1.0"
+  uid f01f7d9dfe20981177dd34b9662c2f077d818f82
+  resolved "git+https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
+  dependencies:
+    microee "0.0.6"
+
 "minilog@https://github.com/cozy/minilog.git#master":
   version "3.1.0"
   resolved "https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
@@ -11452,6 +11440,11 @@ pako@^0.2.5:
 pako@~1.0.5:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
+
+papaparse@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.1.1.tgz#1da66a039f80e2db43a1226b0bf44106451e9a2d"
+  integrity sha512-KPkW4GNQxunmYTeJIjHFrvilcNuHBWrfgbyvmagEmfGOA4hnP1WIkPbv4yABhj1Nam3as4w+7MBiI27BntwqVg==
 
 parallel-transform@^1.1.0:
   version "1.2.0"
@@ -12996,16 +12989,6 @@ react-dom@^16.12.0:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
-react-dom@^16.9.0:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.9.0.tgz#5e65527a5e26f22ae3701131bcccaee9fb0d3962"
-  integrity sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.15.0"
-
 react-error-overlay@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.1.tgz#417addb0814a90f3a7082eacba7cee588d00da89"
@@ -13421,15 +13404,6 @@ react@^16.12.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
   integrity sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-
-react@^16.8.3:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
-  integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Since the sort does not specify a number, false or true are used and falsy
values come first, this mean the search can find a cipher with a different
   password that what is searched. Another check is necessary if no cipher
   with the same password have ever been added.

   For a reason I still ignore, this resulted in ciphers with null values 
   after both ciphers with different password were merged because the 
   deciphering would not work (mac failed error)