### PR TITLE
feat: Add flag garbage collection

### DIFF
--- a/packages/cozy-flags/src/flag.js
+++ b/packages/cozy-flags/src/flag.js
@@ -157,6 +157,18 @@ class FlagClientPlugin {
   }
 }
 
+/** Reset flags, keeping only those not set to null */
+export const garbageCollect = () => {
+  const notNullFlags = flag
+    .list()
+    .map(name => [name, flag(name)])
+    .filter(x => x[1] !== null)
+    .map(x => x[0])
+  flag.reset()
+  for (const flagName of notNullFlags) {
+    flag(flagName, true)
+  }
+}
 FlagClientPlugin.pluginName = 'flags'
 
 flag.store = store
@@ -167,5 +179,6 @@ flag.initializeFromRemote = initializeFromRemote
 flag.initializeFromDOM = initializeFromDOM
 flag.initialize = initialize
 flag.plugin = FlagClientPlugin
+flag.garbageCollect = garbageCollect
 
 export default flag

--- a/packages/cozy-flags/src/tests.js
+++ b/packages/cozy-flags/src/tests.js
@@ -165,5 +165,14 @@ export default function testFlagAPI(flag) {
       })
       expect(flag('bar_config')).toEqual({ qux: 'quux' })
     })
+
+    it('should garbage collect flags', () => {
+      flag('a', true)
+      flag('b', true)
+      expect(flag.list()).toEqual(['a', 'b'])
+      flag('a', null)
+      flag.garbageCollect()
+      expect(flag.list()).toEqual(['b'])
+    })
   })
 }


### PR DESCRIPTION
Moved from banks.

Calling `flag.garbageCollect` will remove all the flag that
have been set to null.