### PR TITLE
Feat/avatar has icon

### DIFF
--- a/packages/cozy-codemods/package.json
+++ b/packages/cozy-codemods/package.json
@@ -17,7 +17,6 @@
   },
   "devDependencies": {
     "jest": "^24.8.0",
-    "jscodeshift": "^0.6.4",
     "jsdoc-to-markdown": "^5.0.0"
   }
 }

--- a/packages/cozy-codemods/src/transforms/__testfixtures__/replace-icons-svgr.input.js
+++ b/packages/cozy-codemods/src/transforms/__testfixtures__/replace-icons-svgr.input.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import Button from 'cozy-ui/transpiled/react/Button'
+import Avatar from 'cozy-ui/transpiled/react/Avatar'
 import CustomIcon from './CustomIcon'
 
 const App = () => {
@@ -12,6 +13,7 @@ const App = () => {
       <Icon icon={CustomIcon} className="u-m-3" />
       <Icon icon="file-outline" className="u-m-3" />
       <Button icon="file-outline" className="u-m-3" />
+      <Avatar icon="link" className="u-m-3" />
     </div>
   )
 }

--- a/packages/cozy-codemods/src/transforms/__testfixtures__/replace-icons-svgr.output.js
+++ b/packages/cozy-codemods/src/transforms/__testfixtures__/replace-icons-svgr.output.js
@@ -1,11 +1,13 @@
 import React from 'react'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import Button from 'cozy-ui/transpiled/react/Button'
+import Avatar from 'cozy-ui/transpiled/react/Avatar'
 import CustomIcon from './CustomIcon'
 
 import MagnifierIcon from "cozy-ui/transpiled/react/Icons/Magnifier";
 import LeftIcon from "cozy-ui/transpiled/react/Icons/Left";
 import FileOutlineIcon from "cozy-ui/transpiled/react/Icons/FileOutline";
+import LinkIcon from "cozy-ui/transpiled/react/Icons/Link";
 
 const App = () => {
   return (
@@ -16,6 +18,7 @@ const App = () => {
       <Icon icon={CustomIcon} className="u-m-3" />
       <Icon icon={FileOutlineIcon} className="u-m-3" />
       <Button icon={<Icon icon={FileOutlineIcon} />} className="u-m-3" />
+      <Avatar icon={<Icon icon={LinkIcon} />} className="u-m-3" />
     </div>
   );
 }

--- a/packages/cozy-codemods/src/transforms/replace-icons-svgr.js
+++ b/packages/cozy-codemods/src/transforms/replace-icons-svgr.js
@@ -70,5 +70,36 @@ export default function replaceSvgrIcons(file, api) {
       }
     })
 
+  root
+    .find(j.JSXOpeningElement, {
+      name: {
+        name: 'Avatar'
+      }
+    })
+    .forEach(path => {
+      const iconAttr = path.node.attributes.find(
+        attr => attr.name && attr.name.name === 'icon'
+      )
+
+      if (iconAttr && iconAttr.value.type === 'Literal') {
+        const componentName = iconNameToComponentName(iconAttr.value.value)
+
+        imports.ensure(
+          root,
+          {
+            default: `${componentName}Icon`
+          },
+          `cozy-ui/transpiled/react/Icons/${componentName}`
+        )
+        imports.ensure(
+          root,
+          {
+            default: `Icon`
+          },
+          `cozy-ui/transpiled/react/Icon`
+        )
+        iconAttr.value = `{<Icon icon={${componentName}Icon} />}`
+      }
+    })
   return root.toSource()
 }


### PR DESCRIPTION
Replace avatar icon="left" 


Is there a way to pass, I don't know, an array to `find()` in order to manage in only one method all our components with `icon` props instead of duplicating the code for each one? 

