### PR TITLE
fix: SharingAvatar link is not separated + avatar size

### DIFF
--- a/packages/cozy-sharing/src/components/Recipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient.jsx
@@ -97,10 +97,7 @@ export const RecipientsAvatars = ({
             <RecipientAvatar
               recipient={recipient}
               size={size}
-              className={cx(styles['recipients-avatars--avatar'], {
-                [styles['recipients-avatars--avatar--noMarginRight']]:
-                  !isAvatarPlusX && idx === 0
-              })}
+              className={cx(styles['recipients-avatars--avatar'])}
             />
           </span>
         ))}

--- a/packages/cozy-sharing/src/components/recipient.styl
+++ b/packages/cozy-sharing/src/components/recipient.styl
@@ -66,15 +66,12 @@
         border-width 2px
         border-style solid
         border-color var(--white)
-        box-sizing border-box
 
     &--link
         background-color var(--genericRecipientBackground)
         svg
             fill: var(--genericRecipientColor)
 
+    &--plusX,
     &--avatar
         margin-right -0.6rem
-
-        &--noMarginRight
-            margin-right 0


### PR DESCRIPTION
On ne veut pas que l'icone de lien soit décalé par rapport aux autres. Correction de la taille des avatars qui doit faire 24px hors bordure (et non avec bordure).

![Capture d’écran 2020-11-19 à 10 37 35](https://user-images.githubusercontent.com/67680939/99648404-4c8ea100-2a53-11eb-91cb-6faeb536fb5f.png)