### PR TITLE
Improvements to harvest modal

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModal.jsx
@@ -20,8 +20,8 @@ import withLocales from './hoc/withLocales'
 import DialogContent from '@material-ui/core/DialogContent'
 
 /**
- * AccountModal take an accountId and a list of accounts containing their
- * respecting triggers and display the selected account and the accounts linked
+ * Takes an accountId and a list of accounts containing their respecting triggers
+ * isplays the selected account and the accounts linked
  * to this konnector
  *
  * You have to pass an array of accounts containing their associated trigger:
@@ -214,7 +214,6 @@ AccountModal.propTypes = {
 export default flow(
   withClient,
   withLocales,
-  translate(),
   withMountPointPushHistory,
   withBreakpoints()
 )(AccountModal)

--- a/packages/cozy-harvest-lib/src/components/AccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModal.jsx
@@ -7,7 +7,6 @@ import { withClient } from 'cozy-client'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Infos from 'cozy-ui/transpiled/react/Infos'
 import Button from 'cozy-ui/transpiled/react/Button'
-import { translate } from 'cozy-ui/transpiled/react/I18n'
 import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
 
 import { fetchAccount } from '../connections/accounts'

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback, useEffect } from 'react'
+import React, { useState, useRef, useCallback } from 'react'
 import PropTypes from 'prop-types'
 
 import { Tab, Tabs } from 'cozy-ui/transpiled/react/MuiTabs'
@@ -9,6 +9,7 @@ import WarningIcon from 'cozy-ui/transpiled/react/Icons/Warning'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import SwipeableViews from 'react-swipeable-views'
 
+import useDOMMutations from '../hooks/useDOMMutations'
 import FlowProvider from '../FlowProvider'
 import DataTab from './DataTab'
 import ConfigurationTab from './ConfigurationTab'
@@ -56,22 +57,6 @@ export const KonnectorAccountTabsTabs = ({ tab, onChange, flowState }) => {
       />
     </Tabs>
   )
-}
-
-const useDOMMutations = (node, config, cb) => {
-  useEffect(() => {
-    let observer
-    if (!window.MutationObserver) {
-      return
-    }
-    if (node) {
-      observer = new MutationObserver(cb)
-      observer.observe(node, config)
-    }
-    return () => {
-      observer && observer.disconnect()
-    }
-  }, [node, config, cb])
 }
 
 const domMutationsConfig = { childList: true, subtree: true }

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
@@ -61,6 +61,9 @@ export const KonnectorAccountTabsTabs = ({ tab, onChange, flowState }) => {
 const useDOMMutations = (node, config, cb) => {
   useEffect(() => {
     let observer
+    if (!window.MutationObserver) {
+      return
+    }
     if (node) {
       observer = new MutationObserver(cb)
       observer.observe(node, config)

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
@@ -106,7 +106,10 @@ const DumbKonnectorAccountTabs = props => {
   const swipeableActions = useRef()
   const nodeRef = useRef()
 
-  const updateSwiperHeight = useCallback(() => swipeableActions.current.updateHeight(), [swipeableActions])
+  const updateSwiperHeight = useCallback(
+    () => swipeableActions.current.updateHeight(),
+    [swipeableActions]
+  )
   useDOMMutations(nodeRef.current, domMutationsConfig, updateSwiperHeight)
 
   return (
@@ -122,7 +125,9 @@ const DumbKonnectorAccountTabs = props => {
         index={tab}
         disabled
         animateTransitions={isMobile}
-        action={actions => {swipeableActions.current = actions}}
+        action={actions => {
+          swipeableActions.current = actions
+        }}
       >
         <DataTab konnector={konnector} trigger={initialTrigger} flow={flow} />
         <ConfigurationTab

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useRef, useCallback, useEffect } from 'react'
 import PropTypes from 'prop-types'
 
 import { Tab, Tabs } from 'cozy-ui/transpiled/react/MuiTabs'
@@ -58,6 +58,21 @@ export const KonnectorAccountTabsTabs = ({ tab, onChange, flowState }) => {
   )
 }
 
+const useDOMMutations = (node, config, cb) => {
+  useEffect(() => {
+    let observer
+    if (node) {
+      observer = new MutationObserver(cb)
+      observer.observe(node, config)
+    }
+    return () => {
+      observer && observer.disconnect()
+    }
+  }, [node, config, cb])
+}
+
+const domMutationsConfig = { childList: true, subtree: true }
+
 const DumbKonnectorAccountTabs = props => {
   const {
     konnector,
@@ -85,8 +100,14 @@ const DumbKonnectorAccountTabs = props => {
   const hasError = !!error
   const hasLoginError = hasError && error.isLoginError()
 
+  const swipeableActions = useRef()
+  const nodeRef = useRef()
+
+  const updateSwiperHeight = useCallback(() => swipeableActions.current.updateHeight(), [swipeableActions])
+  useDOMMutations(nodeRef.current, domMutationsConfig, updateSwiperHeight)
+
   return (
-    <>
+    <div ref={nodeRef}>
       <KonnectorAccountTabsTabs
         tab={tab}
         onChange={handleTabChange}
@@ -98,6 +119,7 @@ const DumbKonnectorAccountTabs = props => {
         index={tab}
         disabled
         animateTransitions={isMobile}
+        action={actions => {swipeableActions.current = actions}}
       >
         <DataTab konnector={konnector} trigger={initialTrigger} flow={flow} />
         <ConfigurationTab
@@ -109,7 +131,7 @@ const DumbKonnectorAccountTabs = props => {
           showNewAccountButton={showNewAccountButton}
         />
       </SwipeableViews>
-    </>
+    </div>
   )
 }
 

--- a/packages/cozy-harvest-lib/src/components/Routes.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes.jsx
@@ -1,7 +1,14 @@
 import React from 'react'
 import { Switch, Route, Redirect } from 'react-router'
-import KonnectorAccounts from './KonnectorAccounts'
+import { withStyles } from '@material-ui/core/styles'
 
+import Dialog from 'cozy-ui/transpiled/react/Dialog'
+import {
+  DialogCloseButton,
+  useCozyDialog
+} from 'cozy-ui/transpiled/react/CozyDialogs'
+
+import KonnectorAccounts from './KonnectorAccounts'
 import AccountModal from './AccountModal'
 import NewAccountModal from './NewAccountModal'
 import EditAccountModal from './EditAccountModal'
@@ -9,12 +16,19 @@ import KonnectorSuccess from './KonnectorSuccess'
 import HarvestModalRoot from './HarvestModalRoot'
 import HarvestVaultProvider from './HarvestVaultProvider'
 import { MountPointProvider } from './MountPointContext'
-import Dialog from 'cozy-ui/transpiled/react/Dialog'
-import {
-  DialogCloseButton,
-  useCozyDialog
-} from 'cozy-ui/transpiled/react/CozyDialogs'
 import DialogContext from './DialogContext'
+
+/**
+ * Dialog will not be centered vertically since we need the modal to "stay in place"
+ * when changing tabs. Since tabs content's height is not the same between the data
+ * tab and the configuration, having the modal vertically centered makes it "jump"
+ * when changing tabs.
+ */
+const HarvestDialog = withStyles({
+  scrollPaper: {
+    alignItems: 'start'
+  }
+})(Dialog)
 
 const Routes = ({ konnectorRoot, konnector, onDismiss }) => {
   const dialogContext = useCozyDialog({
@@ -26,7 +40,7 @@ const Routes = ({ konnectorRoot, konnector, onDismiss }) => {
     <MountPointProvider baseRoute={konnectorRoot}>
       <DialogContext.Provider value={dialogContext}>
         <HarvestVaultProvider>
-          <Dialog {...dialogContext.dialogProps} aria-label={konnector.name}>
+          <HarvestDialog {...dialogContext.dialogProps} aria-label={konnector.name}>
             <DialogCloseButton onClick={onDismiss} />
             <KonnectorAccounts konnector={konnector}>
               {accountsAndTriggers => (
@@ -95,7 +109,7 @@ const Routes = ({ konnectorRoot, konnector, onDismiss }) => {
                 </Switch>
               )}
             </KonnectorAccounts>
-          </Dialog>
+          </HarvestDialog>
         </HarvestVaultProvider>
       </DialogContext.Provider>
     </MountPointProvider>

--- a/packages/cozy-harvest-lib/src/components/Routes.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes.jsx
@@ -40,7 +40,10 @@ const Routes = ({ konnectorRoot, konnector, onDismiss }) => {
     <MountPointProvider baseRoute={konnectorRoot}>
       <DialogContext.Provider value={dialogContext}>
         <HarvestVaultProvider>
-          <HarvestDialog {...dialogContext.dialogProps} aria-label={konnector.name}>
+          <HarvestDialog
+            {...dialogContext.dialogProps}
+            aria-label={konnector.name}
+          >
             <DialogCloseButton onClick={onDismiss} />
             <KonnectorAccounts konnector={konnector}>
               {accountsAndTriggers => (

--- a/packages/cozy-harvest-lib/src/components/hooks/useDOMMutations.jsx
+++ b/packages/cozy-harvest-lib/src/components/hooks/useDOMMutations.jsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+
+const useDOMMutations = (node, config, cb) => {
+  useEffect(() => {
+    let observer
+    if (!window.MutationObserver) {
+      return
+    }
+    if (node) {
+      observer = new MutationObserver(cb)
+      observer.observe(node, config)
+    }
+    return () => {
+      observer && observer.disconnect()
+    }
+  }, [node, config, cb])
+}
+
+export default useDOMMutations


### PR DESCRIPTION
- Do not center the modal to prevent jumps due to tab change
- Update modal height after subtree change