### PR TITLE
feat: Use logger from harvest for BI

### DIFF
--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -18,12 +18,10 @@ import { mkConnAuth, biErrorMap } from 'cozy-bi-auth'
 import biPublicKeyProd from './bi-public-key-prod.json'
 import { KonnectorJobError } from '../helpers/konnectors'
 import { LOGIN_SUCCESS_EVENT } from '../models/ConnectionFlow'
-import harvestLogger from '../logger'
+import logger from '../logger'
 
 const DECOUPLED_ERROR = 'decoupled'
 const ADDITIONAL_INFORMATION_NEEDED_ERROR = 'additionalInformationNeeded'
-
-const logger = harvestLogger('harvest/bi')
 
 const configsByMode = {
   prod: {


### PR DESCRIPTION
It is not possible to create a sublogger with logger(namespace),
it would only emit a log. It returned the logger so it looked
like it worked