### PR TITLE
feat: Use partial index to speed up contact search

### DIFF
--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -41,7 +41,7 @@
     "babel-jest": "26.6.3",
     "babel-plugin-css-modules-transform": "^1.6.2",
     "babel-plugin-inline-react-svg": "^1.1.0",
-    "cozy-client": "16.0.0",
+    "cozy-client": "16.8.0",
     "cozy-ui": "40.9.1",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.2",

--- a/packages/cozy-sharing/src/components/EditableSharingModal.jsx
+++ b/packages/cozy-sharing/src/components/EditableSharingModal.jsx
@@ -97,6 +97,7 @@ const contactsQuery = () =>
       ]
     })
     .indexFields(['_id'])
+    .limitBy(1000)
 
 const groupsQuery = () => Q(Group.doctype)
 

--- a/packages/cozy-sharing/src/components/EditableSharingModal.jsx
+++ b/packages/cozy-sharing/src/components/EditableSharingModal.jsx
@@ -8,6 +8,7 @@ import SharingContext from '../context'
 import ContactsAndGroupsDataLoader from './ContactsAndGroupsDataLoader'
 import { default as DumbShareModal } from './ShareModal'
 import { useFetchDocumentPath } from './useFetchDocumentPath'
+
 export const EditableSharingModal = ({
   contacts,
   document,
@@ -75,7 +76,9 @@ const contactsQuery = () =>
     .where({
       _id: {
         $gt: null
-      },
+      }
+    })
+    .partialIndex({
       trashed: {
         $or: [{ $eq: false }, { $exists: false }]
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5142,28 +5142,6 @@ cozy-client@14.4.0:
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
-cozy-client@16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-16.0.0.tgz#8e3333f7ee42e996c79d1d150651c0e480d02495"
-  integrity sha512-Q8owRCIVxfeDZiAvokcIvduA9Ei1dtbNGSnYQcYOKLh3dDcKVQ12KmuodgyFj4792eruNy3oR43xLqi7wccAmg==
-  dependencies:
-    "@cozy/minilog" "1.0.0"
-    btoa "^1.2.1"
-    cozy-device-helper "^1.7.3"
-    cozy-logger "^1.6.0"
-    cozy-stack-client "^16.0.0"
-    isomorphic-fetch "^2.2.1"
-    lodash "^4.17.13"
-    microee "^0.0.6"
-    open "^7.0.2"
-    prop-types "^15.6.2"
-    react-redux "^7.2.0"
-    redux "^3.7.2"
-    redux-thunk "^2.3.0"
-    server-destroy "^1.0.1"
-    sift "^6.0.0"
-    url-search-params-polyfill "^7.0.0"
-
 cozy-client@16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-16.2.0.tgz#6b1168cf2a91592da5a4dde1d237084dd90aa338"
@@ -5177,6 +5155,28 @@ cozy-client@16.2.0:
     isomorphic-fetch "^3.0.0"
     lodash "^4.17.13"
     microee "^0.0.6"
+    open "^7.0.2"
+    prop-types "^15.6.2"
+    react-redux "^7.2.0"
+    redux "^3.7.2"
+    redux-thunk "^2.3.0"
+    server-destroy "^1.0.1"
+    sift "^6.0.0"
+    url-search-params-polyfill "^7.0.0"
+
+cozy-client@16.8.0:
+  version "16.8.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-16.8.0.tgz#44378ed226697a1d4000f8ac6b5f7ca1ba66bd01"
+  integrity sha512-FeCpbXAEl40WPYneIWo8S6F2FaJWGq1PE2XG2qyGZ/iyWrAtX5O5IUL9/oEG1B2C1ZVlNgXENDoqp6UIlHbLOQ==
+  dependencies:
+    "@cozy/minilog" "1.0.0"
+    btoa "^1.2.1"
+    cozy-device-helper "^1.7.3"
+    cozy-logger "^1.6.0"
+    cozy-stack-client "^16.8.0"
+    lodash "^4.17.13"
+    microee "^0.0.6"
+    node-fetch "^2.6.1"
     open "^7.0.2"
     prop-types "^15.6.2"
     react-redux "^7.2.0"
@@ -5246,6 +5246,15 @@ cozy-stack-client@^16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-16.0.0.tgz#9946dd2b7afe3ac7b747156ef47e3af20b37759d"
   integrity sha512-FV+wnjeVzdy3Gv/YQInIVeGO0CFFpATNfXW599+cxPQPejvzAq7XkGYLx2zw6Bmu/2vyBxk8UoomtA2eB27oXA==
+  dependencies:
+    detect-node "^2.0.4"
+    mime "^2.4.0"
+    qs "^6.7.0"
+
+cozy-stack-client@^16.8.0:
+  version "16.8.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-16.8.0.tgz#091d76ce6368594ab345ab6bb942a105a62c2dd5"
+  integrity sha512-7B2j9OMGMv6hnwQ+L6i6gXBOEQJ1QOcoi+x9N4PFhDM0Wy76UaGUwsciKhUiJ3dr34IxhEa/VywK023nybG0rA==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
This can greatly speed up contact search for sharing.

With 5K contacts, including only 1 relevant contact (having an email for instance) : 
* Without partial index : ~4700 ms
* With partial index : ~20 ms 

In any case, the query will be faster as the partial index filter out contacts without email/url and deleted contacts.