### PR TITLE
fix: No special case for sharing notes

### DIFF
--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -205,15 +205,10 @@ export class SharingProvider extends Component {
   }
 
   shareByLink = async document => {
-    const { documentType } = this.state
-    // Notes should be shared with write permissions
-    // so that the recipient may edit the content of the note
-    const options =
-      documentType === 'Notes' ? { verbs: ['GET', 'POST', 'PUT', 'PATCH'] } : {}
     trackSharingByLink(document)
     const resp = await this.props.client
       .collection('io.cozy.permissions')
-      .createSharingLink(document, options)
+      .createSharingLink(document)
     this.dispatch(addSharingLink(resp.data))
     return resp
   }


### PR DESCRIPTION
This commit essentially reverts 300e88dab97fe95dd63fde2a667cd444b3df11ed. The notes app is about to get an upgrade where it will behave the same as drive, eg. the user can chose when sharing by link whether the sharing should be read-only or not.