### PR TITLE
Fix/sharing creation

### DIFF
--- a/packages/cozy-sharing/__tests__/fixtures.js
+++ b/packages/cozy-sharing/__tests__/fixtures.js
@@ -184,6 +184,50 @@ export const SHARING_NO_ACTIVE = {
   }
 }
 
+export const SHARING_READ_ONLY = {
+  type: 'io.cozy.sharings',
+  id: 'sharing_read_only',
+  attributes: {
+    active: true,
+    owner: true,
+    description: 'Holidays',
+    app_slug: 'drive',
+    created_at: '2018-05-21T11:52:19.732097476+02:00',
+    updated_at: '2018-05-21T11:52:19.732097476+02:00',
+    rules: [
+      {
+        title: 'Holidays',
+        doctype: 'io.cozy.files',
+        values: ['folder_1'],
+        add: 'push',
+        update: 'push',
+        remove: 'push'
+      }
+    ],
+    members: [
+      {
+        status: 'owner',
+        name: 'Jane Doe',
+        email: 'jane@doe.com',
+        instance: 'http://cozy.tools:8080'
+      },
+      {
+        status: 'pending',
+        name: 'Johnny Doe',
+        email: 'johnny@doe.com',
+        instance: 'http://cozy.foo:8080'
+      }
+    ]
+  },
+  relationships: {
+    shared_docs: {
+      data: [
+        { id: 'folder_1_1', type: 'io.cozy.files' },
+        { id: 'folder_1_2', type: 'io.cozy.files' }
+      ]
+    }
+  }
+}
 export const SHARING_WITH_SHORTCUT = {
   type: 'io.cozy.sharings',
   id: 'sharing_5',

--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -40,7 +40,7 @@
     "@material-ui/core": "3",
     "babel-jest": "^24.9.0",
     "babel-plugin-css-modules-transform": "^1.6.2",
-    "cozy-client": "13.15.1",
+    "cozy-client": "15.5.0",
     "cozy-ui": "38.2.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.2",

--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -40,7 +40,7 @@
     "@material-ui/core": "3",
     "babel-jest": "^24.9.0",
     "babel-plugin-css-modules-transform": "^1.6.2",
-    "cozy-client": "15.5.0",
+    "cozy-client": "16.0.0",
     "cozy-ui": "38.2.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.2",
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "@material-ui/core": "3",
-    "cozy-client": "^13.15.1",
+    "cozy-client": "^16",
     "cozy-ui": "^38.0.0",
     "prop-types": "^15.7.2",
     "react": "^16.12.0"

--- a/packages/cozy-sharing/src/DoctypeContact.js
+++ b/packages/cozy-sharing/src/DoctypeContact.js
@@ -1,27 +1,28 @@
+import { models } from 'cozy-client'
 import { Contact as DoctypeContact } from 'cozy-doctypes'
+const ContactModel = models.contact
 
-class Contact extends DoctypeContact {
-  static getInitials(contactOrRecipient, defaultValue = '') {
-    if (Contact.isContact(contactOrRecipient)) {
-      return DoctypeContact.getInitials(contactOrRecipient)
-    } else {
-      const s =
-        contactOrRecipient.public_name ||
-        contactOrRecipient.name ||
-        contactOrRecipient.email
-      return (s && s[0].toUpperCase()) || defaultValue
-    }
-  }
-
-  static getDisplayName(contact, defaultValue = '') {
-    if (Contact.isContact(contact)) {
-      return DoctypeContact.getDisplayName(contact)
-    } else {
-      return (
-        contact.public_name || contact.name || contact.email || defaultValue
-      )
-    }
+const isContact = candidate => {
+  return candidate._type === 'io.cozy.contacts'
+}
+export const getInitials = (contactOrRecipient, defaultValue = '') => {
+  if (isContact(contactOrRecipient)) {
+    return ContactModel.getInitials(contactOrRecipient)
+  } else {
+    const s =
+      contactOrRecipient.public_name ||
+      contactOrRecipient.name ||
+      contactOrRecipient.email
+    return (s && s[0].toUpperCase()) || defaultValue
   }
 }
 
-export default Contact
+export const getDisplayName = (contact, defaultValue = '') => {
+  if (isContact(contact)) {
+    return ContactModel.getDisplayName(contact)
+  } else {
+    return contact.public_name || contact.name || contact.email || defaultValue
+  }
+}
+
+export default DoctypeContact

--- a/packages/cozy-sharing/src/DoctypeContact.js
+++ b/packages/cozy-sharing/src/DoctypeContact.js
@@ -9,6 +9,7 @@ export const getInitials = (contactOrRecipient, defaultValue = '') => {
   if (isContact(contactOrRecipient)) {
     return ContactModel.getInitials(contactOrRecipient)
   } else {
+    // @todo Extract to RecipientModel ?
     const s =
       contactOrRecipient.public_name ||
       contactOrRecipient.name ||
@@ -21,6 +22,7 @@ export const getDisplayName = (contact, defaultValue = '') => {
   if (isContact(contact)) {
     return ContactModel.getDisplayName(contact)
   } else {
+    // @todo Extract to RecipientModel ?
     return contact.public_name || contact.name || contact.email || defaultValue
   }
 }

--- a/packages/cozy-sharing/src/DoctypeContact.spec.js
+++ b/packages/cozy-sharing/src/DoctypeContact.spec.js
@@ -1,4 +1,4 @@
-import Contact from './DoctypeContact'
+import { getDisplayName, getInitials } from './DoctypeContact'
 
 describe('Contact model', () => {
   describe('getInitials method', () => {
@@ -7,7 +7,7 @@ describe('Contact model', () => {
         name: 'whatever',
         public_name: 'janedoe'
       }
-      const result = Contact.getInitials(recipient)
+      const result = getInitials(recipient)
       expect(result).toEqual('J')
     })
 
@@ -15,7 +15,7 @@ describe('Contact model', () => {
       const recipient = {
         name: 'janedoe'
       }
-      const result = Contact.getInitials(recipient)
+      const result = getInitials(recipient)
       expect(result).toEqual('J')
     })
 
@@ -25,19 +25,19 @@ describe('Contact model', () => {
         public_name: undefined,
         email: 'janedoe@example.com'
       }
-      const result = Contact.getInitials(recipient)
+      const result = getInitials(recipient)
       expect(result).toEqual('J')
     })
 
     it('should return an empty string if name/public_name are undefined', () => {
       const recipient = {}
-      const result = Contact.getInitials(recipient)
+      const result = getInitials(recipient)
       expect(result).toEqual('')
     })
 
     it('should use a default value if name/public_name are undefined', () => {
       const recipient = {}
-      const result = Contact.getInitials(recipient, 'A')
+      const result = getInitials(recipient, 'A')
       expect(result).toEqual('A')
     })
 
@@ -50,7 +50,7 @@ describe('Contact model', () => {
           familyName: 'Stark'
         }
       }
-      const result = Contact.getInitials(contact)
+      const result = getInitials(contact)
       expect(result).toEqual('AS')
     })
   })
@@ -66,7 +66,7 @@ describe('Contact model', () => {
           familyName: 'Stark'
         }
       }
-      const result = Contact.getDisplayName(contact)
+      const result = getDisplayName(contact)
       expect(result).toEqual('Arya Stark')
     })
 
@@ -76,7 +76,7 @@ describe('Contact model', () => {
         name: 'Arya Stark',
         public_name: 'aryastark'
       }
-      const result = Contact.getDisplayName(contact)
+      const result = getDisplayName(contact)
       expect(result).toEqual('aryastark')
     })
 
