### PR TITLE
fix: Close edit contract modal on escape

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/EditContract.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/EditContract.jsx
@@ -176,11 +176,12 @@ const EditContract = props => {
 
   const { dialogProps, dialogTitleProps } = useCozyDialog({
     size: 'medium',
-    open: true
+    open: true,
+    onClose
   })
 
   return (
-    <Dialog onClose={onClose} {...dialogProps}>
+    <Dialog {...dialogProps}>
       <DialogCloseButton onClick={onClose} />
       <DialogTitle {...dialogTitleProps}>
         {isMobile ? <DialogBackButton onClick={onClose} /> : null}


### PR DESCRIPTION
onClose was overriden by the dialogProps, we need to pass onClose to
useCozyDialog