### PR TITLE
refactor: Use logger for logs

### DIFF
--- a/packages/cozy-app-publish/src/cozy-app-publish.js
+++ b/packages/cozy-app-publish/src/cozy-app-publish.js
@@ -3,10 +3,12 @@
 'use strict'
 
 const { ArgumentParser } = require('argparse')
-const colorize = require('./utils/colorize')
-const scripts = require('./index')
 const capitalize = require('lodash/capitalize')
 const omitBy = require('lodash/omitBy')
+
+const logger = require('./utils/logger')
+const colorize = require('./utils/colorize')
+const scripts = require('./index')
 
 const pkg = require('../package.json')
 
@@ -82,7 +84,7 @@ parser.addArgument('--verbose', {
 })
 
 const handleError = error => {
-  console.log(colorize.red(`Publishing failed: ${error.message}`))
+  logger.error(colorize.red(`Publishing failed: ${error.message}`))
   process.exit(1)
 }
 
@@ -108,11 +110,10 @@ async function publishApp(cliOptions) {
   const publishMode = _getPublishMode()
   const publishFn = scripts[publishMode]
 
-  console.log()
-  console.log(
+  logger.log(
     `${colorize.bold(capitalize(publishMode))} ${colorize.blue('publish mode')}`
   )
-  console.log()
+
   return publishFn({
     appBuildUrl: cliOptions.buildUrl,
     buildCommit: cliOptions.buildCommit,

--- a/packages/cozy-app-publish/src/git.js
+++ b/packages/cozy-app-publish/src/git.js
@@ -1,7 +1,7 @@
 const spawn = require('child_process').spawn
+const logger = require('./utils/logger')
 
 const launchCmd = (cmd, params, options) => {
-  console.log('Spawning', cmd, params) // eslint-disable-line no-console
   return new Promise(async (resolve, reject) => {
     const result = { stdout: [], stderr: [] }
     const cmdOptions = { encoding: 'utf8', ...options }
@@ -34,16 +34,19 @@ const getCurrentTags = async () => {
     // get tag on head commit
     const result = await launchCmd('git', ['tag', '-l', '--points-at', 'HEAD'])
     if (result.stdout.length === 0) {
+      logger.info('No tags')
       return []
     }
     const gitTags = result.stdout
       .join('')
       .split('\n')
       .filter(Boolean)
+
+    logger.info('Current tags: ', gitTags.join(', '))
     return gitTags
   } catch (e) {
-    console.error(`\n⚠️  Erreur lors de la récupération du tag :\n`)
-    console.error(' ', e.stderr ? e.stderr : e, '\n')
+    logger.error(`\n⚠️  Erreur lors de la récupération du tag :\n`)
+    logger.error(' ', e.stderr ? e.stderr : e, '\n')
     process.exit(1)
   }
 }

--- a/packages/cozy-app-publish/src/hooks/post/mattermost.js
+++ b/packages/cozy-app-publish/src/hooks/post/mattermost.js
@@ -1,6 +1,7 @@
 const https = require('https')
 const url = require('url')
 const tags = require('../../tags')
+const logger = require('../../utils/logger')
 
 const appTypeLabelMap = {
   webapp: 'Application',
@@ -43,7 +44,7 @@ const sendMattermostMessage = options => {
   const mattermostHookUrl = url.parse(hookURL)
 
   return new Promise((resolve, reject) => {
-    console.log(
+    logger.log(
       `↳ ℹ️  Sending to mattermost channel ${channel} the following message: "${message}"`
     )
     const postData = JSON.stringify({
@@ -115,7 +116,7 @@ const sendMattermostReleaseMessage = async options => {
   const username = 'Travis'
   const message = getMessage(options)
   for (const channel of channels) {
-    console.log('↳ ℹ️  Sending message to Mattermost')
+    logger.log('↳ ℹ️  Sending message to Mattermost')
     await sendMattermostMessage({
       hookURL,
       iconURL,
@@ -143,7 +144,7 @@ if (require.main === module) {
     spaceName,
     appType
   }).catch(e => {
-    console.error(e)
+    logger.error(e)
     process.exit(1)
   })
 }

--- a/packages/cozy-app-publish/src/hooks/pre/downcloud.js
+++ b/packages/cozy-app-publish/src/hooks/pre/downcloud.js
@@ -28,7 +28,7 @@ module.exports = async options => {
   try {
     downcloudOptions = await pushArchive(archiveFileName, downcloudOptions)
   } catch (error) {
-    console.error(`↳ ❌  Error while uploading: ${error.message}`)
+    logger.error(`↳ ❌  Error while uploading: ${error.message}`)
     throw new Error('Downcloud publishing error')
   }
 

--- a/packages/cozy-app-publish/src/hooks/pre/helpers.js
+++ b/packages/cozy-app-publish/src/hooks/pre/helpers.js
@@ -2,6 +2,7 @@ const tar = require('tar')
 const { spawn } = require('child_process')
 const fs = require('fs-extra')
 const path = require('path')
+const logger = require('../../utils/logger')
 
 const UPLOAD_DIR = 'www-upload/'
 const USER = 'upload'
@@ -31,12 +32,12 @@ const deleteArchive = async archivePath => {
   try {
     await fs.remove(archivePath)
   } catch (error) {
-    console.error(`↳ ⚠️  Unable to delete the previous archive.`)
+    logger.error(`↳ ⚠️  Unable to delete the previous archive.`)
   }
 }
 
 const sshCommand = async (cmd, hostString) => {
-  console.log('Launching', cmd, 'on', hostString)
+  logger.log('Launching', cmd, 'on', hostString)
   return launchCmd('ssh', ['-o', 'StrictHostKeyChecking=no', hostString, cmd])
 }
 
@@ -81,7 +82,7 @@ const getAppBuildUrl = remoteArchivePath => {
 
 const pushArchive = async (archiveFileName, options) => {
   const { buildDir } = options
-  console.log(`↳ ℹ️  Sending archive to downcloud`)
+  logger.log(`↳ ℹ️  Sending archive to downcloud`)
 
   const remoteDir = getRemoteDir(options)
   const uploadDir = path.join(UPLOAD_DIR, remoteDir)
@@ -96,7 +97,7 @@ const pushArchive = async (archiveFileName, options) => {
 
   await rsync(archiveFileName, uploadDir, { cwd: buildDir })
 
-  console.log(`↳ ℹ️  Upload to downcloud complete.`)
+  logger.log(`↳ ℹ️  Upload to downcloud complete.`)
   return {
     ...options,
     appBuildUrl: getAppBuildUrl(path.join(remoteDir, archiveFileName))
@@ -108,7 +109,7 @@ const getArchiveFileName = slug => {
 }
 
 const createArchive = async archivePath => {
-  console.log(`↳ ℹ️  Creating archive ${archivePath}`)
+  logger.log(`↳ ℹ️  Creating archive ${archivePath}`)
   const cwd = path.resolve(path.dirname(archivePath))
   const fileList = await fs.readdir(path.dirname(archivePath))
   const options = {
@@ -119,7 +120,7 @@ const createArchive = async archivePath => {
   try {
     await tar.c(options, fileList)
   } catch (error) {
-    console.error(
+    logger.error(
       `↳ ❌ Unable to generate app archive. Is tar installed as a dependency ? Error : ${error.message}`
     )
     throw new Error('Unable to generate archive')

--- a/packages/cozy-app-publish/src/manual.js
+++ b/packages/cozy-app-publish/src/manual.js
@@ -3,6 +3,7 @@ const fs = require('fs-extra')
 const getManifestAsObject = require('./utils/getManifestAsObject')
 const tags = require('./tags')
 const publisher = require('./publisher')
+const logger = require('./utils/logger')
 
 const getManifestManual = ctx => {
   return getManifestAsObject(
@@ -23,6 +24,12 @@ const getAppVersionManual = async ctx => {
       devVersion = await tags.getDevVersion(ctx.appManifestObj.version)
     }
   }
+
+  logger.info(
+    `Getting app version ${
+      ctx.tagPrefix ? ` with prefix ${ctx.tagPrefix}` : ''
+    }`
+  )
   return (
     tagVersion || devVersion || ctx.manualVersion || ctx.appManifestObj.version
   )

--- a/packages/cozy-app-publish/src/test/jest.setup.js
+++ b/packages/cozy-app-publish/src/test/jest.setup.js
@@ -6,5 +6,6 @@ jest.doMock('node-fetch', () => fetch.mockResponse({ status: 201 }))
 jest.mock('../utils/logger', () => ({
   log: jest.fn(),
   warn: jest.fn(),
-  error: jest.fn()
+  error: jest.fn(),
+  info: jest.fn()
 }))

--- a/packages/cozy-app-publish/src/utils/logger.js
+++ b/packages/cozy-app-publish/src/utils/logger.js
@@ -1,7 +1,8 @@
 const logger = {
   log: console.log.bind(console),
   warn: console.warn.bind(console),
-  error: console.error.bind(console)
+  error: console.error.bind(console),
+  info: console.info.bind(console)
 }
 
 module.exports = logger


### PR DESCRIPTION
- Helps to distinguish normal publish output from console.logs
- Can be used to increase / decrease verbosity level via CLI args
  in the future