@@ -84,7 +84,7 @@ describe('Contact model', () => {
       const contact = {
         name: 'Arya Stark'
       }
-      const result = Contact.getDisplayName(contact)
+      const result = getDisplayName(contact)
       expect(result).toEqual('Arya Stark')
     })
 
@@ -92,19 +92,19 @@ describe('Contact model', () => {
       const recipient = {
         email: 'arya.stark@winterfell.westeros'
       }
-      const result = Contact.getDisplayName(recipient)
+      const result = getDisplayName(recipient)
       expect(result).toEqual('arya.stark@winterfell.westeros')
     })
 
     it('should use an empty string as default value if nothing is available', () => {
       const recipient = {}
-      const result = Contact.getDisplayName(recipient)
+      const result = getDisplayName(recipient)
       expect(result).toEqual('')
     })
 
     it('should use a default value if nothing is available', () => {
       const recipient = {}
-      const result = Contact.getDisplayName(recipient, 'Anonymous')
+      const result = getDisplayName(recipient, 'Anonymous')
       expect(result).toEqual('Anonymous')
     })
   })

--- a/packages/cozy-sharing/src/SharingDetailsModal.jsx
+++ b/packages/cozy-sharing/src/SharingDetailsModal.jsx
@@ -2,12 +2,12 @@ import styles from './share.styl'
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { translate } from 'cozy-ui/transpiled/react/I18n'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Modal, { ModalContent } from 'cozy-ui/transpiled/react/Modal'
 
 import { OwnerIdentity } from './components/Recipient'
 import WhoHasAccess from './components/WhoHasAccess'
