### PR TITLE
fix(cozy-doctypes): CreditCardMatch handle acount without number

### DIFF
--- a/packages/cozy-doctypes/src/banking/matching-accounts.js
+++ b/packages/cozy-doctypes/src/banking/matching-accounts.js
@@ -73,14 +73,14 @@ const approxNumberMatch = (account, existingAccount) => {
 const creditCardMatch = (account, existingAccount) => {
   let ccAccount, lastDigits
   for (let acc of [account, existingAccount]) {
-    const match = acc.number && acc.number.match(redactedCreditCard)
+    const match = acc && acc.number && acc.number.match(redactedCreditCard)
     if (match) {
       ccAccount = acc
       lastDigits = match[1]
     }
   }
   const other = ccAccount === account ? existingAccount : account
-  if (other.number.slice(-4) === lastDigits) {
+  if (other && other.number && other.number.slice(-4) === lastDigits) {
     return true
   }
 }
@@ -249,5 +249,6 @@ const matchAccounts = (fetchedAccountsArg, existingAccounts) => {
 module.exports = {
   matchAccounts,
   normalizeAccountNumber,
-  score
+  score,
+  creditCardMatch
 }

--- a/packages/cozy-doctypes/src/banking/matching-accounts.spec.js
+++ b/packages/cozy-doctypes/src/banking/matching-accounts.spec.js
@@ -3,7 +3,8 @@ const path = require('path')
 const {
   matchAccounts,
   normalizeAccountNumber,
-  score
+  score,
+  creditCardMatch
 } = require('./matching-accounts')
 
 const BANK_ACCOUNT_DOCTYPE = 'io.cozy.bank.accounts'
@@ -95,4 +96,32 @@ it('should normalize account number', () => {
   expect(normalizeAccountNumber('')).toBe('')
   expect(normalizeAccountNumber(null)).toBe(null)
   expect(normalizeAccountNumber(undefined)).toBe(undefined)
+})
+
+describe('creditCardMatch', () => {
+  it('should not throw when an account does not have a number', () => {
+    expect(creditCardMatch).not.toThrow()
+    // real paypal example
+    expect(
+      creditCardMatch(
+        {
+          balance: 0,
+          comingBalance: 0,
+          currency: 'EUR',
+          label: 'xxx EUR PERSONAL',
+          metadata: {
+            dateImport: '2020-11-04T18:06:57.857Z',
+            vendor: 'budget-insight',
+            version: 1,
+            updatedAt: '2020-11-04T18:45:42'
+          },
+          shortLabel: 'xxx EUR PERSONAL',
+          type: 'Checkings',
+          vendorId: '230',
+          institutionLabel: 'Paypal REST API'
+        },
+        { number: '13002900002' }
+      )
+    ).toBe(undefined)
+  })
 })


### PR DESCRIPTION
This is a case I met with the paypal bi connector