### PR TITLE
feat(harvest): Upgrade cozy-bi-auth

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@cozy/minilog": "^1.0.0",
     "@material-ui/core": "3",
-    "cozy-bi-auth": "0.0.15",
+    "cozy-bi-auth": "0.0.16",
     "cozy-doctypes": "^1.75.0",
     "cozy-keys-lib": "^3.1.2",
     "cozy-logger": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5085,10 +5085,10 @@ cosmiconfig@^5.0.0, cosmiconfig@^5.0.7, cosmiconfig@^5.1.0, cosmiconfig@^5.2.0:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-cozy-bi-auth@0.0.15:
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.15.tgz#c3d450b1d4c5b053101888f6d139d5a1ef806a27"
-  integrity sha512-qZAYjUoyQFhqKiVph6k/P3d/GQMR+K6pQr4bqhzdGoDhrBjMZYvho6doQpyKYZpWiJCjHXaX4aJDOtfC5Qwinw==
+cozy-bi-auth@0.0.16:
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.16.tgz#82ac022b3a7a76aa9cce28cc2827e79a4c35a671"
+  integrity sha512-XC9hkmND7YA/qFLy8KTTqZMhRFNWsuU5ys2st3ZuvB+EXqAferMamWlfgPl6ogIDpt8zr4ldqf9U3dX2S79GKg==
   dependencies:
     cozy-logger "^1.3.0"
     lodash "^4.17.20"


### PR DESCRIPTION
A quick Pr to update cozy-bi-auth to v 0.16.0
It brings a new complete BI mapping for 35 new banking connectors