### PR TITLE
Sharing link with write permissions

### DIFF
--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -64,11 +64,19 @@
       "sharedWithMe": "Shared with me",
       "sharedBy": "Shared by %{name}",
       "shareByLink": {
-        "subtitle": "By public link",
-        "creating": "Creating your link...",
+        "subtitle": "Or share by link",
+        "create": "Generate a link",
+        "activated": "Link activated",
         "copy": "Copy link",
         "copied": "Link has been copied to clipboard",
-        "failed": "Unable to copy to clipboard"
+        "failed": "Unable to copy to clipboard",
+        "ro": "Can read",
+        "rw": "Can change",
+        "desc": {
+          "ro": "Link holders can only read or download content.",
+          "rw": "Link holders can alter and delete content."
+        },
+        "deactivate": "Deactivate link"
       },
       "shareByEmail": {
         "subtitle": "By email",
@@ -139,12 +147,20 @@
       "sharedWithMe": "Shared with me",
       "sharedBy": "Shared by %{name}",
       "shareByLink": {
-        "subtitle": "By public link",
+        "subtitle": "Share by link",
         "desc": "Anyone with the provided link can see and edit your note.",
-        "creating": "Creating your link...",
+        "create": "Generate a link",
+        "activated": "Link activated",
         "copy": "Copy link",
         "copied": "Link has been copied to clipboard",
-        "failed": "Unable to copy to clipboard"
+        "failed": "Unable to copy to clipboard",
+        "ro": "Can read",
+        "rw": "Can change",
+        "desc": {
+          "ro": "Link holders can only read or download content.",
+          "rw": "Link holders can alter and delete content."
+        },
+        "deactivate": "Deactivate link"
       },
       "shareByEmail": {
         "subtitle": "By email",
@@ -211,13 +227,21 @@
       "sharedByMe": "Shared",
       "sharedWithMe": "Shared with me",
       "shareByLink": {
-        "subtitle": "By public link",
+        "subtitle": "Or share by link",
         "desc": "Anyone with the provided link can see and download your photos.",
         "fetchFailed": "Woops! It seems your connectivity is limited, try again later when it gets better.",
-        "creating": "Creating your link...",
+        "create": "Generate a link",
+        "activated": "Link activated",
         "copy": "Copy link",
         "copied": "Link has been copied to clipboard",
-        "failed": "Unable to copy to clipboard"
+        "failed": "Unable to copy to clipboard",
+        "ro": "Can read",
+        "rw": "Can change",
+        "desc": {
+          "ro": "Link holders can only read or download content.",
+          "rw": "Link holders can alter and delete content."
+        },
+        "deactivate": "Deactivate link"
       },
       "shareByEmail": {
         "title": "By email",

--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -64,7 +64,6 @@
       "sharedBy": "Shared by %{name}",
       "shareByLink": {
         "subtitle": "By public link",
-        "desc": "Anyone with the provided link can see and download your files.",
         "creating": "Creating your link...",
         "copy": "Copy link",
         "copied": "Link has been copied to clipboard",

--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -240,7 +240,7 @@
         "rw": "Can change",
         "desc": {
           "ro": "Link holders can only read or download content.",
-          "rw": "Link holders can alter and delete content."
+          "rw": "Link holders can change and delete content."
         },
         "deactivate": "Deactivate link"
       },

--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -154,6 +154,7 @@
         "copy": "Copy link",
         "copied": "Link has been copied to clipboard",
         "failed": "Unable to copy to clipboard",
+        "permserror": "An error occurred while changing the permissions of the link, please try again.",
         "ro": "Can read",
         "rw": "Can change",
         "desc": {

--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -36,7 +36,8 @@
         "desc": "Authorize the application to access to your Cozy's contacts: you'll be able to select them next time.",
         "action": "Authorize access",
         "success": "The application has access to your contacts"
-      }
+      },
+      "defaultDisplayName": "Anonymous"
     }
   },
   "Sharings": {

--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -239,7 +239,7 @@
         "rw": "Peut modifier",
         "desc": {
           "ro": "Les détenteurs du lien peuvent uniquement consulter ou télécharger le contenu.",
-          "rw": "Les détenteurs du lien peuvent modifier et supprimer le contenu. "
+          "rw": "Les détenteurs du lien peuvent modifier et supprimer le contenu."
         },
         "deactivate": "Désactiver le lien"
       },

