### PR TITLE
feat: Turn off logging by default on harvest

### DIFF
--- a/packages/cozy-harvest-lib/src/logger.js
+++ b/packages/cozy-harvest-lib/src/logger.js
@@ -5,7 +5,6 @@ const minilog = (inBrowser && window.minilog) || minilog_
 
 const logger = minilog('harvest')
 
-minilog.suggest.allow('harvest', 'log')
-minilog.suggest.allow('harvest', 'info')
+minilog.suggest.deny('harvest', 'info')
 
 export default logger


### PR DESCRIPTION
Logging can be turned on on a case by case basis
See https://docs.cozy.io/en/cozy-client/details/#how-to-activate-logging
for more information

T