### PR TITLE
fix: Set peerDep same as devDep

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -72,10 +72,10 @@
   },
   "peerDependencies": {
     "cozy-client": "^14.4.0",
-    "cozy-device-helper": "^1.7.1",
+    "cozy-device-helper": "^1.10.2",
     "cozy-keys-lib": "^3.1.0",
-    "cozy-realtime": "^3.1.0",
-    "cozy-ui": "^35.45.0"
+    "cozy-realtime": "^3.10.5",
+    "cozy-ui": "^37.6.0"
   },
   "sideEffects": false
 }


### PR DESCRIPTION
Currently Harvest have a few old version in peerDep. We should kept them synched with the devDep? 