### PR TITLE
feat: Remove harvest.bi-konnector-policy flag

### DIFF
--- a/packages/cozy-harvest-lib/src/cli/cli.js
+++ b/packages/cozy-harvest-lib/src/cli/cli.js
@@ -9,12 +9,9 @@ import ConnectionFlow, {
   UPDATE_EVENT
 } from '../models/ConnectionFlow'
 import minilog from 'minilog'
-import flag from 'cozy-flags'
 import logger from '../logger'
 import { multiPrompt } from './prompt'
 import assert from '../assert'
-
-flag('bi-konnector-policy', true)
 
 minilog.enable()
 

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.spec.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.spec.js
@@ -18,14 +18,6 @@ jest.mock('../../src/connections/files', () => ({
   createDirectoryByPath: jest.fn()
 }))
 
-jest.mock('cozy-flags', () => name => {
-  if (name === 'harvest.bi-konnector-policy') {
-    return true
-  } else {
-    return false
-  }
-})
-
 jest.mock('../../src/services/budget-insight', () => {
   const originalBudgetInsight = jest.requireActual(
     '../../src/services/budget-insight'

--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -19,7 +19,6 @@ import biPublicKeyProd from './bi-public-key-prod.json'
 import { KonnectorJobError } from '../helpers/konnectors'
 import { LOGIN_SUCCESS_EVENT } from '../models/ConnectionFlow'
 import harvestLogger from '../logger'
-import flag from 'cozy-flags'
 
 const DECOUPLED_ERROR = 'decoupled'
 const ADDITIONAL_INFORMATION_NEEDED_ERROR = 'additionalInformationNeeded'
@@ -90,9 +89,6 @@ export const getBIConfigForCozyURL = url => {
 }
 
 export const isBudgetInsightConnector = konnector => {
-  if (!flag('harvest.bi-konnector-policy')) {
-    return false
-  }
   return (
     konnector.partnership &&
     konnector.partnership.domain.includes('budget-insight')

--- a/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
+++ b/packages/cozy-harvest-lib/test/components/TriggerManager.spec.js
@@ -8,14 +8,6 @@ import fixtures from '../../test/fixtures'
 import ConnectionFlow from '../../src/models/ConnectionFlow'
 import CozyClient from 'cozy-client'
 
-jest.mock('cozy-flags', () => name => {
-  if (name === 'bi-konnector-policy') {
-    return true
-  } else {
-    return false
-  }
-})
-
 jest.mock('cozy-keys-lib')
 jest.mock('cozy-ui/transpiled/react/utils/color')
 jest.mock('cozy-doctypes', () => {


### PR DESCRIPTION
It has been set to true for a long time in the home and we do not
need the rollback capability anymore.