### PR TITLE
fix: Flaky builds due to SyntaxError

### DIFF
--- a/packages/babel-preset-cozy-app/index.js
+++ b/packages/babel-preset-cozy-app/index.js
@@ -60,7 +60,7 @@ const validators = mapValues(optionConfigs, x => x.validator)
 const defaultOptions = mapValues(optionConfigs, x => x.default)
 
 const mkConfig = (api, options) => {
-  const presetOptions = merge(defaultOptions, options)
+  const presetOptions = merge({}, defaultOptions, options)
 
   try {
     validate(presetOptions, validators)


### PR DESCRIPTION
A default options object was modified. This could cause race problems
when building a service and an app, the service configuring the
default options to have { node: true } in the babel-preset-cozy-app
default options, preventing the code from the app to be correctly
parsed.

Example of error:

"Support for the experimental syntax 'jsx' isn't currently enabled"

This error would disappear on subsequent builds, because of caching
(not sure why caching helps though). It was particularly problematic on
the CI where there's no cache and where builds must work the 1st time.

Fixes https://github.com/cozy/create-cozy-app/issues/1342