### PR TITLE
feat(Harvest): Ignore soft deleted ciphers

### DIFF
--- a/packages/cozy-harvest-lib/src/components/VaultCiphersList/VaultCiphersList.jsx
+++ b/packages/cozy-harvest-lib/src/components/VaultCiphersList/VaultCiphersList.jsx
@@ -15,14 +15,16 @@ export const DumbVaultCiphersList = ({ konnector, onSelect, ciphers, t }) => {
         {t('vaultCiphersList.title')}
       </Title>
       <List>
-        {ciphers.map(cipherView => (
-          <CiphersListItem
-            key={cipherView.id}
-            cipherView={cipherView}
-            konnector={konnector}
-            onClick={() => onSelect(cipherView)}
-          />
-        ))}
+        {ciphers
+          .filter(cipherView => !cipherView.deletedDate)
+          .map(cipherView => (
+            <CiphersListItem
+              key={cipherView.id}
+              cipherView={cipherView}
+              konnector={konnector}
+              onClick={() => onSelect(cipherView)}
+            />
+          ))}
 
         <OtherAccountListItem onClick={() => onSelect(null)} />
       </List>

--- a/packages/cozy-harvest-lib/src/components/VaultCiphersList/VaultCiphersList.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/VaultCiphersList/VaultCiphersList.spec.jsx
@@ -35,7 +35,7 @@ describe('when there is some ciphers', () => {
     expect(onSelect).toHaveBeenCalledWith(ciphers[0])
   })
 
-  it('should ignore trashed ciphers', async () => {
+  it('should ignore soft deleted ciphers', async () => {
     const onSelect = jest.fn()
     const ciphers = [
       {

--- a/packages/cozy-harvest-lib/src/components/VaultCiphersList/VaultCiphersList.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/VaultCiphersList/VaultCiphersList.spec.jsx
@@ -6,7 +6,7 @@ import I18n from 'cozy-ui/transpiled/react/I18n'
 jest.mock('cozy-ui/transpiled/react/AppIcon', () => () => null)
 
 describe('when there is some ciphers', () => {
-  it('should handler cipher select', async () => {
+  it('should handle cipher select', async () => {
     const onSelect = jest.fn()
     const ciphers = [
       {
@@ -33,6 +33,40 @@ describe('when there is some ciphers', () => {
     fireEvent.click(node)
 
     expect(onSelect).toHaveBeenCalledWith(ciphers[0])
+  })
+
+  it('should ignore trashed ciphers', async () => {
+    const onSelect = jest.fn()
+    const ciphers = [
+      {
+        id: 'alan',
+        name: 'Alan',
+        login: {
+          username: 'isabelledurand'
+        }
+      },
+      {
+        id: 'trashed',
+        name: 'trash',
+        login: {
+          username: 'toignore'
+        },
+        deletedDate: '2020-11-03'
+      }
+    ]
+    const { queryByText } = render(
+      <I18n lang="en" dictRequire={() => {}}>
+        <DumbVaultCiphersList
+          konnector={{ vendor_link: 'https://alan.com' }}
+          ciphers={ciphers}
+          onSelect={onSelect}
+          t={key => key}
+        />
+      </I18n>
+    )
+
+    const node = await queryByText('toignore')
+    expect(node).toBe(null)
   })
 
   it('should handle "other account" select', async () => {


### PR DESCRIPTION
Ignore ciphers deleted by cozy-pass when proposing import on new account creation