### PR TITLE
SharedStatus shows avatars

### DIFF
--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -42,7 +42,7 @@
     "babel-jest": "^24.9.0",
     "babel-plugin-css-modules-transform": "^1.6.2",
     "cozy-client": "16.0.0",
-    "cozy-ui": "40.1.0",
+    "cozy-ui": "40.2.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.2",
     "enzyme-to-json": "3.4.4",

--- a/packages/cozy-sharing/src/components/Recipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient.jsx
@@ -79,6 +79,9 @@ export const RecipientAvatar = ({ recipient, ...rest }) => {
       image={`${client.options.uri}${recipient.avatarPath}`}
       text={getInitials(recipient)}
       textId={getDisplayName(recipient)}
+      disabled={
+        recipient.status === 'pending' || recipient.status === 'mail-not-send'
+      }
       {...rest}
     />
   )

--- a/packages/cozy-sharing/src/components/RecipientsAvatars.spec.jsx
+++ b/packages/cozy-sharing/src/components/RecipientsAvatars.spec.jsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import { createMockClient } from 'cozy-client'
+import { render } from '@testing-library/react'
+
+import { RecipientsAvatars, MAX_DISPLAYED_RECIPIENTS } from './Recipient'
+import AppLike from '../../test/AppLike'
+
+const mockRecipients = new Array(MAX_DISPLAYED_RECIPIENTS - 1)
+  .fill(
+    {
+      status: 'owner',
+      public_name: 'cozy'
+    },
+    0,
+    1
+  )
+  .fill(
+    {
+      status: 'pending',
+      name: 'Mitch Young'
+    },
+    1
+  )
+
+const mockMoreRecipientsThanMaxDisplayed = [
+  ...mockRecipients,
+  {
+    status: 'mail-not-send',
+    name: 'Lyn Webster'
+  },
+  {
+    status: 'ready',
+    name: 'Richelle Young'
+  },
+  {
+    status: 'ready',
+    name: 'John Connor'
+  }
+]
+
+describe('RecipientsAvatars', () => {
+  const client = createMockClient({})
+
+  const setup = ({
+    recipients = mockRecipients,
+    link = false,
+    isOwner = true,
+    onClick = () => jest.fn(),
+    ...rest
+  }) => {
+    return render(
+      <AppLike client={client}>
+        <RecipientsAvatars
+          recipients={recipients}
+          onClick={onClick}
+          isOwner={isOwner}
+          link={link}
+          {...rest}
+        />
+      </AppLike>
+    )
+  }
+
+  it('should render link icon if a link is generated', () => {
+    const { getByTestId } = setup({
+      link: true
+    })
+
+    expect(getByTestId('recipientsAvatars-link')).toBeTruthy()
+  })
+
+  it('should not render link icon if a link is not generated', () => {
+    const { queryByTestId } = setup({})
+
+    expect(queryByTestId('recipientsAvatars-link')).toBeNull()
+  })
+
+  it('should hide me as owner by default', () => {
+    const { queryByTestId } = setup({})
+
+    expect(queryByTestId('recipientsAvatars-avatar-owner')).toBeNull()
+  })
+
+  it('should show me as owner if required', () => {
+    const { getByTestId } = setup({
+      showMeAsOwner: true
+    })
+
+    expect(getByTestId('recipientsAvatars-avatar-owner')).toBeTruthy()
+  })
+
+  it('should show a +X icon with the correct number if there is more avatars than expected', () => {
+    const { getByTestId, getByText } = setup({
+      recipients: mockMoreRecipientsThanMaxDisplayed,
+      showMeAsOwner: true
+    })
+
+    const delta =
+      mockMoreRecipientsThanMaxDisplayed.length - MAX_DISPLAYED_RECIPIENTS
+
+    expect(getByTestId('recipientsAvatars-plusX')).toBeTruthy()
+    expect(getByText(`+${delta}`)).toBeTruthy()
+  })
+
+  it('should show both +X and link icon if necessary', () => {
+    const { getByTestId } = setup({
+      recipients: mockMoreRecipientsThanMaxDisplayed,
+      showMeAsOwner: true,
+      link: true
+    })
+
+    expect(getByTestId('recipientsAvatars-plusX')).toBeTruthy()
+    expect(getByTestId('recipientsAvatars-link')).toBeTruthy()
+  })
+})

