### PR TITLE
SVGr icons in cozy-authentications and cozy-sharing

### DIFF
--- a/packages/cozy-authentication/package.json
+++ b/packages/cozy-authentication/package.json
@@ -23,7 +23,7 @@
     "@babel/polyfill": "7.12.1",
     "babel-preset-cozy-app": "^1.10.0",
     "cozy-client": "13.15.1",
-    "cozy-ui": "35.39.0",
+    "cozy-ui": "40.9.1",
     "cssnano-preset-advanced": "^4.0.7",
     "date-fns": "^1.29.0",
     "enzyme": "3.11.0",

--- a/packages/cozy-authentication/package.json
+++ b/packages/cozy-authentication/package.json
@@ -67,7 +67,7 @@
   },
   "peerDependencies": {
     "cozy-client": ">=13.15.1",
-    "cozy-ui": ">=35.39.0",
+    "cozy-ui": ">=40.9.1",
     "react": ">=15",
     "react-router": "3"
   }

--- a/packages/cozy-authentication/package.json
+++ b/packages/cozy-authentication/package.json
@@ -14,7 +14,7 @@
     "watch": "yarn build -w",
     "test": "yarn jest src",
     "copy-files": "cp -r src/locales/ dist/locales/",
-    "lint": "cd ..; yarn lint packages/cozy-authentication",
+    "lint": "cd ..; yarn eslint --ext js,jsx packages/cozy-authentication",
     "example": "nf start",
     "example-server": "parcel --port 1234 $(pwd)/examples/index.html"
   },

--- a/packages/cozy-authentication/src/steps/SelectServer.jsx
+++ b/packages/cozy-authentication/src/steps/SelectServer.jsx
@@ -31,6 +31,9 @@ import {
   WizardDualFieldInput
 } from 'cozy-ui/transpiled/react/Wizard'
 
+import LockIcon from 'cozy-ui/transpiled/react/Icons/Lock'
+import NextIcon from 'cozy-ui/transpiled/react/Icons/Next'
+
 require('url-polyfill')
 
 const ERR_WRONG_ADDRESS = 'mobile.onboarding.server_selection.wrong_address'
