### PR TITLE
fix: Upgrade to latest cozy-ui

### DIFF
--- a/packages/cozy-scanner/package.json
+++ b/packages/cozy-scanner/package.json
@@ -30,7 +30,7 @@
     "babel-jest": "^24.9.0",
     "babel-preset-cozy-app": "^1.8.1",
     "cozy-doctypes": "1.67.0",
-    "cozy-ui": "^32.0.1",
+    "cozy-ui": "^35.13.0",
     "jest": "24.1.0",
     "jest-dom": "^4.0.0",
     "mockdate": "^2.0.5",
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "cozy-client": "7.14.0",
     "cozy-doctypes": "1.67.0",
-    "cozy-ui": "^32"
+    "cozy-ui": "^35.13.0"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/packages/cozy-scanner/src/DocumentCategory.jsx
+++ b/packages/cozy-scanner/src/DocumentCategory.jsx
@@ -33,12 +33,12 @@ class DocumentCategory extends Component {
     isMenuDisplayed: false
   }
 
-  toggleMenu() {
-    this.setState(prevState => {
-      return {
-        isMenuDisplayed: !prevState.isMenuDisplayed
-      }
-    })
+  openMenu = () => {
+    this.setState({ isMenuDisplayed: true })
+  }
+
+  closeMenu = () => {
+    this.setState({ isMenuDisplayed: false })
   }
 
   onSelect = item => {
@@ -50,7 +50,7 @@ class DocumentCategory extends Component {
     const { category, isSelected, selectedItem, items, t } = this.props
     return (
       <>
-        <GridItem onClick={() => this.toggleMenu()}>
+        <GridItem onClick={this.openMenu}>
           <CategoryGridItem
             isSelected={isSelected}
             icon={category.icon}
@@ -62,7 +62,7 @@ class DocumentCategory extends Component {
         </GridItem>
 
         {isMenuDisplayed && (
-          <ActionMenu onClose={() => this.toggleMenu()}>
+          <ActionMenu onClose={this.closeMenu} autoclose>
             <ActionMenuHeader>
               <Media>
                 <Img>
@@ -99,7 +99,6 @@ class DocumentCategory extends Component {
                       categoryLabel: category.label,
                       itemId: item.id
                     })
-                    this.toggleMenu()
                   }}
                   key={item.id}
                 >

--- a/packages/cozy-scanner/src/__snapshots__/DocumentCategory.spec.jsx.snap
+++ b/packages/cozy-scanner/src/__snapshots__/DocumentCategory.spec.jsx.snap
@@ -112,7 +112,7 @@ exports[`DocumentCategory should match snapshot if selected and icon 2`] = `
       class="styles__c-actionmenu___22Fp1 styles__c-actionmenu--inline___1SXZa"
     >
       <div
-        class="styles__media___cSJMp styles__c-actionmenu-item___gODqd"
+        class="styles__media___cSJMp styles__media--top___K9w0I styles__c-actionmenu-item___gODqd"
       >
         <div
           class="styles__bd___1Uv-F u-mh-1"
@@ -121,7 +121,7 @@ exports[`DocumentCategory should match snapshot if selected and icon 2`] = `
         </div>
       </div>
       <div
-        class="styles__media___cSJMp styles__c-actionmenu-item___gODqd"
+        class="styles__media___cSJMp styles__media--top___K9w0I styles__c-actionmenu-item___gODqd"
       >
         <div
           class="styles__bd___1Uv-F u-mh-1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4853,10 +4853,10 @@ cozy-ui@30.7.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@^32.0.1:
-  version "32.0.1"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-32.0.1.tgz#b03769c982dda09169785a0f0abaf81032ac9775"
-  integrity sha512-EeMHZZAxS0Ep6QldLkEDgkRNgB6otkBMyXRlLvHiP+p7n3thy56qDjwVKHi97CrbmMGsJ5fdjkYS2Tmgg3284g==
+cozy-ui@^35.1.0:
+  version "35.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.1.0.tgz#df5dd3e601c8d2b73860b03e6924ee986c7ea477"
+  integrity sha512-F9husNZbFFfI6LzMi9nZpub7RyYdbsK5mQ1DPfxRRGZREF0ujNPoprIuEznKA2tG8KZYj5Ry+xZqeBh1Kxp9AA==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"
@@ -4871,10 +4871,10 @@ cozy-ui@^32.0.1:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@^35.1.0:
-  version "35.1.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.1.0.tgz#df5dd3e601c8d2b73860b03e6924ee986c7ea477"
-  integrity sha512-F9husNZbFFfI6LzMi9nZpub7RyYdbsK5mQ1DPfxRRGZREF0ujNPoprIuEznKA2tG8KZYj5Ry+xZqeBh1Kxp9AA==
+cozy-ui@^35.13.0:
+  version "35.19.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.19.0.tgz#cec3cdc74d1f5067c35210996f60302b726ff6ec"
+  integrity sha512-UsWHYVsQRZB8VAxvAc9kCaSlB08Fm0iG/kNPbTlYozchl1x04T1KeVsCM2DfHrryhJyRZ0iLGfMSzGqWOuovyg==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"


### PR DESCRIPTION
This PR updates the scanner ActionMenu to use the autoclosing feature from https://github.com/cozy/cozy-ui/pull/1452.

The existing test is literally about opening and closing the menu so I'm not sure what to add, but let me know if you have suggestions!