### PR TITLE
feat: Use VError to chain stack traces

### DIFF
--- a/packages/cozy-app-publish/src/__snapshots__/travis.spec.js.snap
+++ b/packages/cozy-app-publish/src/__snapshots__/travis.spec.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Travis publishing script should fail on postPublish error 1`] = `[Error: Postpublish hooks failed: Postpublish test error]`;
+exports[`Travis publishing script should fail on postPublish error 1`] = `[VError: Postpublish hooks failed: Postpublish test error]`;
 
-exports[`Travis publishing script should fail on prePublish error 1`] = `[Error: Prepublish failed: Prepublish test error]`;
+exports[`Travis publishing script should fail on prePublish error 1`] = `[VError: Prepublish failed: Prepublish test error]`;
 
-exports[`Travis publishing script should fail on publish error 1`] = `[Error: Publish failed: Publish test error]`;
+exports[`Travis publishing script should fail on publish error 1`] = `[VError: Publish failed: Publish test error]`;
 
 exports[`Travis publishing script should support prefix 1`] = `
 Object {

--- a/packages/cozy-app-publish/src/publish.js
+++ b/packages/cozy-app-publish/src/publish.js
@@ -42,12 +42,12 @@ module.exports = async ({
     throw new Error(text)
   } else if (response.status !== 201) {
     let errorMsg
+    let resp2 = response.clone()
     try {
       const body = await response.json()
       errorMsg = body.error
     } catch (e) {
-      const text = await response.text()
-      errorMsg = text
+      errorMsg = await resp2.text()
     }
     throw new Error(`${response.status} ${response.statusText}: ${errorMsg}`)
   }

--- a/packages/cozy-app-publish/src/publisher.js
+++ b/packages/cozy-app-publish/src/publisher.js
@@ -6,6 +6,7 @@ const constants = require('./constants')
 const promptConfirm = require('./confirm')
 const defaults = require('lodash/defaults')
 const logger = require('./utils/logger')
+const { VError } = require('verror')
 
 const {
   DEFAULT_REGISTRY_URL,
@@ -81,7 +82,7 @@ const publisher = ({
       appType
     })
   } catch (error) {
-    throw new Error(`Prepublish failed: ${error.message}`)
+    throw new VError(error, 'Prepublish failed')
   }
 
   // ready publish the application on the registry
@@ -111,13 +112,13 @@ const publisher = ({
   try {
     await publish(publishOptions)
   } catch (error) {
-    throw new Error(`Publish failed: ${error.message}`)
+    throw new VError(error, 'Publish failed')
   }
 
   try {
     await postpublish({ ...publishOptions, postpublishHook })
   } catch (error) {
-    throw new Error(`Postpublish hooks failed: ${error.message}`)
+    throw new VError(error, 'Postpublish hooks failed')
   }
 }
 


### PR DESCRIPTION
`verror` is a library from joyent to facilitate error handling. It makes it
easy to chain errors (keeping stack traces along the way), or to deal with
MultiErrors. This makes it easier to understand where an error comes from.

Additionally, when handling the .json() decoding error, we would reuse the
body from the response to do .text(); this is not possible, we need to
clone the Response.