### PR TITLE
fix: Better error message when using a logged off client with realtime

### DIFF
--- a/packages/cozy-realtime/src/RealtimePlugin.js
+++ b/packages/cozy-realtime/src/RealtimePlugin.js
@@ -37,10 +37,18 @@ class RealtimePlugin {
     this.realtime = null
   }
 
+  checkRealtimeInstance() {
+    if (!this.realtime)
+      throw new Error(
+        'Unable to use realtime while cozy-client is not logged in'
+      )
+  }
+
   /**
    * @see CozyRealtime.subscribe
    */
   subscribe(...args) {
+    this.checkRealtimeInstance()
     this.realtime.subscribe(...args)
   }
 
@@ -48,6 +56,7 @@ class RealtimePlugin {
    * @see CozyRealtime.unsubscribe
    */
   unsubscribe(...args) {
+    this.checkRealtimeInstance()
     this.realtime.unsubscribe(...args)
   }
 
@@ -55,6 +64,7 @@ class RealtimePlugin {
    * @see CozyRealtime.unsubscribeAll
    */
   unsubscribeAll() {
+    this.checkRealtimeInstance()
     this.realtime.unsubscribeAll()
   }
 }

--- a/packages/cozy-realtime/src/RealtimePlugin.spec.js
+++ b/packages/cozy-realtime/src/RealtimePlugin.spec.js
@@ -35,3 +35,29 @@ it('should login/logout correctly', async () => {
   await client.logout()
   expect(client.plugins.realtime.realtime).toBeNull()
 })
+
+it('throws user friendly errors when trying to use the realtime while logged out', async () => {
+  const errorMessage =
+    'Unable to use realtime while cozy-client is not logged in'
+  client = new CozyClient({})
+  client.registerPlugin(RealtimePlugin)
+  expect(() => client.plugins.realtime.subscribe()).toThrowError(errorMessage)
+  expect(() => client.plugins.realtime.unsubscribe()).toThrowError(errorMessage)
+  expect(() => client.plugins.realtime.unsubscribeAll()).toThrowError(
+    errorMessage
+  )
+
+  await client.login({
+    uri: 'http://cozy.tools:8080',
+    token: 'fake-token'
+  })
+  expect(() => client.plugins.realtime.subscribe()).not.toThrowError(
+    errorMessage
+  )
+  expect(() => client.plugins.realtime.unsubscribe()).not.toThrowError(
+    errorMessage
+  )
+  expect(() => client.plugins.realtime.unsubscribeAll()).not.toThrowError(
+    errorMessage
+  )
+})


### PR DESCRIPTION
When calling `cozy.plugins.realtime.subscribe()` while cozy-client is **not** logged in, a misleading error was produced — "Cannot call subscribe on null" or something like that, but `cozy.plugins.realtime` was not null so it was quite confusing. With this PR we still throw an error, but makes it clear what the actual problem is.