### PR TITLE
fix(Harvest): deliver an harvest 2.2.0 with only WebsiteLink component addition

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-harvest-lib",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Provides logic, modules and components for Cozy's harvest applications.",
   "main": "dist/index.js",
   "author": "Cozy",

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
@@ -11,6 +11,7 @@ import KonnectorUpdateInfos from '../../../components/infos/KonnectorUpdateInfos
 import LaunchTriggerCard from '../../../components/cards/LaunchTriggerCard'
 import KonnectorMaintenance from '../../../components/Maintenance'
 import AppLinkCard from '../../../components/cards/AppLinkCard'
+import WebsiteLinkCard from '../../../components/cards/WebsiteLinkCard'
 import TriggerErrorInfo from '../../../components/infos/TriggerErrorInfo'
 import useMaintenanceStatus from '../../../components/hooks/useMaintenanceStatus'
 import getRelatedAppsSlugs from '../../../models/getRelatedAppsSlugs'
@@ -70,6 +71,9 @@ export const DataTab = ({ konnector, trigger, client, flow }) => {
         {appLinks.map(({ slug, ...otherProps }) => (
           <AppLinkCard key={slug} slug={slug} {...otherProps} />
         ))}
+        {konnector.vendor_link && (
+          <WebsiteLinkCard link={konnector.vendor_link} />
+        )}
       </Stack>
     </ModalContent>
   )

--- a/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import logger from '../../logger'
 import Card from 'cozy-ui/transpiled/react/Card'
 import { SubTitle, Caption } from 'cozy-ui/transpiled/react/Text'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
