### PR TITLE
fix(Harvest): Some regressions which affected the 2FA flow

### DIFF
--- a/packages/cozy-harvest-lib/src/components/FlowProvider.jsx
+++ b/packages/cozy-harvest-lib/src/components/FlowProvider.jsx
@@ -94,7 +94,6 @@ export class FlowProvider extends Component {
     if (this.state.showTwoFAModal) {
       this.dismissTwoFAModal()
     }
-    this.stopWatchingConnectionFlow()
 
     const { onError } = this.props
     if (typeof onError === 'function') onError(error)
@@ -113,7 +112,6 @@ export class FlowProvider extends Component {
     if (this.state.showTwoFAModal) {
       this.dismissTwoFAModal()
     }
-    this.stopWatchingConnectionFlow()
     const { onSuccess } = this.props
     const flow = this.flow
     if (typeof onSuccess === 'function') onSuccess(flow.trigger)
@@ -171,7 +169,7 @@ FlowProvider.propTypes = {
    */
   client: PropTypes.object.isRequired,
   /**
-   * konnector manifest
+   * Konnector manifest
    */
   konnector: PropTypes.object.isRequired,
   /**

--- a/packages/cozy-harvest-lib/src/components/FlowProvider.jsx
+++ b/packages/cozy-harvest-lib/src/components/FlowProvider.jsx
@@ -32,7 +32,7 @@ import ConnectionFlow, {
 export class FlowProvider extends Component {
   constructor(props, context) {
     super(props, context)
-    const { initialTrigger } = this.props
+    const { initialTrigger, konnector } = this.props
     this.state = {
       showTwoFAModal: false
     }
@@ -44,12 +44,12 @@ export class FlowProvider extends Component {
     this.handleLoginSuccess = this.handleLoginSuccess.bind(this)
     this.handleFlowUpdate = this.handleFlowUpdate.bind(this)
 
-    this.setupConnectionFlow(initialTrigger)
+    this.setupConnectionFlow(initialTrigger, konnector)
   }
 
-  setupConnectionFlow(trigger) {
+  setupConnectionFlow(trigger, konnector) {
     const { client } = this.props
-    this.flow = new ConnectionFlow(client, trigger)
+    this.flow = new ConnectionFlow(client, trigger, konnector)
     this.flow
       .on(ERROR_EVENT, this.handleError)
       .on(SUCCESS_EVENT, this.handleSuccess)
@@ -170,6 +170,10 @@ FlowProvider.propTypes = {
    * CozyClient instance
    */
   client: PropTypes.object.isRequired,
+  /**
+   * konnector manifest
+   */
+  konnector: PropTypes.object.isRequired,
   /**
    * Callback to call when the trigger is launched
    */

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
@@ -31,7 +31,7 @@ export const KonnectorAccountTabs = ({
   t
 }) => {
   return (
-    <FlowProvider initialTrigger={initialTrigger}>
+    <FlowProvider initialTrigger={initialTrigger} konnector={konnector}>
       {({ flow }) => {
         const flowState = flow.getState()
         const { error } = flowState

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -135,9 +135,10 @@ export const createOrUpdateAccount = async ({
  * This should be the go to source of truth for the state of a Konnector Job.
  */
 export class ConnectionFlow {
-  constructor(client, trigger) {
+  constructor(client, trigger, konnector) {
     this.client = client
     this.trigger = trigger
+    this.konnector = konnector
     this.unsubscribeAllRealtime = null
 
     // Bind methods used as callbacks

--- a/packages/cozy-harvest-lib/test/components/FlowProvider.spec.jsx
+++ b/packages/cozy-harvest-lib/test/components/FlowProvider.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import { FlowProvider } from 'components/FlowProvider'
 import {
+  ERROR_EVENT,
   SUCCESS_EVENT,
   LOGIN_SUCCESS_EVENT,
   TWO_FA_REQUEST_EVENT
@@ -80,6 +81,8 @@ describe('FlowProvider', () => {
     wrapper.update()
     expect(wrapper.find(TwoFAModal).length).toBe(0)
     expect(children.mock.calls[2][0].flow.getState().status).toEqual('SUCCESS')
+    expect(flow.listeners(SUCCESS_EVENT).length).toEqual(1)
+    expect(flow.listeners(ERROR_EVENT).length).toEqual(1)
   })
 
   it('should support a flow with a LOGIN_SUCCESS', () => {
@@ -98,6 +101,8 @@ describe('FlowProvider', () => {
     expect(children.mock.calls[2][0].flow.getState().status).toEqual(
       'LOGIN_SUCCESS'
     )
+    expect(flow.listeners(SUCCESS_EVENT).length).toEqual(1)
+    expect(flow.listeners(ERROR_EVENT).length).toEqual(1)
   })
 
   it('should call the onLoginSuccess callback', () => {
@@ -119,6 +124,8 @@ describe('FlowProvider', () => {
         }
       })
     )
+    expect(flow.listeners(SUCCESS_EVENT).length).toEqual(1)
+    expect(flow.listeners(ERROR_EVENT).length).toEqual(1)
   })
 
   it('should detect an error in the initial trigger', () => {

--- a/packages/cozy-harvest-lib/test/components/FlowProvider.spec.jsx
+++ b/packages/cozy-harvest-lib/test/components/FlowProvider.spec.jsx
@@ -37,6 +37,9 @@ const triggersMutationsMock = {
 const props = {
   client,
   initialTrigger: trigger,
+  konnector: {
+    slug: 'konnectorslug'
+  },
   ...triggersMutationsMock
 }
 
@@ -53,6 +56,13 @@ describe('FlowProvider', () => {
 
   afterAll(() => {
     jest.resetAllMocks()
+  })
+
+  it('should pass the konnector to the flow', () => {
+    const children = jest.fn()
+    const wrapper = shallow(<FlowProvider {...props}>{children}</FlowProvider>)
+    const flow = wrapper.instance().flow
+    expect(flow.konnector).toEqual(props.konnector)
   })
 
   it('should support a flow with a SUCCESS', () => {

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -66,7 +66,7 @@ const tMock = jest.fn()
 const client = new CozyClient({})
 const props = {
   konnector: fixtures.konnector,
-  flow: new ConnectionFlow(client),
+  flow: new ConnectionFlow(client, undefined, fixtures.konnector),
   flowState: {},
   t: tMock,
   vaultClient: mockVaultClient,
@@ -76,8 +76,24 @@ const props = {
 
 const propsWithAccount = {
   ...props,
+  flow: new ConnectionFlow(
+    client,
+    fixtures.existingTrigger,
+    fixtures.konnector
+  ),
   account: fixtures.existingAccount,
   trigger: fixtures.existingTrigger
+}
+
+const oAuthKonnector = {
+  oauth: {
+    scope: 'test'
+  }
+}
+const oAuthProps = {
+  ...props,
+  konnector: oAuthKonnector,
+  flow: new ConnectionFlow(client, undefined, oAuthKonnector)
 }
 
 describe('TriggerManager', () => {
@@ -94,13 +110,8 @@ describe('TriggerManager', () => {
 
   describe('when given an oauth konnector', () => {
     it('should redirect to OAuthForm', () => {
-      const konnector = {
-        oauth: {
-          scope: 'test'
-        }
-      }
       const component = shallow(
-        <TriggerManager {...props} konnector={konnector} />
+        <TriggerManager {...oAuthProps} konnector={oAuthKonnector} />
       ).getElement()
       expect(component).toMatchSnapshot()
     })

--- a/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
+++ b/packages/cozy-harvest-lib/test/components/__snapshots__/TriggerManager.spec.js.snap
@@ -123,6 +123,11 @@ exports[`TriggerManager when given an oauth konnector should redirect to OAuthFo
       "handleAccountUpdated": [Function],
       "handleJobUpdated": [Function],
       "handleTwoFA": [Function],
+      "konnector": Object {
+        "oauth": Object {
+          "scope": "test",
+        },
+      },
       "launch": [Function],
       "realtime": CozyRealtime {
         "client": CozyClient {


### PR DESCRIPTION
Keep watching connection flow when connector execution is finished
Give connector information to the flow in all the contexts to allow it to get the associated policies