### PR TITLE
fix: Handle case when all contracts have been deleted

### DIFF
--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -21,7 +21,8 @@
       "bankAccounts": "Bank accounts",
       "default": "Contracts"
     },
-    "deleted": "Deleted"
+    "deleted": "Deleted",
+    "no-contracts": "No contracts anymore"
   },
   "contractForm": {
     "details": "Details",

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -21,7 +21,8 @@
       "bankAccounts": "Comptes et livrets d'épargne",
       "default": "Contrats"
     },
-    "deleted": "Supprimé"
+    "deleted": "Supprimé",
+    "no-contracts": "Vous n'avez plus de contrats"
   },
   "contractForm": {
     "details": "Détails",


### PR DESCRIPTION
If all contracts have been deleted, we still need to show
the icon of the konnector.