### PR TITLE
fix: Qualification sub menu on desktop

### DIFF
--- a/packages/cozy-scanner/package.json
+++ b/packages/cozy-scanner/package.json
@@ -31,7 +31,7 @@
     "babel-preset-cozy-app": "^1.9.1",
     "cozy-client": "13.15.1",
     "cozy-doctypes": "1.67.0",
-    "cozy-ui": "35.39.0",
+    "cozy-ui": "35.40.2",
     "jest": "24.9.0",
     "jest-dom": "^4.0.0",
     "mockdate": "^2.0.5",
@@ -43,7 +43,7 @@
   "peerDependencies": {
     "cozy-client": "^13.15.1",
     "cozy-doctypes": "1.67.0",
-    "cozy-ui": "^35.39.0"
+    "cozy-ui": "^35.40.2"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/packages/cozy-scanner/src/DocumentCategory.jsx
+++ b/packages/cozy-scanner/src/DocumentCategory.jsx
@@ -62,7 +62,11 @@ class DocumentCategory extends Component {
         </GridItem>
 
         {isMenuDisplayed && (
-          <ActionMenu onClose={this.closeMenu} autoclose>
+          <ActionMenu
+            onClose={this.closeMenu}
+            autoclose
+            popperOptions={{ strategy: 'fixed' }}
+          >
             <ActionMenuHeader>
               <Media>
                 <Img>

--- a/packages/cozy-scanner/src/__snapshots__/DocumentCategory.spec.jsx.snap
+++ b/packages/cozy-scanner/src/__snapshots__/DocumentCategory.spec.jsx.snap
@@ -109,7 +109,7 @@ exports[`DocumentCategory should match snapshot if selected and icon 2`] = `
   </div>
   <div>
     <div
-      style="position: absolute; left: 0px; top: 0px; z-index: #fff;"
+      style="position: fixed; left: 0px; top: 0px; z-index: #fff;"
     >
       <div
         class="styles__c-actionmenu___22Fp1 styles__c-actionmenu--inline___1SXZa"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5342,6 +5342,28 @@ cozy-ui@35.39.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
+cozy-ui@35.40.2:
+  version "35.40.2"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.40.2.tgz#58866f9a8307e373f74ad09fc2700fbe227860b5"
+  integrity sha512-kNlz1FsgYsp67Kvxo5od62wgE/Wy9MQ5tuiH2e3WSpDa4kHl/+mNXM3/lDys+LQi4hKYZePRfQiZcW/M6Vc/yg==
+  dependencies:
+    "@babel/runtime" "^7.3.4"
+    "@popperjs/core" "^2.4.4"
+    body-scroll-lock "^2.5.8"
+    classnames "^2.2.5"
+    cozy-interapp "0.5.4"
+    date-fns "^1.28.5"
+    hammerjs "^2.0.8"
+    intersection-observer "0.11.0"
+    node-polyglot "^2.2.2"
+    normalize.css "^7.0.0"
+    react-hot-loader "^4.3.11"
+    react-markdown "^4.0.8"
+    react-pdf "^4.0.5"
+    react-popper "^2.2.3"
+    react-select "2.2.0"
+    react-swipeable-views "0.13.3"
+
 create-ecdh@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"


### PR DESCRIPTION
Depends on https://github.com/cozy/cozy-ui/pull/1518

The ActionMenu in the qualification modal was displayed *under* the modal, because we're using ExperimentalModal and that was missing a PopperContext. WIth https://github.com/cozy/cozy-ui/pull/1518 the context is no longer required and the menu is above the modal.

However the menu is very large and parts of it are sometimes cut off by the modal, so we use the fixed positioning strategy of popper.js.