@@ -280,7 +283,7 @@ export class SelectServer extends Component {
             >
               {!isTiny && (
                 <WizardProtocol>
-                  <Icon icon="lock" />
+                  <Icon icon={LockIcon} />
                   <span>https://</span>
                 </WizardProtocol>
               )}
@@ -344,7 +347,7 @@ export class SelectServer extends Component {
               label={t('mobile.onboarding.server_selection.button')}
               size={isTiny ? 'normal' : 'large'}
             >
-              {!fetching && <Icon icon="next" color="white" />}
+              {!fetching && <Icon icon={NextIcon} color="white" />}
             </WizardNextButton>
             <ButtonLinkRegistration
               className={classNames('wizard-buttonlink')}

--- a/packages/cozy-codemods/src/transforms/__testfixtures__/replace-icons-svgr.input.js
+++ b/packages/cozy-codemods/src/transforms/__testfixtures__/replace-icons-svgr.input.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import Button from 'cozy-ui/transpiled/react/Button'
+import Button, { ButtonLink } from 'cozy-ui/transpiled/react/Button'
+import Avatar from 'cozy-ui/transpiled/react/Avatar'
 import CustomIcon from './CustomIcon'
 
 const App = () => {
@@ -12,6 +13,8 @@ const App = () => {
       <Icon icon={CustomIcon} className="u-m-3" />
       <Icon icon="file-outline" className="u-m-3" />
       <Button icon="file-outline" className="u-m-3" />
+      <Avatar icon="left" className="u-m-3" />
+      <ButtonLink icon="right" className="u-m-3" />
     </div>
   )
 }

--- a/packages/cozy-codemods/src/transforms/__testfixtures__/replace-icons-svgr.output.js
+++ b/packages/cozy-codemods/src/transforms/__testfixtures__/replace-icons-svgr.output.js
@@ -1,11 +1,13 @@
 import React from 'react'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import Button from 'cozy-ui/transpiled/react/Button'
+import Button, { ButtonLink } from 'cozy-ui/transpiled/react/Button'
+import Avatar from 'cozy-ui/transpiled/react/Avatar'
 import CustomIcon from './CustomIcon'
 
-import MagnifierIcon from "cozy-ui/transpiled/react/Icons/Magnifier";
 import LeftIcon from "cozy-ui/transpiled/react/Icons/Left";
+import MagnifierIcon from "cozy-ui/transpiled/react/Icons/Magnifier";
 import FileOutlineIcon from "cozy-ui/transpiled/react/Icons/FileOutline";
+import RightIcon from "cozy-ui/transpiled/react/Icons/Right";
 
 const App = () => {
   return (
@@ -15,7 +17,9 @@ const App = () => {
       <Icon icon={LeftIcon} className="u-m-1" />
       <Icon icon={CustomIcon} className="u-m-3" />
       <Icon icon={FileOutlineIcon} className="u-m-3" />
-      <Button icon={<Icon icon={FileOutlineIcon} />} className="u-m-3" />
+      <Button icon={FileOutlineIcon} className="u-m-3" />
+      <Avatar icon={LeftIcon} className="u-m-3" />
+      <ButtonLink icon={RightIcon} className="u-m-3" />
     </div>
   );
 }

--- a/packages/cozy-codemods/src/transforms/replace-icons-svgr.js
+++ b/packages/cozy-codemods/src/transforms/replace-icons-svgr.js
@@ -32,37 +32,15 @@ export default function replaceSvgrIcons(file, api) {
     }
   }
 
-  root
-    .find(j.JSXOpeningElement, {
-      name: {
-        name: 'Avatar'
-      }
-    })
-    .forEach(transform)
-
-  root
-    .find(j.JSXOpeningElement, {
-      name: {
-        name: 'Icon'
-      }
-    })
-    .forEach(transform)
-
-  root
-    .find(j.JSXOpeningElement, {
-      name: {
-        name: 'Button'
-      }
-    })
-    .forEach(transform)
-
-  root
-    .find(j.JSXOpeningElement, {
-      name: {
-        name: 'ButtonLink'
-      }
-    })
-    .forEach(transform)
+  for (let componentName of ['Avatar', 'Icon', 'Button', 'ButtonLink']) {
+    root
+      .find(j.JSXOpeningElement, {
+        name: {
+          name: componentName
+        }
+      })
+      .forEach(transform)
+  }
 
   return root.toSource()
 }

--- a/packages/cozy-codemods/src/transforms/replace-icons-svgr.js
+++ b/packages/cozy-codemods/src/transforms/replace-icons-svgr.js
@@ -11,32 +11,42 @@ export default function replaceSvgrIcons(file, api) {
   const j = api.jscodeshift
   const root = j(file.source)
 
+  const transform = path => {
+    const iconAttr = path.node.attributes.find(
+      attr => attr.name && attr.name.name === 'icon'
+    )
+
+    if (iconAttr && iconAttr.value.type === 'Literal') {
+      const componentName = iconNameToComponentName(iconAttr.value.value)
+
+      imports.ensure(
+        root,
+        {
+          default: `${componentName}Icon`
+        },
+        `cozy-ui/transpiled/react/Icons/${componentName}`
+      )
+      iconAttr.value = j.jsxExpressionContainer(
+        j.jsxIdentifier(`${componentName}Icon`)
+      )
+    }
+  }
+
+  root
+    .find(j.JSXOpeningElement, {
+      name: {
+        name: 'Avatar'
+      }
+    })
+    .forEach(transform)
+
   root
     .find(j.JSXOpeningElement, {
       name: {
         name: 'Icon'
       }
     })
-    .forEach(path => {
-      const iconAttr = path.node.attributes.find(
-        attr => attr.name.name === 'icon'
-      )
-
-      if (iconAttr.value.type === 'Literal') {
-        const componentName = iconNameToComponentName(iconAttr.value.value)
-
-        imports.ensure(
-          root,
-          {
-            default: `${componentName}Icon`
-          },
-          `cozy-ui/transpiled/react/Icons/${componentName}`
-        )
-        iconAttr.value = j.jsxExpressionContainer(
-          j.jsxIdentifier(`${componentName}Icon`)
-        )
-      }
-    })
+    .forEach(transform)
 
   root
     .find(j.JSXOpeningElement, {
@@ -44,31 +54,15 @@ export default function replaceSvgrIcons(file, api) {
         name: 'Button'
       }
     })
-    .forEach(path => {
-      const iconAttr = path.node.attributes.find(
-        attr => attr.name && attr.name.name === 'icon'
-      )
+    .forEach(transform)
 
-      if (iconAttr && iconAttr.value.type === 'Literal') {
-        const componentName = iconNameToComponentName(iconAttr.value.value)
-
-        imports.ensure(
-          root,
-          {
-            default: `${componentName}Icon`
-          },
-          `cozy-ui/transpiled/react/Icons/${componentName}`
-        )
-        imports.ensure(
-          root,
-          {
-            default: `Icon`
-          },
-          `cozy-ui/transpiled/react/Icon`
-        )
-        iconAttr.value = `{<Icon icon={${componentName}Icon} />}`
+  root
+    .find(j.JSXOpeningElement, {
+      name: {
+        name: 'ButtonLink'
       }
     })
+    .forEach(transform)
 
   return root.toSource()
 }

--- a/packages/cozy-doctypes/package.json
+++ b/packages/cozy-doctypes/package.json
@@ -33,7 +33,7 @@
     "cozy-stack-client": ">=13.15.1"
   },
   "scripts": {
-    "lint": "cd ../../; yarn lint packages/cozy-doctypes",
+    "lint": "cd ../../; yarn eslint --ext js,jsx packages/cozy-doctypes",
     "build": "babel src -d dist",
     "test": "jest src/",
     "encrypt-banking-tests": "cd src/banking/; make encrypted.tar.gz.gpg",

--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -20,7 +20,7 @@
     "prepublishOnly": "yarn check-locales && yarn build",
     "check-locales": "./scripts/check-locales.sh",
     "test": "jest --runInBand",
-    "lint": "cd .. && yarn lint packages/cozy-harvest-lib",
+    "lint": "cd .. && yarn eslint --ext js,jsx packages/cozy-harvest-lib",
     "watch": "yarn build --watch",
     "cli": "env BABEL_ENV=es5 node src/cli/index.js",
     "watch:doc:react": "(cd ../.. && TARGET=cozy-harvest-lib yarn watch:doc:react)"

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/BanksLink.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/BanksLink.jsx
@@ -7,6 +7,8 @@ import useAppLinkWithStoreFallback from '../../hooks/useAppLinkWithStoreFallback
 
 import withLocales from '../../hoc/withLocales'
 
+import OpenwithIcon from 'cozy-ui/transpiled/react/Icons/Openwith'
+
 const BanksLinkRedirectStore = ({ client, t }) => {
   const slug = 'banks'
   const { fetchStatus, url } = useAppLinkWithStoreFallback(slug, client)
@@ -16,7 +18,7 @@ const BanksLinkRedirectStore = ({ client, t }) => {
       <AppLinker slug={slug} href={url}>
         {({ href, name }) => (
           <ButtonLink
-            icon="openwith"
+            icon={OpenwithIcon}
             href={href}
             label={t('account.success.banksLinkText', {
               appName: name
@@ -29,7 +31,7 @@ const BanksLinkRedirectStore = ({ client, t }) => {
   } else {
     return (
       <ButtonLink
-        icon="openwith"
+        icon={OpenwithIcon}
         label={t('account.success.banksLinkText', {
           appName: name
         })}

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/DriveLink.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/DriveLink.jsx
@@ -6,6 +6,8 @@ import { translate } from 'cozy-ui/transpiled/react/I18n'
 import { withClient } from 'cozy-client'
 import useAppLinkWithStoreFallback from '../../hooks/useAppLinkWithStoreFallback'
 
+import OpenwithIcon from 'cozy-ui/transpiled/react/Icons/Openwith'
+
 const DriveLink = memo(({ folderId, client, t }) => {
   const slug = 'drive'
   const path = `#/files/${folderId}`
@@ -16,7 +18,7 @@ const DriveLink = memo(({ folderId, client, t }) => {
       <AppLinker slug={slug} href={url} nativePath={path}>
         {({ href, name }) => (
           <ButtonLink
-            icon="openwith"
+            icon={OpenwithIcon}
             href={href}
             label={t('account.success.driveLinkText', {
               appName: name
@@ -29,7 +31,7 @@ const DriveLink = memo(({ folderId, client, t }) => {
   } else {
     return (
       <ButtonLink
-        icon="openwith"
+        icon={OpenwithIcon}
         label={t('account.success.banksLinkText', {
           appName: name
         })}

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -9,6 +9,7 @@ import Modal, {
   ModalContent,
   ModalHeader
 } from 'cozy-ui/transpiled/react/Modal'
+import CrossIcon from 'cozy-ui/transpiled/react/Icons/Cross'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
@@ -237,7 +238,7 @@ export class KonnectorModal extends PureComponent {
               )}
             </div>
             <Button
-              icon={<Icon icon={'cross'} size={'24'} />}
+              icon={<Icon icon={CrossIcon} size={'24'} />}
               onClick={dismissAction}
               iconOnly
               label={t('close')}

--- a/packages/cozy-harvest-lib/src/components/KonnectorUpdateLinker.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorUpdateLinker.jsx
@@ -7,12 +7,14 @@ import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
 
 import { Application } from 'cozy-doctypes'
 
+import EyeIcon from 'cozy-ui/transpiled/react/Icons/Eye'
+
 const KonnectorUpdateButton = ({ disabled, isBlocking, href, label }) => (
   <ButtonLink
     disabled={disabled}
     className="u-m-0"
     href={href}
-    icon="eye"
+    icon={EyeIcon}
     label={label}
     theme={isBlocking ? 'danger' : 'secondary'}
   />

--- a/packages/cozy-notifications/package.json
+++ b/packages/cozy-notifications/package.json
@@ -28,7 +28,7 @@
     "word-wrap": "^1.2.3"
   },
   "peerDependencies": {
-    "cozy-ui": ">=35.39.0"
+    "cozy-ui": ">=40.9.1"
   },
   "devDependencies": {
     "@babel/cli": "7.12.1",

--- a/packages/cozy-procedures/package.json
+++ b/packages/cozy-procedures/package.json
@@ -37,7 +37,7 @@
     "babel-plugin-inline-react-svg": "^1.1.0",
     "babel-preset-cozy-app": "^1.10.0",
     "cozy-client": "13.15.1",
-    "cozy-ui": "35.39.0",
+    "cozy-ui": "40.9.1",
     "enzyme-to-json": "3.4.4",
     "jest": "26.2.2",
     "react": "^16.12.0"
@@ -49,7 +49,7 @@
     "cozy-client": ">=13.15.1",
     "cozy-doctypes": ">=1.49.3",
     "cozy-realtime": "^3.11.0",
-    "cozy-ui": ">=35.39.0"
+    "cozy-ui": ">=40.9.1"
   },
   "jest": {
     "setupFiles": [

--- a/packages/cozy-procedures/package.json
+++ b/packages/cozy-procedures/package.json
@@ -16,7 +16,7 @@
     "build": "env BABEL_ENV=transpilation yarn babel src/ --out-dir dist && yarn run copy-files",
     "copy-files": "cp -rf src/locales dist/",
     "test": "jest",
-    "lint": "cd ..; yarn lint packages/cozy-procedures"
+    "lint": "cd ..; yarn eslint --ext js,jsx packages/cozy-procedures"
   },
   "dependencies": {
     "date-fns": "^1.30.1",

--- a/packages/cozy-procedures/src/components/Topbar.jsx
+++ b/packages/cozy-procedures/src/components/Topbar.jsx
@@ -12,6 +12,8 @@ import {
   Button
 } from 'cozy-ui/transpiled/react'
 
+import PreviousIcon from 'cozy-ui/transpiled/react/Icons/Previous'
+
 const Topbar = ({ t, title, router, breakpoints: { isMobile } }) => {
   const hasCozyBar = !!cozy.bar
 
@@ -35,7 +37,7 @@ const Topbar = ({ t, title, router, breakpoints: { isMobile } }) => {
           className="u-mr-1"
           theme="secondary"
           subtle
-          icon="previous"
+          icon={PreviousIcon}
           iconOnly
           label={t('back')}
           extension="narrow"

--- a/packages/cozy-procedures/src/components/documents/DocumentHolder.jsx
+++ b/packages/cozy-procedures/src/components/documents/DocumentHolder.jsx
@@ -13,6 +13,8 @@ import { CozyFile } from 'cozy-doctypes'
 import DocumentsDataFormContainer from '../../containers/DocumentsDataForm'
 import flow from 'lodash/flow'
 
+import CrossIcon from 'cozy-ui/transpiled/react/Icons/Cross'
+
 class DocumentHolder extends Component {
   state = {
     isUnlinkConfirmationModalOpened: false,
@@ -75,7 +77,7 @@ class DocumentHolder extends Component {
             <span className="u-coolGrey">{splittedName.extension}</span>
           </span>
           <Icon
-            icon="cross"
+            icon={CrossIcon}
             size={16}
             className="u-pr-1 u-c-pointer u-flex-shrink-0"
             onClick={e => {

--- a/packages/cozy-procedures/src/components/documents/menuUpload/MenuUploadMobile.jsx
+++ b/packages/cozy-procedures/src/components/documents/menuUpload/MenuUploadMobile.jsx
@@ -16,6 +16,9 @@ import { ActionMenuHeader } from 'cozy-ui/transpiled/react/ActionMenu'
 import { isAndroidApp } from 'cozy-device-helper'
 import UploadInputLabel from '../UploadInputLabel'
 
+import PlusIcon from 'cozy-ui/transpiled/react/Icons/Plus'
+import FileIcon from 'cozy-ui/transpiled/react/Icons/File'
+
 class MenuUploadMobile extends Component {
   state = {
     menuDisplayed: false
@@ -40,7 +43,7 @@ class MenuUploadMobile extends Component {
           label={t('documents.import')}
           iconOnly
         >
-          <Icon icon="plus" size={16} className="u-mr-1 u-pa-half" />
+          <Icon icon={PlusIcon} size={16} className="u-mr-1 u-pa-half" />
           <span>{t('documents.import')}</span>
         </Button>
         {this.state.menuDisplayed && (
@@ -50,7 +53,7 @@ class MenuUploadMobile extends Component {
             </ActionMenuHeader>
 
             <MenuItem
-              icon={<Icon icon="file" />}
+              icon={<Icon icon={FileIcon} />}
               onClick={e => e.stopPropagation()}
               disabled
             >
@@ -58,7 +61,7 @@ class MenuUploadMobile extends Component {
               <Caption>{t('documents.upload.soon_available')}</Caption>
             </MenuItem>
             <MenuItem
-              icon={<Icon icon="file" />}
+              icon={<Icon icon={FileIcon} />}
               disabled
               onClick={e => e.stopPropagation()}
             >
@@ -66,7 +69,7 @@ class MenuUploadMobile extends Component {
               <Caption>{t('documents.upload.soon_available')}</Caption>
             </MenuItem>
             <MenuItem
-              icon={<Icon icon="file" />}
+              icon={<Icon icon={FileIcon} />}
               /**
                * We need to stop the propagation since when we click on an Item, MenuItem closes the Menu
                *
@@ -83,7 +86,7 @@ class MenuUploadMobile extends Component {
 
             {isAndroidApp() && (
               <MenuItem
-                icon={<Icon icon="file" />}
+                icon={<Icon icon={FileIcon} />}
                 onClick={e => e.stopPropagation()}
                 disabled
               >

--- a/packages/cozy-procedures/src/components/documents/menuUpload/MenuUploadWeb.jsx
+++ b/packages/cozy-procedures/src/components/documents/menuUpload/MenuUploadWeb.jsx
@@ -13,6 +13,9 @@ import {
 
 import UploadInputLabel from '../UploadInputLabel'
 
+import PlusIcon from 'cozy-ui/transpiled/react/Icons/Plus'
+import FileIcon from 'cozy-ui/transpiled/react/Icons/File'
+
 class MenuUploadWeb extends Component {
   render() {
     const { t, onChange } = this.props
@@ -26,7 +29,7 @@ class MenuUploadWeb extends Component {
             label={t('documents.import')}
             iconOnly
           >
-            <Icon icon="plus" size={16} className="u-mr-1 u-pa-half" />
+            <Icon icon={PlusIcon} size={16} className="u-mr-1 u-pa-half" />
             <span>{t('documents.import')}</span>
           </Button>
         }
@@ -39,15 +42,15 @@ class MenuUploadWeb extends Component {
          */
         onSelect={() => false}
       >
-        <MenuItem icon={<Icon icon="file" />} disabled>
+        <MenuItem icon={<Icon icon={FileIcon} />} disabled>
           <span>{t('documents.upload.from_other_service')}</span>
           <Caption>{t('documents.upload.soon_available')}</Caption>
         </MenuItem>
-        <MenuItem icon={<Icon icon="file" />} disabled>
+        <MenuItem icon={<Icon icon={FileIcon} />} disabled>
           <span>{t('documents.upload.from_drive')}</span>
           <Caption>{t('documents.upload.soon_available')}</Caption>
         </MenuItem>
-        <MenuItem icon={<Icon icon="file" />}>
+        <MenuItem icon={<Icon icon={FileIcon} />}>
           <FileInput onChange={file => onChange(file)} hidden={true}>
             <UploadInputLabel />
           </FileInput>

--- a/packages/cozy-procedures/src/components/overview/DocumentsFullyCompleted.jsx
+++ b/packages/cozy-procedures/src/components/overview/DocumentsFullyCompleted.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { InlineCard, Icon } from 'cozy-ui/transpiled/react'
+import FileTypeFilesIcon from 'cozy-ui/transpiled/react/Icons/FileTypeFiles'
 const DocumentsFullyCompleted = ({ documents, navigateTo }) => {
   const flatennedFiles = []
   Object.values(documents).map(document => {
@@ -17,7 +18,7 @@ const DocumentsFullyCompleted = ({ documents, navigateTo }) => {
       {flatennedFiles.map((file, index) => {
         return (
           <div className={'u-flex u-pv-half'} key={index}>
-            <Icon icon="file-type-files" className={'u-flex-shrink-0'} />
+            <Icon icon={FileTypeFilesIcon} className={'u-flex-shrink-0'} />
             <span className="u-ml-half u-ellipsis ">{file.name}</span>
           </div>
         )

--- a/packages/cozy-procedures/src/components/overview/DocumentsNotFullyCompleted.jsx
+++ b/packages/cozy-procedures/src/components/overview/DocumentsNotFullyCompleted.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 
 import { Button, Chip, translate } from 'cozy-ui/transpiled/react'
 
+import PenIcon from 'cozy-ui/transpiled/react/Icons/Pen'
+
 const DocumentsNotFullyCompleted = ({
   documentsCompleted,
   documentsTotal,
@@ -22,7 +24,7 @@ const DocumentsNotFullyCompleted = ({
       theme="ghost"
       extension="full"
       size="large"
-      icon="pen"
+      icon={PenIcon}
     />
   )
 }

--- a/packages/cozy-procedures/src/components/overview/PersonalDataNotFullyCompleted.jsx
+++ b/packages/cozy-procedures/src/components/overview/PersonalDataNotFullyCompleted.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { Button, Chip, translate } from 'cozy-ui/transpiled/react'
+import PenIcon from 'cozy-ui/transpiled/react/Icons/Pen'
 const PersonalDataNotFullyCompleted = ({
   navigateTo,
   personalDataFieldsCompleted,
@@ -21,7 +22,7 @@ const PersonalDataNotFullyCompleted = ({
       theme="ghost"
       extension="full"
       size="large"
-      icon="pen"
+      icon={PenIcon}
     />
   )
 }

--- a/packages/cozy-scanner/package.json
+++ b/packages/cozy-scanner/package.json
@@ -17,7 +17,7 @@
     "build": "env BABEL_ENV=transpilation yarn babel src/ --out-dir dist --copy-files --verbose",
     "copy-files": "cp -rf src/locales dist/",
     "test": "jest src/",
-    "lint": "cd .. && yarn lint packages/cozy-scanner",
+    "lint": "cd .. && yarn eslint --ext js,jsx packages/cozy-scanner",
     "watch": "yarn build --watch"
   },
   "devDependencies": {

--- a/packages/cozy-scanner/package.json
+++ b/packages/cozy-scanner/package.json
@@ -41,7 +41,7 @@
     "@babel/runtime": ">=7.12.5",
     "cozy-client": ">=13.15.1",
     "cozy-doctypes": ">=1.67.0",
-    "cozy-ui": ">=40"
+    "cozy-ui": ">=40.9.1"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/packages/cozy-scanner/src/DocumentQualification.jsx
+++ b/packages/cozy-scanner/src/DocumentQualification.jsx
@@ -18,6 +18,8 @@ import { themes } from './DocumentTypeData'
 import GridItem from 'cozy-ui/transpiled/react/Labs/GridItem'
 import styles from './stylesheet.css'
 
+import QualifyIcon from 'cozy-ui/transpiled/react/Icons/Qualify'
+
 const fileExtension = '.jpg'
 const idFileInput = 'filename_input'
 
@@ -141,7 +143,7 @@ export class DocumentQualification extends Component {
 
         {title && (
           <div className="u-flex u-flex-items-center u-mt-1-half">
-            <Icon icon="qualify" />
+            <Icon icon={QualifyIcon} />
             <Title
               className={classNames(
                 styles['grid-item-title'],

--- a/packages/cozy-scanner/src/__snapshots__/DocumentQualification.spec.jsx.snap
+++ b/packages/cozy-scanner/src/__snapshots__/DocumentQualification.spec.jsx.snap
@@ -38,10 +38,12 @@ exports[`DocumentQualification Initial render + selection + filename 1`] = `
     <svg
       class="styles__icon___23x3R"
       height="16"
+      viewBox="0 0 16 16"
       width="16"
     >
-      <use
-        xlink:href="#qualify"
+      <path
+        d="M2 2h8.002a2 2 0 011.414.586l4 4a2 2 0 010 2.828l-4 4a2 2 0 01-1.414.586H2a2 2 0 01-2-2V4a2 2 0 012-2z"
+        fill-rule="evenodd"
       />
     </svg>
     <div
@@ -489,10 +491,12 @@ exports[`DocumentQualification Initial render + selection + filename 2`] = `
     <svg
       class="styles__icon___23x3R"
       height="16"
+      viewBox="0 0 16 16"
       width="16"
     >
-      <use
-        xlink:href="#qualify"
+      <path
+        d="M2 2h8.002a2 2 0 011.414.586l4 4a2 2 0 010 2.828l-4 4a2 2 0 01-1.414.586H2a2 2 0 01-2-2V4a2 2 0 012-2z"
+        fill-rule="evenodd"
       />
     </svg>
     <div

--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -20,7 +20,7 @@
     "deploy:doc": "(cd ../.. && yarn deploy:doc)",
     "prepublishOnly": "yarn build",
     "test": "env NODE_ENV=test jest",
-    "lint": "cd .. && yarn lint packages/cozy-sharing",
+    "lint": "cd .. && yarn eslint --ext js,jsx packages/cozy-sharing",
     "watch": "yarn build --watch",
     "watch:doc:react": "(cd ../.. && TARGET=cozy-sharing yarn watch:doc:react)"
   },

--- a/packages/cozy-sharing/src/components/Recipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient.jsx
@@ -227,10 +227,7 @@ export const Permissions = ({
             >
               <ActionMenuItem
                 left={
-                  <Icon
-                    icon={PermissionIcon}
-                    color="var(--primaryTextColor)"
-                  />
+                  <Icon icon={PermissionIcon} color="var(--primaryTextColor)" />
                 }
               >
                 {t(`Share.type.${type}`)}

--- a/packages/cozy-sharing/src/components/Recipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient.jsx
@@ -24,6 +24,8 @@ import modalStyles from '../share.styl'
 import { getDisplayName, getInitials } from '../models'
 import Identity from './Identity'
 
+import LinkIcon from 'cozy-ui/transpiled/react/Icons/Link'
+
 export const MAX_DISPLAYED_RECIPIENTS = 3
 const DEFAULT_DISPLAY_NAME = 'Share.contacts.defaultDisplayName'
 
@@ -88,7 +90,7 @@ export const RecipientsAvatars = ({
         <span data-testid="recipientsAvatars-link">
           <Avatar
             className={styles['recipients-avatars--link']}
-            icon="link"
+            icon={LinkIcon}
             size={size}
           />
         </span>

--- a/packages/cozy-sharing/src/components/Recipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import cx from 'classnames'
 
 import { useClient } from 'cozy-client'
-import { Spinner } from 'cozy-ui/transpiled/react'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Avatar from 'cozy-ui/transpiled/react/Avatar'
 import CompositeRow from 'cozy-ui/transpiled/react/CompositeRow'
@@ -12,6 +12,11 @@ import ActionMenu, { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu'
 import { Text, Caption } from 'cozy-ui/transpiled/react/Text'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import { Media, Img, Bd } from 'cozy-ui/transpiled/react/Media'
+import RenameIcon from 'cozy-ui/transpiled/react/Icons/Rename'
+import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
+import EyeIcon from 'cozy-ui/transpiled/react/Icons/Eye'
+import PaperplaneIcon from 'cozy-ui/transpiled/react/Icons/Paperplane'
+import ToTheCloudIcon from 'cozy-ui/transpiled/react/Icons/ToTheCloud'
 
 import AvatarPlusX from './AvatarPlusX'
 import styles from './recipient.styl'
@@ -190,7 +195,7 @@ export const Permissions = ({
   }, [isOwner, onRevoke, onRevokeSelf, document, sharingId, index])
 
   const buttonRef = React.createRef()
-  const permissionIconName = type === 'two-way' ? 'rename' : 'eye'
+  const PermissionIcon = type === 'two-way' ? RenameIcon : EyeIcon
 
   return (
     <div className={className}>
@@ -223,7 +228,7 @@ export const Permissions = ({
               <ActionMenuItem
                 left={
                   <Icon
-                    icon={permissionIconName}
+                    icon={PermissionIcon}
                     color="var(--primaryTextColor)"
                   />
                 }
@@ -234,7 +239,7 @@ export const Permissions = ({
               <hr />
               <ActionMenuItem
                 onClick={onRevokeClick}
-                left={<Icon icon="trash" color="var(--pomegranate)" />}
+                left={<Icon icon={TrashIcon} color="var(--pomegranate)" />}
               >
                 <Text className="u-pomegranate">
                   {isOwner
@@ -263,17 +268,17 @@ const Status = ({ status, isMe, instance }) => {
   let text, icon
   if (isReady) {
     text = instance
-    icon = 'to-the-cloud'
+    icon = ToTheCloudIcon
   } else if (isSendingEmail) {
     text = t('Share.status.mail-not-sent')
-    icon = 'paperplane'
+    icon = PaperplaneIcon
   } else {
     const supportedStatus = ['pending', 'seen']
     text = supportedStatus.includes(status)
       ? t(`Share.status.${status}`)
       : t('Share.status.pending')
 
-    icon = status === 'seen' ? 'eye' : 'paperplane'
+    icon = status === 'seen' ? EyeIcon : PaperplaneIcon
   }
 
   return (

--- a/packages/cozy-sharing/src/components/ShareButton.jsx
+++ b/packages/cozy-sharing/src/components/ShareButton.jsx
@@ -4,13 +4,16 @@ import { Button } from 'cozy-ui/transpiled/react'
 
 import styles from './button.styl'
 
+import ShareIcon from 'cozy-ui/transpiled/react/Icons/Share'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+
 export const ShareButton = ({ label, onClick, className, ...props }) => (
   <Button
     data-test-id="share-button"
     theme="secondary"
     className={className}
     onClick={() => onClick()}
-    icon="share"
+    icon={<Icon icon={ShareIcon} />}
     label={label}
     {...props}
   />
@@ -21,7 +24,7 @@ export const SharedByMeButton = ({ label, onClick, className, ...props }) => (
     data-test-id="share-by-me-button"
     className={classNames(styles['coz-btn-shared'], className)}
     onClick={() => onClick()}
-    icon="share"
+    icon={<Icon icon={ShareIcon} />}
     label={label}
     {...props}
   />
@@ -31,7 +34,7 @@ export const SharedWithMeButton = ({ label, onClick, className, ...props }) => (
   <Button
     className={classNames(styles['coz-btn-sharedWithMe'], className)}
     onClick={() => onClick()}
-    icon="share"
+    icon={<Icon icon={ShareIcon} />}
     label={label}
     {...props}
   />

--- a/packages/cozy-sharing/src/components/ShareByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareByLink.jsx
@@ -18,6 +18,9 @@ import styles from '../share.styl'
 
 import palette from 'cozy-ui/transpiled/react/palette'
 
+import LinkIcon from 'cozy-ui/transpiled/react/Icons/Link'
+import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
+
 const permissionModel = models.permission
 
 const checkIsReadOnlyPermissions = permissions => {
@@ -148,7 +151,7 @@ class ShareByLink extends React.Component {
             }
             image={
               <Circle backgroundColor="var(--silver)">
-                <Icon icon="link" color="var(--charcoalGrey)" />
+                <Icon icon={LinkIcon} color="var(--charcoalGrey)" />
               </Circle>
             }
             right={
@@ -218,7 +221,9 @@ class ShareByLink extends React.Component {
                     </ActionMenuItem>
                     <hr />
                     <ActionMenuItem
-                      left={<Icon icon="trash" color={palette.pomegranate} />}
+                      left={
+                        <Icon icon={TrashIcon} color={palette.pomegranate} />
+                      }
                       onClick={() => {
                         this.toggleMenu()
                         this.deleteShareLink()

--- a/packages/cozy-sharing/src/components/SharedBadge.jsx
+++ b/packages/cozy-sharing/src/components/SharedBadge.jsx
@@ -4,6 +4,8 @@ import Icon from 'cozy-ui/transpiled/react/Icon'
 import styles from './badge.styl'
 import palette from 'cozy-ui/transpiled/react/palette'
 
+import ShareIcon from 'cozy-ui/transpiled/react/Icons/Share'
+
 const SharedBadge = ({ byMe, className, small, xsmall }) => (
   <div
     className={classNames(
@@ -15,7 +17,7 @@ const SharedBadge = ({ byMe, className, small, xsmall }) => (
     )}
   >
     <Icon
-      icon="share"
+      icon={ShareIcon}
       color={palette.white}
       className={styles['shared-badge-icon']}
     />

--- a/packages/cozy-sharing/src/components/Sharetypeselect.jsx
+++ b/packages/cozy-sharing/src/components/Sharetypeselect.jsx
@@ -10,15 +10,18 @@ import styles from '../share.styl'
 
 import logger from '../logger'
 
+import BottomIcon from 'cozy-ui/transpiled/react/Icons/Bottom'
+import CheckIcon from 'cozy-ui/transpiled/react/Icons/Check'
+
 const DropdownIndicator = props => (
   <components.DropdownIndicator {...props}>
-    <Icon icon="bottom" color={palette.coolGrey} />
+    <Icon icon={BottomIcon} color={palette.coolGrey} />
   </components.DropdownIndicator>
 )
 const Option = props => (
   <components.Option {...props}>
     <div className={cx(styles['select-option'])}>
-      {props.isSelected && <Icon icon="check" color={palette.dodgerBlue} />}
+      {props.isSelected && <Icon icon={CheckIcon} color={palette.dodgerBlue} />}
       <div>
         <div className={styles['select-option-label']}>{props.label}</div>
         <div className={styles['select-option-desc']}>{props.data.desc}</div>

--- a/packages/playgrounds/package.json
+++ b/packages/playgrounds/package.json
@@ -17,7 +17,7 @@
     "cozy-doctypes": "^1.75.0",
     "cozy-realtime": "^3.12.0",
     "cozy-sharing": "^2.9.0",
-    "cozy-ui": "35.39.0",
+    "cozy-ui": "40.9.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-redux": "^7.0.3",


### PR DESCRIPTION
This way, apps do not have to include the full icon sprite.

- [x] ButtonLink
- [x] Avatar
- [x] Updated cozy-ui peerDependency version so that app are informed that they need a recent version of cozy-ui