### PR TITLE
feat(Harvest): Handle webauth connectors

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -29,7 +29,7 @@
     "@babel/runtime": "^7.5.2",
     "@material-ui/core": "3",
     "@testing-library/react": "^10.4.9",
-    "cozy-bi-auth": "0.0.11",
+    "cozy-bi-auth": "0.0.13",
     "cozy-doctypes": "^1.74.7",
     "cozy-keys-lib": "3.1.2",
     "cozy-logger": "1.6.0",

--- a/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
@@ -5,7 +5,9 @@ import Button from 'cozy-ui/transpiled/react/Button'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import OAuthWindow from './OAuthWindow'
 import compose from 'lodash/flowRight'
+import get from 'lodash/get'
 import withConnectionFlow from '../models/withConnectionFlow'
+import { findKonnectorPolicy } from '../konnector-policies'
 
 /**
  * The OAuth Form is responsible for displaying a form for OAuth konnectors. It
@@ -17,6 +19,7 @@ export class OAuthForm extends PureComponent {
     this.handleAccountId = this.handleAccountId.bind(this)
     this.handleConnect = this.handleConnect.bind(this)
     this.handleOAuthCancel = this.handleOAuthCancel.bind(this)
+    this.handleMoreParams = this.handleMoreParams.bind(this)
     this.state = {
       initialValues: null,
       showingOAuthModal: false
@@ -24,14 +27,31 @@ export class OAuthForm extends PureComponent {
   }
 
   componentDidMount() {
-    const { account } = this.props
+    const { account, konnector, flow, client } = this.props
     this.setState({ initialValues: account ? account.oauth : null })
+
+    const konnectorPolicy = findKonnectorPolicy(konnector)
+
+    if (konnectorPolicy.fetchMoreOAuthUrlParams) {
+      this.setState({ needMoreParams: true })
+      konnectorPolicy.fetchMoreOAuthUrlParams({
+        flow,
+        konnector,
+        client,
+        onSuccess: this.handleMoreParams
+      })
+    }
+  }
+
+  handleMoreParams(moreParams) {
+    this.setState({ moreParams: moreParams })
   }
 
   handleAccountId(accountId) {
     const { onSuccess } = this.props
     this.hideOAuthWindow()
-    if (typeof onSuccess === 'function') onSuccess(accountId)
+    if (typeof onSuccess === 'function')
+      onSuccess(accountId, get(this.state, 'moreParams.id_connector'))
   }
 
   handleConnect() {
@@ -52,7 +72,12 @@ export class OAuthForm extends PureComponent {
 
   render() {
     const { konnector, t, flowState } = this.props
-    const { initialValues, showOAuthWindow } = this.state
+    const {
+      initialValues,
+      showOAuthWindow,
+      needMoreParams,
+      moreParams
+    } = this.state
     const isBusy = showOAuthWindow === true || flowState.running
 
     return initialValues ? null : (
@@ -65,8 +90,9 @@ export class OAuthForm extends PureComponent {
           label={t('oauth.connect.label')}
           onClick={this.handleConnect}
         />
-        {showOAuthWindow && (
+        {showOAuthWindow && (!needMoreParams || moreParams) && (
           <OAuthWindow
+            moreParams={moreParams}
             konnector={konnector}
             onSuccess={this.handleAccountId}
             onCancel={this.handleOAuthCancel}

--- a/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
@@ -19,7 +19,7 @@ export class OAuthForm extends PureComponent {
     this.handleAccountId = this.handleAccountId.bind(this)
     this.handleConnect = this.handleConnect.bind(this)
     this.handleOAuthCancel = this.handleOAuthCancel.bind(this)
-    this.handleMoreParams = this.handleMoreParams.bind(this)
+    this.handleExtraParams = this.handleExtraParams.bind(this)
     this.state = {
       initialValues: null,
       showingOAuthModal: false
@@ -32,26 +32,26 @@ export class OAuthForm extends PureComponent {
 
     const konnectorPolicy = findKonnectorPolicy(konnector)
 
-    if (konnectorPolicy.fetchMoreOAuthUrlParams) {
-      this.setState({ needMoreParams: true })
-      konnectorPolicy.fetchMoreOAuthUrlParams({
-        flow,
-        konnector,
-        client,
-        onSuccess: this.handleMoreParams
-      })
+    if (konnectorPolicy.fetchExtraOAuthUrlParams) {
+      this.setState({ needExtraParams: true })
+      konnectorPolicy
+        .fetchExtraOAuthUrlParams({
+          flow,
+          konnector,
+          client
+        })
+        .then(this.handleExtraParams)
     }
   }
 
-  handleMoreParams(moreParams) {
-    this.setState({ moreParams: moreParams })
+  handleExtraParams(extraParams) {
+    this.setState({ extraParams: extraParams })
   }
 
   handleAccountId(accountId) {
     const { onSuccess } = this.props
     this.hideOAuthWindow()
-    if (typeof onSuccess === 'function')
-      onSuccess(accountId, get(this.state, 'moreParams.id_connector'))
+    if (typeof onSuccess === 'function') onSuccess(accountId)
   }
 
   handleConnect() {
@@ -75,8 +75,8 @@ export class OAuthForm extends PureComponent {
     const {
       initialValues,
       showOAuthWindow,
-      needMoreParams,
-      moreParams
+      needExtraParams,
+      extraParams
     } = this.state
     const isBusy = showOAuthWindow === true || flowState.running
 
@@ -90,9 +90,9 @@ export class OAuthForm extends PureComponent {
           label={t('oauth.connect.label')}
           onClick={this.handleConnect}
         />
-        {showOAuthWindow && (!needMoreParams || moreParams) && (
+        {showOAuthWindow && (!needExtraParams || extraParams) && (
           <OAuthWindow
-            moreParams={moreParams}
+            extraParams={extraParams}
             konnector={konnector}
             onSuccess={this.handleAccountId}
             onCancel={this.handleOAuthCancel}

--- a/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
@@ -5,7 +5,6 @@ import Button from 'cozy-ui/transpiled/react/Button'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import OAuthWindow from './OAuthWindow'
 import compose from 'lodash/flowRight'
-import get from 'lodash/get'
 import withConnectionFlow from '../models/withConnectionFlow'
 import { findKonnectorPolicy } from '../konnector-policies'
 

--- a/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
@@ -43,7 +43,7 @@ export class OAuthWindow extends PureComponent {
   }
 
   componentDidMount() {
-    const { client, konnector, redirectSlug, moreParams } = this.props
+    const { client, konnector, redirectSlug, extraParams } = this.props
     this.realtime = new CozyRealtime({ client })
     this.realtime.subscribe(
       'notified',
@@ -55,7 +55,7 @@ export class OAuthWindow extends PureComponent {
       client,
       konnector,
       redirectSlug,
-      moreParams
+      extraParams
     )
     this.setState({ oAuthStateKey, oAuthUrl, succeed: false })
   }

--- a/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
@@ -43,7 +43,7 @@ export class OAuthWindow extends PureComponent {
   }
 
   componentDidMount() {
-    const { client, konnector, redirectSlug } = this.props
+    const { client, konnector, redirectSlug, moreParams } = this.props
     this.realtime = new CozyRealtime({ client })
     this.realtime.subscribe(
       'notified',
@@ -54,7 +54,8 @@ export class OAuthWindow extends PureComponent {
     const { oAuthStateKey, oAuthUrl } = prepareOAuth(
       client,
       konnector,
-      redirectSlug
+      redirectSlug,
+      moreParams
     )
     this.setState({ oAuthStateKey, oAuthUrl, succeed: false })
   }

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -97,19 +97,17 @@ export class DumbTriggerManager extends Component {
    * OAuth Form success handler. OAuthForm retrieves an account id created by the
    * cozy stack
    * @param  {string}  accountId
-   * @param  {integer} bankId
    */
