### PR TITLE
feat: Apply strict validation

### DIFF
--- a/packages/cozy-notifications/src/mjmlUtils.js
+++ b/packages/cozy-notifications/src/mjmlUtils.js
@@ -1,15 +1,6 @@
 import mjml2html from 'mjml'
 
 export const renderMJML = mjmlContent => {
-  const obj = mjml2html(mjmlContent)
-  obj.errors.forEach(err => {
-    // eslint-disable-next-line no-console
-    console.warn(err.formattedMessage)
-  })
-
-  if (obj.html) {
-    return obj.html
-  } else {
-    throw new Error('Error during HTML generation')
-  }
+  const obj = mjml2html(mjmlContent, { validationLevel: 'strict' })
+  return obj.html
 }


### PR DESCRIPTION
Otherwise, we may send empty / malformed emails. MJML validation errors
can pop up when the JS minification is too strong, preventing MJML
to have its components correctly registered resulting in "Element a
doesn't exist or is not registered" errors