### PR TITLE
fix: Put cozy-flags as peer-dep

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -31,7 +31,6 @@
     "@testing-library/react": "^10.4.9",
     "cozy-bi-auth": "0.0.11",
     "cozy-doctypes": "^1.74.7",
-    "cozy-flags": "^2.4.0",
     "cozy-keys-lib": "3.1.2",
     "cozy-logger": "1.6.0",
     "date-fns": "^1.30.1",
@@ -55,6 +54,7 @@
     "babel-preset-cozy-app": "^1.9.3",
     "cozy-client": "14.4.0",
     "cozy-device-helper": "^1.10.3",
+    "cozy-flags": "^2.3.5",
     "cozy-keys-lib": "^3.1.0",
     "cozy-realtime": "^3.10.6",
     "cozy-ui": "37.6.0",
@@ -73,6 +73,7 @@
   "peerDependencies": {
     "cozy-client": "^14.4.0",
     "cozy-device-helper": "^1.10.2",
+    "cozy-flags": "^2.3.5",
     "cozy-keys-lib": "^3.1.0",
     "cozy-realtime": "^3.10.5",
     "cozy-ui": "^37.6.0"


### PR DESCRIPTION
It's problematic when libs have not the same version of cozy-flags
as the host app since cozy-flags keeps a internal cache of flags.

If the app's cozy-flags is not the same as the libs' flag, the
lib's cozy-flags will not populated with the flags that are 
fetched at login time (on mobile) or at page resume time (both
on mobile and browser).