### PR TITLE
Sharing hooks

### DIFF
--- a/packages/cozy-sharing/README.md
+++ b/packages/cozy-sharing/README.md
@@ -2,12 +2,61 @@
 
 Open the playgrounds in cozy-libs and run `yarn start`
 
-# How to use the lib 
+# How to use the lib
 
-In your app, you have to : 
+In your app, you have to :
 
-- import the Provider: ```import SharingProvider, { ShareButton, ShareModal } from 'cozy-sharing'```
-- import the sylesheet.css: ```import 'cozy-sharing/dist/stylesheet.css'```
+- import the Provider: `import SharingProvider, { ShareButton, ShareModal } from 'cozy-sharing'`
+- import the stylesheet.css: `import 'cozy-sharing/dist/stylesheet.css'`
+
+## Using the built-in components
+
+Some of the exposed components are fully featured components, ready to render. They need a `SharingProvider` above them in the render tree and the imported stylesheet for their styles.
+
+```
+import { ShareModal } from 'cozy-sharing'
+
+const ToggleModal = () => {
+  const [isModalDisplayed, setIsModalDisplayed] = useState(false)
+
+  return (
+    <div>
+      <Button onClick={() => setIsModalDisplayed(true)}>Open modal</Button>
+      {isModalDisplayed && <ShareModal document={doc} />}
+    </div>
+  )
+}
+```
+
+Other components accept a render prop as children that receive some information from the sharing context.
+
+```
+import { SharedDocument } from 'cozy-sharing'
+
+const MyComp = () => {
+  return (
+    <SharedDocument docId='123'>
+      {({ isShared, link }) => (
+        {isShared ? link : 'Not shared yet'}
+      )}
+    </SharedDocument>
+  )
+}
+```
+
+## Usage with hooks
+
+`cozy-sharing` can now be used with hooks as well:
+
+```
+import { SharingContext } from 'cozy-sharing'
+
+const MyComp = () => {
+  const { share } = useContext(SharingContext)
+
+  return <Button onClick={() => share(document, recipients, sharingType, description)}>Share</Button>
+}
+```
 
 # Share and send mail in development
 
@@ -42,4 +91,4 @@ Then simply run `mailhog` and open http://cozy.tools:8025/.
 
 ## Retrieve sent emails
 
-With MailHog, **every email** sent by cozy-stack is caught. That means the email address *does not have to be a real one*, ie. `bob@cozy`, `bob@cozy.tools` are perfectly fine. It *could be a real one*, but the email will not reach the real recipient's inbox, say `contact@cozycloud.cc`.
+With MailHog, **every email** sent by cozy-stack is caught. That means the email address _does not have to be a real one_, ie. `bob@cozy`, `bob@cozy.tools` are perfectly fine. It _could be a real one_, but the email will not reach the real recipient's inbox, say `contact@cozycloud.cc`.

--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -84,7 +84,8 @@ export class SharingProvider extends Component {
       revokeSharingLink: this.revokeSharingLink,
       hasLoadedAtLeastOnePage: false,
       revokeAllRecipients: this.revokeAllRecipients,
-      refresh: this.fetchAllSharings
+      refresh: this.fetchAllSharings,
+      hasWriteAccess: this.hasWriteAccess
     }
   }
 
@@ -224,6 +225,17 @@ export class SharingProvider extends Component {
     this.dispatch(revokeSharingLink(perms))
   }
 
