### PR TITLE
Fix/share modal

### DIFF
--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -64,6 +64,7 @@
       "sharedByMe": "Shared by me",
       "sharedWithMe": "Shared with me",
       "sharedBy": "Shared by %{name}",
+      "sharedByLink": "Shared by link",
       "shareByLink": {
         "subtitle": "Or share by link",
         "create": "Generate a link",
@@ -146,7 +147,6 @@
       "sharedBy": "Shared by %{name}",
       "shareByLink": {
         "subtitle": "Share by link",
-        "desc": "Anyone with the provided link can see and edit your note.",
         "create": "Generate a link",
         "activated": "Link activated",
         "copy": "Copy link",
@@ -226,8 +226,7 @@
       "sharedByMe": "Shared",
       "sharedWithMe": "Shared with me",
       "shareByLink": {
-        "subtitle": "Or share by link",
-        "desc": "Anyone with the provided link can see and download your photos.",
+        "subtitle": "Share by link",
         "fetchFailed": "Woops! It seems your connectivity is limited, try again later when it gets better.",
         "create": "Generate a link",
         "activated": "Link activated",

--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -42,7 +42,7 @@
     "babel-jest": "^24.9.0",
     "babel-plugin-css-modules-transform": "^1.6.2",
     "cozy-client": "16.0.0",
-    "cozy-ui": "40.3.0",
+    "cozy-ui": "40.4.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.2",
     "enzyme-to-json": "3.4.4",
@@ -53,7 +53,7 @@
     "@material-ui/core": "3",
     "@material-ui/styles": "4.10.0",
     "cozy-client": "^16",
-    "cozy-ui": "^40.1.0",
+    "cozy-ui": "^40.4.0",
     "prop-types": "^15.7.2",
     "react": "^16.12.0"
   },

--- a/packages/cozy-sharing/src/components/EditableSharingModal.jsx
+++ b/packages/cozy-sharing/src/components/EditableSharingModal.jsx
@@ -21,39 +21,39 @@ export const EditableSharingModal = ({
       <SharingContext.Consumer>
         {({
           documentType,
-          isOwner,
-          getRecipients,
-          getSharingLink,
           getDocumentPermissions,
-          share,
-          revoke,
-          shareByLink,
-          updateDocumentPermissions,
-          revokeSharingLink,
-          hasSharedParent,
+          getRecipients,
+          getSharingForSelf,
+          getSharingLink,
           hasSharedChild,
+          hasSharedParent,
+          isOwner,
+          revoke,
           revokeSelf,
-          getSharingForSelf
+          revokeSharingLink,
+          share,
+          shareByLink,
+          updateDocumentPermissions
         }) => {
           return (
             <DumbShareModal
-              document={document}
-              documentType={documentType}
               contacts={contacts}
               createContact={contact => client.create(Contact.doctype, contact)}
+              document={document}
+              documentType={documentType}
               groups={groups}
-              recipients={getRecipients(document.id)}
-              link={getSharingLink(document.id)}
-              permissions={getDocumentPermissions(document.id)}
-              isOwner={isOwner(document.id)}
-              hasSharedParent={documentPath && hasSharedParent(documentPath)}
               hasSharedChild={documentPath && hasSharedChild(documentPath)}
-              onShare={share}
+              hasSharedParent={documentPath && hasSharedParent(documentPath)}
+              isOwner={isOwner(document.id)}
+              link={getSharingLink(document.id)}
               onRevoke={revoke}
-              onShareByLink={shareByLink}
-              onUpdateShareLinkPermissions={updateDocumentPermissions}
               onRevokeLink={revokeSharingLink}
               onRevokeSelf={revokeSelf}
+              onShare={share}
+              onShareByLink={shareByLink}
+              onUpdateShareLinkPermissions={updateDocumentPermissions}
+              permissions={getDocumentPermissions(document.id)}
+              recipients={getRecipients(document.id)}
               sharing={getSharingForSelf(document.id)}
               {...rest}
             />
@@ -65,8 +65,8 @@ export const EditableSharingModal = ({
 }
 
 EditableSharingModal.propTypes = {
-  document: PropTypes.object,
   contacts: contactsResponseType,
+  document: PropTypes.object,
   groups: groupsResponseType
 }
 

--- a/packages/cozy-sharing/src/components/EditableSharingModal.jsx
+++ b/packages/cozy-sharing/src/components/EditableSharingModal.jsx
@@ -65,10 +65,9 @@ export const EditableSharingModal = ({
 }
 
 EditableSharingModal.propTypes = {
-  client: PropTypes.object.isRequired,
   document: PropTypes.object,
-  contacts: contactsResponseType.isRequired,
-  groups: groupsResponseType.isRequired
+  contacts: contactsResponseType,
+  groups: groupsResponseType
 }
 
 const contactsQuery = () =>

--- a/packages/cozy-sharing/src/components/ShareByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareByLink.jsx
@@ -109,7 +109,7 @@ class ShareByLink extends React.Component {
 
   render() {
     const { loading, menuIsOpen } = this.state
-    const { checked, documentType, permissions, t } = this.props
+    const { checked, documentType, permissions, t, popperOptions } = this.props
 
     const hasReadOnlyPermissions = checkIsReadOnlyPermissions(permissions)
 
@@ -168,6 +168,7 @@ class ShareByLink extends React.Component {
                     placement="bottom-end"
                     containerElRef={this.containerRef}
                     anchorElRef={this.containerRef}
+                    popperOptions={popperOptions ? popperOptions : undefined}
                   >
                     <ActionMenuItem
                       left={

--- a/packages/cozy-sharing/src/components/ShareByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareByLink.jsx
@@ -168,7 +168,7 @@ class ShareByLink extends React.Component {
                     placement="bottom-end"
                     containerElRef={this.containerRef}
                     anchorElRef={this.containerRef}
-                    popperOptions={popperOptions ? popperOptions : undefined}
+                    popperOptions={popperOptions}
                   >
                     <ActionMenuItem
                       left={

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
@@ -36,6 +36,7 @@ const ShareDialogCozyToCozy = ({
   const { t } = useI18n()
   return (
     <FixedDialog
+      disableEnforceFocus
       opened={true}
       onClose={onClose}
       title={t(`${documentType}.share.title`, { name: document.name })}

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
@@ -37,7 +37,7 @@ const ShareDialogCozyToCozy = ({
   return (
     <FixedDialog
       disableEnforceFocus
-      opened={true}
+      open={true}
       onClose={onClose}
       title={t(`${documentType}.share.title`, { name: document.name })}
       content={

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
@@ -9,29 +9,29 @@ import WhoHasAccess from './WhoHasAccess'
 import cx from 'classnames'
 import styles from '../share.styl'
 const ShareDialogCozyToCozy = ({
-  onClose,
-  documentType,
-  document,
-  permissions,
-  link,
-  onShareByLink,
-  onRevokeLink,
-  onUpdateShareLinkPermissions,
-  showShareOnlyByLink,
-  showShareByEmail,
-  hasSharedParent,
-  recipients,
-  sharingDesc,
   contacts,
-  groups,
   createContact,
-  onShare,
-  needsContactsPermission,
-  sharing,
-  showWhoHasAccess,
+  document,
+  documentType,
+  groups,
+  hasSharedParent,
   isOwner,
+  link,
+  needsContactsPermission,
+  onClose,
   onRevoke,
-  onRevokeSelf
+  onRevokeLink,
+  onRevokeSelf,
+  onShare,
+  onShareByLink,
+  onUpdateShareLinkPermissions,
+  permissions,
+  recipients,
+  sharing,
+  sharingDesc,
+  showShareByEmail,
+  showShareOnlyByLink,
+  showWhoHasAccess
 }) => {
   const { t } = useI18n()
   return (
@@ -62,41 +62,41 @@ const ShareDialogCozyToCozy = ({
           )}
           {showShareByEmail && (
             <DumbShareByEmail
+              contacts={contacts}
+              createContact={createContact}
               currentRecipients={recipients}
               document={document}
               documentType={documentType}
-              sharingDesc={sharingDesc}
-              contacts={contacts}
               groups={groups}
-              createContact={createContact}
-              onShare={onShare}
               needsContactsPermission={needsContactsPermission}
+              onShare={onShare}
               sharing={sharing}
+              sharingDesc={sharingDesc}
             />
           )}
           {showWhoHasAccess && (
             <WhoHasAccess
               className={'u-mt-1'}
-              isOwner={isOwner}
-              recipients={recipients}
               document={document}
               documentType={documentType}
+              isOwner={isOwner}
               onRevoke={onRevoke}
               onRevokeSelf={onRevokeSelf}
+              recipients={recipients}
             />
           )}
         </div>
       }
       actions={
         <DumbShareByLink
-          document={document}
-          permissions={permissions}
-          documentType={documentType}
           checked={link !== null}
+          document={document}
+          documentType={documentType}
           link={link}
-          onEnable={onShareByLink}
-          onDisable={onRevokeLink}
           onChangePermissions={onUpdateShareLinkPermissions}
+          onDisable={onRevokeLink}
+          onEnable={onShareByLink}
+          permissions={permissions}
         />
       }
     />

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
@@ -1,0 +1,105 @@
+import React from 'react'
+import { FixedDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+import { default as DumbShareByLink } from './ShareByLink'
+import { default as DumbShareByEmail } from './ShareByEmail'
+import WhoHasAccess from './WhoHasAccess'
+
+import cx from 'classnames'
+import styles from '../share.styl'
+const ShareDialogCozyToCozy = ({
+  onClose,
+  documentType,
+  document,
+  permissions,
+  link,
+  onShareByLink,
+  onRevokeLink,
+  onUpdateShareLinkPermissions,
+  showShareOnlyByLink,
+  showShareByEmail,
+  hasSharedParent,
+  recipients,
+  sharingDesc,
+  contacts,
+  groups,
+  createContact,
+  onShare,
+  needsContactsPermission,
+  sharing,
+  showWhoHasAccess,
+  isOwner,
+  onRevoke,
+  onRevokeSelf
+}) => {
+  const { t } = useI18n()
+  return (
+    <FixedDialog
+      opened={true}
+      onClose={onClose}
+      title={t(`${documentType}.share.title`, { name: document.name })}
+      content={
+        <div className={cx(styles['share-modal-content'])}>
+          {showShareOnlyByLink && (
+            <div className={styles['share-byemail-onlybylink']}>
+              {t(`${documentType}.share.shareByEmail.onlyByLink`, {
+                type: t(
+                  `${documentType}.share.shareByEmail.type.${
+                    document.type === 'directory' ? 'folder' : 'file'
+                  }`
+                )
+              })}{' '}
+              <strong>
+                {t(
+                  `${documentType}.share.shareByEmail.${
+                    hasSharedParent ? 'hasSharedParent' : 'hasSharedChild'
+                  }`
+                )}
+              </strong>
+            </div>
+          )}
+          {showShareByEmail && (
+            <DumbShareByEmail
+              currentRecipients={recipients}
+              document={document}
+              documentType={documentType}
+              sharingDesc={sharingDesc}
+              contacts={contacts}
+              groups={groups}
+              createContact={createContact}
+              onShare={onShare}
+              needsContactsPermission={needsContactsPermission}
+              sharing={sharing}
+            />
+          )}
+          {showWhoHasAccess && (
+            <WhoHasAccess
+              className={'u-mt-1'}
+              isOwner={isOwner}
+              recipients={recipients}
+              document={document}
+              documentType={documentType}
+              onRevoke={onRevoke}
+              onRevokeSelf={onRevokeSelf}
+            />
+          )}
+        </div>
+      }
+      actions={
+        <DumbShareByLink
+          document={document}
+          permissions={permissions}
+          documentType={documentType}
+          checked={link !== null}
+          link={link}
+          onEnable={onShareByLink}
+          onDisable={onRevokeLink}
+          onChangePermissions={onUpdateShareLinkPermissions}
+        />
+      }
+    />
+  )
+}
+
+export default ShareDialogCozyToCozy

--- a/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.jsx
@@ -5,14 +5,14 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { default as DumbShareByLink } from './ShareByLink'
 
 const ShareDialogOnlyByLink = ({
-  onClose,
-  documentType,
   document,
-  permissions,
+  documentType,
   link,
-  onShareByLink,
+  onClose,
   onRevokeLink,
-  onUpdateShareLinkPermissions
+  onShareByLink,
+  onUpdateShareLinkPermissions,
+  permissions
 }) => {
   const { t } = useI18n()
   return (
@@ -25,14 +25,14 @@ const ShareDialogOnlyByLink = ({
       })}
       content={
         <DumbShareByLink
-          document={document}
-          permissions={permissions}
-          documentType={documentType}
           checked={link !== null}
+          document={document}
+          documentType={documentType}
           link={link}
-          onEnable={onShareByLink}
-          onDisable={onRevokeLink}
           onChangePermissions={onUpdateShareLinkPermissions}
+          onDisable={onRevokeLink}
+          onEnable={onShareByLink}
+          permissions={permissions}
           popperOptions={{
             strategy: 'fixed'
           }}

--- a/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.jsx
@@ -18,7 +18,7 @@ const ShareDialogOnlyByLink = ({
   return (
     <Dialog
       disableEnforceFocus
-      opened={true}
+      open={true}
       onClose={onClose}
       title={t(`${documentType}.share.title`, {
         name: document.name || document.attributes.name

--- a/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.jsx
@@ -30,6 +30,9 @@ const ShareDialogOnlyByLink = ({
           onEnable={onShareByLink}
           onDisable={onRevokeLink}
           onChangePermissions={onUpdateShareLinkPermissions}
+          popperOptions={{
+            strategy: 'fixed'
+          }}
         />
       }
     />

--- a/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.jsx
@@ -19,7 +19,9 @@ const ShareDialogOnlyByLink = ({
     <Dialog
       opened={true}
       onClose={onClose}
-      title={t(`${documentType}.share.title`, { name: document.name })}
+      title={t(`${documentType}.share.title`, {
+        name: document.name || document.attributes.name
+      })}
       content={
         <DumbShareByLink
           document={document}

--- a/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+import { default as DumbShareByLink } from './ShareByLink'
+
+const ShareDialogOnlyByLink = ({
+  onClose,
+  documentType,
+  document,
+  permissions,
+  link,
+  onShareByLink,
+  onRevokeLink,
+  onUpdateShareLinkPermissions
+}) => {
+  const { t } = useI18n()
+  return (
+    <Dialog
+      opened={true}
+      onClose={onClose}
+      title={t(`${documentType}.share.title`, { name: document.name })}
+      content={
+        <DumbShareByLink
+          document={document}
+          permissions={permissions}
+          documentType={documentType}
+          checked={link !== null}
+          link={link}
+          onEnable={onShareByLink}
+          onDisable={onRevokeLink}
+          onChangePermissions={onUpdateShareLinkPermissions}
+        />
+      }
+    />
+  )
+}
+export default ShareDialogOnlyByLink

--- a/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.jsx
@@ -17,6 +17,7 @@ const ShareDialogOnlyByLink = ({
   const { t } = useI18n()
   return (
     <Dialog
+      disableEnforceFocus
       opened={true}
       onClose={onClose}
       title={t(`${documentType}.share.title`, {

--- a/packages/cozy-sharing/src/components/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal.jsx
@@ -6,27 +6,27 @@ import { contactsResponseType, groupsResponseType } from '../propTypes'
 import ShareDialogCozyToCozy from './ShareDialogCozyToCozy'
 import ShareDialogOnlyByLink from './ShareDialogOnlyByLink'
 export const ShareModal = ({
-  document,
-  isOwner,
-  sharingDesc,
   contacts,
-  groups,
   createContact,
-  link,
-  permissions,
-  recipients,
+  document,
   documentType = 'Document',
-  needsContactsPermission,
-  hasSharedParent,
+  groups,
   hasSharedChild,
+  hasSharedParent,
+  isOwner,
+  link,
+  needsContactsPermission,
   onClose,
-  onShare,
   onRevoke,
-  onShareByLink,
-  onUpdateShareLinkPermissions,
   onRevokeLink,
   onRevokeSelf,
-  sharing
+  onShare,
+  onShareByLink,
+  onUpdateShareLinkPermissions,
+  permissions,
+  recipients,
+  sharing,
+  sharingDesc
 }) => {
   const showShareByEmail =
     documentType !== 'Notes' &&
@@ -40,41 +40,41 @@ export const ShareModal = ({
     <>
       {(documentType === 'Notes' || documentType === 'Albums') && (
         <ShareDialogOnlyByLink
-          onClose={onClose}
-          documentType={documentType}
           document={document}
-          permissions={permissions}
+          documentType={documentType}
           link={link}
-          onShareByLink={onShareByLink}
+          onClose={onClose}
           onRevokeLink={onRevokeLink}
+          onShareByLink={onShareByLink}
           onUpdateShareLinkPermissions={onUpdateShareLinkPermissions}
+          permissions={permissions}
         />
       )}
       {documentType !== 'Notes' && documentType !== 'Albums' && (
         <ShareDialogCozyToCozy
-          onClose={onClose}
-          documentType={documentType}
-          document={document}
-          permissions={permissions}
-          link={link}
-          onShareByLink={onShareByLink}
-          onRevokeLink={onRevokeLink}
-          onUpdateShareLinkPermissions={onUpdateShareLinkPermissions}
-          showShareOnlyByLink={showShareOnlyByLink}
-          showShareByEmail={showShareByEmail}
-          hasSharedParent={hasSharedParent}
-          recipients={recipients}
-          sharingDesc={sharingDesc}
           contacts={contacts}
-          groups={groups}
           createContact={createContact}
-          onShare={onShare}
-          needsContactsPermission={needsContactsPermission}
-          sharing={sharing}
-          showWhoHasAccess={showWhoHasAccess}
+          document={document}
+          documentType={documentType}
+          groups={groups}
+          hasSharedParent={hasSharedParent}
           isOwner={isOwner}
+          link={link}
+          needsContactsPermission={needsContactsPermission}
+          onClose={onClose}
           onRevoke={onRevoke}
+          onRevokeLink={onRevokeLink}
           onRevokeSelf={onRevokeSelf}
+          onShare={onShare}
+          onShareByLink={onShareByLink}
+          onUpdateShareLinkPermissions={onUpdateShareLinkPermissions}
+          permissions={permissions}
+          recipients={recipients}
+          sharing={sharing}
+          sharingDesc={sharingDesc}
+          showShareByEmail={showShareByEmail}
+          showShareOnlyByLink={showShareOnlyByLink}
+          showWhoHasAccess={showWhoHasAccess}
         />
       )}
     </>
@@ -84,23 +84,23 @@ export const ShareModal = ({
 export default ShareModal
 
 ShareModal.propTypes = {
-  document: PropTypes.object.isRequired,
-  permissions: PropTypes.array.isRequired,
-  isOwner: PropTypes.bool,
-  sharingDesc: PropTypes.string,
   contacts: contactsResponseType.isRequired,
-  groups: groupsResponseType.isRequired,
   createContact: PropTypes.func.isRequired,
-  recipients: PropTypes.array.isRequired,
-  link: PropTypes.string.isRequired,
+  document: PropTypes.object.isRequired,
   documentType: PropTypes.string,
-  needsContactsPermission: PropTypes.bool,
-  hasSharedParent: PropTypes.bool,
+  groups: groupsResponseType.isRequired,
   hasSharedChild: PropTypes.bool,
+  hasSharedParent: PropTypes.bool,
+  isOwner: PropTypes.bool,
+  link: PropTypes.string.isRequired,
+  needsContactsPermission: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
-  onShare: PropTypes.func.isRequired,
   onRevoke: PropTypes.func.isRequired,
+  onRevokeLink: PropTypes.func.isRequired,
+  onShare: PropTypes.func.isRequired,
   onShareByLink: PropTypes.func.isRequired,
   onUpdateShareLinkPermissions: PropTypes.func.isRequired,
-  onRevokeLink: PropTypes.func.isRequired
+  permissions: PropTypes.array.isRequired,
+  recipients: PropTypes.array.isRequired,
+  sharingDesc: PropTypes.string
 }

--- a/packages/cozy-sharing/src/components/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal.jsx
@@ -1,17 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import cx from 'classnames'
 
-import { useI18n } from 'cozy-ui/transpiled/react/I18n'
-import { FixedDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
-import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
-
-import styles from '../share.styl'
 import { contactsResponseType, groupsResponseType } from '../propTypes'
-import { default as DumbShareByLink } from './ShareByLink'
-import { default as DumbShareByEmail } from './ShareByEmail'
-import WhoHasAccess from './WhoHasAccess'
 
+import ShareDialogCozyToCozy from './ShareDialogCozyToCozy'
+import ShareDialogOnlyByLink from './ShareDialogOnlyByLink'
 export const ShareModal = ({
   document,
   isOwner,
@@ -35,8 +28,6 @@ export const ShareModal = ({
   onRevokeSelf,
   sharing
 }) => {
-  const { t } = useI18n()
-
   const showShareByEmail =
     documentType !== 'Notes' &&
     documentType !== 'Albums' &&
@@ -46,72 +37,47 @@ export const ShareModal = ({
   const showWhoHasAccess = documentType !== 'Albums'
 
   return (
-    <MuiCozyTheme>
-      <FixedDialog
-        open={true}
-        onClose={onClose}
-        title={t(`${documentType}.share.title`, { name: document.name })}
-        content={
-          <div className={cx(styles['share-modal-content'])}>
-            {showShareOnlyByLink && (
-              <div className={styles['share-byemail-onlybylink']}>
-                {t(`${documentType}.share.shareByEmail.onlyByLink`, {
-                  type: t(
-                    `${documentType}.share.shareByEmail.type.${
-                      document.type === 'directory' ? 'folder' : 'file'
-                    }`
-                  )
-                })}{' '}
-                <strong>
-                  {t(
-                    `${documentType}.share.shareByEmail.${
-                      hasSharedParent ? 'hasSharedParent' : 'hasSharedChild'
-                    }`
-                  )}
-                </strong>
-              </div>
-            )}
-            {showShareByEmail && (
-              <DumbShareByEmail
-                currentRecipients={recipients}
-                document={document}
-                documentType={documentType}
-                sharingDesc={sharingDesc}
-                contacts={contacts}
-                groups={groups}
-                createContact={createContact}
-                onShare={onShare}
-                needsContactsPermission={needsContactsPermission}
-                sharing={sharing}
-              />
-            )}
-            {showWhoHasAccess && (
-              <WhoHasAccess
-                className={'u-mt-1'}
-                isOwner={isOwner}
-                recipients={recipients}
-                document={document}
-                documentType={documentType}
-                onRevoke={onRevoke}
-                onRevokeSelf={onRevokeSelf}
-              />
-            )}
-          </div>
-        }
-        actions={
-          <DumbShareByLink
-            document={document}
-            permissions={permissions}
-            documentType={documentType}
-            checked={link !== null}
-            link={link}
-            onEnable={onShareByLink}
-            onDisable={onRevokeLink}
-            onChangePermissions={onUpdateShareLinkPermissions}
-          />
-        }
-      />
-    </MuiCozyTheme>
+    <>
+      {(documentType === 'Notes' || documentType === 'Albums') && (
+        <ShareDialogOnlyByLink
+          onClose={onClose}
+          documentType={documentType}
+          document={document}
+          permissions={permissions}
+          link={link}
+          onShareByLink={onShareByLink}
+          onRevokeLink={onRevokeLink}
+          onUpdateShareLinkPermissions={onUpdateShareLinkPermissions}
+        />
+      )}
+      {documentType !== 'Notes' && documentType !== 'Albums' && (
+        <ShareDialogCozyToCozy
+          onClose={onClose}
+          documentType={documentType}
+          document={document}
+          permissions={permissions}
+          link={link}
+          onShareByLink={onShareByLink}
+          onRevokeLink={onRevokeLink}
+          onUpdateShareLinkPermissions={onUpdateShareLinkPermissions}
+          showShareOnlyByLink={showShareOnlyByLink}
+          showShareByEmail={showShareByEmail}
+          hasSharedParent={hasSharedParent}
+          recipients={recipients}
+          sharingDesc={sharingDesc}
+          contacts={contacts}
+          groups={groups}
+          createContact={createContact}
+          onShare={onShare}
+          needsContactsPermission={needsContactsPermission}
+          sharing={sharing}
+          showWhoHasAccess={showWhoHasAccess}
+          isOwner={isOwner}
+          onRevoke={onRevoke}
+          onRevokeSelf={onRevokeSelf}
+        />
+      )}
+    </>
   )
 }
 

--- a/packages/cozy-sharing/src/components/SharedStatus.jsx
+++ b/packages/cozy-sharing/src/components/SharedStatus.jsx
@@ -39,7 +39,7 @@ export const SharedStatus = ({ className, docId, recipients, link }) => {
           />
 
           <SharingTooltip id={`linkfor${docId}`}>
-            <span>{t('Files.share.shareByLink.subtitle')}</span>
+            <span>{t('Files.share.sharedByLink')}</span>
           </SharingTooltip>
         </>
       )}

--- a/packages/cozy-sharing/src/components/__snapshots__/SharedStatus.spec.js.snap
+++ b/packages/cozy-sharing/src/components/__snapshots__/SharedStatus.spec.js.snap
@@ -68,7 +68,7 @@ exports[`SharedStatus component should display the link if there is a link 1`] =
           id="linkfor1"
         >
           <span>
-            Or share by link
+            Shared by link
           </span>
         </div>
       </ReactTooltip>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5529,10 +5529,10 @@ cozy-ui@40.1.1:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@40.3.0:
-  version "40.3.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-40.3.0.tgz#f0c00f9c36a291fa6e94ec5389c4a41341830039"
-  integrity sha512-EC859D3pWO6uGHMZAil1rM8HjIopyG9fuYd93xOHzSEDQdkoqOSAro7GZ146z8Ok1Q0+8fvR4+8WnVY5V05Z4A==
+cozy-ui@40.4.0:
+  version "40.4.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-40.4.0.tgz#1b5f302bab116e6348f07c192deeeb27f2e8ca73"
+  integrity sha512-dinvj4BrPHKc36ade4R+EsOAOV1/FQNFbyWcZG7CYf1BgQSDY4bnKN0ehsMhJmy0JPESZAxqagNcCGdLyc8YVQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"


### PR DESCRIPTION
Before we had only one modal to rule them all. The result was that we had CSS hacks in all directions to properly manage the display for all cases (only sharable by link, sharable cozy to cozy and by link, sharable cozy to cozy but disable and by link). 

The main idea here is to split the modal. One for sharable only by link and one for cozy-to-cozy (even disabled).

Few screenshots: 

![Capture d’écran 2020-11-04 à 08 51 24](https://user-images.githubusercontent.com/1107936/98099799-4a8fe400-1e90-11eb-8946-dae04e1b7062.png)
![Capture d’écran 2020-11-04 à 10 28 26](https://user-images.githubusercontent.com/1107936/98099803-4b287a80-1e90-11eb-82a7-a3c049fdd5a9.png)
![Capture d’écran 2020-11-04 à 10 30 45](https://user-images.githubusercontent.com/1107936/98099804-4bc11100-1e90-11eb-8445-5dfde272afcf.png)
![Capture d’écran 2020-11-04 à 10 30 48](https://user-images.githubusercontent.com/1107936/98099805-4c59a780-1e90-11eb-921e-9b8624d63b5a.png)

![Capture d’écran 2020-11-04 à 08 51 17](https://user-images.githubusercontent.com/1107936/98099797-49f74d80-1e90-11eb-8f20-66d073f98837.png)

