### PR TITLE
feat: Emit events when realtime is ready

### DIFF
--- a/packages/cozy-flags/src/flag.js
+++ b/packages/cozy-flags/src/flag.js
@@ -150,10 +150,12 @@ class FlagClientPlugin {
   async handleLogin() {
     await flag.initialize(this.client)
     this.resolveInitializing()
+    this.client.emit('plugin:flag:login')
   }
 
   async handleLogout() {
     flag.reset()
+    this.client.emit('plugin:flag:logout')
   }
 }
 

--- a/packages/cozy-flags/src/tests.js
+++ b/packages/cozy-flags/src/tests.js
@@ -105,12 +105,15 @@ export default function testFlagAPI(flag) {
         const { client } = setup()
         client.isLogged = true
         client.registerPlugin(flag.plugin)
+        const onLogin = jest.fn()
+        client.on('plugin:flag:login', onLogin)
         await client.plugins.flags.initializing
         expect(flag('has_feature1')).toBe(true)
         expect(flag('has_feature2')).toBe(false)
         expect(flag('from_remote')).toBe(true)
         expect(flag('number_of_foos')).toBe(10)
         expect(flag('bar_config')).toEqual({ qux: 'quux' })
+        expect(onLogin).toHaveBeenCalled()
       })
     })
 

--- a/packages/cozy-realtime/src/RealtimePlugin.js
+++ b/packages/cozy-realtime/src/RealtimePlugin.js
@@ -30,11 +30,13 @@ class RealtimePlugin {
     this.realtime = new CozyRealtime({
       client: this.client
     })
+    this.client.emit('plugin:realtime:login')
   }
 
   handleLogout() {
     this.unsubscribeAll()
     this.realtime = null
+    this.client.emit('plugin:realtime:logout')
   }
 
   checkRealtimeInstance() {

--- a/packages/cozy-realtime/src/RealtimePlugin.spec.js
+++ b/packages/cozy-realtime/src/RealtimePlugin.spec.js
@@ -26,14 +26,23 @@ it('should expose the same API as CozyRealtime', () => {
 it('should login/logout correctly', async () => {
   client = new CozyClient({})
   client.registerPlugin(RealtimePlugin)
+
+  const onLogin = jest.fn()
+  const onLogout = jest.fn()
+  client.on('plugin:realtime:login', onLogin)
+  client.on('plugin:realtime:logout', onLogout)
   expect(client.plugins.realtime.realtime).toBeNull()
   await client.login({
     uri: 'http://cozy.tools:8080',
     token: 'fake-token'
   })
   expect(client.plugins.realtime.realtime).not.toBeNull()
+  expect(onLogin).toHaveBeenCalledTimes(1)
+  expect(onLogout).toHaveBeenCalledTimes(0)
   await client.logout()
   expect(client.plugins.realtime.realtime).toBeNull()
+  expect(onLogin).toHaveBeenCalledTimes(1)
+  expect(onLogout).toHaveBeenCalledTimes(1)
 })
 
 it('throws user friendly errors when trying to use the realtime while logged out', async () => {


### PR DESCRIPTION
We want to use cozy-client plugins, but it may be hard to know when they are ready to be used. We can't rely on `client.on('login')` because the call order of the listeners is not guaranteed. Instead, plugins can now emit events through cozy-client to notify other parts of an app when  they are ready.