### PR TITLE
feat(Harvest): Reuse unlinked accounts

### DIFF
--- a/packages/cozy-harvest-lib/src/connections/accounts.js
+++ b/packages/cozy-harvest-lib/src/connections/accounts.js
@@ -195,9 +195,14 @@ export const fetchAccountsFromTriggers = async (client, triggers) => {
  * @param  {Array}  triggers io.cozy.triggers documents
  */
 export const fetchAccountsWithoutTriggers = async (client, triggers) => {
-  const accountCol = client.collection('io.cozy.accounts')
-  const accountIdToTrigger = keyBy(triggers, triggersModel.getAccountId)
-  return (await accountCol.all({ limit: null })).data.filter(
-    account => !accountIdToTrigger[account.id]
+  const triggerAccountIds = triggers.map(trigger =>
+    triggersModel.getAccountId(trigger)
   )
+  return (await client.query(
+    Q(ACCOUNTS_DOCTYPE).where({
+      _id: {
+        $nin: triggerAccountIds
+      }
+    })
+  )).data
 }

--- a/packages/cozy-harvest-lib/src/connections/accounts.js
+++ b/packages/cozy-harvest-lib/src/connections/accounts.js
@@ -187,3 +187,17 @@ export const fetchAccountsFromTriggers = async (client, triggers) => {
     .filter(Boolean)
     .map(account => ({ account, trigger: accountIdToTrigger[account._id] }))
 }
+
+/**
+ * Returns the list of accounts which do not have any associated trigger
+ *
+ * @param  {Object}  client  CozyClient
+ * @param  {Array}  triggers io.cozy.triggers documents
+ */
+export const fetchAccountsWithoutTriggers = async (client, triggers) => {
+  const accountCol = client.collection('io.cozy.accounts')
+  const accountIdToTrigger = keyBy(triggers, triggersModel.getAccountId)
+  return (await accountCol.all({ limit: null })).data.filter(
+    account => !accountIdToTrigger[account.id]
+  )
+}

--- a/packages/cozy-harvest-lib/src/connections/accounts.spec.js
+++ b/packages/cozy-harvest-lib/src/connections/accounts.spec.js
@@ -5,13 +5,15 @@ import {
   createAccount,
   updateAccount,
   saveAccount,
-  deleteAccount
+  deleteAccount,
+  fetchAccountsWithoutTriggers
 } from 'connections/accounts'
 
 const client = {
   collection: jest.fn().mockReturnValue({
     add: jest.fn(),
-    get: jest.fn()
+    get: jest.fn(),
+    all: jest.fn()
   }),
   create: jest.fn(),
   destroy: jest.fn(),
@@ -78,6 +80,29 @@ const fixtures = {
     _id: 'kaggregated-aggregator'
   }
 }
+
+describe('fetchAccountsWithoutTriggers', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should fetch the list of accounts without triggers', async () => {
+    client.collection().all.mockResolvedValue({
+      data: [fixtures.existingAccount]
+    })
+    const triggers = [
+      { message: { account: 'toto' } },
+      { message: { account: '561be660ff384ce0846c8f20e829ad62' } }
+    ]
+    expect(await fetchAccountsWithoutTriggers(client, triggers)).toEqual([
+      fixtures.existingAccount
+    ])
+  })
+})
 
 describe('Account mutations', () => {
   beforeEach(() => {

--- a/packages/cozy-harvest-lib/src/connections/accounts.spec.js
+++ b/packages/cozy-harvest-lib/src/connections/accounts.spec.js
@@ -91,7 +91,7 @@ describe('fetchAccountsWithoutTriggers', () => {
   })
 
   it('should fetch the list of accounts without triggers', async () => {
-    client.collection().all.mockResolvedValue({
+    client.query.mockResolvedValue({
       data: [fixtures.existingAccount]
     })
     const triggers = [

--- a/packages/cozy-harvest-lib/src/helpers/accounts.js
+++ b/packages/cozy-harvest-lib/src/helpers/accounts.js
@@ -203,6 +203,18 @@ export const setSessionResetIfNecessary = (account, changedFields = {}) => {
     : account
 }
 
+export const getRescuableAccount = (accounts, konnector, userCredentials) => {
+  const identifierProperty = manifest.getIdentifier(konnector.fields)
+  return accounts.find(account => {
+    return (
+      account.account_type === konnector.slug &&
+      userCredentials[identifierProperty] ===
+        get(account, `auth.${identifierProperty}`) &&
+      userCredentials.password === get(account, 'auth.password')
+    )
+  })
+}
+
 export default {
   build,
   getLabel,
@@ -216,5 +228,6 @@ export default {
   setSessionResetIfNecessary,
   updateTwoFaCode,
   setVaultCipherRelationship,
-  getVaultCipherId
+  getVaultCipherId,
+  getRescuableAccount
 }

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.spec.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.spec.js
@@ -1,7 +1,9 @@
-import CozyClient from 'cozy-client'
 import ConnectionFlow from './ConnectionFlow'
 import cronHelpers from 'helpers/cron'
-import { saveAccount } from '../connections/accounts'
+import {
+  saveAccount,
+  fetchAccountsWithoutTriggers
+} from '../connections/accounts'
 import {
   createTrigger,
   ensureTrigger,
@@ -37,7 +39,8 @@ CozyRealtime.prototype.subscribe = jest.fn()
 CozyRealtime.prototype.unsubscribe = jest.fn()
 
 jest.mock('../connections/accounts', () => ({
-  saveAccount: jest.fn()
+  saveAccount: jest.fn(),
+  fetchAccountsWithoutTriggers: jest.fn()
 }))
 
 jest.mock('../connections/triggers', () => {
@@ -66,6 +69,10 @@ saveAccount.mockImplementation(async (client, konnector, account) => {
   return _id ? fixtures.updatedAccount : fixtures.createdAccount
 })
 
+fetchAccountsWithoutTriggers.mockImplementation(async () => {
+  return []
+})
+
 const mockVaultClient = {
   createNewCipher: jest.fn(),
   saveCipher: jest.fn(),
@@ -80,7 +87,11 @@ const mockVaultClient = {
 }
 
 const setup = ({ trigger } = {}) => {
-  const client = new CozyClient({})
+  const client = {
+    collection: jest.fn().mockReturnValue({
+      all: jest.fn()
+    })
+  }
   const flow = new ConnectionFlow(client, trigger)
   return { flow, client }
 }

--- a/packages/cozy-harvest-lib/test/helpers/accounts.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/accounts.spec.js
@@ -5,7 +5,8 @@ import {
   updateTwoFaCode,
   resetState,
   getVaultCipherId,
-  setSessionResetIfNecessary
+  setSessionResetIfNecessary,
+  getRescuableAccount
 } from 'helpers/accounts'
 
 const fixtures = {
@@ -171,6 +172,43 @@ describe('Accounts Helper', () => {
           }
         })
       ).toEqual('cipher-id')
+    })
+  })
+
+  describe('getRescuableAccount', () => {
+    it('should return the right account when possible', () => {
+      const accounts = [
+        {
+          account_type: 'konnectest',
+          auth: { login: 'badlogin', password: 'toto' }
+        },
+        {
+          account_type: 'konnectest',
+          auth: { login: 'goodlogin', password: 'badpassword' }
+        },
+        {
+          account_type: 'konnectest',
+          auth: { login: 'goodlogin', password: 'secretpassword' }
+        }
+      ]
+      expect(
+        getRescuableAccount(accounts, fixtures.konnector, {
+          login: 'goodlogin',
+          password: 'secretpassword'
+        })
+      ).toEqual({
+        account_type: 'konnectest',
+        auth: { login: 'goodlogin', password: 'secretpassword' }
+      })
+    })
+
+    it('should return undefined when no correct account available', () => {
+      expect(
+        getRescuableAccount([], fixtures.konnector, {
+          login: 'goodlogin',
+          password: 'secretpassword'
+        })
+      ).toBe(undefined)
     })
   })
 })


### PR DESCRIPTION
Some accounts are not linked to any trigger anymore.
This is due to old bugs or when the user closes his window
too soon.

This PR will reuse these accounts, related to the same connector (via
account_type), fill them with new identifiers and link them to a new
trigger.