### PR TITLE
fix(Harvest): Display disconnect button for OAuth connectors

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
@@ -115,55 +115,53 @@ const ConfigurationTab = ({
           {flag('harvest.show-contracts') ? (
             <ContractsForAccount konnector={konnector} account={account} />
           ) : null}
-          {!konnector.oauth ? (
-            <>
-              <NavigationListHeader>
-                {t('modal.updateAccount.general-subheader')}
-              </NavigationListHeader>
-              <NavigationListSection>
-                <ListItem
-                  className="u-c-pointer"
-                  onClick={() => pushHistory(`/accounts/${account._id}/edit`)}
-                >
-                  <ListItemIcon>
-                    <Icon icon="key" color={palette['slateGrey']} />
-                  </ListItemIcon>
-                  <ListItemText
-                    primaryText={t('modal.updateAccount.identifiers')}
-                    secondaryText={Account.getAccountName(account)}
-                  />
-                  <ListItemSecondaryAction>
-                    <div>
-                      {running && <Spinner />}
-                      <Icon
-                        className="u-mr-1"
-                        icon="right"
-                        color={palette['coolGrey']}
-                      />
-                    </div>
-                  </ListItemSecondaryAction>
-                </ListItem>
-                <ListItem className="u-c-pointer" onClick={handleDeleteRequest}>
-                  <ListItemIcon>
-                    <Icon icon="unlink" className="u-error" />
-                  </ListItemIcon>
-                  <ListItemText
-                    primaryTextClassName="u-error"
-                    primaryText={t('accountForm.disconnect.button')}
-                  />
-                  <ListItemSecondaryAction>
-                    {deleting && <Spinner />}
-                  </ListItemSecondaryAction>
-                </ListItem>
-                {requestingDeletion ? (
-                  <ConfirmationDialog
-                    onCancel={handleCancelDeleteRequest}
-                    onConfirm={handleDeleteAccount}
-                  />
-                ) : null}
-              </NavigationListSection>
-            </>
-          ) : null}
+          <NavigationListHeader>
+            {t('modal.updateAccount.general-subheader')}
+          </NavigationListHeader>
+          <NavigationListSection>
+            {konnector.oauth ? null : (
+              <ListItem
+                className="u-c-pointer"
+                onClick={() => pushHistory(`/accounts/${account._id}/edit`)}
+              >
+                <ListItemIcon>
+                  <Icon icon="key" color={palette['slateGrey']} />
+                </ListItemIcon>
+                <ListItemText
+                  primaryText={t('modal.updateAccount.identifiers')}
+                  secondaryText={Account.getAccountName(account)}
+                />
+                <ListItemSecondaryAction>
+                  <div>
+                    {running && <Spinner />}
+                    <Icon
+                      className="u-mr-1"
+                      icon="right"
+                      color={palette['coolGrey']}
+                    />
+                  </div>
+                </ListItemSecondaryAction>
+              </ListItem>
+            )}
+            <ListItem className="u-c-pointer" onClick={handleDeleteRequest}>
+              <ListItemIcon>
+                <Icon icon="unlink" className="u-error" />
+              </ListItemIcon>
+              <ListItemText
+                primaryTextClassName="u-error"
+                primaryText={t('accountForm.disconnect.button')}
+              />
+              <ListItemSecondaryAction>
+                {deleting && <Spinner />}
+              </ListItemSecondaryAction>
+            </ListItem>
+            {requestingDeletion ? (
+              <ConfirmationDialog
+                onCancel={handleCancelDeleteRequest}
+                onConfirm={handleDeleteAccount}
+              />
+            ) : null}
+          </NavigationListSection>
         </NavigationList>
         {showNewAccountButton ? (
           <div className={cx('u-ta-right u-mt-1', isMobile ? 'u-ph-1' : null)}>

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.spec.js
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.spec.js
@@ -1,0 +1,63 @@
+/* eslint no-console: off */
+
+import { render } from '@testing-library/react'
+import ConfigurationTab from './index'
+import React from 'react'
+import I18n from 'cozy-ui/transpiled/react/I18n'
+import enLocale from '../../../locales/en.json'
+import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import { MountPointProvider } from '../../../components/MountPointContext'
+
+describe('ConfigurationTab', () => {
+  let originalWarn
+  beforeEach(() => {
+    originalWarn = console.warn
+    console.warn = function(msg) {
+      if (msg && msg.includes && msg.includes('componentWillReceiveProps')) {
+        return
+      }
+      return originalWarn.apply(this, arguments)
+    }
+  })
+
+  afterEach(() => {
+    console.warn = originalWarn
+  })
+
+  function setup({ konnector = {} } = {}) {
+    const account = {}
+    const addAccount = jest.fn()
+    const onAccountDeleted = jest.fn()
+    const flow = {
+      getState: jest.fn().mockReturnValue({
+        error: null,
+        running: true
+      })
+    }
+    const root = render(
+      <MountPointProvider baseRoute="/">
+        <BreakpointsProvider>
+          <I18n lang="en" dictRequire={() => enLocale}>
+            <ConfigurationTab
+              konnector={konnector}
+              account={account}
+              addAccount={addAccount}
+              onAccountDeleted={onAccountDeleted}
+              flow={flow}
+            />
+          </I18n>
+        </BreakpointsProvider>
+      </MountPointProvider>
+    )
+    return { root }
+  }
+
+  it('should render', () => {
+    const { root } = setup()
+    expect(root.getByText('Identifiers')).toBeTruthy()
+  })
+  it('should not render identifiers for oauth konnectors', () => {
+    const { root } = setup({ konnector: { oauth: true } })
+    expect(root.queryByText('Identifiers')).toBe(null)
+  })
+})


### PR DESCRIPTION
At the moment, this disconnect button is hidden for OAuth connectors since the contract selection feature