-  async handleOAuthAccountId(accountId, bankId) {
+  async handleOAuthAccountId(accountId) {
     const { client, flow, konnector, t } = this.props
     let oAuthAccount = await fetchAccount(client, accountId)
 
     const konnectorPolicy = findKonnectorPolicy(konnector)
 
-    let foundWebauthConnection = false
-    if (konnectorPolicy.handleWebauthAccount) {
-      foundWebauthConnection = await konnectorPolicy.handleWebauthAccount({
+    let foundOAuthConnection = false
+    if (konnectorPolicy.handleOAuthAccount) {
+      foundOAuthConnection = await konnectorPolicy.handleOAuthAccount({
         account: oAuthAccount,
-        bankId,
         flow,
         konnector,
         client,
@@ -118,7 +116,7 @@ export class DumbTriggerManager extends Component {
     }
 
     // for "normal" OAuth connectors
-    if (!foundWebauthConnection) {
+    if (!foundOAuthConnection) {
       flow.ensureTriggerAndLaunch(client, {
         account: oAuthAccount,
         konnector: konnector,

--- a/packages/cozy-harvest-lib/src/helpers/accounts.js
+++ b/packages/cozy-harvest-lib/src/helpers/accounts.js
@@ -192,7 +192,7 @@ export const resetState = account => ({
  * @param  {object} account   io.cozy.accounts document
  * @return {object}           io.cozy.accounts updated document
  */
-export const setSessionResetIfNecessary = (account, changedFields) => {
+export const setSessionResetIfNecessary = (account, changedFields = {}) => {
   const isPasswordChanged =
     !!account && !!(changedFields.password || changedFields.passphrase)
   return isPasswordChanged

--- a/packages/cozy-harvest-lib/src/helpers/oauth.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.js
@@ -93,6 +93,7 @@ export const handleOAuthResponse = (options = {}) => {
  * @param  {Object} oAuthConf connector manifest oauth configuration
  * @param  {string} redirectSlug The app we want to redirect the user on after the end of the flow
  * @param  {string} nonce unique nonce string
+ * @param  {Object} extraParams some extra parameters to add to the query string
  */
 export const getOAuthUrl = ({
   cozyUrl,
@@ -101,7 +102,7 @@ export const getOAuthUrl = ({
   oAuthConf,
   nonce,
   redirectSlug,
-  moreParams
+  extraParams
 }) => {
   let oAuthUrl = `${cozyUrl}/accounts/${accountType}/start?state=${oAuthStateKey}&nonce=${nonce}`
   if (
@@ -118,9 +119,9 @@ export const getOAuthUrl = ({
     oAuthUrl += `&slug=${redirectSlug}`
   }
 
-  if (moreParams) {
-    for (const key in moreParams) {
-      oAuthUrl += `&${key}=${moreParams[key]}`
+  if (extraParams) {
+    for (const key in extraParams) {
+      oAuthUrl += `&${key}=${extraParams[key]}`
     }
   }
 
@@ -137,7 +138,7 @@ export const getOAuthUrl = ({
  * @return {Object}           Object containing: `oAuthUrl` (URL of cozy stack
  * OAuth endpoint) and `oAuthStateKey` (localStorage key)
  */
-export const prepareOAuth = (client, konnector, redirectSlug, moreParams) => {
+export const prepareOAuth = (client, konnector, redirectSlug, extraParams) => {
   const { oauth } = konnector
   const accountType = konnectors.getAccountType(konnector)
 
@@ -157,7 +158,7 @@ export const prepareOAuth = (client, konnector, redirectSlug, moreParams) => {
     oAuthConf: oauth,
     nonce: Date.now(),
     redirectSlug,
-    moreParams
+    extraParams
   })
 
   return { oAuthStateKey, oAuthUrl }

--- a/packages/cozy-harvest-lib/src/helpers/oauth.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.js
@@ -100,7 +100,8 @@ export const getOAuthUrl = ({
   oAuthStateKey,
   oAuthConf,
   nonce,
-  redirectSlug
+  redirectSlug,
+  moreParams
 }) => {
   let oAuthUrl = `${cozyUrl}/accounts/${accountType}/start?state=${oAuthStateKey}&nonce=${nonce}`
   if (
@@ -116,6 +117,13 @@ export const getOAuthUrl = ({
   if (redirectSlug) {
     oAuthUrl += `&slug=${redirectSlug}`
   }
+
+  if (moreParams) {
+    for (const key in moreParams) {
+      oAuthUrl += `&${key}=${moreParams[key]}`
+    }
+  }
+
   return oAuthUrl
 }
 
@@ -129,7 +137,7 @@ export const getOAuthUrl = ({
  * @return {Object}           Object containing: `oAuthUrl` (URL of cozy stack
  * OAuth endpoint) and `oAuthStateKey` (localStorage key)
  */
-export const prepareOAuth = (client, konnector, redirectSlug) => {
+export const prepareOAuth = (client, konnector, redirectSlug, moreParams) => {
   const { oauth } = konnector
   const accountType = konnectors.getAccountType(konnector)
 
@@ -148,7 +156,8 @@ export const prepareOAuth = (client, konnector, redirectSlug) => {
     oAuthStateKey,
     oAuthConf: oauth,
     nonce: Date.now(),
-    redirectSlug
+    redirectSlug,
+    moreParams
   })
 
   return { oAuthStateKey, oAuthUrl }

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -75,7 +75,6 @@ export const createOrUpdateAccount = async ({
   userCredentials
 }) => {
   assert(flow, 'No flow')
-  assert(userCredentials, 'No user credentials')
   const isUpdate = !!account
 
   if (isUpdate) {

--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -398,14 +398,14 @@ export const fetchMoreOAuthUrlParams = async ({
 }) => {
   const cozyUrl = client.stackClient.uri
   const config = getBIConfigForCozyURL(cozyUrl)
-  const id_connector = getMappingLinxoBI(config)[konnector.parameters.bankId].id
+  const id_connector = getBankId({ client, konnector })
   const token = await createTemporaryToken({
     client,
     bankId: id_connector,
     konnector
   })
 
-  onSuccess({ id_connector, token })
+  return { id_connector, token }
 }
 
 export const konnectorPolicy = {
@@ -414,7 +414,7 @@ export const konnectorPolicy = {
   saveInVault: false,
   onAccountCreation: onBIAccountCreation,
   sendAdditionalInformation: sendAdditionalInformation,
-  fetchMoreOAuthUrlParams: fetchMoreOAuthUrlParams,
+  fetchExtraOAuthUrlParams: fetchExtraOAuthUrlParams,
   getAdditionalInformationNeeded,
   handleWebauthAccount,
   setSync

--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -99,17 +99,16 @@ export const isBudgetInsightConnector = konnector => {
   )
 }
 
-const createTemporaryToken = async ({ client, account, konnector }) => {
+const createTemporaryToken = async ({ client, bankId, konnector }) => {
   assert(
-    account && account._id,
-    'createTemporaryToken: Account without id passed to createTemporaryToken'
+    bankId,
+    'createTemporaryToken: no bankId passed to createTemporaryToken'
   )
   assert(konnector.slug, 'createTemporaryToken: No konnector slug')
   const jobResponse = await client.stackClient.jobs.create('konnector', {
     mode: 'getTemporaryToken',
     konnector: konnector.slug,
-    account: account._id,
-    bankId: account.auth.bankId
+    bankId
   })
   const event = await waitForRealtimeEvent(
     client,
@@ -156,7 +155,7 @@ export const createOrUpdateBIConnection = async ({
   logger.info('Creating temporary token...')
 
   const tempToken = await createTemporaryToken({
-    account,
+    bankId: account.auth.bankId,
     client,
     konnector
   })
@@ -291,7 +290,7 @@ export const onBIAccountCreation = async ({
 
   account = await flow.saveAccount(setBIConnectionId(account, biConnection.id))
 
-  // At this point, we can be in two fa request stat
+  // At this point, we can be in two fa request state
   await finishConnection({
     account,
     biConnection,
@@ -326,7 +325,7 @@ export const setSync = async ({
   syncStatus
 }) => {
   const temporaryToken = await createTemporaryToken({
-    account,
+    bankId: account.auth.bankId,
     client,
     konnector
   })

--- a/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
@@ -3,7 +3,7 @@ import {
   createOrUpdateBIConnection,
   onBIAccountCreation,
   getBIConfigForCozyURL,
-  fetchMoreOAuthUrlParams,
+  fetchExtraOAuthUrlParams,
   handleWebauthAccount
 } from './budget-insight'
 import { waitForRealtimeEvent } from './jobUtils'
@@ -301,7 +301,7 @@ describe('createOrUpdateBIConnection', () => {
   })
 })
 
-describe('fetchMoreOAuthUrlParams', () => {
+describe('fetchExtraOAuthUrlParams', () => {
   const setup = () => {
     const client = new CozyClient({
       uri: 'http://testcozy.mycozy.cloud'
@@ -340,7 +340,7 @@ describe('fetchMoreOAuthUrlParams', () => {
       expect(id_connector).toEqual(TEST_BANK_BI_ID)
     }
 
-    await fetchMoreOAuthUrlParams({ client, konnector, onSuccess })
+    await fetchExtraOAuthUrlParams({ client, konnector, onSuccess })
   })
 })
 

--- a/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
@@ -60,7 +60,8 @@ const account = {
   _id: '1337',
   auth: {
     login: '80546578',
-    secret: 'secretsecret'
+    secret: 'secretsecret',
+    bankId: TEST_BANK_COZY_ID
   }
 }
 

--- a/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
@@ -4,7 +4,7 @@ import {
   onBIAccountCreation,
   getBIConfigForCozyURL,
   fetchExtraOAuthUrlParams,
-  handleWebauthAccount
+  handleOAuthAccount
 } from './budget-insight'
 import { waitForRealtimeEvent } from './jobUtils'
 import { createBIConnection, updateBIConnection } from './bi-http'
@@ -344,7 +344,7 @@ describe('fetchExtraOAuthUrlParams', () => {
   })
 })
 
-describe('handleWebauthAccount', () => {
+describe('handleOAuthAccount', () => {
   it('should handle webauth if any connection is found in the account', async () => {
     const client = new CozyClient({
       uri: 'http://testcozy.mycozy.cloud'
@@ -353,14 +353,13 @@ describe('handleWebauthAccount', () => {
     flow.handleFormSubmit = jest.fn()
     flow.saveAccount = async account => account
     const account = { oauth: { query: { id_connection: ['12'] } } }
-    const konnector = {}
+    const konnector = { parameters: { bankId: TEST_BANK_COZY_ID } }
     const t = jest.fn()
-    await handleWebauthAccount({
+    await handleOAuthAccount({
       account,
-      bankId: 12,
       flow,
       client,
-      konnector: {},
+      konnector: { parameters: { bankId: TEST_BANK_COZY_ID } },
       t
     })
     expect(flow.handleFormSubmit).toHaveBeenCalledWith({
@@ -369,7 +368,7 @@ describe('handleWebauthAccount', () => {
       t,
       account: {
         ...account,
-        ...{ auth: { bankId: 12 } },
+        ...{ auth: { bankId: TEST_BANK_BI_ID } },
         ...{ data: { auth: { bi: { connId: 12 } } } }
       }
     })

--- a/packages/cozy-harvest-lib/test/helpers/accounts.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/accounts.spec.js
@@ -4,7 +4,8 @@ import {
   mergeAuth,
   updateTwoFaCode,
   resetState,
-  getVaultCipherId
+  getVaultCipherId,
+  setSessionResetIfNecessary
 } from 'helpers/accounts'
 
 const fixtures = {
@@ -93,6 +94,34 @@ describe('Accounts Helper', () => {
       ).toEqual({
         ...fixtures.account,
         state: null
+      })
+    })
+  })
+
+  describe('setSessionResetIfNecessary', () => {
+    it('should set session reset when password is changed', () => {
+      expect(
+        setSessionResetIfNecessary(
+          {
+            ...fixtures.account,
+            state: 'TWOFA_NEEDED'
+          },
+          { password: 'newpassword' }
+        )
+      ).toEqual({
+        ...fixtures.account,
+        state: 'RESET_SESSION'
+      })
+    })
+    it('should not fail when no changed field', () => {
+      expect(
+        setSessionResetIfNecessary({
+          ...fixtures.account,
+          state: 'TWOFA_NEEDED'
+        })
+      ).toEqual({
+        ...fixtures.account,
+        state: 'TWOFA_NEEDED'
       })
     })
   })

--- a/packages/cozy-harvest-lib/test/helpers/oauth.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/oauth.spec.js
@@ -63,6 +63,19 @@ describe('Oauth helper', () => {
         'https://cozyurl/accounts/testslug/start?state=statekey&nonce=1234&slug=drive'
       )
     })
+    it('should use moreParams if present', () => {
+      const url = getOAuthUrl({
+        ...defaultConf,
+        oAuthConf: {},
+        moreParams: {
+          token: 'thetoken',
+          id_connector: 40
+        }
+      })
+      expect(url).toEqual(
+        'https://cozyurl/accounts/testslug/start?state=statekey&nonce=1234&token=thetoken&id_connector=40'
+      )
+    })
   })
   describe('handleOAuthResponse', () => {
     let originalLocation

--- a/packages/cozy-harvest-lib/test/helpers/oauth.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/oauth.spec.js
@@ -63,11 +63,11 @@ describe('Oauth helper', () => {
         'https://cozyurl/accounts/testslug/start?state=statekey&nonce=1234&slug=drive'
       )
     })
-    it('should use moreParams if present', () => {
+    it('should use extraParams if present', () => {
       const url = getOAuthUrl({
         ...defaultConf,
         oAuthConf: {},
-        moreParams: {
+        extraParams: {
           token: 'thetoken',
           id_connector: 40
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5256,10 +5256,10 @@ cosmiconfig@^5.0.0, cosmiconfig@^5.0.7, cosmiconfig@^5.1.0, cosmiconfig@^5.2.0:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-cozy-bi-auth@0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.11.tgz#95e8229fef454f25a8166baff8736b786df29814"
-  integrity sha512-HJTWaEsGqvNcSviazNqER7IkwXFzb4BayYo1dCuOOu1/lSe29MER+DuTc84MPwKTgoQsdmVUhKJIpQBBX/7L8g==
+cozy-bi-auth@0.0.13:
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.13.tgz#b7b7028dda7508e1ca4e6072614030976ed09a7a"
+  integrity sha512-vz6TcLtT00wzpw53x1NYzCds6hAKBDyTcZZ4Ef+vs10a5MpLIKbLX/iepOaRs39gy+hvcbJNEhXKRifUpt9Tyg==
   dependencies:
     cozy-logger "^1.3.0"
     lodash "^4.17.20"


### PR DESCRIPTION
Webauth is a protocol similar to OAuth but specific Budget Insight.

This PR needs https://github.com/cozy/cozy-stack/pull/2667 to be deployed in the stack to work properly + some specific secrets to be available.

For us, what is specific to webauth is that OAuth url must contain a temporary token generated by the connector and the resulting callback url, returned by BI will contain a new connection id which must be saved in the account.