### PR TITLE
fix: Ability to copy links

### DIFF
--- a/packages/cozy-sharing/src/components/ShareByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareByLink.jsx
@@ -52,12 +52,13 @@ class ShareByLink extends React.Component {
     }
   }
 
-  copyLinkToClipboard = () => {
+  copyLinkToClipboard = ({ isAutomaticCopy }) => {
     if (copy(this.props.link))
       Alerter.success(
         this.props.t(`${this.props.documentType}.share.shareByLink.copied`)
       )
-    else
+    else if (!isAutomaticCopy)
+      // In case of automatic copy, the browser can block the copy request. This is not shown to the user since it is expected and can be circumvented by clicking directly on the copy link
       Alerter.error(
         this.props.t(`${this.props.documentType}.share.shareByLink.failed`)
       )
@@ -122,7 +123,7 @@ class ShareByLink extends React.Component {
               className={styles['aligned-dropdown-button']}
               onClick={async () => {
                 await this.createShareLink()
-                this.copyLinkToClipboard()
+                this.copyLinkToClipboard({ isAutomaticCopy: true })
               }}
               busy={loading}
               label={t(`${documentType}.share.shareByLink.create`)}

--- a/packages/cozy-sharing/src/components/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal.jsx
@@ -48,6 +48,7 @@ export const ShareModal = ({
         open={true}
         onClose={onClose}
         PaperProps={{ className: 'u-pb-half' }}
+        disableEnforceFocus
       >
         <DialogCloseButton onClick={onClose} />
         <ExperimentalDialogTitle>


### PR DESCRIPTION
By default, MUI Dialog keeps the focus on Dialogs for accessibility reasons. Most of the time that's good, but here our copy to clipboard lib needs control over the focus to do it's job.