### PR TITLE
fix: Grid spacing

### DIFF
--- a/packages/cozy-scanner/src/DocumentQualification.jsx
+++ b/packages/cozy-scanner/src/DocumentQualification.jsx
@@ -156,7 +156,7 @@ export class DocumentQualification extends Component {
             </Title>
           </div>
         )}
-        <Grid container spacing={1}>
+        <Grid container spacing={8}>
           <GridItem
             onClick={() => this.onSelect({ categoryLabel: null, itemId: null })}
           >

--- a/packages/cozy-scanner/src/__snapshots__/DocumentQualification.spec.jsx.snap
+++ b/packages/cozy-scanner/src/__snapshots__/DocumentQualification.spec.jsx.snap
@@ -51,7 +51,7 @@ exports[`DocumentQualification Initial render + selection + filename 1`] = `
     </div>
   </div>
   <div
-    class="MuiGrid-container-1"
+    class="MuiGrid-container-1 MuiGrid-spacing-xs-8-23"
   >
     <div
       class="MuiGrid-item-2 MuiGrid-grid-xs-3-32 MuiGrid-grid-sm-2-45 styles__gridItem-container___387sO"
@@ -502,7 +502,7 @@ exports[`DocumentQualification Initial render + selection + filename 2`] = `
     </div>
   </div>
   <div
-    class="MuiGrid-container-1"
+    class="MuiGrid-container-1 MuiGrid-spacing-xs-8-23"
   >
     <div
       class="MuiGrid-item-2 MuiGrid-grid-xs-3-32 MuiGrid-grid-sm-2-45 styles__gridItem-container___387sO"


### PR DESCRIPTION
Drive was using MUI V4. We downgraded it to use V3 as UI. V3 and V4 don't have the same implementation.

In v4 spacing = 8 means 8*8, in v3 spacing 8 means what we want 