### PR TITLE
fix: Remove import to stylesheet

### DIFF
--- a/packages/cozy-authentication/src/index.js
+++ b/packages/cozy-authentication/src/index.js
@@ -5,6 +5,3 @@ import Revoked from './Revoked'
 
 export { Authentication }
 export { Revoked }
-
-// stylesheet.css is created when transpiling
-import stylesheet from './stylesheet.css' // eslint-disable-line no-unused-vars


### PR DESCRIPTION
Stylesheet transpiling was removed since there was no stylus files
transpiled anymore. But, the import had not been removed resulting in
an import error when importing cozy-authentication. The stylesheet that
was imported before was empty (cozy-authentication@2.3.3), so this is
not a breaking change.