### PR TITLE
Add aria-label + test on DisconnectedAccountModal

### DIFF
--- a/packages/cozy-harvest-lib/src/components/DisconnectedAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/DisconnectedAccountModal.jsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from 'react'
-import { Contracts } from 'cozy-harvest-lib/dist/components/KonnectorConfiguration/ConfigurationTab/Contracts'
-import KonnectorModalHeader from 'cozy-harvest-lib/dist/components/KonnectorModalHeader'
+import PropTypes from 'prop-types'
+import { Contracts } from './KonnectorConfiguration/ConfigurationTab/Contracts'
+import KonnectorModalHeader from './KonnectorModalHeader'
 
 import { getCreatedByApp } from 'cozy-client/dist/models/utils'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
@@ -47,7 +48,11 @@ const DisconnectedModal = ({ accounts, onClose, initialActiveTab }) => {
   const [activeTab, setActiveTab] = useState(initialActiveTab)
 
   return (
-    <Modal mobileFullscreen={true} dismissAction={onClose}>
+    <Modal
+      aria-label={t('modal.aria-label')}
+      mobileFullscreen={true}
+      dismissAction={onClose}
+    >
       <KonnectorModalHeader konnector={konnectorRef.current} />
       <ModalContent className={isMobile ? 'u-p-0' : null}>
         <Tabs initialActiveTab={initialActiveTab}>
@@ -86,6 +91,10 @@ const DisconnectedModal = ({ accounts, onClose, initialActiveTab }) => {
 
 DisconnectedModal.defaultProps = {
   initialActiveTab: 'configuration'
+}
+
+DisconnectedModal.propTypes = {
+  accounts: PropTypes.array.isRequired
 }
 
 export default withLocales(DisconnectedModal)

--- a/packages/cozy-harvest-lib/src/components/DisconnectedAccountModal.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/DisconnectedAccountModal.spec.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import { CozyProvider } from 'cozy-client'
+import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import I18n from 'cozy-ui/transpiled/react/I18n'
+
+import DisconnectedAccountModal from './DisconnectedAccountModal'
+import bankAccounts from './KonnectorConfiguration/ConfigurationTab/bank-account-fixture.json'
+import en from '../locales/en.json'
+
+describe('DisconnectedAccountModal', () => {
+  const setup = () => {
+    const mockClient = {}
+    const root = render(
+      <CozyProvider client={mockClient}>
+        <I18n lang="en" dictRequire={() => en}>
+          <BreakpointsProvider>
+            <DisconnectedAccountModal accounts={[bankAccounts]} />
+          </BreakpointsProvider>
+        </I18n>
+      </CozyProvider>
+    )
+  }
+
+  it('should render a modal without warnings', () => {
+    setup()
+  })
+})

--- a/packages/cozy-harvest-lib/src/components/DisconnectedAccountModal.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/DisconnectedAccountModal.spec.jsx
@@ -21,9 +21,11 @@ describe('DisconnectedAccountModal', () => {
         </I18n>
       </CozyProvider>
     )
+    return { root }
   }
 
   it('should render a modal without warnings', () => {
-    setup()
+    const { root } = setup()
+    expect(() => root.getByText('Mon Compte Societaire')).not.toThrow()
   })
 })

--- a/packages/cozy-harvest-lib/test/jest.setup.js
+++ b/packages/cozy-harvest-lib/test/jest.setup.js
@@ -27,6 +27,7 @@ console.warn = function(message) {
   ) {
     return
   } else {
-    return originalConsoleWarn.apply(this, arguments)
+    originalConsoleWarn.apply(this, arguments)
+    throw new Error('console.warn should not be called during tests')
   }
 }


### PR DESCRIPTION
Without aria-label we have a warning and this is problematic
for apps that do no want warnings in their console.

Here I also make it so that console.warn throws during tests.