### PR TITLE
fix: Rename vehicle registration

### DIFF
--- a/packages/cozy-scanner/src/locales/en.json
+++ b/packages/cozy-scanner/src/locales/en.json
@@ -55,7 +55,7 @@
       "prescription": "Prescription",
       "health_invoice": "Health invoice",
       "other_health_document": "Other health document",
-      "vehicle_registration": "Regisration",
+      "vehicle_registration": "Vehicle registration",
       "car_insurance": "Car insurance",
       "mechanic_invoice": "Repair bill",
       "transport_invoice": "Transport invoice",


### PR DESCRIPTION
The previous label had a typo + was missing precision about the vehicle