@@ -11,9 +12,17 @@ import palette from 'cozy-ui/transpiled/react/palette'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 const WebsiteLinkCard = ({ link }) => {
-  const linkStyle = { textTransform: 'lowercase' }
-  const label = new URL(link).host
   const { t } = useI18n()
+  let url = null
+  try {
+    url = new URL(link)
+  } catch (err) {
+    logger('warn', err.message)
+    return null
+  }
+
+  const linkStyle = { textTransform: 'lowercase' }
+  const label = url.host
 
   return (
     <Card>

--- a/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.jsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import Card from 'cozy-ui/transpiled/react/Card'
+import { SubTitle, Caption } from 'cozy-ui/transpiled/react/Text'
+import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
+import { Media, Img, Bd } from 'cozy-ui/transpiled/react/Media'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import palette from 'cozy-ui/transpiled/react/palette'
+
+import { translate } from 'cozy-ui/transpiled/react/I18n'
+
+const WebsiteLinkCard = ({ link, t }) => {
+  const imgStyle = { paddingRight: '1rem' }
+  const linkStyle = { textTransform: 'lowercase', margin: 0 }
+  const hrStyle = { color: palette['silver'] }
+  const label = new URL(link).host
+
+  return (
+    <Card>
+      <SubTitle className="u-mb-1">{t('card.websiteLink.title')}</SubTitle>
+      <hr style={hrStyle} />
+      <Media align="top">
+        <Img style={imgStyle}>
+          <Icon icon="globe" color={palette['coolGrey']} />
+        </Img>
+        <Bd>
+          <ButtonLink
+            subtle
+            target="_blank"
+            href={link}
+            label={label}
+            theme="text"
+            className="u-dodgerBlue"
+            style={linkStyle}
+          />
+          <Caption>{t('card.websiteLink.description')}</Caption>
+        </Bd>
+      </Media>
+    </Card>
+  )
+}
+
+WebsiteLinkCard.propTypes = {
+  link: PropTypes.string.isRequired
+}
+
+export default translate()(WebsiteLinkCard)

--- a/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.jsx
@@ -11,17 +11,15 @@ import palette from 'cozy-ui/transpiled/react/palette'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 
 const WebsiteLinkCard = ({ link, t }) => {
-  const imgStyle = { paddingRight: '1rem' }
-  const linkStyle = { textTransform: 'lowercase', margin: 0 }
-  const hrStyle = { color: palette['silver'] }
+  const linkStyle = { textTransform: 'lowercase' }
   const label = new URL(link).host
 
   return (
     <Card>
       <SubTitle className="u-mb-1">{t('card.websiteLink.title')}</SubTitle>
-      <hr style={hrStyle} />
+      <hr className="u-silver" />
       <Media align="top">
-        <Img style={imgStyle}>
+        <Img className="u-pr-1">
           <Icon icon="globe" color={palette['coolGrey']} />
         </Img>
         <Bd>
@@ -31,7 +29,7 @@ const WebsiteLinkCard = ({ link, t }) => {
             href={link}
             label={label}
             theme="text"
-            className="u-dodgerBlue"
+            className="u-dodgerBlue u-m-0"
             style={linkStyle}
           />
           <Caption>{t('card.websiteLink.description')}</Caption>

--- a/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 import Card from 'cozy-ui/transpiled/react/Card'
 import { SubTitle, Caption } from 'cozy-ui/transpiled/react/Text'
+import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
 import { Media, Img, Bd } from 'cozy-ui/transpiled/react/Media'
 import Icon from 'cozy-ui/transpiled/react/Icon'
@@ -11,18 +12,13 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 const WebsiteLinkCard = ({ link }) => {
   const linkStyle = { textTransform: 'lowercase' }
-  const hrStyle = {
-    height: '1px',
-    border: 'none',
-    backgroundColor: palette['silver']
-  }
   const label = new URL(link).host
   const { t } = useI18n()
 
   return (
     <Card>
       <SubTitle className="u-mb-1">{t('card.websiteLink.title')}</SubTitle>
-      <hr style={hrStyle} />
+      <Divider className="u-ml-0 u-maw-100" />
       <Media align="top">
         <Img className="u-pr-1">
           <Icon icon="globe" color={palette['coolGrey']} />

--- a/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.jsx
@@ -19,7 +19,7 @@ const WebsiteLinkCard = ({ link }) => {
     <Card>
       <SubTitle className="u-mb-1">{t('card.websiteLink.title')}</SubTitle>
       <Divider className="u-ml-0 u-maw-100" />
-      <Media align="top">
+      <Media className="u-mt-1" align="top">
         <Img className="u-pr-1">
           <Icon icon="globe" color={palette['coolGrey']} />
         </Img>

--- a/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.jsx
@@ -11,13 +11,18 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 const WebsiteLinkCard = ({ link }) => {
   const linkStyle = { textTransform: 'lowercase' }
+  const hrStyle = {
+    height: '1px',
+    border: 'none',
+    backgroundColor: palette['silver']
+  }
   const label = new URL(link).host
   const { t } = useI18n()
 
   return (
     <Card>
       <SubTitle className="u-mb-1">{t('card.websiteLink.title')}</SubTitle>
-      <hr className="u-silver" />
+      <hr style={hrStyle} />
       <Media align="top">
         <Img className="u-pr-1">
           <Icon icon="globe" color={palette['coolGrey']} />

--- a/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.jsx
@@ -7,12 +7,12 @@ import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
 import { Media, Img, Bd } from 'cozy-ui/transpiled/react/Media'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import palette from 'cozy-ui/transpiled/react/palette'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
-import { translate } from 'cozy-ui/transpiled/react/I18n'
-
-const WebsiteLinkCard = ({ link, t }) => {
+const WebsiteLinkCard = ({ link }) => {
   const linkStyle = { textTransform: 'lowercase' }
   const label = new URL(link).host
+  const { t } = useI18n()
 
   return (
     <Card>
@@ -43,4 +43,4 @@ WebsiteLinkCard.propTypes = {
   link: PropTypes.string.isRequired
 }
 
-export default translate()(WebsiteLinkCard)
+export default WebsiteLinkCard

--- a/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.spec.jsx
@@ -19,4 +19,14 @@ describe('WebsiteLinkCard', () => {
       'fc.assure.ameli.fr'
     )
   })
+  it('should ignore invalid urls', () => {
+    const link = 'www.trainline.fr'
+    const wrapper = mount(
+      <I18n dictRequire={() => enLocale} lang="en">
+        <WebsiteLinkCard link={link} />)
+      </I18n>
+    )
+    const component = wrapper.find(WebsiteLinkCard)
+    expect(component.exists('ButtonLink')).toEqual(false)
+  })
 })

--- a/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { mount } from 'enzyme'
 import I18n from 'cozy-ui/transpiled/react/I18n'
 
 import WebsiteLinkCard from './WebsiteLinkCard'
@@ -7,12 +7,16 @@ import enLocale from '../../locales/en'
 
 describe('WebsiteLinkCard', () => {
   it('should render', () => {
-    const wrapper = shallow(
+    const link = 'https://fc.assure.ameli.fr/FRCO-app/login'
+    const wrapper = mount(
       <I18n dictRequire={() => enLocale} lang="en">
-        <WebsiteLinkCard link="https://fc.assure.ameli.fr/FRCO-app/login" />
+        <WebsiteLinkCard link={link} />)
       </I18n>
     )
-    const component = wrapper.shallow()
-    expect(component.getElement()).toMatchSnapshot()
+    const component = wrapper.find(WebsiteLinkCard)
+    expect(component.find('ButtonLink').props().href).toEqual(link)
+    expect(component.find('ButtonLink').props().label).toEqual(
+      'fc.assure.ameli.fr'
+    )
   })
 })

--- a/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.spec.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import I18n from 'cozy-ui/transpiled/react/I18n'
+
+import WebsiteLinkCard from './WebsiteLinkCard'
+import enLocale from '../../locales/en'
+
+describe('WebsiteLinkCard', () => {
+  it('should render', () => {
+    const wrapper = shallow(
+      <I18n dictRequire={() => enLocale} lang="en">
+        <WebsiteLinkCard link="https://fc.assure.ameli.fr/FRCO-app/login" />
+      </I18n>
+    )
+    const component = wrapper.shallow()
+    expect(component.getElement()).toMatchSnapshot()
+  })
+})

--- a/packages/cozy-harvest-lib/src/components/cards/__snapshots__/WebsiteLinkCard.spec.jsx.snap
+++ b/packages/cozy-harvest-lib/src/components/cards/__snapshots__/WebsiteLinkCard.spec.jsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WebsiteLinkCard should render 1`] = `
+<withI18n(WebsiteLinkCard)
+  link="https://fc.assure.ameli.fr/FRCO-app/login"
+/>
+`;

--- a/packages/cozy-harvest-lib/src/components/cards/__snapshots__/WebsiteLinkCard.spec.jsx.snap
+++ b/packages/cozy-harvest-lib/src/components/cards/__snapshots__/WebsiteLinkCard.spec.jsx.snap
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`WebsiteLinkCard should render 1`] = `
-<withI18n(WebsiteLinkCard)
-  link="https://fc.assure.ameli.fr/FRCO-app/login"
-/>
-`;

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -92,6 +92,10 @@
         "button": "Access bank accounts",
         "install": "Discover Cozy Banks"
       }
+    },
+    "websiteLink": {
+      "title": "Useful information",
+      "description": "Service website"
     }
   },
   "default": {

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -91,6 +91,10 @@
         "button": "Accéder aux comptes bancaires",
         "install": "Découvrir Cozy Banks"
       }
+    },
+    "websiteLink": {
+      "title": "Informations utiles",
+      "description": "Site du service"
     }
   },
   "default": {


### PR DESCRIPTION
This branch takes its root from the 2.2.0 version of harvest (used
in last 1.30.5 version of cozy-home) and only adds cherry-picked
commits related to WebSiteLink component.

This will allow to deliver the next 1.30.6 version of cozy-home with
the WebSiteLink component and without more impactful and still to
be validated changes.

I also added a fix to not throw a error when the vendor_link is not
a valid url.


Do not throw error on invalid url in manifest