### PR TITLE
fix: Tooltip on sharingAvatars show only the row recipients

### DIFF
--- a/packages/cozy-sharing/src/components/AvatarPlusX.jsx
+++ b/packages/cozy-sharing/src/components/AvatarPlusX.jsx
@@ -1,26 +1,31 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import uniqueId from 'lodash/uniqueId'
 
 import Avatar from 'cozy-ui/transpiled/react/Avatar'
 
 import { SharingTooltip, TooltipRecipientList } from './Tooltip'
 
-const AvatarPlusX = ({ className, size, extraRecipients = [] }) => (
-  <span data-tip data-for="extra-recipients-avatar" className="u-db">
-    <Avatar
-      className={className}
-      size={size}
-      text={`+${Math.min(extraRecipients.length, 99)}`}
-      style={{
-        backgroundColor: 'var(--genericRecipientBackground)',
-        color: 'var(--genericRecipientColor)'
-      }}
-    />
-    <SharingTooltip id="extra-recipients-avatar">
-      <TooltipRecipientList recipientNames={extraRecipients} />
-    </SharingTooltip>
-  </span>
-)
+const AvatarPlusX = ({ className, size, extraRecipients = [] }) => {
+  const sharingTooltipId = uniqueId('extra-recipients-avatar-')
+
+  return (
+    <span data-tip data-for={sharingTooltipId} className="u-db">
+      <Avatar
+        className={className}
+        size={size}
+        text={`+${Math.min(extraRecipients.length, 99)}`}
+        style={{
+          backgroundColor: 'var(--genericRecipientBackground)',
+          color: 'var(--genericRecipientColor)'
+        }}
+      />
+      <SharingTooltip id={sharingTooltipId}>
+        <TooltipRecipientList recipientNames={extraRecipients} />
+      </SharingTooltip>
+    </span>
+  )
+}
 
 AvatarPlusX.propTypes = {
   extraRecipients: PropTypes.arrayOf(PropTypes.string),

--- a/packages/cozy-sharing/src/components/Recipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient.jsx
@@ -53,6 +53,10 @@ export const RecipientsAvatars = ({
   // we reverse the recipients array because we use `flex-direction: row-reverse` to display them correctly
 
   const isAvatarPlusX = filteredRecipients.length > MAX_DISPLAYED_RECIPIENTS
+  const extraRecipients = filteredRecipients
+    .slice(MAX_DISPLAYED_RECIPIENTS)
+    .map(recipient => getDisplayName(recipient))
+  const shownRecipients = filteredRecipients.slice(0, MAX_DISPLAYED_RECIPIENTS)
 
   return (
     <div
@@ -78,29 +82,25 @@ export const RecipientsAvatars = ({
         <span data-testid="recipientsAvatars-plusX">
           <AvatarPlusX
             className={styles['recipients-avatars--plusX']}
-            extraRecipients={filteredRecipients
-              .slice(MAX_DISPLAYED_RECIPIENTS)
-              .map(recipient => getDisplayName(recipient))}
+            extraRecipients={extraRecipients}
             size={size}
           />
         </span>
       )}
-      {filteredRecipients
-        .slice(0, MAX_DISPLAYED_RECIPIENTS)
-        .map((recipient, idx) => (
-          <span
-            data-testid={`recipientsAvatars-avatar${
-              recipient.status === 'owner' ? '-owner' : ''
-            }`}
-            key={idx}
-          >
-            <RecipientAvatar
-              recipient={recipient}
-              size={size}
-              className={cx(styles['recipients-avatars--avatar'])}
-            />
-          </span>
-        ))}
+      {shownRecipients.map((recipient, idx) => (
+        <span
+          data-testid={`recipientsAvatars-avatar${
+            recipient.status === 'owner' ? '-owner' : ''
+          }`}
+          key={idx}
+        >
+          <RecipientAvatar
+            recipient={recipient}
+            size={size}
+            className={cx(styles['recipients-avatars--avatar'])}
+          />
+        </span>
+      ))}
     </div>
   )
 }


### PR DESCRIPTION
**Before** : All tooltips of all lines are displayed.
![Capture d’écran 2020-11-19 à 12 28 17](https://user-images.githubusercontent.com/67680939/99660666-f6295e80-2a62-11eb-8336-0e9309522948.png)
![Capture d’écran 2020-11-19 à 12 28 27](https://user-images.githubusercontent.com/67680939/99660668-f6c1f500-2a62-11eb-98e1-a1265b52e203.png)

---

**After**
![Capture d’écran 2020-11-19 à 12 27 00](https://user-images.githubusercontent.com/67680939/99660657-f3c70480-2a62-11eb-9d98-cbf1c4ece9e6.png)
![Capture d’écran 2020-11-19 à 12 27 11](https://user-images.githubusercontent.com/67680939/99660662-f590c800-2a62-11eb-8b9d-b2a1b576ae6a.png)