--- a/packages/cozy-sharing/src/components/__snapshots__/ContactSuggestion.spec.jsx.snap
+++ b/packages/cozy-sharing/src/components/__snapshots__/ContactSuggestion.spec.jsx.snap
@@ -62,11 +62,10 @@ exports[`ContactSuggestion component should display contact suggestion for a con
       text="JS"
     >
       <div
-        className="styles__c-avatar___PpDI- styles__c-avatar--small___1Y_Pv"
+        className="styles__c-avatar___PpDI- styles__c-avatar--small___1Y_Pv styles__c-avatar--text___2dvna"
         style={
           Object {
             "backgroundColor": "var(--lavender)",
-            "color": "white",
           }
         }
       >
@@ -144,11 +143,10 @@ exports[`ContactSuggestion component should display contact suggestion for a con
       text="J"
     >
       <div
-        className="styles__c-avatar___PpDI- styles__c-avatar--small___1Y_Pv"
+        className="styles__c-avatar___PpDI- styles__c-avatar--small___1Y_Pv styles__c-avatar--text___2dvna"
         style={
           Object {
             "backgroundColor": "var(--puertoRico)",
-            "color": "white",
           }
         }
       >
@@ -277,11 +275,10 @@ exports[`ContactSuggestion component should display contact suggestion for a gro
       text="G"
     >
       <div
-        className="styles__c-avatar___PpDI- styles__c-avatar--small___1Y_Pv"
+        className="styles__c-avatar___PpDI- styles__c-avatar--small___1Y_Pv styles__c-avatar--text___2dvna"
         style={
           Object {
             "backgroundColor": "var(--purpley)",
-            "color": "white",
           }
         }
       >

--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -39,7 +39,6 @@ import EditableSharingModal from './components/EditableSharingModal'
 import { SharingDetailsModal } from './SharingDetailsModal'
 import { default as RecipientsList } from './components/WhoHasAccessLight'
 import { RecipientsAvatars, RecipientAvatar } from './components/Recipient'
-import { default as DumbSharedStatus } from './components/SharedStatus'
 import { withClient } from 'cozy-client'
 
 import withLocales from './withLocales'
@@ -389,17 +388,20 @@ export const SharedDocument = ({ docId, children }) => (
 )
 
 export const SharedStatus = withLocales(
-  ({ docId, className, noSharedClassName }) => (
+  ({ docId, className, noSharedClassName, onClick, showMeAsOwner }) => (
     <SharingContext.Consumer>
-      {({ byDocId, getRecipients, getSharingLink } = {}) =>
+      {({ byDocId, getRecipients, getSharingLink, isOwner } = {}) =>
         !byDocId || !byDocId[docId] ? (
           <span className={className + ' ' + noSharedClassName}>—</span>
         ) : (
-          <DumbSharedStatus
+          <RecipientsAvatars
             className={className}
             recipients={getRecipients(docId)}
-            docId={docId}
             link={getSharingLink(docId) !== null}
+            onClick={onClick}
+            isOwner={isOwner(docId)}
+            size="small"
+            showMeAsOwner={showMeAsOwner}
           />
         )
       }
@@ -429,12 +431,13 @@ export const SharingOwnerAvatar = withLocales(({ docId, ...rest }) => (
 
 export const SharedRecipients = withLocales(({ docId, onClick, ...rest }) => (
   <SharingContext.Consumer>
-    {({ byDocId, getRecipients, getSharingLink } = {}) =>
+    {({ byDocId, getRecipients, getSharingLink, isOwner } = {}) =>
       !byDocId || !byDocId[docId] ? null : (
         <RecipientsAvatars
           recipients={getRecipients(docId)}
           link={getSharingLink(docId) !== null}
           onClick={onClick}
+          isOwner={isOwner(docId)}
           {...rest}
         />
       )

--- a/yarn.lock
+++ b/yarn.lock
@@ -5508,10 +5508,10 @@ cozy-ui@38.3.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@40.1.0:
-  version "40.1.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-40.1.0.tgz#358577bb8f978f4ebcc81d93fc198f6f41ee6ffd"
-  integrity sha512-+XoXQxLBL5tHJvhkIVemDTpu8L8B11j7t9WL1j5Ou1cHOcWAM0WPSYh+mk9aIzsVQ5OJDbO8X5mqvzZYBPzq6A==
+cozy-ui@40.1.1:
+  version "40.1.1"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-40.1.1.tgz#679c489f4d2be080f67649a1fefffc75968f1f28"
+  integrity sha512-lfRaBCE/D43T/ZmxXRSfExnMmuaN2GKIcE6bvck/1Uj2O14gFbm2+c0Qvq5DJQ4KEGKBUKMziuppTuxfnHtP2w==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"
@@ -5529,10 +5529,10 @@ cozy-ui@40.1.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@40.1.1:
-  version "40.1.1"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-40.1.1.tgz#679c489f4d2be080f67649a1fefffc75968f1f28"
-  integrity sha512-lfRaBCE/D43T/ZmxXRSfExnMmuaN2GKIcE6bvck/1Uj2O14gFbm2+c0Qvq5DJQ4KEGKBUKMziuppTuxfnHtP2w==
+cozy-ui@40.2.0:
+  version "40.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-40.2.0.tgz#b9192c580566eb6f42bb36788b25f5158567a059"
+  integrity sha512-S9Bvlvqm/YHhVzf/wrnPAOl2uzrL9B3BkRiXGdPORWvUeco5m9twxm4FrS4zD8QoEMdk3mX/h2yR3mRqkT3X9A==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"


### PR DESCRIPTION
**Need to update cozy-ui before merging**

Précédemment on affichait les destinataires d'un partage dans la colonne statut via un texte et un tooltip. On affiche maintenant directement les avatars (en me retirant de la liste si je suis le propriétaire) comme on le fait déjà sur mobile, ou dans la vue d'un dossier.