### PR TITLE
feat: Use @cozy/minilog instead of minilog

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.2",
+    "@cozy/minilog": "^1.0.0",
     "@material-ui/core": "3",
     "@testing-library/react": "^10.4.9",
     "cozy-bi-auth": "0.0.11",
@@ -37,7 +38,6 @@
     "final-form": "4.18.5",
     "lodash": "4.17.19",
     "microee": "^0.0.6",
-    "minilog": "https://github.com/cozy/minilog.git#master",
     "node-polyglot": "^2.4.0",
     "react-final-form": "3.7.0",
     "react-markdown": "4.2.2",

--- a/packages/cozy-harvest-lib/src/cli/cli.js
+++ b/packages/cozy-harvest-lib/src/cli/cli.js
@@ -8,7 +8,7 @@ import ConnectionFlow, {
   TWO_FA_REQUEST_EVENT,
   UPDATE_EVENT
 } from '../models/ConnectionFlow'
-import minilog from 'minilog'
+import minilog from '@cozy/minilog'
 import logger from '../logger'
 import { multiPrompt } from './prompt'
 import assert from '../assert'

--- a/packages/cozy-harvest-lib/src/logger.js
+++ b/packages/cozy-harvest-lib/src/logger.js
@@ -1,4 +1,4 @@
-import minilog_ from 'minilog'
+import minilog_ from '@cozy/minilog'
 
 const inBrowser = typeof window !== 'undefined'
 const minilog = (inBrowser && window.minilog) || minilog_

--- a/packages/cozy-harvest-lib/test/jest.setup.js
+++ b/packages/cozy-harvest-lib/test/jest.setup.js
@@ -2,7 +2,7 @@ import { configure } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import '@testing-library/jest-dom/extend-expect'
 import 'isomorphic-fetch'
-import minilog from 'minilog'
+import minilog from '@cozy/minilog'
 
 minilog.suggest.deny('harvest', 'warn')
 minilog.suggest.deny('harvest', 'error')

--- a/packages/cozy-realtime/package.json
+++ b/packages/cozy-realtime/package.json
@@ -43,7 +43,7 @@
     ]
   },
   "dependencies": {
-    "cozy-device-helper": "^1.10.3",
-    "minilog": "https://github.com/cozy/minilog.git#master"
+    "@cozy/minilog": "^1.0.0",
+    "cozy-device-helper": "^1.10.3"
   }
 }

--- a/packages/cozy-realtime/src/CozyRealtime.legacy.spec.js
+++ b/packages/cozy-realtime/src/CozyRealtime.legacy.spec.js
@@ -7,7 +7,7 @@ import CozyRealtime from './CozyRealtime'
 import { Server } from 'mock-socket'
 import MicroEE from 'microee'
 
-import Minilog from 'minilog'
+import Minilog from '@cozy/minilog'
 Minilog.disable()
 
 const COZY_URL = 'http://cozy.tools:8888'

--- a/packages/cozy-realtime/src/logger.js
+++ b/packages/cozy-realtime/src/logger.js
@@ -1,4 +1,4 @@
-import importedMinilog from 'minilog'
+import importedMinilog from '@cozy/minilog'
 
 const inBrowser = typeof window !== 'undefined'
 const minilog = (inBrowser && window.minilog) || importedMinilog

--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -25,6 +25,7 @@
     "watch:doc:react": "(cd ../.. && TARGET=cozy-sharing yarn watch:doc:react)"
   },
   "dependencies": {
+    "@cozy/minilog": "^1.0.0",
     "babel-plugin-inline-react-svg": "^1.1.0",
     "classnames": "^2.2.6",
     "copy-text-to-clipboard": "^2.1.1",
@@ -32,7 +33,6 @@
     "cozy-doctypes": "^1.74.7",
     "cozy-realtime": "^3.10.6",
     "lodash": "^4.17.19",
-    "minilog": "https://github.com/cozy/minilog.git#master",
     "react-autosuggest": "^9.4.3",
     "react-tooltip": "^3.11.1"
   },

--- a/packages/cozy-sharing/src/logger.js
+++ b/packages/cozy-sharing/src/logger.js
@@ -1,4 +1,4 @@
-import minilog_ from 'minilog'
+import minilog_ from '@cozy/minilog'
 
 const inBrowser = typeof window !== 'undefined'
 const minilog = (inBrowser && window.minilog) || minilog_

--- a/yarn.lock
+++ b/yarn.lock
@@ -1494,6 +1494,13 @@
   dependencies:
     find-up "^2.1.0"
 
+"@cozy/minilog@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@cozy/minilog/-/minilog-1.0.0.tgz#1acc1aad849261e931e255a5f181b638315f7b84"
+  integrity sha512-IkDHF9CLh0kQeSEVsou59ar/VehvenpbEUjLfwhckJyOUqZnKAWmXy8qrBgMT5Loxr8Xjs2wmMnj0D67wP00eQ==
+  dependencies:
+    microee "0.0.6"
+
 "@emotion/cache@^10.0.14":
   version "10.0.17"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.17.tgz#3491a035f62f276620d586677bfc3d4fad0b8472"


### PR DESCRIPTION
Our own fork solves a problem with octal literals in strict mode