+  hasWriteAccess = docId => {
+    const instanceUri = this.props.client.getStackClient().uri
+
+    return (
+      !this.state.byDocId ||
+      !this.state.byDocId[docId] ||
+      isOwner(this.state, docId) ||
+      getSharingType(this.state, docId, instanceUri) === 'two-way'
+    )
+  }
+
   render() {
     // WARN: whe shouldn't do this (https://reactjs.org/docs/context.html#caveats)
     // but if we don't, consumers don't rerender when the state changes after loading the sharings,
@@ -239,20 +251,16 @@ export default withClient(SharingProvider)
 export const SharedDocument = ({ docId, children }) => (
   <SharingContext.Consumer>
     {({
+      hasWriteAccess,
       byDocId,
       isOwner,
-      getSharingType,
       getRecipients,
       getSharingLink,
       refresh,
       revokeSelf
     } = {}) =>
       children({
-        hasWriteAccess:
-          !byDocId ||
-          !byDocId[docId] ||
-          isOwner(docId) ||
-          getSharingType(docId) === 'two-way',
+        hasWriteAccess: hasWriteAccess(docId),
         isShared: byDocId !== undefined && byDocId[docId],
         isSharedByMe: byDocId !== undefined && byDocId[docId] && isOwner(docId),
         isSharedWithMe:

--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -392,3 +392,5 @@ export const RefreshableSharings = ({ children }) => (
     }
   </SharingContext.Consumer>
 )
+
+export { SharingContext }

--- a/packages/cozy-sharing/src/index.spec.jsx
+++ b/packages/cozy-sharing/src/index.spec.jsx
@@ -2,30 +2,125 @@ import React from 'react'
 import { mount } from 'enzyme'
 import { createMockClient } from 'cozy-client'
 
+import SharingContext from './context'
 import { RefreshableSharings, SharingProvider } from './'
 import AppLike from '../test/AppLike'
+
+import { receiveSharings } from './state'
 
 const DumbComponent = () => {
   return <div>test </div>
 }
+
+const AppWrapper = ({ children, client }) => {
+  return (
+    <AppLike client={client}>
+      <SharingProvider client={client}>{children}</SharingProvider>
+    </AppLike>
+  )
+}
+
+describe('hasWriteAccess', () => {
+  it('tells if a doc is writtable', () => {
+    const client = createMockClient({})
+    client.stackClient.uri = 'http://cozy.tools:8080'
+
+    const component = mount(
+      <AppWrapper client={client}>
+        <SharingContext.Consumer>
+          {({ hasWriteAccess }) => (
+            <>
+              <div data-id="no-sharing">
+                {hasWriteAccess('no-sharing') ? 'yes' : 'no'}
+              </div>
+              <div data-id="owner-doc">
+                {hasWriteAccess('owner-doc') ? 'yes' : 'no'}
+              </div>
+              <div data-id="synced-doc">
+                {hasWriteAccess('synced-doc') ? 'yes' : 'no'}
+              </div>
+              <div data-id="read-only-doc">
+                {hasWriteAccess('read-only-doc') ? 'yes' : 'no'}
+              </div>
+            </>
+          )}
+        </SharingContext.Consumer>
+      </AppWrapper>
+    )
+
+    expect(component.find('div[data-id="no-sharing"]').text()).toBe('yes')
+    expect(component.find('div[data-id="owner-doc"]').text()).toBe('yes')
+    expect(component.find('div[data-id="synced-doc"]').text()).toBe('yes')
+    expect(component.find('div[data-id="read-only-doc"]').text()).toBe('yes')
+
+    const provider = component.find(SharingProvider)
+    provider.instance().dispatch(
+      receiveSharings({
+        sharings: [
+          {
+            id: '123',
+            type: 'io.cozy.sharings',
+            attributes: {
+              owner: true,
+              members: [
+                { read_only: false, instance: 'http://cozy.tools:8080' }
+              ],
+              rules: [{ values: ['owner-doc'] }]
+            }
+          },
+          {
+            id: '456',
+            type: 'io.cozy.sharings',
+            attributes: {
+              owner: false,
+              members: [
+                { read_only: false, instance: 'http://cozy.tools:8080' }
+              ],
+              rules: [
+                { values: ['synced-doc'], update: 'sync', remove: 'sync' }
+              ]
+            }
+          },
+          {
+            id: '789',
+            type: 'io.cozy.sharings',
+            attributes: {
+              owner: false,
+              members: [
+                { read_only: true, instance: 'http://cozy.tools:8080' }
+              ],
+              rules: [{ values: ['read-only-doc'] }]
+            }
+          }
+        ]
+      })
+    )
+
+    component.update()
+
+    expect(component.find('div[data-id="no-sharing"]').text()).toBe('yes')
+    expect(component.find('div[data-id="owner-doc"]').text()).toBe('yes')
+    expect(component.find('div[data-id="synced-doc"]').text()).toBe('yes')
+    expect(component.find('div[data-id="read-only-doc"]').text()).toBe('no')
+  })
+})
+
 describe('RefreshableSharings', () => {
   it('should test', () => {
     const client = createMockClient({})
 
     const component = mount(
-      <AppLike client={client}>
-        <SharingProvider client={client}>
-          <RefreshableSharings>
-            {({ refresh }) => (
-              <DumbComponent
-                client={client}
-                t={x => x}
-                refreshSharings={refresh}
-              />
-            )}
-          </RefreshableSharings>
-        </SharingProvider>
-      </AppLike>
+      <AppWrapper client={client}>
+        <RefreshableSharings>
+          {({ refresh }) => (
+            <DumbComponent
+              client={client}
+              t={x => x}
+              refreshSharings={refresh}
+            />
+          )}
+        </RefreshableSharings>
+      </AppWrapper>
     )
     const refreshMethod = component.find(DumbComponent).prop('refreshSharings')
 


### PR DESCRIPTION
At the moment cozy-sharings exposes a variety of components that in turn expose a subset of the context. That's cool but doesn't work with hooks at all.

This PR exposes the `SharingContext` so that it can be called with `useContext`.  
It also exposes the `hasWriteAccess` function in the context so that it can be used outside of `<SharedDocument />`.