### PR TITLE
feat: Check if deps are at the same version

### DIFF
--- a/packages/repo-doctor/src/rules/depSameVersion.js
+++ b/packages/repo-doctor/src/rules/depSameVersion.js
@@ -22,7 +22,7 @@ class DepSameVersion {
         versions.slice(1).filter(x => x !== versions[0]).length > 0
       if (notSameVersion) {
         yield {
-          severity: 'warning',
+          severity: 'warn',
           type: 'DepSameVersion',
           message: `Different versions for ${repoDeps
             .map(r => `${r.name}@${r.version}`)


### PR DESCRIPTION
Across our repositories, we have dependency that should be at
the same version no matter what. It can be the case for cozy-client
dependencies, jest dependencies or babel dependencies.

Here, a rule is added that checks if a list of dependencies are
at the same version.

Result:

```
Repository: cozy/cozy-drive
  DepSameVersion: Different versions for cozy-client@13.14.2, cozy-stack-client@13.15.1, cozy-pouch-link@13.13.1
Repository: cozy/cozy-banks
  DepSameVersion: Different versions for cozy-client@13.15.1, cozy-stack-client@13.8.3, cozy-pouch-link@13.15.1
```