### PR TITLE
Add softDeleteOrRestoreAccounts service

### DIFF
--- a/packages/cozy-harvest-lib/src/connections/triggers.js
+++ b/packages/cozy-harvest-lib/src/connections/triggers.js
@@ -23,6 +23,12 @@ export const createTrigger = async (client, attributes) => {
   return data
 }
 
+/**
+ * Fetch the trigger based on its id
+ * @param  {Object} client CozyClient
+ * @param  {string} id
+ * @return {Object} Fetched trigger
+ */
 export const fetchTrigger = async (client, id) => {
   const { data } = await client.collection(TRIGGERS_DOCTYPE).get(id)
   return data

--- a/packages/cozy-harvest-lib/src/services/softDeleteOrRestoreAccounts.js
+++ b/packages/cozy-harvest-lib/src/services/softDeleteOrRestoreAccounts.js
@@ -32,7 +32,7 @@ const makeDecrypt = (vaultClient, orgKey) => encryptedVal =>
 
  * When a cipher is soft deleted, a deletedDate field is added to the
  * cipher. Then, the service removes the encrypted credentials from the
- * referenced account and delete the associated trigger.
+ * referenced account and deletes the associated trigger.
 
  * When the cipher is restored, the deletedDate is removed: the service
  * recreates the account's trigger. The account's credentials are then

--- a/packages/cozy-harvest-lib/src/services/softDeleteOrRestoreAccounts.js
+++ b/packages/cozy-harvest-lib/src/services/softDeleteOrRestoreAccounts.js
@@ -1,0 +1,85 @@
+import logger from './logger'
+import {
+  decryptString,
+  getOrganizationKey,
+  fetchAccountsForCipherId,
+  fetchKonnectorFromAccount,
+  fetchTriggersFromAccount,
+  updateAccountsAuth
+} from './utils'
+import get from 'lodash/get'
+import { ensureTrigger } from '../connections/triggers'
+import { translate as t } from 'cozy-ui/transpiled/react/I18n'
+
+const makeDecrypt = (vaultClient, orgKey) => encryptedVal =>
+  decryptString(encryptedVal, vaultClient, orgKey)
+
+const softDeleteOrRestoreAccounts = async (
+  cozyClient,
+  vaultClient,
+  cipherDoc
+) => {
+  const cipherId = get(cipherDoc, '_id')
+
+  logger.debug(`Fetching accounts for cipher ${cipherId}...`)
+  const accounts = await fetchAccountsForCipherId(cozyClient, cipherId)
+  if (accounts.data.length < 1) {
+    logger.debug('No account found for this cipher.')
+    return
+  }
+  const orgKey = await getOrganizationKey(cozyClient, vaultClient)
+  const decrypt = makeDecrypt(vaultClient, orgKey)
+
+  const encryptedPassword = get(cipherDoc, 'login.password')
+  const encryptedUsername = get(cipherDoc, 'login.username')
+
+  const encryptedFields = get(cipherDoc, 'fields') || []
+  const decryptedFields = {}
+  for (const encryptedField of encryptedFields) {
+    const fieldName = await decrypt(encryptedField.name)
+    const fieldValue = await decrypt(encryptedField.value)
+    decryptedFields[fieldName] = fieldValue
+  }
+
+  const decryptedPassword = await decrypt(encryptedPassword)
+  const decryptedUsername = await decrypt(encryptedUsername)
+  if (decryptedPassword === null || decryptedUsername === null) {
+    throw new Error('DECRYPT_FAILED')
+  }
+  if (cipherDoc.deletedDate) {
+    // Soft delete from bitwarden
+    logger.debug('Remove accounts credentials and triggers...')
+
+    // Delete triggers
+    for (const account of accounts.data) {
+      const triggers = await fetchTriggersFromAccount(cozyClient, account)
+      for (const trigger of triggers) {
+        logger.debug(`Remove trigger ${trigger._id}`)
+        await cozyClient.destroy(trigger)
+      }
+    }
+    // Remove credentials
+    logger.debug('Remove accounts credentials...')
+    await updateAccountsAuth(cozyClient, accounts.data, {
+      login: decryptedUsername,
+      ...decryptedFields
+    })
+  } else {
+    // Restore from bitwarden
+    logger.debug('Restore accounts triggers...')
+
+    // Restore triggers
+    for (const account of accounts.data) {
+      const konnector = await fetchKonnectorFromAccount(cozyClient, account)
+
+      await ensureTrigger(cozyClient, {
+        account,
+        t,
+        konnector
+      })
+    }
+    // Note: there is no need to restore credentials here, because it is already
+    // done by the updateAccountsFromCipher service.
+  }
+}
+export default softDeleteOrRestoreAccounts

--- a/packages/cozy-harvest-lib/src/services/softDeleteOrRestoreAccounts.js
+++ b/packages/cozy-harvest-lib/src/services/softDeleteOrRestoreAccounts.js
@@ -5,22 +5,11 @@ import {
   fetchAccountsForCipherId,
   fetchKonnectorFromAccount,
   fetchTriggersFromAccount,
-  updateAccountsAuth
+  updateAccountsAuth,
+  getT
 } from './utils'
 import get from 'lodash/get'
 import { ensureTrigger } from '../connections/triggers'
-const Polyglot = require('node-polyglot')
-
-const supportedLocales = ['en', 'fr', 'es']
-
-const getT = () => {
-  const locale =
-    supportedLocales.find(l => l === process.env.COZY_LOCALE) || 'en'
-  const locales = require(`../locales/${locale}.json`)
-  const polyglot = new Polyglot()
-  polyglot.extend(locales)
-  return polyglot.t.bind(polyglot)
-}
 
 const makeDecrypt = (vaultClient, orgKey) => encryptedVal =>
   decryptString(encryptedVal, vaultClient, orgKey)

--- a/packages/cozy-harvest-lib/src/services/softDeleteOrRestoreAccounts.js
+++ b/packages/cozy-harvest-lib/src/services/softDeleteOrRestoreAccounts.js
@@ -9,7 +9,18 @@ import {
 } from './utils'
 import get from 'lodash/get'
 import { ensureTrigger } from '../connections/triggers'
-import { translate as t } from 'cozy-ui/transpiled/react/I18n'
+const Polyglot = require('node-polyglot')
+
+const supportedLocales = ['en', 'fr', 'es']
+
+const getT = () => {
+  const locale =
+    supportedLocales.find(l => l === process.env.COZY_LOCALE) || 'en'
+  const locales = require(`../locales/${locale}.json`)
+  const polyglot = new Polyglot()
+  polyglot.extend(locales)
+  return polyglot.t.bind(polyglot)
+}
 
 const makeDecrypt = (vaultClient, orgKey) => encryptedVal =>
   decryptString(encryptedVal, vaultClient, orgKey)
@@ -89,7 +100,7 @@ const softDeleteOrRestoreAccounts = async (
 
       await ensureTrigger(cozyClient, {
         account,
-        t,
+        t: getT(),
         konnector
       })
     }

--- a/packages/cozy-harvest-lib/src/services/softDeleteOrRestoreAccounts.spec.js
+++ b/packages/cozy-harvest-lib/src/services/softDeleteOrRestoreAccounts.spec.js
@@ -6,10 +6,10 @@ import {
   fetchAccountsForCipherId,
   fetchTriggersFromAccount,
   fetchKonnectorFromAccount,
-  updateAccountsAuth
+  updateAccountsAuth,
+  getT
 } from 'services/utils'
 
-import { translate as t } from 'cozy-ui/transpiled/react/I18n'
 import { ensureTrigger } from '../connections/triggers'
 
 jest.mock('services/utils')
@@ -18,11 +18,9 @@ jest.mock('services/logger')
 jest.mock('../connections/triggers', () => ({
   ensureTrigger: jest.fn()
 }))
-jest.mock('cozy-ui/transpiled/react/I18n', () => {
-  return () => jest.fn()
-})
 
 decryptString.mockImplementation(str => `${str}_decrypted`)
+getT.mockImplementation(() => ({}))
 
 const mockCozyClient = {
   getStackClient: () => mockCozyClient,
@@ -119,7 +117,7 @@ describe('restore from cipher', () => {
 
     expect(ensureTrigger).toHaveBeenCalledWith(mockCozyClient, {
       account: accounts.data[0],
-      t,
+      t: {},
       konnector
     })
   })

--- a/packages/cozy-harvest-lib/src/services/softDeleteOrRestoreAccounts.spec.js
+++ b/packages/cozy-harvest-lib/src/services/softDeleteOrRestoreAccounts.spec.js
@@ -1,0 +1,126 @@
+import softDeleteOrRestoreAccounts from './softDeleteOrRestoreAccounts'
+
+import {
+  decryptString,
+  getOrganizationKey,
+  fetchAccountsForCipherId,
+  fetchTriggersFromAccount,
+  fetchKonnectorFromAccount,
+  updateAccountsAuth
+} from 'services/utils'
+
+import { translate as t } from 'cozy-ui/transpiled/react/I18n'
+import { ensureTrigger } from '../connections/triggers'
+
+jest.mock('services/utils')
+jest.mock('services/logger')
+
+jest.mock('../connections/triggers', () => ({
+  ensureTrigger: jest.fn()
+}))
+jest.mock('cozy-ui/transpiled/react/I18n', () => {
+  return () => jest.fn()
+})
+
+decryptString.mockImplementation(str => `${str}_decrypted`)
+
+const mockCozyClient = {
+  getStackClient: () => mockCozyClient,
+  find: () => mockCozyClient,
+  where: () => mockCozyClient,
+  indexFields: () => mockCozyClient,
+  query: jest.fn(),
+  save: jest.fn(),
+  fetchJSON: jest.fn(),
+  destroy: jest.fn()
+}
+
+const mockVaultClient = {
+  Utils: {
+    fromB64ToArray: str => str
+  },
+  cryptoService: {
+    aesDecryptToUtf8: jest.fn(str => str)
+  }
+}
+
+getOrganizationKey.mockResolvedValue({})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('soft delete from cipher', () => {
+  it('should remove encrypted password and delete trigger', async () => {
+    const accounts = {
+      data: [
+        {
+          auth: {
+            credentials_encrypted: 'abc123',
+            login: 'A'
+          }
+        }
+      ]
+    }
+    const triggers = [
+      {
+        message: {
+          konnector: 'dummy'
+        }
+      }
+    ]
+
+    fetchAccountsForCipherId.mockResolvedValue(accounts)
+    fetchTriggersFromAccount.mockResolvedValue(triggers)
+
+    await softDeleteOrRestoreAccounts(mockCozyClient, mockVaultClient, {
+      login: {
+        password: 'abc123',
+        username: 'A'
+      },
+      deletedDate: '2020-01-01'
+    })
+
+    expect(updateAccountsAuth).toHaveBeenCalledWith(
+      mockCozyClient,
+      accounts.data,
+      {
+        login: 'A_decrypted'
+      }
+    )
+    expect(mockCozyClient.destroy).toHaveBeenCalledWith(triggers[0])
+  })
+})
+
+describe('restore from cipher', () => {
+  it('should restore trigger', async () => {
+    const accounts = {
+      data: [
+        {
+          auth: {
+            login: 'A'
+          }
+        }
+      ]
+    }
+    const konnector = {
+      name: 'dummy'
+    }
+
+    fetchAccountsForCipherId.mockResolvedValue(accounts)
+    fetchKonnectorFromAccount.mockResolvedValue(konnector)
+
+    await softDeleteOrRestoreAccounts(mockCozyClient, mockVaultClient, {
+      login: {
+        password: 'abc123',
+        username: 'A'
+      }
+    })
+
+    expect(ensureTrigger).toHaveBeenCalledWith(mockCozyClient, {
+      account: accounts.data[0],
+      t,
+      konnector
+    })
+  })
+})

--- a/packages/cozy-harvest-lib/src/services/updateAccountsFromCipher.js
+++ b/packages/cozy-harvest-lib/src/services/updateAccountsFromCipher.js
@@ -23,6 +23,12 @@ const updateAccountsFromCipher = async (
   const encryptedUsername = get(bitwardenCipherDocument, 'login.username')
   const bitwardenCipherId = get(bitwardenCipherDocument, '_id')
 
+  const isSoftDeleted = get(bitwardenCipherDocument, 'deletedDate')
+  if (isSoftDeleted) {
+    logger.debug('Cipher is soft deleted: do not update.')
+    return
+  }
+
   logger.debug('Fetching organization key...')
   const orgKey = await getOrganizationKey(cozyClient, vaultClient)
   logger.debug('Fetched organization key')

--- a/packages/cozy-harvest-lib/src/services/updateAccountsFromCipher.js
+++ b/packages/cozy-harvest-lib/src/services/updateAccountsFromCipher.js
@@ -14,6 +14,9 @@ import logger from './logger'
 const makeDecrypt = (vaultClient, orgKey) => encryptedVal =>
   decryptString(encryptedVal, vaultClient, orgKey)
 
+/**
+ * This service updates the accounts referencing an updated cipher.
+ */
 const updateAccountsFromCipher = async (
   cozyClient,
   vaultClient,

--- a/packages/cozy-harvest-lib/src/services/updateAccountsFromCipher.spec.js
+++ b/packages/cozy-harvest-lib/src/services/updateAccountsFromCipher.spec.js
@@ -52,9 +52,7 @@ describe('update accounts from cipher', () => {
   it('should update accounts', async () => {
     const orgKey = {}
     getOrganizationKey.mockResolvedValue(orgKey)
-
     decryptString.mockImplementation(str => `${str}_decrypted`)
-
     const accounts = {
       data: [
         {

--- a/packages/cozy-harvest-lib/src/services/utils.js
+++ b/packages/cozy-harvest-lib/src/services/utils.js
@@ -47,6 +47,31 @@ export const fetchAccountsForCipherId = async (cozyClient, cipherId) => {
   return accounts
 }
 
+export const fetchKonnectorFromAccount = async (cozyClient, account) => {
+  const konnectorDoctype = 'io.cozy.konnectors'
+  const slug = account.account_type
+  const konnector = await cozyClient.query(
+    cozyClient.get(konnectorDoctype, slug)
+  )
+  return konnector.data
+    ? {
+        _id: konnector.data._id,
+        _type: konnector.data.type,
+        ...konnector.data.attributes
+      }
+    : null
+}
+
+export const fetchTriggersFromAccount = async (cozyClient, account) => {
+  const triggers = await cozyClient.queryAll(
+    cozyClient.find('io.cozy.triggers').where({
+      worker: 'konnector',
+      'message.account': account._id
+    })
+  )
+  return triggers
+}
+
 export const updateAccountsAuth = async (cozyClient, accounts, authData) => {
   await Promise.all(
     accounts.map(account => {

--- a/packages/cozy-harvest-lib/src/services/utils.js
+++ b/packages/cozy-harvest-lib/src/services/utils.js
@@ -2,6 +2,7 @@ import SymmetricCryptoKey from 'cozy-keys-lib/transpiled/SymmetricCryptoKey'
 import EncryptionType from 'cozy-keys-lib/transpiled/EncryptionType'
 import merge from 'lodash/merge'
 import unset from 'lodash/unset'
+const Polyglot = require('node-polyglot')
 
 export const decryptString = (encryptedString, vaultClient, orgKey) => {
   const [encTypeAndIv, data, mac] = encryptedString.split('|')
@@ -15,6 +16,16 @@ export const decryptString = (encryptedString, vaultClient, orgKey) => {
     mac,
     orgKey
   )
+}
+
+export const getT = () => {
+  const supportedLocales = ['en', 'fr', 'es']
+  const locale =
+    supportedLocales.find(l => l === process.env.COZY_LOCALE) || 'en'
+  const locales = require(`../locales/${locale}.json`)
+  const polyglot = new Polyglot()
+  polyglot.extend(locales)
+  return polyglot.t.bind(polyglot)
 }
 
 export const getOrganizationKey = async (cozyClient, vaultClient) => {


### PR DESCRIPTION
This service is useful to deal with soft delete and restore from
bitwarden, used for a trash feature. See [the stack PR](https://github.com/cozy/cozy-stack/pull/2633).

When a cipher is soft deleted, a `deletedDate` field is added to the
cipher. Then, the service removes the encrypted credentials from the
referenced account and delete the associated trigger.

When the cipher is restored, the `deletedDate` is removed: the service
recreates the account's trigger. The account's credentials are then
restored through the `updateAccountsFromCipher` service.