--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -64,11 +64,19 @@
       "sharedWithMe": "Partagé avec moi",
       "sharedBy": "Partagé par %{name}",
       "shareByLink": {
-        "subtitle": "Par lien public",
-        "creating": "Création du lien...",
+        "subtitle": "Ou partager par lien",
+        "create": "Générer un lien",
+        "activated": "Lien activé",
         "copy": "Copier le lien",
         "copied": "Lien copié dans le presse-papiers.",
-        "failed": "Impossible de copier dans le presse papier"
+        "failed": "Impossible de copier dans le presse papier",
+        "ro": "Peut consulter",
+        "rw": "Peut modifier",
+        "desc": {
+          "ro": "Les détenteurs du lien peuvent uniquement consulter ou télécharger le contenu.",
+          "rw": "Les détenteurs du lien peuvent modifier et supprimer le contenu. "
+        },
+        "deactivate": "Désactiver le lien"
       },
       "shareByEmail": {
         "subtitle": "Par email",
@@ -139,12 +147,20 @@
       "sharedWithMe": "Partagé avec moi",
       "sharedBy": "Partagé par %{name}",
       "shareByLink": {
-        "subtitle": "Par lien public",
+        "subtitle": "Partager par lien",
         "desc": "Chaque personne possédant le lien fourni peut voir et modifier votre note.",
-        "creating": "Création du lien...",
+        "create": "Générer un lien",
+        "activated": "Lien activé",
         "copy": "Copier le lien",
         "copied": "Lien copié dans le presse-papiers.",
-        "failed": "Impossible de copier dans le presse papier"
+        "failed": "Impossible de copier dans le presse papier",
+        "ro": "Peut consulter",
+        "rw": "Peut modifier",
+        "desc": {
+          "ro": "Les détenteurs du lien peuvent uniquement consulter ou télécharger le contenu.",
+          "rw": "Les détenteurs du lien peuvent modifier et supprimer le contenu. "
+        },
+        "deactivate": "Désactiver le lien"
       },
       "shareByEmail": {
         "subtitle": "Par email",
@@ -211,13 +227,21 @@
       "sharedByMe": "Partagé",
       "sharedWithMe": "Partagé avec moi",
       "shareByLink": {
-        "subtitle": "Par lien public",
+        "subtitle": "Ou partager par lien",
         "desc": "Chaque personne possédant le lien fourni peut voir et télécharger vos photos.",
         "fetchFailed": "Oups ! Il semblerait que votre connexion internet soit limitée, réessayez plus tard quand le réseau sera meilleur.",
-        "creating": "Création de votre lien...",
+        "create": "Générer un lien",
+        "activated": "Lien activé",
         "copy": "Copier le lien",
         "copied": "Lien copié dans le presse-papier",
-        "failed": "Impossible de copier dans le presse-papier"
+        "failed": "Impossible de copier dans le presse-papier",
+        "ro": "Peut consulter",
+        "rw": "Peut modifier",
+        "desc": {
+          "ro": "Les détenteurs du lien peuvent uniquement consulter ou télécharger le contenu.",
+          "rw": "Les détenteurs du lien peuvent modifier et supprimer le contenu. "
+        },
+        "deactivate": "Désactiver le lien"
       },
       "shareByEmail": {
         "title": "Par e-mail",

--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -70,6 +70,7 @@
         "copy": "Copier le lien",
         "copied": "Lien copié dans le presse-papiers.",
         "failed": "Impossible de copier dans le presse papier",
+        "permserror": "Une erreur est survenue lors du changement de permissions du lien, merci de réessayer.",
         "ro": "Peut consulter",
         "rw": "Peut modifier",
         "desc": {

--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -64,7 +64,6 @@
       "sharedBy": "Partagé par %{name}",
       "shareByLink": {
         "subtitle": "Par lien public",
-        "desc": "Chaque personne possédant le lien fourni peut voir et télécharger vos fichiers.",
         "creating": "Création du lien...",
         "copy": "Copier le lien",
         "copied": "Lien copié dans le presse-papiers.",

--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -36,7 +36,8 @@
         "desc": "Autorisez l'application à accéder aux contacts de votre Cozy : vous pourrez les sélectionner la prochaine fois.",
         "action": "Autoriser l'accès",
         "success": "L'application a accès à vos contacts"
-      }
+      },
+      "defaultDisplayName": "Anonyme"
     }
   },
   "Sharings": {

--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -39,8 +39,8 @@
   "devDependencies": {
     "babel-jest": "^24.9.0",
     "babel-plugin-css-modules-transform": "^1.6.2",
-    "cozy-client": "^10.4.0",
-    "cozy-ui": "28.13.0",
+    "cozy-client": "^13.4.2",
+    "cozy-ui": "^35.1.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.2",
     "enzyme-to-json": "3.4.4",
@@ -48,8 +48,8 @@
     "react-dom": "^16.12.0"
   },
   "peerDependencies": {
-    "cozy-client": "^10.4.0",
-    "cozy-ui": "^28.4.1",
+    "cozy-client": "^13.4.2",
+    "cozy-ui": "^35.1.0",
     "prop-types": "^15.7.2",
     "react": "^16.12.0"
   },

--- a/packages/cozy-sharing/src/components/EditableSharingModal.jsx
+++ b/packages/cozy-sharing/src/components/EditableSharingModal.jsx
@@ -24,9 +24,11 @@ const EditableSharingModal = ({
           isOwner,
           getRecipients,
           getSharingLink,
+          getDocumentPermissions,
           share,
           revoke,
           shareByLink,
+          updateDocumentPermissions,
           revokeSharingLink,
           hasSharedParent,
           hasSharedChild,
@@ -41,12 +43,14 @@ const EditableSharingModal = ({
               groups={groups}
               recipients={getRecipients(document.id)}
               link={getSharingLink(document.id)}
+              permissions={getDocumentPermissions(document.id)}
               isOwner={isOwner(document.id)}
               hasSharedParent={hasSharedParent(document)}
               hasSharedChild={hasSharedChild(document)}
               onShare={share}
               onRevoke={revoke}
               onShareByLink={shareByLink}
+              onUpdateShareLinkPermissions={updateDocumentPermissions}
               onRevokeLink={revokeSharingLink}
               onRevokeSelf={revokeSelf}
               {...rest}

--- a/packages/cozy-sharing/src/components/Recipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient.jsx
@@ -18,7 +18,7 @@ import { Contact } from '../models'
 import Identity from './Identity'
 
 const MAX_DISPLAYED_RECIPIENTS = 3
-const DEFAULT_DISPLAY_NAME = 'models.contact.defaultDisplayName'
+const DEFAULT_DISPLAY_NAME = 'Share.contacts.defaultDisplayName'
 
 export const RecipientsAvatars = ({
   recipients,

--- a/packages/cozy-sharing/src/components/ShareByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareByLink.jsx
@@ -10,16 +10,13 @@ import Icon from 'cozy-ui/transpiled/react/Icon'
 import Radio from 'cozy-ui/transpiled/react/Radio'
 import DropdownButton from 'cozy-ui/transpiled/react/DropdownButton'
 import ActionMenu, { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 import get from 'lodash/get'
 import logger from '../logger'
 
 import palette from 'cozy-ui/transpiled/react/palette'
 
 class ShareByLink extends React.Component {
-  static contextTypes = {
-    t: PropTypes.func.isRequired
-  }
-
   constructor(props) {
     super(props)
     this.state = {
@@ -41,11 +38,11 @@ class ShareByLink extends React.Component {
   copyLinkToClipboard = () => {
     if (copy(this.props.link))
       Alerter.success(
-        this.context.t(`${this.props.documentType}.share.shareByLink.copied`)
+        this.props.t(`${this.props.documentType}.share.shareByLink.copied`)
       )
     else
       Alerter.error(
-        this.context.t(`${this.props.documentType}.share.shareByLink.failed`)
+        this.props.t(`${this.props.documentType}.share.shareByLink.failed`)
       )
   }
 
@@ -55,7 +52,7 @@ class ShareByLink extends React.Component {
       await this.props.onEnable(this.props.document)
     } catch (e) {
       Alerter.error(
-        this.context.t(`${this.props.documentType}.share.error.generic`)
+        this.props.t(`${this.props.documentType}.share.error.generic`)
       )
       logger.log(e)
     } finally {
@@ -69,7 +66,7 @@ class ShareByLink extends React.Component {
       await this.props.onDisable(this.props.document)
     } catch (e) {
       Alerter.error(
-        this.context.t(`${this.props.documentType}.share.error.revoke`)
+        this.props.t(`${this.props.documentType}.share.error.revoke`)
       )
       logger.log(e)
     } finally {
@@ -82,14 +79,14 @@ class ShareByLink extends React.Component {
   }
 
   render() {
-    const t = this.context.t
     const { loading, menuIsOpen } = this.state
     const {
       checked,
       document,
       documentType,
       permissions,
-      onChangePermissions
+      onChangePermissions,
+      t
     } = this.props
     const permissionCategories = get(
       permissions,
@@ -238,4 +235,4 @@ ShareByLink.propTypes = {
   onDisable: PropTypes.func.isRequired
 }
 
-export default ShareByLink
+export default translate()(ShareByLink)

--- a/packages/cozy-sharing/src/components/ShareByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareByLink.jsx
@@ -74,20 +74,24 @@ class ShareByLink extends React.Component {
     }
   }
 
+  updateLinkPermissions({ isReadOnly }) {
+    const { document, documentType, onChangePermissions, t } = this.props
+    const verbs = isReadOnly ? ['GET'] : ['GET', 'POST', 'PUT', 'PATCH']
+    try {
+      onChangePermissions(document, verbs)
+    } catch (err) {
+      Alerter.error(t(`${documentType}.share.shareByLink.permserror`))
+      logger.log(err)
+    }
+  }
+
   toggleMenu = () => {
     this.setState(state => ({ ...state, menuIsOpen: !state.menuIsOpen }))
   }
 
   render() {
     const { loading, menuIsOpen } = this.state
-    const {
-      checked,
-      document,
-      documentType,
-      permissions,
-      onChangePermissions,
-      t
-    } = this.props
+    const { checked, documentType, permissions, t } = this.props
     const permissionCategories = get(
       permissions,
       '[0].attributes.permissions',
@@ -165,7 +169,7 @@ class ShareByLink extends React.Component {
                       }
                       onClick={() => {
                         this.toggleMenu()
-                        onChangePermissions(document, ['GET'])
+                        this.updateLinkPermissions({ isReadOnly: true })
                       }}
                     >
                       <>
@@ -187,12 +191,7 @@ class ShareByLink extends React.Component {
                       }
                       onClick={() => {
                         this.toggleMenu()
-                        onChangePermissions(document, [
-                          'GET',
-                          'POST',
-                          'PUT',
-                          'PATCH'
-                        ])
+                        this.updateLinkPermissions({ isReadOnly: false })
                       }}
                     >
                       <>

--- a/packages/cozy-sharing/src/components/ShareByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareByLink.jsx
@@ -1,13 +1,18 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import copy from 'copy-text-to-clipboard'
-import Toggle from 'cozy-ui/transpiled/react/Toggle'
-import { Spinner, SubTitle } from 'cozy-ui/transpiled/react'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
-import cx from 'classnames'
+import Text, { Caption } from 'cozy-ui/transpiled/react/Text'
+import Button from 'cozy-ui/transpiled/react/Button'
+import CompositeRow from 'cozy-ui/transpiled/react/CompositeRow'
+import Circle from 'cozy-ui/transpiled/react/Circle'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import Radio from 'cozy-ui/transpiled/react/Radio'
+import DropdownButton from 'cozy-ui/transpiled/react/DropdownButton'
+import ActionMenu, { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu'
+import get from 'lodash/get'
 import logger from '../logger'
 
-import styles from '../share.styl'
 import palette from 'cozy-ui/transpiled/react/palette'
 
 class ShareByLink extends React.Component {
@@ -15,8 +20,14 @@ class ShareByLink extends React.Component {
     t: PropTypes.func.isRequired
   }
 
-  state = {
-    loading: false
+  constructor(props) {
+    super(props)
+    this.state = {
+      loading: false,
+      menuIsOpen: false
+    }
+
+    this.containerRef = React.createRef()
   }
 
   toggleShareLink = checked => {
@@ -66,47 +77,159 @@ class ShareByLink extends React.Component {
     }
   }
 
+  toggleMenu = () => {
+    this.setState(state => ({ ...state, menuIsOpen: !state.menuIsOpen }))
+  }
+
   render() {
     const t = this.context.t
-    const { loading } = this.state
-    const { checked, documentType } = this.props
+    const { loading, menuIsOpen } = this.state
+    const {
+      checked,
+      document,
+      documentType,
+      permissions,
+      onChangePermissions
+    } = this.props
+    const permissionCategories = get(
+      permissions,
+      '[0].attributes.permissions',
+      {}
+    )
+    const hasWritePermissions =
+      Object.values(permissionCategories).filter(permissionCategory =>
+        get(permissionCategory, 'verbs', []).includes('POST')
+      ).length > 0
+
     return (
-      <div>
-        <div
-          data-test-id="share-by-link"
-          className={cx(styles['share-bylink-header'], 'u-mt-1', 'u-mb-1')}
-        >
-          <SubTitle>{t(`${documentType}.share.shareByLink.subtitle`)}</SubTitle>
-          {loading && <Spinner color={palette.dodgerBlue} />}
-          {loading && (
-            <span className={styles['share-bylink-header-creating']}>
-              {t(`${documentType}.share.shareByLink.creating`)}
-            </span>
-          )}
-          {checked && <span className={styles['share-bylink-header-dot']} />}
-          {checked && (
-            <button
-              data-test-url={this.props.link}
-              className={styles['share-bylink-header-copybtn']}
-              onClick={this.copyLinkToClipboard}
+      <div ref={this.containerRef}>
+        <div className="u-flex u-flex-row u-flex-justify-between u-flex-items-center">
+          <Text>{t(`${documentType}.share.shareByLink.subtitle`)}</Text>
+          {!checked && (
+            <Button
+              theme="text"
+              onClick={async () => {
+                await this.createShareLink()
+                this.copyLinkToClipboard()
+              }}
+              busy={loading}
             >
-              {t(`${documentType}.share.shareByLink.copy`)}
-            </button>
+              {t(`${documentType}.share.shareByLink.create`)}
+            </Button>
           )}
-          <Toggle
-            id="share-toggle"
-            name="share"
-            checked={checked}
-            disabled={loading}
-            onToggle={this.toggleShareLink}
-          />
         </div>
+        {checked && (
+          <CompositeRow
+            className={'u-ph-0'}
+            primaryText={
+              <Text onClick={this.copyLinkToClipboard} className="u-c-pointer">
+                {t(`${documentType}.share.shareByLink.activated`)}
+              </Text>
+            }
+            secondaryText={
+              <Text
+                className="u-primaryColor u-fz-tiny u-c-pointer"
+                onClick={this.copyLinkToClipboard}
+              >
+                {t(`${documentType}.share.shareByLink.copy`)}
+              </Text>
+            }
+            image={
+              <Circle backgroundColor="var(--silver)">
+                <Icon icon="link" color="var(--charcoalGrey)" />
+              </Circle>
+            }
+            right={
+              <div>
+                <DropdownButton onClick={this.toggleMenu}>
+                  <Text>
+                    {t(
+                      `${documentType}.share.shareByLink.${
+                        hasWritePermissions ? 'rw' : 'ro'
+                      }`
+                    )}
+                  </Text>
+                </DropdownButton>
+                {menuIsOpen && (
+                  <ActionMenu
+                    onClose={this.toggleMenu}
+                    placement="bottom-end"
+                    containerElRef={this.containerRef}
+                  >
+                    <ActionMenuItem
+                      left={
+                        <Radio
+                          name="permissions"
+                          value="ro"
+                          className="u-w-1 u-h-1"
+                          checked={!hasWritePermissions}
+                          readOnly
+                        />
+                      }
+                      onClick={() => {
+                        this.toggleMenu()
+                        onChangePermissions(document, ['GET'])
+                      }}
+                    >
+                      <>
+                        {t(`${documentType}.share.shareByLink.ro`)}
+                        <Caption className="u-mt-half">
+                          {t(`${documentType}.share.shareByLink.desc.ro`)}
+                        </Caption>
+                      </>
+                    </ActionMenuItem>
+                    <ActionMenuItem
+                      left={
+                        <Radio
+                          name="permissions"
+                          value="rw"
+                          className="u-w-1 u-h-1"
+                          checked={hasWritePermissions}
+                          readOnly
+                        />
+                      }
+                      onClick={() => {
+                        this.toggleMenu()
+                        onChangePermissions(document, [
+                          'GET',
+                          'POST',
+                          'PUT',
+                          'PATCH'
+                        ])
+                      }}
+                    >
+                      <>
+                        {t(`${documentType}.share.shareByLink.rw`)}
+                        <Caption className="u-mt-half">
+                          {t(`${documentType}.share.shareByLink.desc.rw`)}
+                        </Caption>
+                      </>
+                    </ActionMenuItem>
+                    <hr />
+                    <ActionMenuItem
+                      left={<Icon icon="trash" color={palette.pomegranate} />}
+                      onClick={() => {
+                        this.toggleMenu()
+                        this.deleteShareLink()
+                      }}
+                    >
+                      <Text className="u-pomegranate">
+                        {t(`${documentType}.share.shareByLink.deactivate`)}
+                      </Text>
+                    </ActionMenuItem>
+                  </ActionMenu>
+                )}
+              </div>
+            }
+          />
+        )}
       </div>
     )
   }
 }
 
 ShareByLink.propTypes = {
+  permissions: PropTypes.array.isRequired,
   checked: PropTypes.bool.isRequired,
   documentType: PropTypes.string.isRequired,
   document: PropTypes.object.isRequired,

--- a/packages/cozy-sharing/src/components/ShareByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareByLink.jsx
@@ -109,4 +109,13 @@ class ShareByLink extends React.Component {
   }
 }
 
+ShareByLink.propTypes = {
+  checked: PropTypes.bool.isRequired,
+  documentType: PropTypes.string.isRequired,
+  document: PropTypes.object.isRequired,
+  link: PropTypes.string.isRequired,
+  onEnable: PropTypes.func.isRequired,
+  onDisable: PropTypes.func.isRequired
+}
+
 export default ShareByLink

--- a/packages/cozy-sharing/src/components/ShareByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareByLink.jsx
@@ -16,6 +16,19 @@ import logger from '../logger'
 
 import palette from 'cozy-ui/transpiled/react/palette'
 
+const checkWritePermissions = permissions => {
+  const permissionCategories = get(
+    permissions,
+    '[0].attributes.permissions',
+    {}
+  )
+  return (
+    Object.values(permissionCategories).filter(permissionCategory =>
+      get(permissionCategory, 'verbs', []).includes('POST')
+    ).length > 0
+  )
+}
+
 class ShareByLink extends React.Component {
   constructor(props) {
     super(props)
@@ -92,15 +105,8 @@ class ShareByLink extends React.Component {
   render() {
     const { loading, menuIsOpen } = this.state
     const { checked, documentType, permissions, t } = this.props
-    const permissionCategories = get(
-      permissions,
-      '[0].attributes.permissions',
-      {}
-    )
-    const hasWritePermissions =
-      Object.values(permissionCategories).filter(permissionCategory =>
-        get(permissionCategory, 'verbs', []).includes('POST')
-      ).length > 0
+
+    const hasWritePermissions = checkWritePermissions(permissions)
 
     return (
       <div ref={this.containerRef}>

--- a/packages/cozy-sharing/src/components/ShareByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareByLink.jsx
@@ -101,9 +101,6 @@ class ShareByLink extends React.Component {
             onToggle={this.toggleShareLink}
           />
         </div>
-        <div className={styles['share-bylink-desc']}>
-          {t(`${documentType}.share.shareByLink.desc`)}
-        </div>
       </div>
     )
   }

--- a/packages/cozy-sharing/src/components/ShareByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareByLink.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import copy from 'copy-text-to-clipboard'
+import { models } from 'cozy-client'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import Text, { Caption } from 'cozy-ui/transpiled/react/Text'
 import Button from 'cozy-ui/transpiled/react/Button'
@@ -16,7 +17,9 @@ import logger from '../logger'
 
 import palette from 'cozy-ui/transpiled/react/palette'
 
-const checkWritePermissions = permissions => {
+const permissionModel = models.permission
+
+const checkIsReadOnlyPermissions = permissions => {
   const permissionCategories = get(
     permissions,
     '[0].attributes.permissions',
@@ -24,7 +27,7 @@ const checkWritePermissions = permissions => {
   )
   return (
     Object.values(permissionCategories).filter(permissionCategory =>
-      get(permissionCategory, 'verbs', []).includes('POST')
+      permissionModel.isReadOnly(permissionCategory)
     ).length > 0
   )
 }
@@ -106,7 +109,7 @@ class ShareByLink extends React.Component {
     const { loading, menuIsOpen } = this.state
     const { checked, documentType, permissions, t } = this.props
 
-    const hasWritePermissions = checkWritePermissions(permissions)
+    const hasReadOnlyPermissions = checkIsReadOnlyPermissions(permissions)
 
     return (
       <div ref={this.containerRef}>
@@ -152,7 +155,7 @@ class ShareByLink extends React.Component {
                   <Text>
                     {t(
                       `${documentType}.share.shareByLink.${
-                        hasWritePermissions ? 'rw' : 'ro'
+                        hasReadOnlyPermissions ? 'ro' : 'rw'
                       }`
                     )}
                   </Text>
@@ -169,7 +172,7 @@ class ShareByLink extends React.Component {
                           name="permissions"
                           value="ro"
                           className="u-w-1 u-h-1"
-                          checked={!hasWritePermissions}
+                          checked={hasReadOnlyPermissions}
                           readOnly
                         />
                       }
@@ -191,7 +194,7 @@ class ShareByLink extends React.Component {
                           name="permissions"
                           value="rw"
                           className="u-w-1 u-h-1"
-                          checked={hasWritePermissions}
+                          checked={!hasReadOnlyPermissions}
                           readOnly
                         />
                       }

--- a/packages/cozy-sharing/src/components/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal.jsx
@@ -24,6 +24,7 @@ export default class ShareModal extends Component {
       groups,
       createContact,
       link,
+      permissions,
       recipients,
       documentType = 'Document',
       needsContactsPermission,
@@ -33,6 +34,7 @@ export default class ShareModal extends Component {
       onShare,
       onRevoke,
       onShareByLink,
+      onUpdateShareLinkPermissions,
       onRevokeLink,
       onRevokeSelf
     } = this.props
@@ -90,11 +92,13 @@ export default class ShareModal extends Component {
             <div className={cx(styles['share-modal-margins'], 'u-pb-1')}>
               <DumbShareByLink
                 document={document}
+                permissions={permissions}
                 documentType={documentType}
                 checked={link !== null}
                 link={link}
                 onEnable={onShareByLink}
                 onDisable={onRevokeLink}
+                onChangePermissions={onUpdateShareLinkPermissions}
               />
               {documentType !== 'Albums' && (
                 <WhoHasAccess
@@ -117,6 +121,7 @@ export default class ShareModal extends Component {
 
 ShareModal.propTypes = {
   document: PropTypes.object.isRequired,
+  permissions: PropTypes.object.isRequired,
   isOwner: PropTypes.bool,
   sharingDesc: PropTypes.string,
   contacts: contactsResponseType.isRequired,
@@ -132,5 +137,6 @@ ShareModal.propTypes = {
   onShare: PropTypes.func.isRequired,
   onRevoke: PropTypes.func.isRequired,
   onShareByLink: PropTypes.func.isRequired,
+  onUpdateShareLinkPermissions: PropTypes.func.isRequired,
   onRevokeLink: PropTypes.func.isRequired
 }

--- a/packages/cozy-sharing/src/components/__snapshots__/Recipient.spec.jsx.snap
+++ b/packages/cozy-sharing/src/components/__snapshots__/Recipient.spec.jsx.snap
@@ -3,7 +3,7 @@
 exports[`Recipient component should match snapshot if isMe and type file 1`] = `
 <AppLike>
   <TestI18n>
-    <I18n
+    <BaseI18n
       defaultLang="en"
       dictRequire={[Function]}
       lang="en"
@@ -150,7 +150,7 @@ exports[`Recipient component should match snapshot if isMe and type file 1`] = `
           </withBreakpoints(MenuAwareMobile)>
         </div>
       </Status>
-    </I18n>
+    </BaseI18n>
   </TestI18n>
 </AppLike>
 `;
@@ -158,7 +158,7 @@ exports[`Recipient component should match snapshot if isMe and type file 1`] = `
 exports[`Recipient component should match snapshot if isMe and type folder 1`] = `
 <AppLike>
   <TestI18n>
-    <I18n
+    <BaseI18n
       defaultLang="en"
       dictRequire={[Function]}
       lang="en"
@@ -305,7 +305,7 @@ exports[`Recipient component should match snapshot if isMe and type folder 1`] =
           </withBreakpoints(MenuAwareMobile)>
         </div>
       </Status>
-    </I18n>
+    </BaseI18n>
   </TestI18n>
 </AppLike>
 `;
@@ -313,7 +313,7 @@ exports[`Recipient component should match snapshot if isMe and type folder 1`] =
 exports[`Recipient component should match snapshot if isOwner 1`] = `
 <AppLike>
   <TestI18n>
-    <I18n
+    <BaseI18n
       defaultLang="en"
       dictRequire={[Function]}
       lang="en"
@@ -460,7 +460,7 @@ exports[`Recipient component should match snapshot if isOwner 1`] = `
           </withBreakpoints(MenuAwareMobile)>
         </div>
       </Status>
-    </I18n>
+    </BaseI18n>
   </TestI18n>
 </AppLike>
 `;
@@ -468,7 +468,7 @@ exports[`Recipient component should match snapshot if isOwner 1`] = `
 exports[`Recipient component should render if isMe  1`] = `
 <AppLike>
   <TestI18n>
-    <I18n
+    <BaseI18n
       defaultLang="en"
       dictRequire={[Function]}
       lang="en"
@@ -614,7 +614,7 @@ exports[`Recipient component should render if isMe  1`] = `
           </withBreakpoints(MenuAwareMobile)>
         </div>
       </Status>
-    </I18n>
+    </BaseI18n>
   </TestI18n>
 </AppLike>
 `;

--- a/packages/cozy-sharing/src/components/__snapshots__/SharedStatus.spec.js.snap
+++ b/packages/cozy-sharing/src/components/__snapshots__/SharedStatus.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`SharedStatus component should display the link if there is a link 1`] = `
 <AppLike>
   <TestI18n>
-    <I18n
+    <BaseI18n
       defaultLang="en"
       dictRequire={[Function]}
       lang="en"
@@ -83,7 +83,7 @@ exports[`SharedStatus component should display the link if there is a link 1`] =
           </SharingTooltip>
         </span>
       </SharedStatus>
-    </I18n>
+    </BaseI18n>
   </TestI18n>
 </AppLike>
 `;
@@ -91,7 +91,7 @@ exports[`SharedStatus component should display the link if there is a link 1`] =
 exports[`SharedStatus component should have the right display if there is several recipients 1`] = `
 <AppLike>
   <TestI18n>
-    <I18n
+    <BaseI18n
       defaultLang="en"
       dictRequire={[Function]}
       lang="en"
@@ -169,7 +169,7 @@ exports[`SharedStatus component should have the right display if there is severa
           </SharingTooltip>
         </span>
       </SharedStatus>
-    </I18n>
+    </BaseI18n>
   </TestI18n>
 </AppLike>
 `;
@@ -177,7 +177,7 @@ exports[`SharedStatus component should have the right display if there is severa
 exports[`SharedStatus component should just render a span if no sharing 1`] = `
 <AppLike>
   <TestI18n>
-    <I18n
+    <BaseI18n
       defaultLang="en"
       dictRequire={[Function]}
       lang="en"
@@ -190,7 +190,7 @@ exports[`SharedStatus component should just render a span if no sharing 1`] = `
           className="shared-status"
         />
       </SharedStatus>
-    </I18n>
+    </BaseI18n>
   </TestI18n>
 </AppLike>
 `;

--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { getTracker } from 'cozy-ui/transpiled/react/helpers/tracker'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 
 import reducer, {
   receiveSharings,
@@ -40,7 +41,7 @@ import { RecipientsAvatars } from './components/Recipient'
 import { default as DumbSharedStatus } from './components/SharedStatus'
 import { withClient } from 'cozy-client'
 
-export { default as withLocales } from './withLocales'
+import withLocales from './withLocales'
 
 import { fetchNextPermissions } from './fetchNextPermissions'
 const track = (document, action) => {
@@ -247,7 +248,9 @@ export class SharingProvider extends Component {
     )
   }
 }
+
 export default withClient(SharingProvider)
+
 export const SharedDocument = ({ docId, children }) => (
   <SharingContext.Consumer>
     {({
@@ -274,24 +277,26 @@ export const SharedDocument = ({ docId, children }) => (
   </SharingContext.Consumer>
 )
 
-export const SharedStatus = ({ docId, className, noSharedClassName }) => (
-  <SharingContext.Consumer>
-    {({ byDocId, getRecipients, getSharingLink } = {}) =>
-      !byDocId || !byDocId[docId] ? (
-        <span className={className + ' ' + noSharedClassName}>—</span>
-      ) : (
-        <DumbSharedStatus
-          className={className}
-          recipients={getRecipients(docId)}
-          docId={docId}
-          link={getSharingLink(docId) !== null}
-        />
-      )
-    }
-  </SharingContext.Consumer>
+export const SharedStatus = withLocales(
+  ({ docId, className, noSharedClassName }) => (
+    <SharingContext.Consumer>
+      {({ byDocId, getRecipients, getSharingLink } = {}) =>
+        !byDocId || !byDocId[docId] ? (
+          <span className={className + ' ' + noSharedClassName}>—</span>
+        ) : (
+          <DumbSharedStatus
+            className={className}
+            recipients={getRecipients(docId)}
+            docId={docId}
+            link={getSharingLink(docId) !== null}
+          />
+        )
+      }
+    </SharingContext.Consumer>
+  )
 )
 
-export const SharedBadge = ({ docId, ...rest }) => (
+export const SharedBadge = withLocales(({ docId, ...rest }) => (
   <SharingContext.Consumer>
     {({ byDocId, isOwner } = {}) =>
       !byDocId || !byDocId[docId] ? null : (
@@ -299,9 +304,9 @@ export const SharedBadge = ({ docId, ...rest }) => (
       )
     }
   </SharingContext.Consumer>
-)
+))
 
-export const SharedRecipients = ({ docId, onClick, ...rest }) => (
+export const SharedRecipients = withLocales(({ docId, onClick, ...rest }) => (
   <SharingContext.Consumer>
     {({ byDocId, getRecipients, getSharingLink } = {}) =>
       !byDocId || !byDocId[docId] ? null : (
@@ -314,9 +319,9 @@ export const SharedRecipients = ({ docId, onClick, ...rest }) => (
       )
     }
   </SharingContext.Consumer>
-)
+))
 
-export const SharedRecipientsList = ({ docId, ...rest }) => (
+export const SharedRecipientsList = withLocales(({ docId, ...rest }) => (
   <SharingContext.Consumer>
     {({ byDocId, isOwner, getRecipients } = {}) =>
       !byDocId || !byDocId[docId] || !isOwner(docId) ? null : (
@@ -327,26 +332,28 @@ export const SharedRecipientsList = ({ docId, ...rest }) => (
       )
     }
   </SharingContext.Consumer>
-)
+))
 
-export const ShareButton = ({ docId, ...rest }, { t }) => (
-  <SharingContext.Consumer>
-    {({ byDocId, documentType, isOwner }) =>
-      !byDocId[docId] ? (
-        <DumbShareButton label={t(`${documentType}.share.cta`)} {...rest} />
-      ) : isOwner(docId) ? (
-        <SharedByMeButton
-          label={t(`${documentType}.share.sharedByMe`)}
-          {...rest}
-        />
-      ) : (
-        <SharedWithMeButton
-          label={t(`${documentType}.share.sharedWithMe`)}
-          {...rest}
-        />
-      )
-    }
-  </SharingContext.Consumer>
+export const ShareButton = withLocales(
+  translate()(({ t, docId, ...rest }) => (
+    <SharingContext.Consumer>
+      {({ byDocId, documentType, isOwner }) => {
+        return !byDocId[docId] ? (
+          <DumbShareButton label={t(`${documentType}.share.cta`)} {...rest} />
+        ) : isOwner(docId) ? (
+          <SharedByMeButton
+            label={t(`${documentType}.share.sharedByMe`)}
+            {...rest}
+          />
+        ) : (
+          <SharedWithMeButton
+            label={t(`${documentType}.share.sharedWithMe`)}
+            {...rest}
+          />
+        )
+      }}
+    </SharingContext.Consumer>
+  ))
 )
 
 ShareButton.contextTypes = {
@@ -375,7 +382,7 @@ const SharingModal = ({ document, ...rest }) => (
   </SharingContext.Consumer>
 )
 
-export const ShareModal = ({ document, ...rest }) => (
+export const ShareModal = withLocales(({ document, ...rest }) => (
   <SharingContext.Consumer>
     {({ byDocId, isOwner, canReshare }) =>
       !byDocId[document.id] ||
@@ -387,7 +394,8 @@ export const ShareModal = ({ document, ...rest }) => (
       )
     }
   </SharingContext.Consumer>
-)
+))
+
 /**
  * Expose a refresh method
  */
@@ -401,4 +409,4 @@ export const RefreshableSharings = ({ children }) => (
   </SharingContext.Consumer>
 )
 
-export { SharingContext }
+export { SharingContext, withLocales }

--- a/packages/cozy-sharing/src/share.styl
+++ b/packages/cozy-sharing/src/share.styl
@@ -39,10 +39,6 @@
         border  0
         padding 0
 
-.share-bylink-desc
-    color     var(--coolGrey)
-    font-size .875rem
-
 @media (max-width 32em)
     .share-bylink-desc
         width 80%

--- a/packages/cozy-sharing/src/state.js
+++ b/packages/cozy-sharing/src/state.js
@@ -6,6 +6,7 @@ const UPDATE_SHARING = 'UPDATE_SHARING'
 const REVOKE_RECIPIENT = 'REVOKE_RECIPIENT'
 const REVOKE_SELF = 'REVOKE_SELF'
 const ADD_SHARING_LINK = 'ADD_SHARING_LINK'
+const UPDATE_SHARING_LINK = 'UPDATE_SHARING_LINK'
 const REVOKE_SHARING_LINK = 'REVOKE_SHARING_LINK'
 const RECEIVE_PATHS = 'RECEIVE_PATHS'
 
@@ -61,6 +62,7 @@ export const revokeRecipient = (sharing, index, path) => {
 }
 export const revokeSelf = sharing => ({ type: REVOKE_SELF, sharing })
 export const addSharingLink = data => ({ type: ADD_SHARING_LINK, data })
+export const updateSharingLink = data => ({ type: UPDATE_SHARING_LINK, data })
 export const revokeSharingLink = permissions => ({
   type: REVOKE_SHARING_LINK,
   permissions
@@ -176,6 +178,8 @@ const permissions = (state = [], action) => {
       } else {
         return [...state, ...action.data]
       }
+    case UPDATE_SHARING_LINK:
+      return state.map(p => (p.id === action.data.id ? action.data : p))
     case REVOKE_SHARING_LINK:
       // eslint-disable-next-line no-case-declarations
       const permIds = action.permissions.map(p => p.id)

--- a/packages/cozy-sharing/src/state.spec.js
+++ b/packages/cozy-sharing/src/state.spec.js
@@ -2,6 +2,7 @@ import reducer, {
   receiveSharings,
   addSharing,
   addSharingLink,
+  updateSharingLink,
   revokeSharingLink,
   getRecipients,
   revokeRecipient,
@@ -172,6 +173,20 @@ describe('Sharing state', () => {
       folder_2: { sharings: [SHARING_2.id], permissions: [PERM_2.id] }
     })
     expect(newState.permissions).toEqual([PERM_1, PERM_2])
+  })
+
+  it('should update a sharing link', () => {
+    const initialState = reducer(
+      undefined,
+      receiveSharings({
+        permissions: [PERM_1, PERM_2]
+      })
+    )
+    const updatedPerm = { ...PERM_1 }
+    updatedPerm.attributes.permissions.rule0.verbs = ['GET', 'POST']
+
+    const newState = reducer(initialState, updateSharingLink(updatedPerm))
+    expect(newState.permissions).toEqual([updatedPerm, PERM_2])
   })
 
   it('should index an array of sharing links', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4650,21 +4650,22 @@ cozy-client@6.66.0:
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
-cozy-client@^10.4.0:
-  version "10.4.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-10.4.0.tgz#d57384a7f5a4b84a7499b525b5a962c823627217"
-  integrity sha512-CUar2CDYusbRiUXu7KqQex7mFxUzD+QsM5E07kyNYavLYmFQZ/l7tcTzM7GIjjT4hxUaGrwIDzNs3AH1RND5lA==
+cozy-client@^13.4.2:
+  version "13.4.2"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-13.4.2.tgz#b495c4da97db2cc97a99fce341ef4d0f037ebe3c"
+  integrity sha512-r2/RGznnov0VmSAk7onnc75UK9cbmNthGwkASOlCnuDZpSYdOxfcCzjIcYQOmEQFuWbOAQzzFMqhju7FYzwtyA==
   dependencies:
     btoa "^1.2.1"
     cozy-device-helper "^1.7.3"
     cozy-logger "^1.6.0"
-    cozy-stack-client "^10.4.0"
+    cozy-stack-client "^13.4.2"
     isomorphic-fetch "^2.2.1"
     lodash "^4.17.13"
     microee "^0.0.6"
-    opn "^6.0.0"
+    minilog "https://github.com/cozy/minilog.git#master"
+    open "^7.0.2"
     prop-types "^15.6.2"
-    react-redux "^5.0.7"
+    react-redux "^7.2.0"
     redux "^3.7.2"
     redux-thunk "^2.3.0"
     server-destroy "^1.0.1"
@@ -4745,19 +4746,19 @@ cozy-stack-client@6.66.0, cozy-stack-client@^6.66.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^10.4.0:
-  version "10.4.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-10.4.0.tgz#5fc104eb881982c42feae126c2cb6de58e416f9f"
-  integrity sha512-VoiztT2NXaNQYOtp2w4QVQh9Y05ikJ4ityIOATY9mNjG6Ah+cs42P0SxBw9rcG6J6/hRI6gZqeo95qFwixDdMg==
+cozy-stack-client@^10.7.0:
+  version "10.7.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-10.7.0.tgz#2f9a886af423abe9111d6c1524104c29d2ed517f"
+  integrity sha512-O2z9sFwDhcbn/rZJr0f2BL3CAc2L37QMzmIlQXY/70x/SqkSd+zyFhgwfYImqlwYsByf6Mo6qwtpwv5goRj9Ig==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^10.7.0:
-  version "10.7.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-10.7.0.tgz#2f9a886af423abe9111d6c1524104c29d2ed517f"
-  integrity sha512-O2z9sFwDhcbn/rZJr0f2BL3CAc2L37QMzmIlQXY/70x/SqkSd+zyFhgwfYImqlwYsByf6Mo6qwtpwv5goRj9Ig==
+cozy-stack-client@^13.4.2:
+  version "13.4.2"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-13.4.2.tgz#02f0ae98568fe9b90bb8bac84dda80f345bac797"
+  integrity sha512-9htrdXaIMfRk4mzsGnaSRk4/KsdJ6TvnQDC9n6AJtQ2wF9F/GG3p4QZc9sXO/9i9jhhK6kfbUp8UdDu9GZGC8w==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
@@ -4856,6 +4857,24 @@ cozy-ui@^32.0.1:
   version "32.0.1"
   resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-32.0.1.tgz#b03769c982dda09169785a0f0abaf81032ac9775"
   integrity sha512-EeMHZZAxS0Ep6QldLkEDgkRNgB6otkBMyXRlLvHiP+p7n3thy56qDjwVKHi97CrbmMGsJ5fdjkYS2Tmgg3284g==
+  dependencies:
+    "@babel/runtime" "^7.3.4"
+    body-scroll-lock "^2.5.8"
+    classnames "^2.2.5"
+    date-fns "^1.28.5"
+    hammerjs "^2.0.8"
+    node-polyglot "^2.2.2"
+    normalize.css "^7.0.0"
+    react-hot-loader "^4.3.11"
+    react-markdown "^4.0.8"
+    react-pdf "^4.0.5"
+    react-select "2.2.0"
+    react-swipeable-views "0.13.3"
+
+cozy-ui@^35.1.0:
+  version "35.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.1.0.tgz#df5dd3e601c8d2b73860b03e6924ee986c7ea477"
+  integrity sha512-F9husNZbFFfI6LzMi9nZpub7RyYdbsK5mQ1DPfxRRGZREF0ujNPoprIuEznKA2tG8KZYj5Ry+xZqeBh1Kxp9AA==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"
@@ -10119,13 +10138,6 @@ mini-html-webpack-plugin@^0.2.3:
   dependencies:
     webpack-sources "^1.1.0"
 
-"minilog@git+https://github.com/cozy/minilog.git#master":
-  version "3.1.0"
-  uid f01f7d9dfe20981177dd34b9662c2f077d818f82
-  resolved "git+https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
-  dependencies:
-    microee "0.0.6"
-
 "minilog@https://github.com/cozy/minilog.git#master":
   version "3.1.0"
   resolved "https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
@@ -11221,13 +11233,6 @@ opn@5.2.0:
 opn@^5.1.0, opn@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
-  dependencies:
-    is-wsl "^1.1.0"
-
-opn@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/opn/-/opn-6.0.0.tgz#3c5b0db676d5f97da1233d1ed42d182bc5a27d2d"
-  integrity sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==
   dependencies:
     is-wsl "^1.1.0"
 
@@ -13135,6 +13140,17 @@ react-redux@^5.0.7:
     prop-types "^15.6.1"
     react-is "^16.6.0"
     react-lifecycles-compat "^3.0.0"
+
+react-redux@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.0.tgz#f970f62192b3981642fec46fd0db18a074fe879d"
+  integrity sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    hoist-non-react-statics "^3.3.0"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
 
 react-router-dom@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
This PR updates the link sharing UI. Instead of a simple toggle, it's now a 2 step process:

- A button to activate the sharing
- An ActionMenu to change the permissions

<img width="330" alt="Capture d'écran 2020-04-15 10 00 22" src="https://user-images.githubusercontent.com/2261445/79313059-1529a600-7f00-11ea-82e2-c382903163a9.png">
<img width="331" alt="Capture d'écran 2020-04-15 10 01 06" src="https://user-images.githubusercontent.com/2261445/79313066-15c23c80-7f00-11ea-8dec-02b15156894a.png">

