### PR TITLE
fix(Harvest): Remove check on identifiers for account rescue

### DIFF
--- a/packages/cozy-harvest-lib/src/helpers/accounts.js
+++ b/packages/cozy-harvest-lib/src/helpers/accounts.js
@@ -203,15 +203,9 @@ export const setSessionResetIfNecessary = (account, changedFields = {}) => {
     : account
 }
 
-export const getRescuableAccount = (accounts, konnector, userCredentials) => {
-  const identifierProperty = manifest.getIdentifier(konnector.fields)
+export const getRescuableAccount = (accounts, konnector) => {
   return accounts.find(account => {
-    return (
-      account.account_type === konnector.slug &&
-      userCredentials[identifierProperty] ===
-        get(account, `auth.${identifierProperty}`) &&
-      userCredentials.password === get(account, 'auth.password')
-    )
+    return account.account_type === konnector.slug
   })
 }
 

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -108,8 +108,7 @@ export const createOrUpdateAccount = async ({
     )
     const rescuableAccount = accounts.getRescuableAccount(
       accountsWithoutTrigger,
-      konnector,
-      userCredentials
+      konnector
     )
     if (rescuableAccount) {
       accountToSave = accounts.mergeAuth(rescuableAccount, userCredentials)

--- a/packages/cozy-harvest-lib/test/helpers/accounts.spec.js
+++ b/packages/cozy-harvest-lib/test/helpers/accounts.spec.js
@@ -179,11 +179,11 @@ describe('Accounts Helper', () => {
     it('should return the right account when possible', () => {
       const accounts = [
         {
-          account_type: 'konnectest',
+          account_type: 'otherslug',
           auth: { login: 'badlogin', password: 'toto' }
         },
         {
-          account_type: 'konnectest',
+          account_type: 'otherslug',
           auth: { login: 'goodlogin', password: 'badpassword' }
         },
         {
@@ -191,24 +191,14 @@ describe('Accounts Helper', () => {
           auth: { login: 'goodlogin', password: 'secretpassword' }
         }
       ]
-      expect(
-        getRescuableAccount(accounts, fixtures.konnector, {
-          login: 'goodlogin',
-          password: 'secretpassword'
-        })
-      ).toEqual({
+      expect(getRescuableAccount(accounts, fixtures.konnector)).toEqual({
         account_type: 'konnectest',
         auth: { login: 'goodlogin', password: 'secretpassword' }
       })
     })
 
     it('should return undefined when no correct account available', () => {
-      expect(
-        getRescuableAccount([], fixtures.konnector, {
-          login: 'goodlogin',
-          password: 'secretpassword'
-        })
-      ).toBe(undefined)
+      expect(getRescuableAccount([], fixtures.konnector)).toBe(undefined)
     })
   })
 })


### PR DESCRIPTION
When account is soft deleted by cozy pass, identifiers are removed on
the account and checking identifier to restore an account has no
meaning since identifiers will be overwritten just after.