### PR TITLE
Add CLI for @cozy/codemods

### DIFF
--- a/packages/cli-tree/examples/users.js
+++ b/packages/cli-tree/examples/users.js
@@ -37,7 +37,7 @@ const main = async () => {
 
   // You can further customize parser here
   const args = parser.parseArgs()
-  args.handle(args)
+  args.handler(args)
 }
 
 if (require.main === module) {

--- a/packages/cozy-codemods/README.md
+++ b/packages/cozy-codemods/README.md
@@ -16,10 +16,22 @@ See [here][jscodeshift-docs] for more information on codeshifts.
 [jscodeshift]: https://github.com/facebook/jscodeshift
 [jscodeshift-docs]: https://github.com/facebook/jscodeshift/wiki/jscodeshift-Documentation
 
+### Installation
+
+You can install @cozy/codemods globally so that you do not have to pollute your package.json
+and yarn.lock in every project where you use it.
+
+```
+yarn global add @cozy/codemods
+```
+
 ### General usage
 
 ```
-$ jscodeshift -t node_modules/cozy-codeshifts/dist/<TRANSFORM> --parser babel --js,jsx -- src
+$ cozy-codemods --help
+$ cozy-codemods list # List available transforms
+$ cozy-codemods showExample apply-flag # Show an example of what a transform does
+$ cozy-codemods run apply-flag -- --flag=my-flag # Run a transform, pass jscodeshift args after --
 ```
 
 ### Available transforms

--- a/packages/cozy-codemods/package.json
+++ b/packages/cozy-codemods/package.json
@@ -6,12 +6,17 @@
   "repository": "https://github.com/cozy/cozy-libs",
   "author": "Cozy",
   "license": "MIT",
+  "bin": {
+    "cozy-codemods": "src/cli.js"
+  },
   "scripts": {
     "docs": "jsdoc2md -f 'src/**/*.js' -t .README.md.template > README.md",
     "build": "babel src -d dist --verbose",
-    "test": "jest src"
+    "test": "jest src",
+    "cli": "node src/cli.js"
   },
   "dependencies": {
+    "@cozy/cli-tree": "^0.2.1",
     "eslint-config-cozy-app": "^2.0.0",
     "jscodeshift": "^0.11.0"
   },

--- a/packages/cozy-codemods/src/cli.js
+++ b/packages/cozy-codemods/src/cli.js
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+const fs = require('fs')
+const path = require('path')
+const { spawnSync } = require('child_process')
+const { build, completionHandler } = require('@cozy/cli-tree')
+
+const ignored = new Set(['__testfixtures__', '__tests__'])
+
+const getTransformNames = () => {
+  const transformsDir = path.join(__dirname, 'transforms')
+  const transforms = fs.readdirSync(transformsDir).filter(x => !ignored.has(x))
+  const transformNames = transforms.map(x => x.replace(/\.js$/, ''))
+  return transformNames
+}
+
+const listHandler = args => {
+  const transformNames = getTransformNames()
+  for (const name of transformNames) {
+    const mod = require(`./transforms/${name}`)
+    if (args.description && mod.description) {
+      console.log(`${name}: ${mod.description}`)
+    } else {
+      console.log(name)
+    }
+  }
+}
+
+const showExampleHandler = args => {
+  const { transformName } = args
+
+  const inputPath = path.join(
+    __dirname,
+    'transforms/__testfixtures__',
+    `${transformName}.input.js`
+  )
+  const outputPath = path.join(
+    __dirname,
+    'transforms/__testfixtures__',
+    `${transformName}.output.js`
+  )
+
+  if (!fs.existsSync(inputPath)) {
+    console.warn(
+      `There is no example for ${transformName} unfortunately, you can open an issue about that or write the example yourself :)`
+    )
+    return
+  }
+
+  spawnSync(
+    'git',
+    [
+      'diff',
+      '--no-index', // when installed as a package, we are not in a repo
+
+      inputPath,
+      outputPath
+    ],
+    {
+      stdio: 'inherit'
+    }
+  )
+}
+
+const runHandler = args => {
+  const transformFile = path.join(
+    __dirname,
+    'transforms',
+    `${args.transformName}`
+  )
+  const defaultJscodeshiftArgs = args.noDefaultJscodeshiftArgs
+    ? []
+    : [
+        '-t',
+        `${transformFile}.js`,
+        '--parser',
+        'babel',
+        '--extensions',
+        'js,jsx'
+      ]
+  spawnSync('jscodeshift', [...defaultJscodeshiftArgs, ...args.rest], {
+    stdio: 'inherit'
+  })
+
+  console.log('Done ! You might want to run a linter now.')
+}
+
+const transformNameArg = {
+  argument: 'transformName',
+  help: 'Name of transform (use list to show all the transforms)',
+  choices: getTransformNames()
+}
+
+const main = async () => {
+  const commands = {
+    list: {
+      description: 'List codemods',
+      handler: listHandler,
+      arguments: [
+        {
+          argument: '--description',
+          action: 'storeTrue'
+        }
+      ]
+    },
+    run: {
+      description: 'Runs a codemod from @cozy/codemods',
+      arguments: [
+        transformNameArg,
+        {
+          argument: '--no-default-jscodeshift-args',
+          action: 'storeTrue',
+          dest: 'noDefaultJscodeshiftArgs'
+        },
+        {
+          argument: 'rest',
+          nargs: '*',
+          help:
+            'Pass jscodeshift args after --: cozy-codemods run apply-flag -- --ignore-pattern=src/ignored src'
+        }
+      ],
+      handler: runHandler
+    },
+    showExample: {
+      description: 'Shows an example of what the transform will do',
+      arguments: [transformNameArg],
+      handler: showExampleHandler
+    }
+  }
+
+  await completionHandler(commands)
+  const [parser] = build(commands)
+  const args = parser.parseArgs()
+  args.handler(args)
+}
+
+if (require.main === module) {
+  main().catch(e => {
+    console.error(e)
+    process.exit(1)
+  })
+}

--- a/packages/cozy-codemods/src/hoc.js
+++ b/packages/cozy-codemods/src/hoc.js
@@ -50,12 +50,7 @@ const removeHOC = (arrowFunctionBodyPath, hocName, noOptionsHOC) => {
   }
 }
 
