### PR TITLE
refactor: Use primary and secondary instead of primaryText/secondaryText

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -57,7 +57,7 @@
     "cozy-flags": "^2.4.1",
     "cozy-keys-lib": "^3.1.0",
     "cozy-realtime": "^3.11.0",
-    "cozy-ui": "37.6.0",
+    "cozy-ui": "38.3.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.2",
     "form-data": "3.0.0",
@@ -76,7 +76,7 @@
     "cozy-flags": "^2.3.5",
     "cozy-keys-lib": "^3.1.0",
     "cozy-realtime": "^3.10.5",
-    "cozy-ui": "^37.6.0"
+    "cozy-ui": "^38.3.0"
   },
   "sideEffects": false
 }

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/Contracts.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/Contracts.jsx
@@ -55,8 +55,8 @@ const ContractItem = ({ contract, konnector, accountId }) => {
           <Icon icon="wallet" className="u-slateGrey" />
         </ListItemIcon>
         <ListItemText
-          primaryText={startCase(getPrimaryText(contract).toLowerCase())}
-          secondaryText={contract._deleted ? t('contracts.deleted') : null}
+          primary={startCase(getPrimaryText(contract).toLowerCase())}
+          secondary={contract._deleted ? t('contracts.deleted') : null}
         />
         <ListItemSecondaryAction>
           <Icon icon="right" className="u-coolGrey u-mr-1" />

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
@@ -131,8 +131,8 @@ const ConfigurationTab = ({
                   <Icon icon="key" color={palette['slateGrey']} />
                 </ListItemIcon>
                 <ListItemText
-                  primaryText={t('modal.updateAccount.identifiers')}
-                  secondaryText={Account.getAccountName(account)}
+                  primary={t('modal.updateAccount.identifiers')}
+                  secondary={Account.getAccountName(account)}
                 />
                 <ListItemSecondaryAction>
                   <div>
@@ -151,8 +151,11 @@ const ConfigurationTab = ({
                 <Icon icon="unlink" className="u-error" />
               </ListItemIcon>
               <ListItemText
-                primaryTextClassName="u-error"
-                primaryText={t('accountForm.disconnect.button')}
+                primary={
+                  <span className="u-error">
+                    {t('accountForm.disconnect.button')}
+                  </span>
+                }
               />
               <ListItemSecondaryAction>
                 {deleting && <Spinner />}

--- a/packages/cozy-harvest-lib/src/components/VaultCiphersList/CiphersListItem.jsx
+++ b/packages/cozy-harvest-lib/src/components/VaultCiphersList/CiphersListItem.jsx
@@ -27,8 +27,8 @@ const CiphersListItem = props => {
         <CipherIcon konnector={konnector} />
       </ListItemIcon>
       <ListItemText
-        primaryText={get(cipherView, 'login.username')}
-        secondaryText={cipherView.name}
+        primary={get(cipherView, 'login.username')}
+        secondary={cipherView.name}
       />
     </ListItem>
   )

--- a/packages/cozy-harvest-lib/src/components/VaultCiphersList/OtherAccountListItem.jsx
+++ b/packages/cozy-harvest-lib/src/components/VaultCiphersList/OtherAccountListItem.jsx
@@ -20,7 +20,7 @@ const OtherAccountListItem = props => {
       )}
       {...rest}
     >
-      <ListItemText primaryText={t('vaultCiphersList.otherAccount')} />
+      <ListItemText primary={t('vaultCiphersList.otherAccount')} />
     </ListItem>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5425,10 +5425,10 @@ cozy-ui@35.40.2:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@37.6.0:
-  version "37.6.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-37.6.0.tgz#8e8ea9ac2ef8a706f04ce9436c7b05a598f2303a"
-  integrity sha512-5Fp2tja2FKLAGOBVUPC2uJGm0Lnp/u7pCcJd/+OY/d2p6yc9ZDgx6rxlbgRM4s2Ml7RYBjbxdqZwGjXi9o7VYQ==
+cozy-ui@38.2.0:
+  version "38.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-38.2.0.tgz#252363727b2aeb4b427a69315d45a85d9490adc1"
+  integrity sha512-SFotqf11ai+3UoZuyYLtaCwyqEzfk/db2qIBWCsUtNRxdvE2lWCvUyfVsvKjoD4JA90AXPKgHZsjOqweotcbXA==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"
@@ -5440,17 +5440,16 @@ cozy-ui@37.6.0:
     intersection-observer "0.11.0"
     node-polyglot "^2.2.2"
     normalize.css "^7.0.0"
-    react-hot-loader "^4.3.11"
     react-markdown "^4.0.8"
     react-pdf "^4.0.5"
     react-popper "^2.2.3"
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@38.2.0:
-  version "38.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-38.2.0.tgz#252363727b2aeb4b427a69315d45a85d9490adc1"
-  integrity sha512-SFotqf11ai+3UoZuyYLtaCwyqEzfk/db2qIBWCsUtNRxdvE2lWCvUyfVsvKjoD4JA90AXPKgHZsjOqweotcbXA==
+cozy-ui@^38.3.0:
+  version "38.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-38.3.0.tgz#0943d19f5d0f08c31f6bfe12bfe6ad9f30749c82"
+  integrity sha512-eei02zXDWfTNyftS7dHf6GAvS+ffeTHtZou8o9Cm4j7co+n5XiAvUGuSr78sWjRW3oHmlb5C5oG28c9c4m8FeA==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"


### PR DESCRIPTION
The two arguments were deprecated and cause warnings in test.