### PR TITLE
fix: Don't load data if the client isn't ready

### DIFF
--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -30,7 +30,7 @@
     "copy-text-to-clipboard": "^2.1.1",
     "cozy-device-helper": "^1.9.2",
     "cozy-doctypes": "^1.72.2",
-    "cozy-realtime": "^3.8.1",
+    "cozy-realtime": "^3.9.0",
     "lodash": "^4.17.15",
     "minilog": "https://github.com/cozy/minilog.git#master",
     "react-autosuggest": "^9.4.3",

--- a/packages/cozy-sharing/src/index.spec.jsx
+++ b/packages/cozy-sharing/src/index.spec.jsx
@@ -20,6 +20,38 @@ const AppWrapper = ({ children, client }) => {
   )
 }
 
+describe('SharingProvider', () => {
+  const client = createMockClient({})
+
+  client.plugins.realtime = {
+    subscribe: jest.fn(),
+    unsubscribe: jest.fn()
+  }
+  client.collection = jest.fn(() => client)
+  client.isLogged = true
+
+  afterEach(() => jest.resetAllMocks())
+
+  it('loads data on mount', () => {
+    mount(<AppWrapper client={client} />)
+
+    expect(client.plugins.realtime.subscribe).toHaveBeenCalled()
+    expect(client.collection).toHaveBeenCalledWith('io.cozy.sharings')
+  })
+
+  it('loads nothing when the client is not logged in', () => {
+    client.isLogged = false
+    mount(<AppWrapper client={client} />)
+
+    expect(client.plugins.realtime.subscribe).not.toHaveBeenCalled()
+    expect(client.collection).not.toHaveBeenCalledWith('io.cozy.sharings')
+
+    client.emit('plugin:realtime:login')
+    expect(client.plugins.realtime.subscribe).toHaveBeenCalled()
+    expect(client.collection).toHaveBeenCalledWith('io.cozy.sharings')
+  })
+})
+
 describe('hasWriteAccess', () => {
   it('tells if a doc is writtable', () => {
     const client = createMockClient({})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5395,6 +5395,14 @@ cozy-keys-lib@3.1.1:
     tldjs "^2.3.1"
     zxcvbn "^4.4.2"
 
+cozy-realtime@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-3.9.0.tgz#4aa09ac74c973b720d0249ad1c2173ed123b28db"
+  integrity sha512-5TqHDrxKUyNIAxrOb/DlTkhMJj7UnsbKmAriOq6359HjXVlvIUfVMSght44xik3KLQ8inUSmF+1TAFeKe9tBGA==
+  dependencies:
+    cozy-device-helper "^1.9.2"
+    minilog "https://github.com/cozy/minilog.git#master"
+
 cozy-stack-client@6.66.0, cozy-stack-client@^6.66.0:
   version "6.66.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-6.66.0.tgz#ba217c2d615dd31a9f40ae131644c68c4108b101"
@@ -11417,6 +11425,13 @@ mini-html-webpack-plugin@^0.2.3:
   resolved "https://registry.yarnpkg.com/mini-html-webpack-plugin/-/mini-html-webpack-plugin-0.2.3.tgz#2dfbdc3f35f6ae03864a608808381f8137311ea0"
   dependencies:
     webpack-sources "^1.1.0"
+
+"minilog@git+https://github.com/cozy/minilog.git#master":
+  version "3.1.0"
+  uid f01f7d9dfe20981177dd34b9662c2f077d818f82
+  resolved "git+https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
+  dependencies:
+    microee "0.0.6"
 
 "minilog@https://github.com/cozy/minilog.git#master":
   version "3.1.0"


### PR DESCRIPTION
The SharingProvider loads data on `componentDidMount` — this may lead to errors when cozy-client is not connected, for example on a mobile app.