### PR TITLE
Tracking inside harvest

### DIFF
--- a/packages/cozy-codemods/src/find-nearest.js
+++ b/packages/cozy-codemods/src/find-nearest.js
@@ -1,4 +1,5 @@
-const findNearest = (path, condition) => {
+const findNearest = (pathArg, condition) => {
+  let path = pathArg
   while (path && !condition(path) && path.parentPath) {
     path = path.parentPath
   }

--- a/packages/cozy-harvest-lib/README.md
+++ b/packages/cozy-harvest-lib/README.md
@@ -49,6 +49,34 @@ import { withLocales } from 'cozy-harvest-lib'
 const MyTriggerManager = withLocales(TriggerManager)
 ```
 
+# Tracking
+
+Harvest components come with tracking calls (that would be effective only if the
+user has consented to tracking). Your app must provide the correct tracking
+context via the `TrackingContext` component.
+
+Here, we pass a tracker to harvest that prefixes the page names sent by harvest
+with "app-harvest:".
+
+```
+import { useMemo } from 'react'
+import { KonnectorModal, TrackingContext } from 'cozy-harvest-lib'
+
+export default () => {
+  const appTracker = useTracker() // tracker from the app
+  const trackerForHarvest = useMemo(() => {
+    const trackPage = pageName => tracker.trackPage(`app-harvest:${pageName}`)
+    const trackEvent = event => tracker.trackEvent(event)
+    return { trackPage, trackEvent }
+  }, [appTracker])
+  return <TrackingContext.Provider value={trackerForHarvest}>
+    <KonnectorModal />
+  </TrackingContext.Provider>
+}
+```
+
+If the app does not provide a tracking context, tracking calls will do nothing.
+
 # Getting Started
 
 For now it is possible to instanciate a `<TriggerManager />` which will allow to edit an account and launch the trigger.

--- a/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
@@ -16,6 +16,7 @@ import * as triggersModel from '../helpers/triggers'
 import TriggerManager from './TriggerManager'
 import { withMountPointPushHistory } from './MountPointContext'
 import logger from '../logger'
+import { withTracker } from './hoc/tracking'
 
 export class EditAccountModal extends Component {
   constructor(props) {
@@ -46,6 +47,8 @@ export class EditAccountModal extends Component {
     } else {
       logger.warn('No matching trigger for account', accountId)
     }
+
+    this.props.trackPage('harvest:comptes:details')
   }
   /**
    * TODO use queryConnect to know if we're fecthing or not
@@ -137,5 +140,6 @@ EditAccountModal.propTypes = {
 
 export default flow(
   withClient,
-  withMountPointPushHistory
+  withMountPointPushHistory,
+  withTracker
 )(EditAccountModal)

--- a/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
@@ -48,7 +48,7 @@ export class EditAccountModal extends Component {
       logger.warn('No matching trigger for account', accountId)
     }
 
-    this.props.trackPage('harvest:comptes:details')
+    this.props.trackPage('editer_identifiants')
   }
   /**
    * TODO use queryConnect to know if we're fecthing or not

--- a/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
@@ -98,6 +98,7 @@ export class EditAccountModal extends Component {
         dismissAction={this.redirectToAccount}
         mobileFullscreen
         size="small"
+        aria-label={konnector.name}
       >
         <ModalHeader
           title={

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/EditContract.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/EditContract.jsx
@@ -28,6 +28,7 @@ import { findKonnectorPolicy } from '../../../konnector-policies'
 
 import withLocales from '../../hoc/withLocales'
 import { updateContract } from './helpers'
+import { useTracker } from '../../hoc/tracking'
 
 import {
   getAccountLabel,
@@ -80,6 +81,7 @@ const EditContract = props => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const client = useClient()
+  const tracker = useTracker()
 
   const {
     contract,
@@ -122,11 +124,18 @@ const EditContract = props => {
   const handleSubmit = e => {
     e.preventDefault()
     handleSaveContract(contract, { shortLabel, owners })
+    tracker.trackEvent('appliquer')
   }
 
   const handleRequestDeletion = ev => {
     ev.preventDefault()
     setShowDeleteConfirmation(true)
+    tracker.trackEvent('supprimer_compte')
+  }
+
+  const handleCancelDeletion = () => {
+    setShowDeleteConfirmation(false)
+    tracker.trackEvent('annuler')
   }
 
   const handleRemoveContract = async contract => {
@@ -134,6 +143,7 @@ const EditContract = props => {
 
     try {
       await client.destroy(contract)
+      tracker.trackEvent('confirmer_suppression')
 
       if (onAfterRemove) {
         onAfterRemove()
@@ -145,6 +155,11 @@ const EditContract = props => {
     } finally {
       setDeleting(false)
     }
+  }
+
+  const handleChangeOwners = owners => {
+    setOwners(owners)
+    tracker.trackEvent('changement_titulaire')
   }
 
   const confirmPrimaryText = t('contractForm.confirm-deletion.description')
@@ -177,7 +192,7 @@ const EditContract = props => {
               addButtonLabel={t('contractForm.addOwnerBtn')}
               removeButtonLabel={t('contractForm.removeOwnerBtn')}
               variant={fieldVariant}
-              onChange={owners => setOwners(owners)}
+              onChange={handleChangeOwners}
               placeholder={t('contractForm.ownerPlaceholder')}
             />
             <Field
@@ -242,7 +257,7 @@ const EditContract = props => {
           }
           secondaryText={t('contractForm.cancel')}
           onConfirm={() => handleRemoveContract(contract)}
-          onCancel={() => setShowDeleteConfirmation(false)}
+          onCancel={() => handleCancelDeletion()}
         />
       ) : null}
     </Dialog>

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/EditContract.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/EditContract.jsx
@@ -28,7 +28,7 @@ import { findKonnectorPolicy } from '../../../konnector-policies'
 
 import withLocales from '../../hoc/withLocales'
 import { updateContract } from './helpers'
-import { useTracker } from '../../hoc/tracking'
+import { useTracker, useTrackPage } from '../../hoc/tracking'
 
 import {
   getAccountLabel,
@@ -95,6 +95,8 @@ const EditContract = props => {
 
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
   const [deleting, setDeleting] = useState(false)
+
+  useTrackPage('editer_contrat')
 
   const handleSaveContract = async (contract, fields) => {
     await updateContract(client, contract, {

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/SyncContractSwitch.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/SyncContractSwitch.jsx
@@ -1,15 +1,14 @@
 import React from 'react'
-import { withClient, queryConnect, models } from 'cozy-client'
-import { translate } from 'cozy-ui/transpiled/react/I18n'
-
 import compose from 'lodash/flowRight'
 
+import { withClient, queryConnect, models } from 'cozy-client'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 import { Media, Img, Bd } from 'cozy-ui/transpiled/react/Media'
 import Switch from 'cozy-ui/transpiled/react/MuiCozyTheme/Switch'
 
 import { createAccountQuerySpec } from '../../../connections/accounts'
-
 import { findKonnectorPolicy } from '../../../konnector-policies'
+import { withTracker } from '../../hoc/tracking'
 
 const { account: accountModel } = models
 
@@ -58,7 +57,7 @@ export class DumbSyncContractSwitch extends React.Component {
 
   async handleSetSyncStatus(ev) {
     ev.preventDefault()
-    const { client, konnector, contract, accountCol } = this.props
+    const { client, konnector, contract, accountCol, tracker } = this.props
     const { data: account } = accountCol
     const { syncStatus } = this.state
     const newSyncStatus = !syncStatus
@@ -78,6 +77,7 @@ export class DumbSyncContractSwitch extends React.Component {
         newSyncStatus
       )
       await client.save(updatedAccount)
+      tracker.trackEvent(`synchroniser_compte-${newSyncStatus ? 'on' : 'off'}`)
     } catch (e) {
       // eslint-disable-next-line no-console
       console.warn('Could not set sync status', e)
@@ -128,7 +128,8 @@ const SyncContractSwitch = compose(
   translate(),
   queryConnect({
     accountCol: props => createAccountQuerySpec(props.accountId)
-  })
+  }),
+  withTracker
 )(DumbSyncContractSwitch)
 
 export default SyncContractSwitch

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/SyncContractSwitch.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/SyncContractSwitch.spec.jsx
@@ -4,6 +4,7 @@ import { render, fireEvent, act } from '@testing-library/react'
 import { models } from 'cozy-client'
 
 import { findKonnectorPolicy } from '../../../konnector-policies'
+import { trackerShim } from '../../hoc/tracking'
 
 jest.mock('../../../konnector-policies', () => ({
   findKonnectorPolicy: jest.fn()
@@ -32,6 +33,7 @@ describe('SyncContractSwitch', () => {
     const root = render(
       <DumbSyncContractSwitch
         client={mockClient}
+        tracker={trackerShim}
         accountCol={{ data: account, fetchStatus: 'loaded' }}
         contract={contract}
         t={x => x}

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
@@ -22,6 +22,7 @@ import Dialog, {
   DialogContent,
   DialogCloseButton
 } from 'cozy-ui/transpiled/react/Dialog'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import ListItemSecondaryAction from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemSecondaryAction'
@@ -30,11 +31,10 @@ import flag from 'cozy-flags'
 import TriggerErrorInfo from '../../infos/TriggerErrorInfo'
 import { MountPointContext } from '../../MountPointContext'
 import { deleteAccount } from '../../../connections/accounts'
+import { useTrackPage } from '../../hoc/tracking'
 
 import tabSpecs from '../tabSpecs'
 import { ContractsForAccount } from './Contracts'
-
-import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 const tabMobileNavListStyle = { borderTop: 'none' }
 
@@ -81,6 +81,9 @@ const ConfigurationTab = ({
     error,
     flowState
   )
+
+  useTrackPage('configuration')
+
   const hasLoginError = error && error.isLoginError()
 
   const handleDeleteAccount = async () => {

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
@@ -17,6 +17,7 @@ import useMaintenanceStatus from '../../../components/hooks/useMaintenanceStatus
 import getRelatedAppsSlugs from '../../../models/getRelatedAppsSlugs'
 import appLinksProps from '../../../components/KonnectorConfiguration/DataTab/appLinksProps'
 import tabSpecs from '../tabSpecs'
+import { useTrackPage } from '../../../components/hoc/tracking'
 
 export const DataTab = ({ konnector, trigger, client, flow }) => {
   const { isMobile } = useBreakpoints()
@@ -24,6 +25,8 @@ export const DataTab = ({ konnector, trigger, client, flow }) => {
   const { error } = flowState
   const hasLoginError = hasError && error.isLoginError()
   const hasError = !!error
+
+  useTrackPage('donnees')
 
   const shouldDisplayError = tabSpecs.data.errorShouldBeDisplayed(
     error,

--- a/packages/cozy-harvest-lib/src/components/hoc/tracking.jsx
+++ b/packages/cozy-harvest-lib/src/components/hoc/tracking.jsx
@@ -1,11 +1,11 @@
-import { createContext, useContext, useEffect } from 'react'
+import React, { createContext, useContext, useEffect } from 'react'
 
 // When the tracking context is not available, this object is passed
 // so that downstream components do not have to check for existence
 // of the tracker
 export const trackerShim = {
-  trackPage: pageName => {},
-  trackEvent: event => {}
+  trackPage: () => {},
+  trackEvent: () => {}
 }
 
 // This should be used by apps wanting to track actions inside
@@ -21,12 +21,17 @@ export const useTrackPage = pageName => {
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 }
 
-export const withTracker = Component => props => {
-  return (
-    <TrackingContext.Consumer>
-      {({ trackPage, trackEvent }) => (
-        <Component {...props} trackPage={trackPage} trackEvent={trackEvent} />
-      )}
-    </TrackingContext.Consumer>
-  )
+export const withTracker = Component => {
+  const Wrapped = props => {
+    return (
+      <TrackingContext.Consumer>
+        {({ trackPage, trackEvent }) => (
+          <Component {...props} trackPage={trackPage} trackEvent={trackEvent} />
+        )}
+      </TrackingContext.Consumer>
+    )
+  }
+  Wrapped.displayName = `withTracker(${Component.name ||
+    Component.displayName})`
+  return Wrapped
 }

--- a/packages/cozy-harvest-lib/src/components/hoc/tracking.jsx
+++ b/packages/cozy-harvest-lib/src/components/hoc/tracking.jsx
@@ -1,0 +1,25 @@
+import { createContext, useContext } from 'react'
+
+// When the tracking context is not available, this object is passed
+// so that downstream components do not have to check for existence
+// of the tracker
+export const trackerShim = {
+  trackPage: pageName => {},
+  trackEvent: event => {}
+}
+
+// This should be used by apps wanting to track actions inside
+// harvest
+export const TrackingContext = createContext(trackerShim)
+
+export const useTracker = () => useContext(TrackingContext)
+
+export const withTracker = Component => props => {
+  return (
+    <TrackingContext.Consumer>
+      {({ trackPage, trackEvent }) => (
+        <Component {...props} trackPage={trackPage} trackEvent={trackEvent} />
+      )}
+    </TrackingContext.Consumer>
+  )
+}

--- a/packages/cozy-harvest-lib/src/components/hoc/tracking.jsx
+++ b/packages/cozy-harvest-lib/src/components/hoc/tracking.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react'
+import { createContext, useContext, useEffect } from 'react'
 
 // When the tracking context is not available, this object is passed
 // so that downstream components do not have to check for existence
@@ -13,6 +13,13 @@ export const trackerShim = {
 export const TrackingContext = createContext(trackerShim)
 
 export const useTracker = () => useContext(TrackingContext)
+
+export const useTrackPage = pageName => {
+  const tracker = useTracker()
+  useEffect(() => {
+    tracker.trackPage(pageName)
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+}
 
 export const withTracker = Component => props => {
   return (

--- a/packages/cozy-harvest-lib/src/index.js
+++ b/packages/cozy-harvest-lib/src/index.js
@@ -41,3 +41,4 @@ export {
   default as updateAccountsFromCipher
 } from './services/updateAccountsFromCipher'
 export { default as deleteAccounts } from './services/deleteAccounts'
+export { TrackingContext } from './components/hoc/tracking'

--- a/packages/cozy-notifications/src/urls.js
+++ b/packages/cozy-notifications/src/urls.js
@@ -12,8 +12,12 @@ const getUniversalLinkDomain = cozyUrl => {
   }
 }
 
-export const generateWebLink = ({ cozyUrl, nativePath, slug }) => {
-  nativePath = ensureFirstSlash(nativePath)
+export const generateWebLink = ({
+  cozyUrl,
+  nativePath: nativePathArg,
+  slug
+}) => {
+  const nativePath = ensureFirstSlash(nativePathArg)
   const url = new URL(cozyUrl)
   url.host = url.host
     .split('.')


### PR DESCRIPTION
Adds trackPage and trackEvent calls to several components inside
harvest.

Those functions are taken from the context. This is the responsibility
of the app to provide the correct context, connecting the app tracker
to harvest.

If the context is not present, track calls will still work but won't
do nothing.