### PR TITLE
fix(Harvest): Change prod/sandbox environment detection

### DIFF
--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -63,15 +63,23 @@ const getBIModeFromCozyURL = rawCozyURL => {
     .split('.')
     .slice(-2)
     .join('.')
+    .split(':')
+    .shift()
   switch (domain) {
-    case 'cozy.rocks':
-    case 'mycozy.cloud':
-      return 'prod'
+    case 'cozy.tools':
+    case 'cozy.wtf':
+    case 'cozy.blue':
     case 'cozy.works':
+    case 'cozy.red':
+    case 'cozy.company':
+    case 'cozy.solutions':
+    case 'toutatice.fr':
+    case 'cozymaif.cloud':
+    case 'cozy-maif-int.fr':
     case 'cozy.dev':
       return 'dev'
     default:
-      return 'dev'
+      return 'prod'
   }
 }
 

--- a/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
@@ -70,6 +70,7 @@ describe('getBIConfigForCozyURL', () => {
     expect(getBIConfigForCozyURL('https://test.cozy.works').mode).toBe('dev')
     expect(getBIConfigForCozyURL('https://test.cozy.rocks').mode).toBe('prod')
     expect(getBIConfigForCozyURL('https://test.mycozy.cloud').mode).toBe('prod')
+    expect(getBIConfigForCozyURL('https://test.mydomain.net').mode).toBe('prod')
   })
 })
 


### PR DESCRIPTION
We previously detected production environment with production/staging
domains (mycozy.cloud, cozy.rocks) and defaulted to sandbox.
The detection is now inverted, we detect dev,int domains and set them
to sandbox and default to production.
This is a temporary fix, waiting for an api allowing an app to
properly detect it's environment.