### PR TITLE
feat: Add redirectSlug to OAuthWindow

### DIFF
--- a/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
@@ -43,7 +43,7 @@ export class OAuthWindow extends PureComponent {
   }
 
   componentDidMount() {
-    const { client, konnector } = this.props
+    const { client, konnector, redirectSlug } = this.props
     this.realtime = new CozyRealtime({ client })
     this.realtime.subscribe(
       'notified',
@@ -51,7 +51,11 @@ export class OAuthWindow extends PureComponent {
       OAUTH_REALTIME_CHANNEL,
       this.handleMessage
     )
-    const { oAuthStateKey, oAuthUrl } = prepareOAuth(client, konnector)
+    const { oAuthStateKey, oAuthUrl } = prepareOAuth(
+      client,
+      konnector,
+      redirectSlug
+    )
     this.setState({ oAuthStateKey, oAuthUrl, succeed: false })
   }
 
@@ -159,7 +163,9 @@ OAuthWindow.propTypes = {
   onSuccess: PropTypes.func,
   /** Callback called when the OAuth window is closed wihout having retrieved
   an account id */
-  onCancel: PropTypes.func
+  onCancel: PropTypes.func,
+  /** The app we want to redirect the user on, after the OAuth flow. It used by the stack */
+  redirectSlug: PropTypes.string
 }
 
 export default translate()(withClient(OAuthWindow))

--- a/packages/cozy-harvest-lib/src/helpers/oauth.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.js
@@ -91,6 +91,7 @@ export const handleOAuthResponse = (options = {}) => {
  * @param  {string} accountType connector slug
  * @param  {string} oAuthStateKey localStorage key
  * @param  {Object} oAuthConf connector manifest oauth configuration
+ * @param  {string} redirectSlug The app we want to redirect the user on after the end of the flow
  * @param  {string} nonce unique nonce string
  */
 export const getOAuthUrl = ({
@@ -98,7 +99,8 @@ export const getOAuthUrl = ({
   accountType,
   oAuthStateKey,
   oAuthConf,
-  nonce
+  nonce,
+  redirectSlug
 }) => {
   let oAuthUrl = `${cozyUrl}/accounts/${accountType}/start?state=${oAuthStateKey}&nonce=${nonce}`
   if (
@@ -111,6 +113,9 @@ export const getOAuthUrl = ({
       : oAuthConf.scope
     oAuthUrl += `&scope=${urlScope}`
   }
+  if (redirectSlug) {
+    oAuthUrl += `&slug=${redirectSlug}`
+  }
   return oAuthUrl
 }
 
@@ -120,10 +125,11 @@ export const getOAuthUrl = ({
  * passing the localStorage key as state in query string.
  * @param  {string} domain    Cozy domain
  * @param  {Object} konnector
+ * @param  {string} redirectSlug The app we want to redirect the user on after the end of the flow
  * @return {Object}           Object containing: `oAuthUrl` (URL of cozy stack
  * OAuth endpoint) and `oAuthStateKey` (localStorage key)
  */
-export const prepareOAuth = (client, konnector) => {
+export const prepareOAuth = (client, konnector, redirectSlug) => {
   const { oauth } = konnector
   const accountType = konnectors.getAccountType(konnector)
 
@@ -141,7 +147,8 @@ export const prepareOAuth = (client, konnector) => {
     accountType,
     oAuthStateKey,
     oAuthConf: oauth,
-    nonce: Date.now()
+    nonce: Date.now(),
+    redirectSlug
   })
 
   return { oAuthStateKey, oAuthUrl }

--- a/packages/cozy-harvest-lib/test/helpers/oauth.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/oauth.spec.js
@@ -53,6 +53,16 @@ describe('Oauth helper', () => {
         'https://cozyurl/accounts/testslug/start?state=statekey&nonce=1234&scope=thescope+thescope2'
       )
     })
+    it('should use redirectSlug if present', () => {
+      const url = getOAuthUrl({
+        ...defaultConf,
+        oAuthConf: {},
+        redirectSlug: 'drive'
+      })
+      expect(url).toEqual(
+        'https://cozyurl/accounts/testslug/start?state=statekey&nonce=1234&slug=drive'
+      )
+    })
   })
   describe('handleOAuthResponse', () => {
     let originalLocation


### PR DESCRIPTION
Since https://github.com/cozy/cozy-stack/pull/2674, the stack accepts
a new "slug" parameter. This param is used to redirect the user on the
specified slug after the end of the OAuth flow.

Before, the user was always redirected to the Home app, but now that
several apps (internal & external) use Harvest directly, we want to
redirect the user on the right app to provide a good UX.

By good UX, I mean : on web mobile, we open a new tab / window to start the OAuth flow. Before this modification we ended on the Home app all the time. But since we can starts this process from an other app, we ended on the Home without the right informations (state for instance) resulting in a blank screen while the process in the opener tab was finished successfully. 

Context: One of the GL app imports directly the `OAuthWindow`, now this app can pass the slug in props and handle the flow with a great UX 👍 