### PR TITLE
fix: Use model helpers and add test for SyncContractSwitch

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/SyncContractSwitch.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/SyncContractSwitch.jsx
@@ -19,14 +19,20 @@ export class DumbSyncContractSwitch extends React.Component {
       syncStatusLoading: false
     }
     this.handleSetSyncStatus = this.handleSetSyncStatus.bind(this)
-    this.checkToUpdateContractState({ mounting: true })
+    const stateUpdate = this.checkToUpdateContractState()
+    if (stateUpdate) {
+      Object.assign(this.state, stateUpdate)
+    }
   }
 
   componentDidUpdate() {
-    this.checkToUpdateContractState()
+    const stateUpdate = this.checkToUpdateContractState()
+    if (stateUpdate) {
+      this.setState(stateUpdate)
+    }
   }
 
-  checkToUpdateContractState({ mounting = false } = {}) {
+  checkToUpdateContractState() {
     const { accountCol, contract } = this.props
     if (
       accountCol.fetchStatus === 'loaded' &&
@@ -39,12 +45,7 @@ export class DumbSyncContractSwitch extends React.Component {
         contract._id
       )
       if (relSyncStatus !== null) {
-        if (mounting) {
-          // eslint-disable-next-line react/no-direct-mutation-state
-          this.state.syncStatus = relSyncStatus
-        } else {
-          this.setState({ syncStatus: relSyncStatus })
-        }
+        return { syncStatus: relSyncStatus }
       }
     }
   }

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/SyncContractSwitch.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/SyncContractSwitch.spec.jsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import { DumbSyncContractSwitch } from './SyncContractSwitch'
+import { render, fireEvent, act } from '@testing-library/react'
+import { models } from 'cozy-client'
+
+import { findKonnectorPolicy } from '../../../konnector-policies'
+
+jest.mock('../../../konnector-policies', () => ({
+  findKonnectorPolicy: jest.fn()
+}))
+
+const accountModels = models.account
+
+describe('SyncContractSwitch', () => {
+  const mockAccount = {
+    relationships: {
+      contracts: {
+        data: [
+          { _id: 'contract-1', metadata: { imported: true } },
+          { _id: 'contract-2', metadata: { imported: false } }
+        ]
+      }
+    }
+  }
+  const mockContract1 = { _id: 'contract-1' }
+  const mockContract2 = { _id: 'contract-2' }
+
+  const setup = ({ account, contract }) => {
+    const mockClient = {
+      save: jest.fn()
+    }
+    const root = render(
+      <DumbSyncContractSwitch
+        client={mockClient}
+        accountCol={{ data: account, fetchStatus: 'loaded' }}
+        contract={contract}
+        switchProps={{
+          inputProps: { 'data-testid': 'switch' }
+        }}
+      />
+    )
+    return { root, client: mockClient }
+  }
+
+  beforeEach(() => {
+    jest.spyOn(accountModels, 'setContractSyncStatusInAccount')
+    jest.spyOn(accountModels, 'getContractSyncStatusFromAccount')
+  })
+
+  it('should correctly render', () => {
+    const { root } = setup({ account: mockAccount, contract: mockContract1 })
+    const input = root.getByTestId('switch')
+    expect(input.checked).toBe(true)
+  })
+
+  it('should correctly render 2', () => {
+    const { root } = setup({ account: mockAccount, contract: mockContract2 })
+    const input = root.getByTestId('switch')
+    expect(input.checked).toBe(false)
+  })
+
+  it('should correctly behave', async () => {
+    const setSyncProm = Promise.resolve()
+    const setSync = jest.fn().mockReturnValue(setSyncProm)
+    findKonnectorPolicy.mockReturnValue({ setSync })
+    const { root, client } = setup({
+      account: mockAccount,
+      contract: mockContract2
+    })
+    act(() => {
+      const input = root.getByTestId('switch')
+      fireEvent.click(input)
+    })
+
+    expect(setSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        syncStatus: true
+      })
+    )
+    await setSyncProm
+    expect(client.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        relationships: {
+          contracts: {
+            data: [
+              { _id: 'contract-1', metadata: { imported: true } },
+              { _id: 'contract-2', metadata: { imported: true } }
+            ]
+          }
+        }
+      })
+    )
+  })
+})


### PR DESCRIPTION
After extracting the methods from harvest and putting them in cozy-client,
I had forgotten to replace the call points. I took the opportunity to
add tests for SyncContractSwitch since having them would have prevented
this error.