-export const removeDefaultExportHOC = (
-  root,
-  ComponentName,
-  hocName,
-  noOptionsHOC
-) => {
+const removeDefaultExportHOC = (root, ComponentName, hocName, noOptionsHOC) => {
   const defaultExports = root.find(j.ExportDefaultDeclaration)
   if (!defaultExports.length) {
     return

--- a/packages/cozy-codemods/src/imports.js
+++ b/packages/cozy-codemods/src/imports.js
@@ -20,7 +20,7 @@ const mergeSpecifiersToImport = (importDeclaration, specifiers) => {
   }
 }
 
-export const ensure = (root, specifierObj, sourceOrFilter, maybeSource) => {
+const ensure = (root, specifierObj, sourceOrFilter, maybeSource) => {
   if (!specifierObj) {
     // eslint-disable-next-line no-console
     console.warn(`Example usage of imports.add:
@@ -65,7 +65,7 @@ imports.add(root, {
   }
 }
 
-export const removeUnused = root => {
+const removeUnused = root => {
   const removeIfUnused = (importSpecifier, importDeclaration) => {
     if (!importSpecifier.value.local) {
       return
@@ -236,7 +236,7 @@ const mergeImports = root => {
  * import Dialog, { DialogFile, DialogContent } from "cozy-ui/transpiled/react/Dialog";
  * ```
  */
-export const simplify = (root, options) => {
+const simplify = (root, options) => {
   const imports = options.imports
   const identifiers = Object.keys(imports)
   root.find(j.ImportDeclaration).forEach(path => {
@@ -268,4 +268,10 @@ export const simplify = (root, options) => {
     }
   })
   mergeImports(root)
+}
+
+module.exports = {
+  simplify,
+  ensure,
+  removeUnused
 }

--- a/packages/cozy-codemods/src/transforms/apply-flag.js
+++ b/packages/cozy-codemods/src/transforms/apply-flag.js
@@ -1,11 +1,11 @@
-import { simplifyConditions, replaceBooleanVars, jsx, imports } from '..'
+const { simplifyConditions, replaceBooleanVars, jsx, imports } = require('..')
 
 const flagCallFinder = name => ({
   callee: { name: 'flag' },
   arguments: [{ value: name }]
 })
 
-export default function applyFlag(file, api, options) {
+module.exports = function applyFlag(file, api, options) {
   const j = api.jscodeshift
   const root = j(file.source)
 
@@ -30,3 +30,5 @@ export default function applyFlag(file, api, options) {
 
   return root.toSource()
 }
+
+module.exports.description = 'Sets a flag to true in the code'

--- a/packages/cozy-codemods/src/transforms/button-new-api.js
+++ b/packages/cozy-codemods/src/transforms/button-new-api.js
@@ -67,3 +67,5 @@ module.exports = function(file, api) {
   // print
   return root.toSource()
 }
+
+module.exports.description = 'Use the new Button API'

--- a/packages/cozy-codemods/src/transforms/new-icons.js
+++ b/packages/cozy-codemods/src/transforms/new-icons.js
@@ -67,7 +67,7 @@ const updateToNewIcon = (j, jsxComponent) => {
   }
 }
 
-export default function transformer(file, api) {
+module.exports = function transformer(file, api) {
   const j = api.jscodeshift
   const root = j(file.source)
   const imports = root.find(j.ImportDeclaration)

--- a/packages/cozy-codemods/src/transforms/remove-boolean-vars.js
+++ b/packages/cozy-codemods/src/transforms/remove-boolean-vars.js
@@ -1,6 +1,6 @@
-import { removeBooleanVars, simplifyConditions, imports } from '..'
+const { removeBooleanVars, simplifyConditions, imports } = require('..')
 
-export default function(file, api) {
+module.exports = function(file, api) {
   const j = api.jscodeshift
   const root = j(file.source)
 
@@ -10,3 +10,5 @@ export default function(file, api) {
 
   return root.toSource()
 }
+
+module.exports.description = 'Simplify boolean vars'

--- a/packages/cozy-codemods/src/transforms/remove-unused-imports.js
+++ b/packages/cozy-codemods/src/transforms/remove-unused-imports.js
@@ -22,9 +22,9 @@
  * <App />
  * ```
  */
-import { imports } from '..'
+const { imports } = require('..')
 
-export default function removeUnusedImportsTransform(file, api) {
+module.exports = function removeUnusedImportsTransform(file, api) {
   const j = api.jscodeshift
   const root = j(file.source)
   imports.removeUnused(root)

--- a/packages/cozy-codemods/src/transforms/replace-icons-svgr.js
+++ b/packages/cozy-codemods/src/transforms/replace-icons-svgr.js
@@ -7,7 +7,7 @@ const iconNameToComponentName = iconName => {
   )
 }
 
-export default function replaceSvgrIcons(file, api) {
+module.exports = function replaceSvgrIcons(file, api) {
   const j = api.jscodeshift
   const root = j(file.source)
 
@@ -44,3 +44,6 @@ export default function replaceSvgrIcons(file, api) {
 
   return root.toSource()
 }
+
+module.exports.description =
+  'Replaces Icon that come from a sprite with an SVGr version'

--- a/packages/cozy-codemods/src/transforms/transform-list-item-attributes.js
+++ b/packages/cozy-codemods/src/transforms/transform-list-item-attributes.js
@@ -1,4 +1,4 @@
-export default function transformer(file, api) {
+module.exports = function transformer(file, api) {
   const j = api.jscodeshift
   const root = j(file.source)
 

--- a/packages/cozy-codemods/src/transforms/transform-typography.js
+++ b/packages/cozy-codemods/src/transforms/transform-typography.js
@@ -41,7 +41,7 @@ const mappings = {
   }
 }
 
-export default function transformer(file, api) {
+module.exports = function transformer(file, api) {
   const j = api.jscodeshift
   const root = j(file.source)
   let toImport = {}

--- a/packages/cozy-codemods/src/transforms/use-breakpoints.js
+++ b/packages/cozy-codemods/src/transforms/use-breakpoints.js
@@ -1,4 +1,4 @@
-import { hocToHookReplacer } from '../hoc'
+const { hocToHookReplacer } = require('../hoc')
 
 const isBreakpointProp = prop => {
   return prop.key && prop.key.name === 'breakpoints'
@@ -17,7 +17,7 @@ const findBreakpointsProp = objPattern => {
     : []
 }
 
-export default function transformer(file, api) {
+module.exports = function transformer(file, api) {
   const j = api.jscodeshift
   const root = j(file.source)
 

--- a/packages/cozy-codemods/src/transforms/use-client.js
+++ b/packages/cozy-codemods/src/transforms/use-client.js
@@ -1,4 +1,4 @@
-import { hocToHookReplacer } from '../hoc'
+const { hocToHookReplacer } = require('../hoc')
 
 const isClientProp = prop => {
   return prop.key && prop.key.name === 'client'
@@ -16,7 +16,7 @@ const findClientProps = objPattern => {
     : []
 }
 
-export default function transformer(file, api) {
+module.exports = function transformer(file, api) {
   const j = api.jscodeshift
   const root = j(file.source)
 

--- a/packages/cozy-codemods/src/transforms/use-i18n.js
+++ b/packages/cozy-codemods/src/transforms/use-i18n.js
@@ -1,4 +1,4 @@
-import { hocToHookReplacer } from '../hoc'
+const { hocToHookReplacer } = require('../hoc')
 
 const isI18nProp = prop => {
   return prop.key && (prop.key.name === 't' || prop.key.name === 'f')
@@ -16,7 +16,7 @@ const findI18nProps = objPattern => {
     : []
 }
 
-export default function transformer(file, api) {
+module.exports = function transformer(file, api) {
   const j = api.jscodeshift
   const root = j(file.source)
 

--- a/packages/cozy-codemods/src/transforms/use-q.js
+++ b/packages/cozy-codemods/src/transforms/use-q.js
@@ -1,6 +1,6 @@
-import importUtils from '../imports'
+const importUtils = require('../imports')
 
-export default function transformer(file, api) {
+module.exports = function transformer(file, api) {
   const j = api.jscodeshift
   const root = j(file.source)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3897,11 +3897,6 @@ body-parser@1.19.0:
     raw-body "2.4.0"
     type-is "~1.6.17"
 
-body-scroll-lock@^2.5.8:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-2.6.4.tgz#567abc60ef4d656a79156781771398ef40462e94"
-  integrity sha512-NP08WsovlmxEoZP9pdlqrE+AhNaivlTrz9a0FF37BQsnOrpN48eNqivKkE7SYpM9N+YIPjsdVzfLAUQDBm6OQw==
-
 bonjour@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bonjour/-/bonjour-3.5.0.tgz#8e890a183d8ee9a2393b3844c691a42bcf7bc9f5"
@@ -5256,28 +5251,6 @@ cozy-stack-client@^16.0.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-ui@35.39.0:
-  version "35.39.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.39.0.tgz#b15532a809a29f097569b2ef3ebb1991226ef646"
-  integrity sha512-4aKCB6IvDeSV/Mu2fX754UUz6P7A5t0Cqk63CD4wKigLxaNd6rhNZUFpISJy9pkqbl3lX1KgNiesryBt6+gM5g==
-  dependencies:
-    "@babel/runtime" "^7.3.4"
-    "@popperjs/core" "^2.4.4"
-    body-scroll-lock "^2.5.8"
-    classnames "^2.2.5"
-    cozy-interapp "0.5.4"
-    date-fns "^1.28.5"
-    hammerjs "^2.0.8"
-    intersection-observer "0.11.0"
-    node-polyglot "^2.2.2"
-    normalize.css "^7.0.0"
-    react-hot-loader "^4.3.11"
-    react-markdown "^4.0.8"
-    react-pdf "^4.0.5"
-    react-popper "^2.2.3"
-    react-select "2.2.0"
-    react-swipeable-views "0.13.3"
-
 cozy-ui@40.1.1:
   version "40.1.1"
   resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-40.1.1.tgz#679c489f4d2be080f67649a1fefffc75968f1f28"
@@ -6112,10 +6085,6 @@ dom-serializer@~0.1.0, dom-serializer@~0.1.1:
   dependencies:
     domelementtype "^1.3.0"
     entities "^1.1.1"
-
-dom-walk@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
 
 domain-browser@^1.1.1:
   version "1.2.0"
@@ -7657,14 +7626,6 @@ global-prefix@^3.0.0:
     kind-of "^6.0.2"
     which "^1.3.1"
 
-global@^4.3.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
-  integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==
-  dependencies:
-    min-document "^2.19.0"
-    process "^0.11.10"
-
 globals@^11.1.0, globals@^11.7.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
@@ -7919,7 +7880,7 @@ hoist-non-react-statics@^2.3.1:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
-hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -11013,12 +10974,6 @@ mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-min-document@^2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
-  dependencies:
-    dom-walk "^0.1.0"
-
 min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
@@ -13357,7 +13312,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   dependencies:
@@ -13685,20 +13640,6 @@ react-group@^3.0.0:
   integrity sha512-0Jy99MD27jHSJ0PeynomUM0WArxywdcqQUKLttBWV6KYH+zlKWT/RhDwVxrODtMkRxf644BzuJFie1Hvfun7jA==
   dependencies:
     prop-types "^15.7.2"
-
-react-hot-loader@^4.3.11:
-  version "4.12.13"
-  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.12.13.tgz#78dcb55f49f88ce3d4316c7c86a8c01fdd196cd2"
-  integrity sha512-4Byk3aVQhcmTnVCBvDHOEOUnMFMj81r2yRKZQSfLOG2yd/4hm/A3oK15AnCZilQExqSFSsHcK64lIIU+dU2zQQ==
-  dependencies:
-    fast-levenshtein "^2.0.6"
-    global "^4.3.0"
-    hoist-non-react-statics "^3.3.0"
-    loader-utils "^1.1.0"
-    prop-types "^15.6.1"
-    react-lifecycles-compat "^3.0.4"
-    shallowequal "^1.1.0"
-    source-map "^0.7.3"
 
 react-icons@^3.7.0:
   version "3.7.0"
@@ -15217,10 +15158,6 @@ shallow-equal@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.0.tgz#fd828d2029ff4e19569db7e19e535e94e2d1f5cc"
   integrity sha512-Z21pVxR4cXsfwpMKMhCEIO1PCi5sp7KEp+CmOpBQ+E8GpHwKOw2sEzk7sgblM3d/j4z4gakoWEoPcjK0VJQogA==
-
-shallowequal@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Makes it much easier to use.
See README for instructions.

This makes it possible to run a codemod without manually wiring jscodeshift and a @cozy/codemods transform file from node_modules. 

```patch
- $ jscodeshit -t node_modules/@cozy/codemods/src/transforms/apply-flag.js --flag=my-flag
+ $ cozy-codemods run apply-flag -- --flag=my-flag
- $ ls node_modules/@cozy/codemods/src/transforms/
+ $ cozy-codemods list # List available transforms
- $ git diff node_modules/@cozy/codemods/src/transforms/__testfixtures__/apply-flag.{input,output}.js
+ $ cozy-codemods showExample apply-flag # Show an example of what a transform does
```