### PR TITLE
feat: Show confirmation prompt before prepublishing

### DIFF
--- a/packages/cozy-app-publish/src/publisher.js
+++ b/packages/cozy-app-publish/src/publisher.js
@@ -66,6 +66,22 @@ const publisher = ({
   const appVersion = await getAppVersion(ctx)
   const appBuildUrl = getAppBuildURL ? getAppBuildURL(ctx) : ctx.appBuildUrl
 
+  logger.log(
+    `Will publish ${colorize.bold(appSlug)}@${colorize.bold(
+      appVersion
+    )} to ${colorize.bold(registryUrl)} (space: ${spaceName || 'default one'})`
+  )
+
+  if (showConfirmation && !yes) {
+    const goFurther = await promptConfirm(
+      'Are you sure you want to publish this application above?'
+    )
+    if (!goFurther) {
+      logger.log('Publishing cancelled')
+      return
+    }
+  }
+
   let publishOptions
   try {
     publishOptions = await prepublish({
@@ -85,28 +101,12 @@ const publisher = ({
     throw new VError(error, 'Prepublish failed')
   }
 
-  // ready publish the application on the registry
-  logger.log(
-    `Attempting to publish ${colorize.bold(
-      publishOptions.appSlug
-    )} (version ${colorize.bold(
-      publishOptions.appVersion
-    )}) from ${colorize.bold(
-      publishOptions.appBuildUrl
-    )} (sha256 ${colorize.bold(publishOptions.sha256Sum)}) to ${colorize.bold(
-      publishOptions.registryUrl
-    )} (space: ${publishOptions.spaceName || 'default one'})`
-  )
-  logger.log()
-
-  if (showConfirmation && !yes) {
-    const goFurther = await promptConfirm(
-      'Are you sure you want to publish this application above?'
+  if (!appBuildUrl && publishOptions.appBuildUrl) {
+    logger.log(
+      `Uploaded app to ${publishOptions.appBuildUrl} (sha256 ${colorize.bold(
+        publishOptions.sha256Sum
+      )})`
     )
-    if (!goFurther) {
-      logger.log('Publishing cancelled')
-      return
-    }
   }
 
   try {

--- a/packages/repo-doctor/src/rules/index.js
+++ b/packages/repo-doctor/src/rules/index.js
@@ -31,7 +31,7 @@ const setupRules = (config, args) => {
 }
 
 /**
- * Yields ruleResults
+ * Executes rules against a repository and yields rule results
  */
 const runRules = async function*(repositoryInfo, rules) {
   for (const rule of rules) {


### PR DESCRIPTION
Having the prompt after prepublishing causes several problems

- it means that we have to remember to go and say yes after the app has
 been uploaded to downcloud
- if there is an error in the detected slug / version, the app already
 has been uploaded with an error on downcloud

Here the prompt is shown as early as possible, meaning the developer can go
about its business afterwards. Since we do not know the appBuildUrl before
prepublishing if it has not been passed, the logging of its value is kept
after prepublishing, along with the shasum.