### PR TITLE
feat: Fetch documents through cozy-client helper

### DIFF
--- a/packages/cozy-procedures/package.json
+++ b/packages/cozy-procedures/package.json
@@ -36,7 +36,7 @@
     "@material-ui/lab": "^3.0.0-alpha.30",
     "babel-plugin-inline-react-svg": "^1.1.0",
     "babel-preset-cozy-app": "^1.10.0",
-    "cozy-client": "13.15.1",
+    "cozy-client": "16.13.1",
     "cozy-ui": "40.9.1",
     "enzyme-to-json": "3.4.4",
     "jest": "26.2.2",
@@ -46,7 +46,7 @@
     "@babel/runtime": ">=7.12.5",
     "@material-ui/core": ">=3.9.4",
     "@material-ui/lab": ">=3.0.0-alpha.30",
-    "cozy-client": ">=13.15.1",
+    "cozy-client": ">=16.13.1",
     "cozy-doctypes": ">=1.49.3",
     "cozy-realtime": "^3.11.0",
     "cozy-ui": ">=40.9.1"

--- a/packages/cozy-procedures/src/Procedure.jsx
+++ b/packages/cozy-procedures/src/Procedure.jsx
@@ -34,7 +34,7 @@ class Procedure extends React.Component {
 
     const { documents: documentsCategory } = creditApplicationTemplate
     Object.keys(documentsCategory).map(document => {
-      fetchDocumentsByCategory(document)
+      fetchDocumentsByCategory(client, document)
     })
   }
 

--- a/packages/cozy-procedures/src/redux/documentsDataSlice.js
+++ b/packages/cozy-procedures/src/redux/documentsDataSlice.js
@@ -1,7 +1,8 @@
 import { createSlice } from 'redux-starter-kit'
 import get from 'lodash/get'
 import { creditApplicationTemplate } from 'cozy-procedures'
-import { AdministrativeProcedure } from 'cozy-doctypes'
+import { models } from 'cozy-client'
+const { fetchFilesByQualificationRules } = models.file
 
 const documentsSlice = createSlice({
   initialState: {
@@ -124,7 +125,7 @@ export const {
   setLoadingFalse
 } = actions
 
-export function fetchDocumentsByCategory(documentTemplate) {
+export function fetchDocumentsByCategory(client, documentTemplate) {
   return async dispatch => {
     try {
       const docWithRules = creditApplicationTemplate.documents[documentTemplate]
@@ -136,9 +137,7 @@ export function fetchDocumentsByCategory(documentTemplate) {
           })
         )
       }
-
-      const files = await AdministrativeProcedure.getFilesByRules(docWithRules)
-
+      const files = await fetchFilesByQualificationRules(client, docWithRules)
       if (files.data) {
         files.data.map((file, index) => {
           dispatch(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5164,6 +5164,28 @@ cozy-client@16.2.0:
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
+cozy-client@16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-16.13.1.tgz#a944002f74bbc98dd9d052d08ef1349a6461652a"
+  integrity sha512-VrrH83jbHDVy4t1D/mKHVSwjGQPQsDklYz8lB8bRB7ioAF9BN5afvCYJBnoQKp8vrCWxzJZJrDgsgbTvaQW9FA==
+  dependencies:
+    "@cozy/minilog" "1.0.0"
+    btoa "^1.2.1"
+    cozy-device-helper "^1.7.3"
+    cozy-logger "^1.6.0"
+    cozy-stack-client "^16.12.0"
+    lodash "^4.17.13"
+    microee "^0.0.6"
+    node-fetch "^2.6.1"
+    open "^7.0.2"
+    prop-types "^15.6.2"
+    react-redux "^7.2.0"
+    redux "^3.7.2"
+    redux-thunk "^2.3.0"
+    server-destroy "^1.0.1"
+    sift "^6.0.0"
+    url-search-params-polyfill "^7.0.0"
+
 cozy-client@16.8.0:
   version "16.8.0"
   resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-16.8.0.tgz#44378ed226697a1d4000f8ac6b5f7ca1ba66bd01"


### PR DESCRIPTION
We moved this fetching in cozy-client as it is where the qualification
model is handled. This also fix a bug where documents without
`metadata.datetime` were filtered out.