### PR TITLE
feat: Close realtime when the page is hidden

### DIFF
--- a/packages/cozy-realtime/src/CozyRealtime.js
+++ b/packages/cozy-realtime/src/CozyRealtime.js
@@ -16,7 +16,8 @@ import {
   raiseErrorAfterAttempts,
   timeBeforeSuccessful,
   baseWaitAfterFirstFailure,
-  maxWaitBetweenRetries
+  maxWaitBetweenRetries,
+  closeIfHiddenFor
 } from './config'
 
 /**
@@ -659,7 +660,19 @@ class CozyRealtime {
   onVisibilityChange() {
     if (document.visibilityState && document.visibilityState === 'visible') {
       // if we have a reconnect waiting, do it immediatly
+      if (this.visibilityTimeout) {
+        clearTimeout(this.visibilityTimeout)
+        this.visibilityTimeout = null
+      }
       this.retryManager.stopCurrentAttemptWaitingTime()
+    } else {
+      if (!this.visibilityTimeout) {
+        this.visibilityTimeout = setTimeout(() => {
+          if (this.hasWebSocket()) {
+            this.revokeWebSocket()
+          }
+        }, closeIfHiddenFor)
+      }
     }
   }
 }

--- a/packages/cozy-realtime/src/config.js
+++ b/packages/cozy-realtime/src/config.js
@@ -70,6 +70,15 @@ export const allowDoubleSubscriptions = true
 export const requireDoubleUnsubscriptions = true
 
 /**
+ * Close the socket after this period of time if the page becomes hidden
+ * (ie: in a background tab or a minimized window)
+ *
+ * @type {numeric}
+ * @private
+ */
+export const closeIfHiddenFor = 30 * min
+
+/**
  * If one subscribe multiple times to the exact same event with the exact
  * same handler, this function is called. You are welcome to add any
  * log or warning you wish, or even to throw an exception.


### PR DESCRIPTION
When the page is hidden (either the tab is un background or
the window is minimized) for some time, close the socket to
avoid overloading the server.