### PR TITLE
feat: Update lodash accross all packages

### DIFF
--- a/packages/babel-preset-cozy-app/package.json
+++ b/packages/babel-preset-cozy-app/package.json
@@ -26,6 +26,6 @@
     "@babel/preset-react": "7.0.0",
     "@babel/runtime": "7.2.0",
     "browserslist-config-cozy": "^0.3.0",
-    "lodash": "4.17.15"
+    "lodash": "4.17.19"
   }
 }

--- a/packages/cli-tree/package.json
+++ b/packages/cli-tree/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "argparse": "^1.0.10",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.19",
     "tabtab": "^3.0.2"
   },
   "devDependencies": {

--- a/packages/cozy-app-publish/package.json
+++ b/packages/cozy-app-publish/package.json
@@ -24,7 +24,7 @@
     "chalk": "2.4.2",
     "cross-spawn": "6.0.5",
     "fs-extra": "7.0.1",
-    "lodash": "4.17.15",
+    "lodash": "4.17.19",
     "node-fetch": "2.6.0",
     "prompt": "1.0.0",
     "request": "2.88.0",

--- a/packages/cozy-device-helper/package.json
+++ b/packages/cozy-device-helper/package.json
@@ -22,7 +22,7 @@
     "test": "jest src/**"
   },
   "dependencies": {
-    "lodash": "4.17.15"
+    "lodash": "4.17.19"
   },
   "devDependencies": {
     "@babel/cli": "7.2.3",

--- a/packages/cozy-doctypes/package.json
+++ b/packages/cozy-doctypes/package.json
@@ -12,7 +12,7 @@
     "cozy-logger": "^1.6.0",
     "date-fns": "1.30.1",
     "es6-promise-pool": "2.5.0",
-    "lodash": "4.17.15",
+    "lodash": "4.17.19",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {

--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -34,7 +34,7 @@
     "cozy-logger": "1.6.0",
     "date-fns": "^1.30.1",
     "final-form": "4.18.5",
-    "lodash": "4.17.15",
+    "lodash": "4.17.19",
     "microee": "^0.0.6",
     "minilog": "https://github.com/cozy/minilog.git#master",
     "node-polyglot": "^2.4.0",

--- a/packages/cozy-notifications/package.json
+++ b/packages/cozy-notifications/package.json
@@ -24,7 +24,7 @@
     "cozy-ui": "27.11.2",
     "handlebars": "4.1.2",
     "handlebars-layouts": "3.1.4",
-    "lodash": "4.17.15",
+    "lodash": "4.17.19",
     "mjml": "4.3.1",
     "word-wrap": "^1.2.3"
   },

--- a/packages/cozy-procedures/package.json
+++ b/packages/cozy-procedures/package.json
@@ -23,7 +23,7 @@
     "babel-preset-cozy-app": "^1.8.1",
     "cozy-realtime": "^3.9.0",
     "date-fns": "^1.30.1",
-    "lodash": "4.17.15",
+    "lodash": "4.17.19",
     "prop-types": "^15.7.2",
     "react-jsonschema-form": "1.8.0",
     "react-redux": "7.1.1",

--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -31,7 +31,7 @@
     "cozy-device-helper": "^1.9.2",
     "cozy-doctypes": "^1.72.2",
     "cozy-realtime": "^3.9.0",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.19",
     "minilog": "https://github.com/cozy/minilog.git#master",
     "react-autosuggest": "^9.4.3",
     "react-tooltip": "^3.11.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5395,14 +5395,6 @@ cozy-keys-lib@3.1.1:
     tldjs "^2.3.1"
     zxcvbn "^4.4.2"
 
-cozy-realtime@^3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-3.9.0.tgz#4aa09ac74c973b720d0249ad1c2173ed123b28db"
-  integrity sha512-5TqHDrxKUyNIAxrOb/DlTkhMJj7UnsbKmAriOq6359HjXVlvIUfVMSght44xik3KLQ8inUSmF+1TAFeKe9tBGA==
-  dependencies:
-    cozy-device-helper "^1.9.2"
-    minilog "https://github.com/cozy/minilog.git#master"
-
 cozy-stack-client@6.66.0, cozy-stack-client@^6.66.0:
   version "6.66.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-6.66.0.tgz#ba217c2d615dd31a9f40ae131644c68c4108b101"
@@ -10960,6 +10952,11 @@ lodash@4.17.15, lodash@^4.14.2, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
 
+lodash@4.17.19, lodash@^4.17.19:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
 log-symbols@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
@@ -11425,13 +11422,6 @@ mini-html-webpack-plugin@^0.2.3:
   resolved "https://registry.yarnpkg.com/mini-html-webpack-plugin/-/mini-html-webpack-plugin-0.2.3.tgz#2dfbdc3f35f6ae03864a608808381f8137311ea0"
   dependencies:
     webpack-sources "^1.1.0"
-
-"minilog@git+https://github.com/cozy/minilog.git#master":
-  version "3.1.0"
-  uid f01f7d9dfe20981177dd34b9662c2f077d818f82
-  resolved "git+https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
-  dependencies:
-    microee "0.0.6"
 
 "minilog@https://github.com/cozy/minilog.git#master":
   version "3.1.0"


### PR DESCRIPTION
This will fix security vulnerability like this one : https://github.com/konnectors/libs/network/alert/yarn.lock/lodash/open