-import { Contact } from './models'
+import { getDisplayName } from './models'
 
 export const SharingDetailsModal = ({
   onClose,
@@ -17,10 +17,9 @@ export const SharingDetailsModal = ({
   document,
   documentType = 'Document',
   onRevoke,
-  onRevokeSelf,
-  t,
-  f
+  onRevokeSelf
 }) => {
+  const { t, f } = useI18n()
   return (
     <Modal
       title={t(`${documentType}.share.details.title`)}
@@ -34,7 +33,7 @@ export const SharingDetailsModal = ({
         <div className={styles['share-details']}>
           <OwnerIdentity
             name={t(`${documentType}.share.sharedBy`, {
-              name: Contact.getDisplayName(owner)
+              name: getDisplayName(owner)
             })}
             url={owner.instance}
           />
@@ -81,8 +80,6 @@ SharingDetailsModal.propTypes = {
   document: PropTypes.object.isRequired,
   documentType: PropTypes.string.isRequired,
   onRevoke: PropTypes.func.isRequired,
-  onRevokeSelf: PropTypes.func,
-  f: PropTypes.func.isRequired,
-  t: PropTypes.func.isRequired
+  onRevokeSelf: PropTypes.func
 }
-export default translate()(SharingDetailsModal)
+export default SharingDetailsModal

--- a/packages/cozy-sharing/src/components/ContactSuggestion.jsx
+++ b/packages/cozy-sharing/src/components/ContactSuggestion.jsx
@@ -1,12 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import get from 'lodash/get'
+import { models } from 'cozy-client'
+const ContactModel = models.contact
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import Avatar from 'cozy-ui/transpiled/react/Avatar'
 
 import styles from './recipient.styl'
 
-import { Contact, Group } from '../models'
+import { Contact, Group, getDisplayName, getInitials } from '../models'
 import Identity from './Identity'
 
 export const ContactSuggestion = ({ contactOrGroup, contacts, t }) => {
@@ -31,9 +33,9 @@ export const ContactSuggestion = ({ contactOrGroup, contacts, t }) => {
     })
     avatarText = 'G'
   } else {
-    name = Contact.getDisplayName(contactOrGroup)
-    avatarText = Contact.getInitials(contactOrGroup)
-    details = Contact.getPrimaryCozy(contactOrGroup)
+    name = getDisplayName(contactOrGroup)
+    avatarText = getInitials(contactOrGroup)
+    details = ContactModel.getPrimaryCozy(contactOrGroup)
   }
 
   return (

--- a/packages/cozy-sharing/src/components/ContactSuggestion.jsx
+++ b/packages/cozy-sharing/src/components/ContactSuggestion.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import get from 'lodash/get'
 import { models } from 'cozy-client'
 const ContactModel = models.contact
-import { translate } from 'cozy-ui/transpiled/react/I18n'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Avatar from 'cozy-ui/transpiled/react/Avatar'
 
 import styles from './recipient.styl'
@@ -11,7 +11,8 @@ import styles from './recipient.styl'
 import { Contact, Group, getDisplayName, getInitials } from '../models'
 import Identity from './Identity'
 
-export const ContactSuggestion = ({ contactOrGroup, contacts, t }) => {
+export const ContactSuggestion = ({ contactOrGroup, contacts }) => {
+  const { t } = useI18n()
   let avatarText, name, details
   if (contactOrGroup._type === Group.doctype) {
     name = contactOrGroup.name
@@ -49,8 +50,7 @@ export const ContactSuggestion = ({ contactOrGroup, contacts, t }) => {
 ContactSuggestion.propTypes = {
   contactOrGroup: PropTypes.oneOfType([Contact.propType, Group.propType])
     .isRequired,
-  contacts: PropTypes.arrayOf(Contact.propType),
-  t: PropTypes.func.isRequired
+  contacts: PropTypes.arrayOf(Contact.propType)
 }
 
-export default translate()(ContactSuggestion)
+export default ContactSuggestion

--- a/packages/cozy-sharing/src/components/ContactSuggestion.jsx
+++ b/packages/cozy-sharing/src/components/ContactSuggestion.jsx
@@ -41,7 +41,7 @@ export const ContactSuggestion = ({ contactOrGroup, contacts, t }) => {
   return (
     <div className={styles['recipient']}>
       <Avatar text={avatarText} size="small" />
-      <Identity name={name} details={details} />
+      <Identity name={name} details={details === '' ? undefined : details} />
     </div>
   )
 }

--- a/packages/cozy-sharing/src/components/ContactSuggestion.spec.jsx
+++ b/packages/cozy-sharing/src/components/ContactSuggestion.spec.jsx
@@ -1,7 +1,10 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { mount } from 'enzyme'
+
+import AppLike from '../../test/AppLike'
 
 import { ContactSuggestion } from './ContactSuggestion'
+const WrappingComponent = ({ children }) => <AppLike>{children}</AppLike>
 
 describe('ContactSuggestion component', () => {
   const fakeT = jest.fn((s, args) => {
@@ -40,7 +43,9 @@ describe('ContactSuggestion component', () => {
       t: fakeT
     }
     const jsx = <ContactSuggestion {...props} />
-    const wrapper = shallow(jsx)
+    const wrapper = mount(jsx, {
+      wrappingComponent: WrappingComponent
+    })
     expect(wrapper).toMatchSnapshot()
   })
 
@@ -64,7 +69,9 @@ describe('ContactSuggestion component', () => {
       t: fakeT
     }
     const jsx = <ContactSuggestion {...props} />
-    const wrapper = shallow(jsx)
+    const wrapper = mount(jsx, {
+      wrappingComponent: WrappingComponent
+    })
     expect(wrapper).toMatchSnapshot()
   })
 
@@ -137,7 +144,9 @@ describe('ContactSuggestion component', () => {
       t: fakeT
     }
     const jsx = <ContactSuggestion {...props} />
-    const wrapper = shallow(jsx)
+    const wrapper = mount(jsx, {
+      wrappingComponent: WrappingComponent
+    })
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/packages/cozy-sharing/src/components/EditableSharingModal.jsx
+++ b/packages/cozy-sharing/src/components/EditableSharingModal.jsx
@@ -33,7 +33,8 @@ export const EditableSharingModal = ({
           revokeSharingLink,
           hasSharedParent,
           hasSharedChild,
-          revokeSelf
+          revokeSelf,
+          getSharingType
         }) => {
           return (
             <DumbShareModal
@@ -54,6 +55,7 @@ export const EditableSharingModal = ({
               onUpdateShareLinkPermissions={updateDocumentPermissions}
               onRevokeLink={revokeSharingLink}
               onRevokeSelf={revokeSelf}
+              sharingType={getSharingType(document.id)}
               {...rest}
             />
           )

--- a/packages/cozy-sharing/src/components/EditableSharingModal.jsx
+++ b/packages/cozy-sharing/src/components/EditableSharingModal.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import flow from 'lodash/flow'
-import { queryConnect, withClient, Q } from 'cozy-client'
+import { queryConnect, useClient, Q } from 'cozy-client'
 
 import { Contact, Group } from '../models'
 import { contactsResponseType, groupsResponseType } from '../propTypes'
@@ -10,12 +9,12 @@ import ContactsAndGroupsDataLoader from './ContactsAndGroupsDataLoader'
 import { default as DumbShareModal } from './ShareModal'
 import { useFetchDocumentPath } from './useFetchDocumentPath'
 export const EditableSharingModal = ({
-  client,
   contacts,
   document,
   groups,
   ...rest
 }) => {
+  const client = useClient()
   const documentPath = useFetchDocumentPath(client, document)
   return (
     <ContactsAndGroupsDataLoader contacts={contacts} groups={groups}>
@@ -102,16 +101,13 @@ const contactsQuery = () =>
 
 const groupsQuery = () => Q(Group.doctype)
 
-export default flow(
-  queryConnect({
-    contacts: {
-      query: contactsQuery,
-      as: 'contacts'
-    },
-    groups: {
-      query: groupsQuery,
-      as: 'groups'
-    }
-  }),
-  withClient
-)(EditableSharingModal)
+export default queryConnect({
+  contacts: {
+    query: contactsQuery,
+    as: 'contacts'
+  },
+  groups: {
+    query: groupsQuery,
+    as: 'groups'
+  }
+})(EditableSharingModal)

--- a/packages/cozy-sharing/src/components/EditableSharingModal.jsx
+++ b/packages/cozy-sharing/src/components/EditableSharingModal.jsx
@@ -34,7 +34,7 @@ export const EditableSharingModal = ({
           hasSharedParent,
           hasSharedChild,
           revokeSelf,
-          getSharingType
+          getSharingForSelf
         }) => {
           return (
             <DumbShareModal
@@ -55,7 +55,7 @@ export const EditableSharingModal = ({
               onUpdateShareLinkPermissions={updateDocumentPermissions}
               onRevokeLink={revokeSharingLink}
               onRevokeSelf={revokeSelf}
-              sharingType={getSharingType(document.id)}
+              sharing={getSharingForSelf(document.id)}
               {...rest}
             />
           )

--- a/packages/cozy-sharing/src/components/Recipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient.jsx
@@ -18,7 +18,7 @@ import { Media, Img, Bd } from 'cozy-ui/transpiled/react/Media'
 import styles from './recipient.styl'
 import modalStyles from '../share.styl'
 
-import { Contact } from '../models'
+import { getDisplayName, getInitials } from '../models'
 import Identity from './Identity'
 
 const MAX_DISPLAYED_RECIPIENTS = 3
@@ -54,7 +54,7 @@ export const RecipientsAvatars = ({
         <AvatarPlusX
           extraRecipients={reversedRecipients
             .slice(MAX_DISPLAYED_RECIPIENTS)
-            .map(recipient => Contact.getDisplayName(recipient))}
+            .map(recipient => getDisplayName(recipient))}
           size={size}
         />
       )}
@@ -77,8 +77,8 @@ export const RecipientAvatar = ({ recipient, ...rest }) => {
   return (
     <Avatar
       image={`${client.options.uri}${recipient.avatarPath}`}
-      text={Contact.getInitials(recipient)}
-      textId={Contact.getDisplayName(recipient)}
+      text={getInitials(recipient)}
+      textId={getDisplayName(recipient)}
       {...rest}
     />
   )
@@ -87,11 +87,11 @@ export const RecipientAvatar = ({ recipient, ...rest }) => {
 export const OwnerIdentity = ({ url, size, ...rest }) => (
   <div className={styles['avatar']}>
     <Avatar
-      text={Contact.getInitials(rest)}
+      text={getInitials(rest)}
       size={size}
-      textId={Contact.getDisplayName(rest)}
+      textId={getDisplayName(rest)}
     />
-    <Identity name={Contact.getDisplayName(rest)} details={url} />
+    <Identity name={getDisplayName(rest)} details={url} />
   </div>
 )
 
@@ -238,7 +238,7 @@ const Recipient = props => {
   const isMe =
     (isOwner && status === 'owner') || instance === client.options.uri
   const defaultDisplayName = t(DEFAULT_DISPLAY_NAME)
-  const name = Contact.getDisplayName(rest, defaultDisplayName)
+  const name = getDisplayName(rest, defaultDisplayName)
 
   return (
     <CompositeRow
@@ -259,10 +259,10 @@ const Recipient = props => {
 export default Recipient
 
 export const RecipientWithoutStatus = ({ instance, ...rest }) => {
-  const name = Contact.getDisplayName(rest)
+  const name = getDisplayName(rest)
   return (
     <div className={styles['recipient']}>
-      <Avatar text={Contact.getInitials(rest)} textId={name} />
+      <Avatar text={getInitials(rest)} textId={name} />
       <div className={styles['recipient-ident-status']}>
         <Identity name={name} details={instance} />
       </div>
@@ -274,7 +274,7 @@ export const RecipientPlusX = ({ extraRecipients }, { t }) => (
   <div className={styles['recipient']}>
     <AvatarPlusX
       extraRecipients={extraRecipients.map(recipient =>
-        Contact.getDisplayName(recipient)
+        getDisplayName(recipient)
       )}
     />
     <div className={styles['recipient-ident-status']}>

--- a/packages/cozy-sharing/src/components/ShareAutosuggest.jsx
+++ b/packages/cozy-sharing/src/components/ShareAutosuggest.jsx
@@ -8,7 +8,7 @@ import palette from 'cozy-ui/transpiled/react/palette'
 import styles from './autosuggest.styl'
 import BoldCross from '../../assets/icons/icon-cross-bold.svg'
 
-import { Contact } from '../models'
+import { getDisplayName, Contact } from '../models'
 import { cozyUrlMatch, emailMatch, groupNameMatch } from '../suggestionMatchers'
 import ContactSuggestion from './ContactSuggestion'
 import { extractEmails, validateEmail } from '../helpers/email'
@@ -119,7 +119,7 @@ export default class ShareAutocomplete extends Component {
     return (
       <div className={styles['recipientsContainer']}>
         {recipients.map((recipient, idx) => {
-          const value = Contact.getDisplayName(recipient)
+          const value = getDisplayName(recipient)
           return (
             <div
               className={styles['recipientChip']}

--- a/packages/cozy-sharing/src/components/ShareByEmail.jsx
+++ b/packages/cozy-sharing/src/components/ShareByEmail.jsx
@@ -16,10 +16,14 @@ import styles from '../share.styl'
 import { getSuccessMessage } from '../helpers/successMessage'
 import { getOrCreateFromArray } from '../helpers/contacts'
 export class ShareByEmail extends Component {
-  initialState = {
-    recipients: [],
-    sharingType: 'two-way',
-    loading: false
+  constructor(props) {
+    super(props)
+    this.initialState = {
+      recipients: [],
+      sharingType: this.props.sharingType ? this.props.sharingType : 'two-way',
+      loading: false
+    }
+    this.state = { ...this.initialState }
   }
 
   state = { ...this.initialState }
@@ -118,20 +122,20 @@ export class ShareByEmail extends Component {
 
   getSharingTypes = () => {
     const { t } = this.props
-    return [
-      {
-        value: 'two-way',
-        label: t('Share.type.two-way'),
-        desc: t('Share.type.desc.two-way'),
-        disabled: false
-      },
-      {
-        value: 'one-way',
-        label: t('Share.type.one-way'),
-        desc: t('Share.type.desc.one-way'),
-        disabled: false
-      }
-    ]
+    const { sharingType } = this.state
+    const twoWay = {
+      value: 'two-way',
+      label: t('Share.type.two-way'),
+      desc: t('Share.type.desc.two-way'),
+      disabled: false
+    }
+    const oneWay = {
+      value: 'one-way',
+      label: t('Share.type.one-way'),
+      desc: t('Share.type.desc.one-way'),
+      disabled: false
+    }
+    return sharingType === 'two-way' ? [twoWay, oneWay] : [oneWay]
   }
   render() {
     const { contacts, documentType, groups, t } = this.props
@@ -180,7 +184,8 @@ ShareByEmail.propTypes = {
   documentType: PropTypes.string.isRequired,
   sharingDesc: PropTypes.string.isRequired,
   onShare: PropTypes.func.isRequired,
-  createContact: PropTypes.func.isRequired
+  createContact: PropTypes.func.isRequired,
+  sharingType: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])
 }
 
 export default translate()(withClient(ShareByEmail))

--- a/packages/cozy-sharing/src/components/ShareByEmail.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareByEmail.spec.jsx
@@ -22,13 +22,12 @@ describe('ShareByEmailComponent', () => {
     const comp = mount(<ShareByEmail {...props} />)
     comp.instance().onRecipientPick({ id: 1, email: 'quentin@cozycloud.cc' })
     await comp.instance().share()
-    expect(onShare).toHaveBeenCalledWith(
-      {
-        id: 'doc_id'
-      },
-      [{ email: 'quentin@cozycloud.cc', id: 1 }],
-      'two-way',
-      'test'
-    )
+    expect(onShare).toHaveBeenCalledWith({
+      description: props.sharingDesc,
+      document: props.document,
+      openSharing: true,
+      readOnlyRecipients: [],
+      recipients: [{ id: 1, email: 'quentin@cozycloud.cc' }]
+    })
   })
 })

--- a/packages/cozy-sharing/src/components/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal.jsx
@@ -40,7 +40,8 @@ export const ShareModal = ({
   onUpdateShareLinkPermissions,
   onRevokeLink,
   onRevokeSelf,
-  t
+  t,
+  sharingType
 }) => {
   return (
     <MuiCozyTheme>
@@ -85,6 +86,7 @@ export const ShareModal = ({
                 createContact={createContact}
                 onShare={onShare}
                 needsContactsPermission={needsContactsPermission}
+                sharingType={sharingType}
               />
             )}
           {documentType !== 'Albums' && (

--- a/packages/cozy-sharing/src/components/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import { translate } from 'cozy-ui/transpiled/react/I18n'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import Dialog, {
   DialogTitle,
@@ -40,9 +40,9 @@ export const ShareModal = ({
   onUpdateShareLinkPermissions,
   onRevokeLink,
   onRevokeSelf,
-  t,
   sharing
 }) => {
+  const { t } = useI18n()
   return (
     <MuiCozyTheme>
       <Dialog
@@ -118,7 +118,8 @@ export const ShareModal = ({
     </MuiCozyTheme>
   )
 }
-export default translate()(ShareModal)
+export default ShareModal
+
 ShareModal.propTypes = {
   document: PropTypes.object.isRequired,
   permissions: PropTypes.array.isRequired,
@@ -138,6 +139,5 @@ ShareModal.propTypes = {
   onRevoke: PropTypes.func.isRequired,
   onShareByLink: PropTypes.func.isRequired,
   onUpdateShareLinkPermissions: PropTypes.func.isRequired,
-  onRevokeLink: PropTypes.func.isRequired,
-  t: PropTypes.func.isRequired
+  onRevokeLink: PropTypes.func.isRequired
 }

--- a/packages/cozy-sharing/src/components/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal.jsx
@@ -41,7 +41,7 @@ export const ShareModal = ({
   onRevokeLink,
   onRevokeSelf,
   t,
-  sharingType
+  sharing
 }) => {
   return (
     <MuiCozyTheme>
@@ -86,7 +86,7 @@ export const ShareModal = ({
                 createContact={createContact}
                 onShare={onShare}
                 needsContactsPermission={needsContactsPermission}
-                sharingType={sharingType}
+                sharing={sharing}
               />
             )}
           {documentType !== 'Albums' && (

--- a/packages/cozy-sharing/src/components/SharedStatus.jsx
+++ b/packages/cozy-sharing/src/components/SharedStatus.jsx
@@ -1,47 +1,50 @@
 import React from 'react'
-import { translate } from 'cozy-ui/transpiled/react/I18n'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import palette from 'cozy-ui/transpiled/react/palette'
 import { SharingTooltip, TooltipRecipientList } from './Tooltip'
 import cx from 'classnames'
 
-import { Contact } from '../models'
+import { getDisplayName } from '../models'
 import styles from './status.styl'
 import LinkIcon from '../../assets/icons/icon-link.svg'
 
-export const SharedStatus = ({ className, docId, recipients, link, t }) => (
-  <span className={cx(className, styles['shared-status'])}>
-    {recipients.length > 1 && (
-      <a
-        data-tip
-        data-for={`members${docId}`}
-        className={styles['shared-status-label']}
-      >
-        {t('Share.members.count', { smart_count: recipients.length })}
-      </a>
-    )}
-    {recipients.length > 1 && (
-      <SharingTooltip id={`members${docId}`}>
-        <TooltipRecipientList
-          recipientNames={recipients.map(recipient =>
-            Contact.getDisplayName(recipient)
-          )}
-        />
-      </SharingTooltip>
-    )}
-    {link && (
-      <>
-        <LinkIcon
-          style={{ fill: palette.coolGrey }}
+export const SharedStatus = ({ className, docId, recipients, link }) => {
+  const { t } = useI18n()
+  return (
+    <span className={cx(className, styles['shared-status'])}>
+      {recipients.length > 1 && (
+        <a
           data-tip
-          data-for={`linkfor${docId}`}
-        />
-
-        <SharingTooltip id={`linkfor${docId}`}>
-          <span>{t('Files.share.shareByLink.subtitle')}</span>
+          data-for={`members${docId}`}
+          className={styles['shared-status-label']}
+        >
+          {t('Share.members.count', { smart_count: recipients.length })}
+        </a>
+      )}
+      {recipients.length > 1 && (
+        <SharingTooltip id={`members${docId}`}>
+          <TooltipRecipientList
+            recipientNames={recipients.map(recipient =>
+              getDisplayName(recipient)
+            )}
+          />
         </SharingTooltip>
-      </>
-    )}
-  </span>
-)
+      )}
+      {link && (
+        <>
+          <LinkIcon
+            style={{ fill: palette.coolGrey }}
+            data-tip
+            data-for={`linkfor${docId}`}
+          />
 
-export default translate()(SharedStatus)
+          <SharingTooltip id={`linkfor${docId}`}>
+            <span>{t('Files.share.shareByLink.subtitle')}</span>
+          </SharingTooltip>
+        </>
+      )}
+    </span>
+  )
+}
+
+export default SharedStatus

--- a/packages/cozy-sharing/src/components/SharedStatus.spec.js
+++ b/packages/cozy-sharing/src/components/SharedStatus.spec.js
@@ -26,7 +26,6 @@ describe('SharedStatus component', () => {
             name: '2'
           }
         ]}
-        t={x => x}
       />,
       {
         wrappingComponent: WrappingComponent
@@ -37,7 +36,7 @@ describe('SharedStatus component', () => {
 
   it('should display the link if there is a link', () => {
     const component = mount(
-      <SharedStatus docId="1" recipients={[]} t={x => x} link={true} />,
+      <SharedStatus docId="1" recipients={[]} link={true} />,
       {
         wrappingComponent: WrappingComponent
       }

--- a/packages/cozy-sharing/src/components/__snapshots__/ContactSuggestion.spec.jsx.snap
+++ b/packages/cozy-sharing/src/components/__snapshots__/ContactSuggestion.spec.jsx.snap
@@ -1,52 +1,316 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ContactSuggestion component should display contact suggestion for a contact 1`] = `
-<div
-  className="recipient"
+<ContactSuggestion
+  contactOrGroup={
+    Object {
+      "_id": "f3a4e501-abbd",
+      "_type": "io.cozy.contacts",
+      "cozy": Array [
+        Object {
+          "primary": true,
+          "url": "https://jonsnow.mycozy.cloud",
+        },
+      ],
+      "email": Array [
+        Object {
+          "address": "jon.snow@email.com",
+          "type": "primary",
+        },
+      ],
+      "fullname": "Jon Snow",
+      "name": Object {
+        "familyName": "Snow",
+        "givenName": "Jon",
+      },
+    }
+  }
+  contacts={
+    Array [
+      Object {
+        "_id": "f3a4e501-abbd",
+        "_type": "io.cozy.contacts",
+        "cozy": Array [
+          Object {
+            "primary": true,
+            "url": "https://jonsnow.mycozy.cloud",
+          },
+        ],
+        "email": Array [
+          Object {
+            "address": "jon.snow@email.com",
+            "type": "primary",
+          },
+        ],
+        "fullname": "Jon Snow",
+        "name": Object {
+          "familyName": "Snow",
+          "givenName": "Jon",
+        },
+      },
+    ]
+  }
+  t={[MockFunction]}
 >
-  <Avatar
-    className=""
-    image=""
-    size="small"
-    text="JS"
-  />
-  <Identity
-    details="https://jonsnow.mycozy.cloud"
-    name="Jon Snow"
-  />
-</div>
+  <div
+    className="recipient"
+  >
+    <Avatar
+      className=""
+      image=""
+      size="small"
+      text="JS"
+    >
+      <div
+        className="styles__c-avatar___PpDI- styles__c-avatar--small___1Y_Pv"
+        style={
+          Object {
+            "backgroundColor": "var(--lavender)",
+            "color": "white",
+          }
+        }
+      >
+        <span
+          className="styles__c-avatar-initials___310qC"
+        >
+          JS
+        </span>
+      </div>
+    </Avatar>
+    <Identity
+      details="https://jonsnow.mycozy.cloud"
+      name="Jon Snow"
+    >
+      <div
+        className="recipient-idents u-ml-1"
+      >
+        <div
+          className="recipient-user"
+        >
+          Jon Snow
+        </div>
+        <div
+          className="recipient-details"
+        >
+          https://jonsnow.mycozy.cloud
+        </div>
+      </div>
+    </Identity>
+  </div>
+</ContactSuggestion>
 `;
 
 exports[`ContactSuggestion component should display contact suggestion for a contact without fullname (for example created by a share modal) 1`] = `
-<div
-  className="recipient"
+<ContactSuggestion
+  contactOrGroup={
+    Object {
+      "_id": "f3a4e501-abbd",
+      "_type": "io.cozy.contacts",
+      "cozy": Array [],
+      "email": Array [
+        Object {
+          "address": "jon.snow@email.com",
+          "type": "primary",
+        },
+      ],
+      "name": undefined,
+    }
+  }
+  contacts={
+    Array [
+      Object {
+        "_id": "f3a4e501-abbd",
+        "_type": "io.cozy.contacts",
+        "cozy": Array [],
+        "email": Array [
+          Object {
+            "address": "jon.snow@email.com",
+            "type": "primary",
+          },
+        ],
+        "name": undefined,
+      },
+    ]
+  }
+  t={[MockFunction]}
 >
-  <Avatar
-    className=""
-    image=""
-    size="small"
-    text="J"
-  />
-  <Identity
-    details="-"
-    name="jon.snow@email.com"
-  />
-</div>
+  <div
+    className="recipient"
+  >
+    <Avatar
+      className=""
+      image=""
+      size="small"
+      text="J"
+    >
+      <div
+        className="styles__c-avatar___PpDI- styles__c-avatar--small___1Y_Pv"
+        style={
+          Object {
+            "backgroundColor": "var(--puertoRico)",
+            "color": "white",
+          }
+        }
+      >
+        <span
+          className="styles__c-avatar-initials___310qC"
+        >
+          J
+        </span>
+      </div>
+    </Avatar>
+    <Identity
+      details="-"
+      name="jon.snow@email.com"
+    >
+      <div
+        className="recipient-idents u-ml-1"
+      >
+        <div
+          className="recipient-user"
+        >
+          jon.snow@email.com
+        </div>
+        <div
+          className="recipient-details"
+        >
+          -
+        </div>
+      </div>
+    </Identity>
+  </div>
+</ContactSuggestion>
 `;
 
 exports[`ContactSuggestion component should display contact suggestion for a group 1`] = `
-<div
-  className="recipient"
+<ContactSuggestion
+  contactOrGroup={
+    Object {
+      "_id": "610718e6-2d7a",
+      "_type": "io.cozy.contacts.groups",
+      "name": "The Night's Watch",
+    }
+  }
+  contacts={
+    Array [
+      Object {
+        "_id": "f3a4e501-abbd",
+        "_type": "io.cozy.contacts",
+        "email": Array [
+          Object {
+            "address": "jon.snow@email.com",
+            "type": "primary",
+          },
+        ],
+        "fullname": "Jon Snow",
+        "name": Object {
+          "familyName": "Snow",
+          "givenName": "Jon",
+        },
+        "relationships": Object {
+          "groups": Object {
+            "data": Array [
+              Object {
+                "_id": "610718e6-2d7a",
+                "_type": "io.cozy.contacts.groups",
+              },
+            ],
+          },
+        },
+      },
+      Object {
+        "_id": "42dc490a-7878",
+        "_type": "io.cozy.contacts",
+        "email": Array [
+          Object {
+            "address": "cersei@email.com",
+            "type": "primary",
+          },
+        ],
+        "fullname": "Cersei Lannister",
+        "name": Object {
+          "familyName": "Lannister",
+          "givenName": "Cersei",
+        },
+        "relationships": Object {
+          "groups": Object {
+            "data": Array [],
+          },
+        },
+      },
+      Object {
+        "_id": "b5bed853-93da",
+        "_type": "io.cozy.contacts",
+        "email": Array [
+          Object {
+            "address": "samwell@email.com",
+            "type": "primary",
+          },
+        ],
+        "fullname": "Samwell Tarly",
+        "name": Object {
+          "familyName": "Tarly",
+          "givenName": "Samwell",
+        },
+        "relationships": Object {
+          "groups": Object {
+            "data": Array [
+              Object {
+                "_id": "610718e6-2d7a",
+                "_type": "io.cozy.contacts.groups",
+              },
+            ],
+          },
+        },
+      },
+    ]
+  }
+  t={[MockFunction]}
 >
-  <Avatar
-    className=""
-    image=""
-    size="small"
-    text="G"
-  />
-  <Identity
-    details="2 members"
-    name="The Night's Watch"
-  />
-</div>
+  <div
+    className="recipient"
+  >
+    <Avatar
+      className=""
+      image=""
+      size="small"
+      text="G"
+    >
+      <div
+        className="styles__c-avatar___PpDI- styles__c-avatar--small___1Y_Pv"
+        style={
+          Object {
+            "backgroundColor": "var(--purpley)",
+            "color": "white",
+          }
+        }
+      >
+        <span
+          className="styles__c-avatar-initials___310qC"
+        >
+          G
+        </span>
+      </div>
+    </Avatar>
+    <Identity
+      details="2 members"
+      name="The Night's Watch"
+    >
+      <div
+        className="recipient-idents u-ml-1"
+      >
+        <div
+          className="recipient-user"
+        >
+          The Night's Watch
+        </div>
+        <div
+          className="recipient-details"
+        >
+          2 members
+        </div>
+      </div>
+    </Identity>
+  </div>
+</ContactSuggestion>
 `;

--- a/packages/cozy-sharing/src/components/__snapshots__/SharedStatus.spec.js.snap
+++ b/packages/cozy-sharing/src/components/__snapshots__/SharedStatus.spec.js.snap
@@ -5,7 +5,6 @@ exports[`SharedStatus component should display the link if there is a link 1`] =
   docId="1"
   link={true}
   recipients={Array []}
-  t={[Function]}
 >
   <span
     className="shared-status"
@@ -69,7 +68,7 @@ exports[`SharedStatus component should display the link if there is a link 1`] =
           id="linkfor1"
         >
           <span>
-            Files.share.shareByLink.subtitle
+            Or share by link
           </span>
         </div>
       </ReactTooltip>
@@ -93,7 +92,6 @@ exports[`SharedStatus component should have the right display if there is severa
       },
     ]
   }
-  t={[Function]}
 >
   <span
     className="shared-status"
@@ -103,7 +101,7 @@ exports[`SharedStatus component should have the right display if there is severa
       data-for="members1"
       data-tip={true}
     >
-      Share.members.count
+      2 members
     </a>
     <SharingTooltip
       id="members1"

--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -217,20 +217,22 @@ export class SharingProvider extends Component {
     const { client, doctype } = this.props
     const sharing = getDocumentSharing(this.state, document.id)
     if (sharing) return this.addRecipients(sharing, recipients, sharingType)
-    const resp = await this.sharingCol.share(
+    const { data } = await this.sharingCol.share(
       document,
       recipients,
       sharingType,
       description,
-      '/preview'
+      '/preview',
+      true
     )
+
     this.dispatch(
       addSharing(
-        resp.data,
+        data,
         document.path || (await fetchFilesPaths(client, doctype, [document]))
       )
     )
-    return resp.data
+    return data
   }
 
   addRecipients = async (sharing, recipients, sharingType) => {

--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types'
 import { getTracker } from 'cozy-ui/transpiled/react/helpers/tracker'
-import { translate } from 'cozy-ui/transpiled/react/I18n'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import reducer, {
   receiveSharings,
@@ -457,30 +456,30 @@ export const SharedRecipientsList = withLocales(({ docId, ...rest }) => (
 ))
 
 export const ShareButton = withLocales(
-  translate()(({ t, docId, ...rest }) => (
-    <SharingContext.Consumer>
-      {({ byDocId, documentType, isOwner }) => {
-        return !byDocId[docId] ? (
-          <DumbShareButton label={t(`${documentType}.share.cta`)} {...rest} />
-        ) : isOwner(docId) ? (
-          <SharedByMeButton
-            label={t(`${documentType}.share.sharedByMe`)}
-            {...rest}
-          />
-        ) : (
-          <SharedWithMeButton
-            label={t(`${documentType}.share.sharedWithMe`)}
-            {...rest}
-          />
-        )
-      }}
-    </SharingContext.Consumer>
-  ))
+  // eslint-disable-next-line no-unused-vars
+  ({ docId, ...rest }) => {
+    const { t } = useI18n()
+    return (
+      <SharingContext.Consumer>
+        {({ byDocId, documentType, isOwner }) => {
+          return !byDocId[docId] ? (
+            <DumbShareButton label={t(`${documentType}.share.cta`)} {...rest} />
+          ) : isOwner(docId) ? (
+            <SharedByMeButton
+              label={t(`${documentType}.share.sharedByMe`)}
+              {...rest}
+            />
+          ) : (
+            <SharedWithMeButton
+              label={t(`${documentType}.share.sharedWithMe`)}
+              {...rest}
+            />
+          )
+        }}
+      </SharingContext.Consumer>
+    )
+  }
 )
-
-ShareButton.contextTypes = {
-  t: PropTypes.func.isRequired
-}
 
 const SharingModal = ({ document, ...rest }) => (
   <SharingContext.Consumer>

--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -86,6 +86,7 @@ export class SharingProvider extends Component {
       canReshare: docId => canReshare(this.state, docId, instanceUri),
       getOwner: docId => getOwner(this.state, docId),
       getSharingType: docId => getSharingType(this.state, docId, instanceUri),
+      getSharingForSelf: docId => getSharingForSelf(this.state, docId),
       getRecipients: docId => getRecipients(this.state, docId),
       getDocumentPermissions: docId =>
         getDocumentPermissions(this.state, docId),

--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -217,14 +217,14 @@ export class SharingProvider extends Component {
     const { client, doctype } = this.props
     const sharing = getDocumentSharing(this.state, document.id)
     if (sharing) return this.addRecipients(sharing, recipients, sharingType)
-    const { data } = await this.sharingCol.share(
+    const { data } = await this.sharingCol.create({
       document,
       recipients,
-      sharingType,
+      readOnlyRecipients,
       description,
-      '/preview',
-      true
-    )
+      previewPath: '/preview',
+      openSharing
+    })
 
     this.dispatch(
       addSharing(

--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -214,10 +214,22 @@ export class SharingProvider extends Component {
     this.dispatch(receivePaths([...folderPaths, ...filePaths]))
   }
 
-  share = async (document, recipients, sharingType, description) => {
+  share = async ({
+    document,
+    recipients,
+    readOnlyRecipients,
+    description,
+    openSharing
+  }) => {
     const { client, doctype } = this.props
     const sharing = getDocumentSharing(this.state, document.id)
-    if (sharing) return this.addRecipients(sharing, recipients, sharingType)
+    if (sharing)
+      return this.addRecipients({
+        document: sharing,
+        recipients,
+        readOnlyRecipients
+      })
+
     const { data } = await this.sharingCol.create({
       document,
       recipients,
@@ -236,12 +248,12 @@ export class SharingProvider extends Component {
     return data
   }
 
-  addRecipients = async (sharing, recipients, sharingType) => {
-    const resp = await this.sharingCol.addRecipients(
-      sharing,
+  addRecipients = async ({ document, recipients, readOnlyRecipients }) => {
+    const resp = await this.sharingCol.addRecipients({
+      document,
       recipients,
-      sharingType
-    )
+      readOnlyRecipients
+    })
     this.dispatch(updateSharing(resp.data))
   }
 

--- a/packages/cozy-sharing/src/models.js
+++ b/packages/cozy-sharing/src/models.js
@@ -1,4 +1,8 @@
 export { CozyFile } from 'cozy-doctypes'
 export { Group } from 'cozy-doctypes'
 
-export { default as Contact } from './DoctypeContact'
+export {
+  default as Contact,
+  getInitials,
+  getDisplayName
+} from './DoctypeContact'

--- a/packages/cozy-sharing/src/state.js
+++ b/packages/cozy-sharing/src/state.js
@@ -410,6 +410,14 @@ const getDocumentSharingType = (sharing, docId) => {
     : 'one-way'
 }
 
+export const isReadOnlySharing = (sharing, docId) => {
+  const rule = sharing.attributes.rules.find(
+    r => r.values.indexOf(docId) !== -1
+  )
+  // If a document has no rule, it is a shortcut preview of a sharing. Since the sharing hasn't been accepted, it can't be synced so we return the "one-way" type.
+  return rule && rule.update === 'sync' && rule.remove === 'sync' ? false : true
+}
+
 const buildSharingLink = (state, documentType, sharecode) => {
   const appUrl = getAppUrlForDoctype(state, documentType)
   switch (documentType) {

--- a/packages/cozy-sharing/src/state.js
+++ b/packages/cozy-sharing/src/state.js
@@ -317,6 +317,7 @@ export const getSharingForSelf = (state, docId) =>
 
 export const getSharingType = (state, docId, instanceUri) => {
   const sharing = getSharingForSelf(state, docId)
+  if (!sharing) return false
   const type = getDocumentSharingType(sharing, docId)
   if (sharing.attributes.owner) return type
   const me = sharing.attributes.members.find(matchingInstanceName(instanceUri))

--- a/packages/cozy-sharing/src/state.spec.js
+++ b/packages/cozy-sharing/src/state.spec.js
@@ -11,13 +11,15 @@ import reducer, {
   getSharingLink,
   hasSharedParent,
   hasSharedChild,
-  getSharedDocIdsBySharings
+  getSharedDocIdsBySharings,
+  getSharingType
 } from './state'
 
 import {
   SHARING_1,
   SHARING_2,
   SHARING_3,
+  SHARING_READ_ONLY,
   PERM_1,
   PERM_2,
   SHARING_NO_ACTIVE,
@@ -482,5 +484,41 @@ describe('getSharedDocIdsBySharings method', () => {
       data: [SHARING_1, SHARING_NO_ACTIVE]
     })
     expect(sharedDocsId).toEqual(SHARING_1.attributes.rules[0].values)
+  })
+})
+
+describe('getSharingType selector', () => {
+  it('should return false is this a sharingByLink', () => {
+    const newState = reducer({}, addSharingLink(PERM_2))
+    expect(
+      getSharingType(newState, PERM_2.attributes.permissions.rule0.values, '')
+    ).toBe(false)
+  })
+
+  it('should return two-way if the sharing is two-way', () => {
+    const newState = reducer(
+      {},
+      receiveSharings({
+        sharings: [SHARING_3]
+      })
+    )
+    expect(
+      getSharingType(newState, SHARING_3.attributes.rules[0].values[0], '')
+    ).toBe('two-way')
+  })
+  it('should return one-way if the sharing is one-way', () => {
+    const newState = reducer(
+      {},
+      receiveSharings({
+        sharings: [SHARING_READ_ONLY]
+      })
+    )
+    expect(
+      getSharingType(
+        newState,
+        SHARING_READ_ONLY.attributes.rules[0].values[0],
+        ''
+      )
+    ).toBe('one-way')
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1494,7 +1494,7 @@
   dependencies:
     find-up "^2.1.0"
 
-"@cozy/minilog@^1.0.0":
+"@cozy/minilog@1.0.0", "@cozy/minilog@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@cozy/minilog/-/minilog-1.0.0.tgz#1acc1aad849261e931e255a5f181b638315f7b84"
   integrity sha512-IkDHF9CLh0kQeSEVsou59ar/VehvenpbEUjLfwhckJyOUqZnKAWmXy8qrBgMT5Loxr8Xjs2wmMnj0D67wP00eQ==
@@ -5325,6 +5325,28 @@ cozy-client@14.4.0:
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
+cozy-client@15.5.0:
+  version "15.5.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-15.5.0.tgz#5b857dd2692f3980c067b675053764236b93f9fc"
+  integrity sha512-V3QeJhMLl/rZBpLt2RO2oQldSGS9x7rD82RVG/kiM/ISVtMJM+dWYHP+hnwT/5RDPZ53OET0/0Uue9VfevJBfg==
+  dependencies:
+    "@cozy/minilog" "1.0.0"
+    btoa "^1.2.1"
+    cozy-device-helper "^1.7.3"
+    cozy-logger "^1.6.0"
+    cozy-stack-client "^15.5.0"
+    isomorphic-fetch "^2.2.1"
+    lodash "^4.17.13"
+    microee "^0.0.6"
+    open "^7.0.2"
+    prop-types "^15.6.2"
+    react-redux "^7.2.0"
+    redux "^3.7.2"
+    redux-thunk "^2.3.0"
+    server-destroy "^1.0.1"
+    sift "^6.0.0"
+    url-search-params-polyfill "^7.0.0"
+
 cozy-doctypes@1.67.0:
   version "1.67.0"
   resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.67.0.tgz#2e26cf43556cff298d0eec2f06091d15dc1758da"
@@ -5376,6 +5398,15 @@ cozy-stack-client@^14.1.2:
   version "14.1.2"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-14.1.2.tgz#606ce89cabf4def2875cb8749b28b3ee8b96d18f"
   integrity sha512-0IyYvBQu+vuwN9qe6PHA7khXBQT8TGSjVia7SVTGQ88tEFSLLGXjfZe3pkZQ1ihBdJvmeon12dm0BWeEb+9KZw==
+  dependencies:
+    detect-node "^2.0.4"
+    mime "^2.4.0"
+    qs "^6.7.0"
+
+cozy-stack-client@^15.5.0:
+  version "15.5.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-15.5.0.tgz#0ba1bcc798e096e6db7f5506b4c1ec839d0e5460"
+  integrity sha512-qV/28sl6qedHbSwPRqBVaNdRu0KiFxKeSauRnT5gji/mBnxdeimen34uvsZcL+pXq22N9sJ6MaahbexUtcV69g==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5325,16 +5325,16 @@ cozy-client@14.4.0:
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
-cozy-client@15.5.0:
-  version "15.5.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-15.5.0.tgz#5b857dd2692f3980c067b675053764236b93f9fc"
-  integrity sha512-V3QeJhMLl/rZBpLt2RO2oQldSGS9x7rD82RVG/kiM/ISVtMJM+dWYHP+hnwT/5RDPZ53OET0/0Uue9VfevJBfg==
+cozy-client@16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-16.0.0.tgz#8e3333f7ee42e996c79d1d150651c0e480d02495"
+  integrity sha512-Q8owRCIVxfeDZiAvokcIvduA9Ei1dtbNGSnYQcYOKLh3dDcKVQ12KmuodgyFj4792eruNy3oR43xLqi7wccAmg==
   dependencies:
     "@cozy/minilog" "1.0.0"
     btoa "^1.2.1"
     cozy-device-helper "^1.7.3"
     cozy-logger "^1.6.0"
-    cozy-stack-client "^15.5.0"
+    cozy-stack-client "^16.0.0"
     isomorphic-fetch "^2.2.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -5403,10 +5403,10 @@ cozy-stack-client@^14.1.2:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^15.5.0:
-  version "15.5.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-15.5.0.tgz#0ba1bcc798e096e6db7f5506b4c1ec839d0e5460"
-  integrity sha512-qV/28sl6qedHbSwPRqBVaNdRu0KiFxKeSauRnT5gji/mBnxdeimen34uvsZcL+pXq22N9sJ6MaahbexUtcV69g==
+cozy-stack-client@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-16.0.0.tgz#9946dd2b7afe3ac7b747156ef47e3af20b37759d"
+  integrity sha512-FV+wnjeVzdy3Gv/YQInIVeGO0CFFpATNfXW599+cxPQPejvzAq7XkGYLx2zw6Bmu/2vyBxk8UoomtA2eB27oXA==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
- N'affiche plus les 2 types de partage quand le partage a été créé avec un rule.policy en read only vu qu'on ne peut pas changer le type de partage, ça ne sert à rien.  (au début, ça se base sur le sharingType dans le premier commit, mais c'est corrigé ensuite) avec l'ajout d'une méthode isReadOnly pour savoir si le partage est readonly ou pas. 
- Utilisation de la nouvelle API de create() et de addRecipients (besoin de https://github.com/cozy/cozy-client/pull/817) 
- Rewording pour ne plus avoir de sharingType / se baser sur le sharingType 
- Refacto pour utiliser les models de cozy-client et non de cozy-doctype 