### PR TITLE
Keep relationships field when matching accounts

### DIFF
--- a/packages/cozy-doctypes/src/banking/BankAccount.js
+++ b/packages/cozy-doctypes/src/banking/BankAccount.js
@@ -1,5 +1,6 @@
 const groupBy = require('lodash/groupBy')
 const get = require('lodash/get')
+const merge = require('lodash/merge')
 const Document = require('../Document')
 const matching = require('./matching-accounts')
 const { getSlugFromInstitutionLabel } = require('./slug-account')
@@ -13,6 +14,11 @@ class BankAccount extends Document {
     return matchings.map(matching => {
       return {
         ...matching.account,
+        relationships: merge(
+          {},
+          matching.account.relationships,
+          matching.match ? matching.match.relationships : null
+        ),
         _id: matching.match ? matching.match._id : undefined
       }
     })

--- a/packages/cozy-doctypes/src/banking/BankAccount.spec.js
+++ b/packages/cozy-doctypes/src/banking/BankAccount.spec.js
@@ -1,17 +1,38 @@
 const BankAccount = require('./BankAccount')
 
 describe('account reconciliation', () => {
+  const localAccounts = [
+    {
+      _id: 'a1',
+      number: '1',
+      balance: 50,
+      relationships: { aRelationship: { _id: 'fake-id', _type: 'fake-type' } }
+    }
+  ]
+  const remoteAccounts = [
+    {
+      number: '1',
+      balance: 100,
+      relationships: {
+        aRelationship: { _id: 'old-fake-id', _type: 'old-fake-type' },
+        anotherRelationship: { _id: 'fake-id2', _type: 'fake-type2' }
+      }
+    },
+    { number: '2', balance: 200 }
+  ]
+
   it('should correctly match linxo accounts to cozy accounts through number', () => {
-    const localAccounts = [{ _id: 'a1', number: '1', balance: 50 }]
-    const remoteAccounts = [
-      { number: '1', balance: 100 },
-      { number: '2', balance: 200 }
-    ]
     const matchedAccounts = BankAccount.reconciliate(
       remoteAccounts,
       localAccounts
     )
-    expect(matchedAccounts.find(x => x.number === '1')._id).toBe('a1')
+
+    const accountA1 = matchedAccounts.find(x => x.number === '1')
+    expect(accountA1._id).toBe('a1')
+    expect(accountA1.relationships).toEqual({
+      aRelationship: { _id: 'fake-id', _type: 'fake-type' }, // aRelationship is updated
+      anotherRelationship: { _id: 'fake-id2', _type: 'fake-type2' } // anotherRelationship is kept
+    })
     expect(matchedAccounts.find(x => x.number !== '1')._id).toBe(undefined)
     expect(matchedAccounts.length).toBe(2)
   })

--- a/packages/cozy-doctypes/src/banking/matching-accounts.js
+++ b/packages/cozy-doctypes/src/banking/matching-accounts.js
@@ -215,6 +215,20 @@ const findMatch = (account, existingAccounts) => {
   }
 }
 
+/**
+ * Matches existing accounts with accounts fetched on a vendor
+ *
+ * @typedef {MatchResult}
+ * @property {io.cozy.account} account - Account from fetched accounts
+ * @property {io.cozy.account} match - Existing account that was matched. Null if no match was found.
+ * @property {string} method - How the two accounts were matched
+ *
+ * @param  {io.cozy.account} fetchedAccounts - Account that have been fetched
+ * on the vendor and that will be matched with existing accounts
+ * @param  {io.cozy.accounts} existingAccounts - Will be match against (those
+ * io.cozy.accounts already have an _id)
+ * @return {Array<MatchResult>} - Match results (as many results as fetchedAccounts.length)
+ */
 const matchAccounts = (fetchedAccounts, existingAccounts) => {
   fetchedAccounts = fetchedAccounts.map(normalizeAccount)
   const toMatch = [...existingAccounts].map(normalizeAccount)


### PR DESCRIPTION
When matching incoming accounts from a vendor to existing accounts,
we need to merge relationships to existing relationships.