### PR TITLE
fix: Manually add window.opener in OAuth popup

### DIFF
--- a/packages/cozy-harvest-lib/src/components/Popup.jsx
+++ b/packages/cozy-harvest-lib/src/components/Popup.jsx
@@ -111,6 +111,11 @@ export class Popup extends PureComponent {
       title,
       `scrollbars=yes, width=${w}, height=${h}, top=${top}, left=${left}`
     )
+
+    // fixes no window.openen on some new version of safari
+    // at least on IPhone XS with safari 13
+    popup.opener = window
+
     // Puts focus on the newWindow
     if (popup.focus) {
       popup.focus()

--- a/packages/cozy-harvest-lib/src/components/Popup.jsx
+++ b/packages/cozy-harvest-lib/src/components/Popup.jsx
@@ -112,7 +112,7 @@ export class Popup extends PureComponent {
       `scrollbars=yes, width=${w}, height=${h}, top=${top}, left=${left}`
     )
 
-    // fixes no window.openen on some new version of safari
+    // fixes no window.opener on some new version of safari
     // at least on IPhone XS with safari 13
     popup.opener = window
 


### PR DESCRIPTION
This avoids a blank screen in OAuth steps on some version of safari on IPhone and desktop.
At least Safari 13 on IPhone XS (browserstack).