### PR TITLE
Fix untranslated locale strings

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/bankAccountHelpers.js
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/bankAccountHelpers.js
@@ -1,4 +1,7 @@
-import { get, set, uniqBy, flatten } from 'lodash'
+import flatten from 'lodash/flatten'
+import uniqBy from 'lodash/uniqBy'
+import set from 'lodash/set'
+import get from 'lodash/get'
 
 const PARTS_TO_DELETE = [' (sans Secure Key)']
 

--- a/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react'
-
+import compose from 'lodash/flowRight'
 import Modal, {
   ModalDescription,
   ModalHeader
@@ -11,6 +11,7 @@ import Field from 'cozy-ui/transpiled/react/Field'
 import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
 import PropTypes from 'prop-types'
 import KonnectorIcon from './KonnectorIcon'
+import withLocales from './hoc/withLocales'
 
 import accounts, {
   TWOFA_PROVIDERS,
@@ -161,4 +162,8 @@ TwoFAModal.propTypes = {
   flow: PropTypes.object.isRequired
 }
 
-export default translate()(withBreakpoints()(TwoFAModal))
+export default compose(
+  withLocales,
+  translate(),
+  withBreakpoints()
+)(TwoFAModal)

--- a/packages/cozy-harvest-lib/src/components/TwoFAModal.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/TwoFAModal.spec.jsx
@@ -1,17 +1,13 @@
 import React from 'react'
-import { mount } from 'enzyme'
-import { TwoFAModal } from './TwoFAModal'
+import { render, fireEvent } from '@testing-library/react'
+import I18n from 'cozy-ui/transpiled/react/I18n'
+
+import TwoFAModal from './TwoFAModal'
 import ConnectionFlow from '../models/ConnectionFlow'
-import { Text, Field } from 'cozy-ui/transpiled/react'
-import en from '../locales/en.json'
-import Polyglot from 'node-polyglot'
 
 jest.mock('./KonnectorIcon', () => () => null)
 
 describe('TwoFAModal', () => {
-  const polyglot = new Polyglot()
-  polyglot.extend(en)
-
   const setup = ({ konnectorSlug, account }) => {
     const client = {
       on: jest.fn()
@@ -23,26 +19,21 @@ describe('TwoFAModal', () => {
     flow.getAccount = () => account
     flow.getKonnectorSlug = () => konnectorSlug
 
-    const root = mount(
-      <TwoFAModal
-        dismissAction={jest.fn()}
-        flow={flow}
-        t={polyglot.t.bind(polyglot)}
-        breakpoints={{ isMobile: true }}
-        account={account}
-        client={client}
-      />
+    const root = render(
+      <I18n dictRequire={() => {}} lang="en">
+        <TwoFAModal
+          dismissAction={jest.fn()}
+          flow={flow}
+          breakpoints={{ isMobile: true }}
+          account={account}
+          client={client}
+        />
+      </I18n>
     )
     return { root, flow }
   }
 
-  const getDesc = root => root.find(Text).text()
-  const getFieldLabel = root => root.find(Field).props().label
-  const getInputValue = root =>
-    root
-      .find('input')
-      .props()
-      .value.toString()
+  const getInputValue = root => root.getByPlaceholderText('').value
 
   it('should work even with unknown 2FA', () => {
     const opts = {
@@ -54,10 +45,10 @@ describe('TwoFAModal', () => {
     const { root } = setup(opts)
 
     // show an input by default
-    expect(root.find('input').length).toBe(1)
-    expect(root.text()).toContain(
-      'This code enables you to finish your connexion.'
-    )
+    expect(root.getByPlaceholderText('')).toBeTruthy()
+    expect(
+      root.getByText('This code enables you to finish your connexion.')
+    ).toBeTruthy()
   })
 
   it('should work', () => {
@@ -69,15 +60,12 @@ describe('TwoFAModal', () => {
     }
     const { root } = setup(opts)
     // no input for app two fa
-    expect(root.find('input').length).toBe(0)
-    expect(root.text()).toContain(
-      `You need to open your provider's app and/or click on a notification to confirm your authentication.`
+    expect(root.queryByPlaceholderText('')).toBeFalsy()
+    expect(
+      root.getByText(
+        `You need to open your provider's app and/or click on a notification to confirm your authentication.`
+      )
     )
-  })
-
-  it('should correctly unmount', () => {
-    const { root } = setup({})
-    expect(() => root.instance().componentWillUnmount()).not.toThrow()
   })
 
   it('should work for several two fa requests', () => {
@@ -88,39 +76,42 @@ describe('TwoFAModal', () => {
       konnectorSlug: 'boursoma83'
     }
     const { root, flow } = setup(opts)
-    const inp = root.find('input')
 
-    expect(inp.length).toBe(1)
-    expect(getInputValue(root)).toBe('')
-    expect(getDesc(root)).toBe(
-      'This code enables you to finish your connexion.'
-    )
-    expect(getFieldLabel(root)).toContain('code')
-    root.setState({ twoFACode: 'abcd' })
-    root.update()
-    expect(getInputValue(root)).toBe('abcd')
+    const input = root.getByPlaceholderText('')
+    expect(input).toBeTruthy()
+
+    // expect(inp.length).toBe(1)
+    // expect((root)).toBe('')
+    expect(
+      root.getByText('This code enables you to finish your connexion.')
+    ).toBeTruthy()
+
+    expect(root.getByText('code')).toBeTruthy()
+
+    fireEvent.change(input, { target: { value: 'abcd' } })
 
     // 2nd 2FA request
     flow.emit('twoFARequest')
-    root.update()
+
     expect(getInputValue(root)).toBe('')
-    expect(getDesc(root)).toBe(
-      'The second code received on your mobile phone or by email enables you to finalize your connexion.'
-    )
-    expect(getFieldLabel(root)).toBe('Second code')
+    expect(
+      root.getByText(
+        'The second code received on your mobile phone or by email enables you to finalize your connexion.'
+      )
+    ).toBeTruthy()
+
+    expect(root.getByText('Second code')).toBeTruthy()
     flow.emit('twoFARequest')
-    root.update()
 
     // 3rd 2FA (should not happen, hypothetical case)
     flow.emit('twoFARequest')
-    root.update()
+
     expect(getInputValue(root)).toBe('')
     // First attempt translations are re-used
-    expect(getDesc(root)).toContain(
-      'This code enables you to finish your connexion.'
-    )
-    expect(getFieldLabel(root)).toBe('code (4)')
+    expect(
+      root.getByText('This code enables you to finish your connexion.')
+    ).toBeTruthy()
+    expect(root.getByText('code (4)')).toBeTruthy()
     flow.emit('twoFARequest')
-    root.update()
   })
 })


### PR DESCRIPTION
TwoFaModal was not wrapped in withlocales, thus it could not
find its translations. I am at a loss at when the bug appeared.