### PR TITLE
fix: Handle cases where io.cozy.accounts does not have contract

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/EditContract.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/EditContract.jsx
@@ -7,9 +7,8 @@ import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import Button from 'cozy-ui/transpiled/react/Button'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
-import Field, { FieldContainer } from 'cozy-ui/transpiled/react/Field'
+import Field from 'cozy-ui/transpiled/react/Field'
 import CollectionField from 'cozy-ui/transpiled/react/Labs/CollectionField'
-import Label from 'cozy-ui/transpiled/react/Label'
 import Stack from 'cozy-ui/transpiled/react/Stack'
 import BaseContactPicker from 'cozy-ui/transpiled/react/ContactPicker'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
@@ -186,17 +185,12 @@ const EditContract = props => {
               variant={fieldVariant}
             />
             {policy.setSync && flag('harvest.toggle-contract-sync') ? (
-              <FieldContainer variant={fieldVariant}>
-                <Label>{t('contractForm.imported')}</Label>
-                {/* The span is needed otherwise the switch is not correctly rendered */}
-                <span>
-                  <SyncContractSwitch
-                    contract={contract}
-                    accountId={accountId}
-                    konnector={konnector}
-                  />
-                </span>
-              </FieldContainer>
+              <SyncContractSwitch
+                fieldVariant={fieldVariant}
+                contract={contract}
+                accountId={accountId}
+                konnector={konnector}
+              />
             ) : null}
 
             <Button

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/SyncContractSwitch.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/SyncContractSwitch.spec.jsx
@@ -34,6 +34,7 @@ describe('SyncContractSwitch', () => {
         client={mockClient}
         accountCol={{ data: account, fetchStatus: 'loaded' }}
         contract={contract}
+        t={x => x}
         switchProps={{
           inputProps: { 'data-testid': 'switch' }
         }}
@@ -47,16 +48,36 @@ describe('SyncContractSwitch', () => {
     jest.spyOn(accountModels, 'getContractSyncStatusFromAccount')
   })
 
-  it('should correctly render', () => {
+  it('should correctly render (contract synced)', () => {
     const { root } = setup({ account: mockAccount, contract: mockContract1 })
     const input = root.getByTestId('switch')
     expect(input.checked).toBe(true)
   })
 
-  it('should correctly render 2', () => {
+  it('should correctly render (contract is not synced)', () => {
     const { root } = setup({ account: mockAccount, contract: mockContract2 })
     const input = root.getByTestId('switch')
     expect(input.checked).toBe(false)
+  })
+
+  describe('unexisting contract', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      // eslint-disable-next-line no-console
+      console.warn.mockRestore()
+    })
+
+    it('should correctly render (contract does not exist)', () => {
+      const unexistingContract = { ...mockContract2, _id: 'contract-3' }
+      const { root } = setup({
+        account: mockAccount,
+        contract: unexistingContract
+      })
+      expect(root.queryByTestId('switch')).toBe(null)
+    })
   })
 
   it('should correctly behave', async () => {

--- a/packages/cozy-harvest-lib/test/jest.setup.js
+++ b/packages/cozy-harvest-lib/test/jest.setup.js
@@ -18,12 +18,18 @@ console.warn = function(message) {
      * removed when ReactFinalForm/ModalContent is updated and does not use
      * componentWillMount and componentWillUpdate
      */
-    (message.startsWith('Warning: componentWillMount has been renamed') ||
-      message.startsWith('Warning: componentWillUpdate has been renamed')) &&
-    (message.endsWith(
-      'Please update the following components: ReactFinalForm'
-    ) ||
-      message.endsWith('Please update the following components: ModalContent'))
+    ((message.startsWith &&
+      message.startsWith('Warning: componentWillMount has been renamed')) ||
+      (message.startsWith &&
+        message.startsWith('Warning: componentWillUpdate has been renamed'))) &&
+    ((message.endsWith &&
+      message.endsWith(
+        'Please update the following components: ReactFinalForm'
+      )) ||
+      (message.endsWith &&
+        message.endsWith(
+          'Please update the following components: ModalContent'
+        )))
   ) {
     return
   } else {


### PR DESCRIPTION
If an account does not have any contract (for example because its konnector
does not fill its contracts relationship), we should not fail completely.
Here the code has been refactored so that the SyncAccountSwitch also
renders its label, and so that it renders null if the related contract
cannot be found in the account.