### PR TITLE
feat: Add KonnectorBlock to show konnector informations

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -51,7 +51,7 @@
     "babel-jest": "26.6.3",
     "babel-plugin-inline-react-svg": "^1.1.0",
     "babel-preset-cozy-app": "^1.10.0",
-    "cozy-client": "14.4.0",
+    "cozy-client": "16.17.0",
     "cozy-device-helper": "^1.11.0",
     "cozy-flags": "^2.5.0",
     "cozy-keys-lib": "3.7.0",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "@babel/runtime": ">=7.12.5",
-    "cozy-client": ">=14.4.0",
+    "cozy-client": ">=16.17.0",
     "cozy-device-helper": ">=1.10.2",
     "cozy-flags": ">=2.3.5",
     "cozy-keys-lib": ">=3.7.0",

--- a/packages/cozy-harvest-lib/src/components/KonnectorBlock.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorBlock.jsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import get from 'lodash/get'
+
+import { useQuery, useClient } from 'cozy-client'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import { generateUniversalLink } from 'cozy-ui/transpiled/react/AppLinker'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
+import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
+import ListItemSecondaryAction from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemSecondaryAction'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
+import GlobeIcon from 'cozy-ui/transpiled/react/Icons/Globe'
+import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
+
+import withLocales from './hoc/withLocales'
+import { buildKonnectorQuery } from '../helpers/queries'
+
+const KonnectorBlock = ({ file }) => {
+  const client = useClient()
+  const { t } = useI18n()
+
+  const slug = get(file, 'cozyMetadata.uploadedBy.slug')
+
+  const konnectorQuery = buildKonnectorQuery(slug)
+  const konnectorQueryDef = konnectorQuery.definition()
+  konnectorQueryDef.sources = ['stack', 'registry']
+
+  const { data, fetchStatus } = useQuery(
+    konnectorQueryDef,
+    konnectorQuery.options
+  )
+
+  if (fetchStatus !== 'loaded' || !data.length > 0) {
+    return (
+      <div data-testid="KonnectorBlock-spinner">
+        <Spinner className="u-flex u-flex-justify-center u-p-2" size="large" />
+      </div>
+    )
+  }
+
+  const sourceAccount = get(file, 'cozyMetadata.sourceAccount')
+  const link = generateUniversalLink({
+    cozyUrl: client.getStackClient().uri,
+    slug: 'home',
+    subDomainType: client.getInstanceOptions().cozySubdomainType,
+    nativePath: `connected/${slug}/accounts/${sourceAccount}`
+  })
+  const konnector = data[0].attributes
+
+  return (
+    <List>
+      <ListItem className="u-ph-2 u-h-3" button component="a" href={link}>
+        <ListItemIcon>
+          <AppIcon app={konnector.slug} />
+        </ListItemIcon>
+        <ListItemText
+          primary={konnector.name}
+          primaryTypographyProps={{ variant: 'h6' }}
+        />
+        <ListItemSecondaryAction>
+          <Icon
+            icon={RightIcon}
+            className="u-mr-1"
+            color="var(--secondaryTextColor)"
+          />
+        </ListItemSecondaryAction>
+      </ListItem>
+
+      <Divider component="li" />
+
+      <ListItem
+        className="u-ph-2"
+        button
+        component="a"
+        href={konnector.vendor_link}
+        target="_blank"
+      >
+        <ListItemIcon>
+          <Icon icon={GlobeIcon} color="var(--primaryTextColor)" />
+        </ListItemIcon>
+        <ListItemText
+          primary={t('konnectorBlock.account')}
+          secondary={konnector.vendor_link}
+        />
+      </ListItem>
+    </List>
+  )
+}
+
+KonnectorBlock.propTypes = {
+  file: PropTypes.object.isRequired
+}
+
+export default withLocales(KonnectorBlock)

--- a/packages/cozy-harvest-lib/src/components/KonnectorBlock.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorBlock.spec.jsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import { createMockClient, useQuery } from 'cozy-client'
+
+import AppLike from '../../test/AppLike'
+import KonnectorBlock from './KonnectorBlock'
+import en from '../locales/en.json'
+
+jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
+const client = createMockClient({})
+client.getStackClient = jest.fn(() => ({ uri: 'http://cozy.tools:8080' }))
+
+const setup = ({
+  file = {},
+  queryRes = {
+    data: [],
+    fetchStatus: 'pending',
+    hasMore: false,
+    fetchMore: jest.fn()
+  }
+} = {}) => {
+  useQuery.mockReturnValue(queryRes)
+
+  const root = render(
+    <AppLike client={client}>
+      <KonnectorBlock file={file} />
+    </AppLike>
+  )
+  return { root }
+}
+
+describe('KonnectorBlock', () => {
+  it('should show a spinner while there is no data to show', () => {
+    const { root } = setup()
+    const { getByTestId } = root
+
+    expect(getByTestId('KonnectorBlock-spinner'))
+  })
+
+  it('should show konnector title and its link, also customer account and its link', () => {
+    const { root } = setup({
+      file: {
+        cozyMetadata: {
+          uploadedBy: { slug: 'pajemploi' },
+          sourceAccount: '012345'
+        }
+      },
+      queryRes: {
+        data: [
+          {
+            id: 'fromStack',
+            type: 'type',
+            attributes: {
+              slug: 'pajemploi',
+              name: 'Pajemploi',
+              vendor_link: 'https://www.pajemploi.urssaf.fr/'
+            }
+          }
+        ],
+        fetchStatus: 'loaded'
+      }
+    })
+    const { getByText } = root
+
+    expect(getByText('Pajemploi'))
+    expect(getByText('Pajemploi').closest('a')).toHaveAttribute(
+      'href',
+      `https://links.mycozy.cloud/home/connected/pajemploi/accounts/012345?fallback=${encodeURIComponent(
+        'http://cozy-home.tools:8080/#/connected/pajemploi/accounts/012345'
+      )}`
+    )
+    expect(getByText('https://www.pajemploi.urssaf.fr/'))
+    expect(
+      getByText('https://www.pajemploi.urssaf.fr/').closest('a')
+    ).toHaveAttribute('href', 'https://www.pajemploi.urssaf.fr/')
+    expect(getByText(en.konnectorBlock.account))
+  })
+})

--- a/packages/cozy-harvest-lib/src/helpers/queries.js
+++ b/packages/cozy-harvest-lib/src/helpers/queries.js
@@ -1,0 +1,15 @@
+import CozyClient, { Q } from 'cozy-client'
+
+const DEFAULT_CACHE_TIMEOUT_QUERIES = 9 * 60 * 1000
+const defaultFetchPolicy = CozyClient.fetchPolicies.olderThan(
+  DEFAULT_CACHE_TIMEOUT_QUERIES
+)
+
+export const buildKonnectorQuery = slug => ({
+  definition: () =>
+    Q('io.cozy.konnectors').getById(`io.cozy.konnectors/${slug}`),
+  options: {
+    as: `konnector-${slug}`,
+    fetchPolicy: defaultFetchPolicy
+  }
+})

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -474,8 +474,10 @@
       "secondaryText": "Cancel"
     }
   },
-
   "disconnectedAccountModal": {
     "disconnected-help": "This account is disconnected. Your data has been kept. If you want to restart the synchronisation, please reconfigure your account with the \"Add a bank\" button."
+  },
+  "konnectorBlock": {
+    "account": "Customer account"
   }
 }

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -474,8 +474,10 @@
       "secondaryText": "Annuler"
     }
   },
-
   "disconnectedAccountModal": {
     "disconnected-help": "Vous avez déconnecté votre compte. Vous conservez l'historique de vos données déjà importées. Si vous souhaitez reprendre la connexion, reconfigurez votre compte depuis le bouton \"Ajouter une banque\"."
+  },
+  "konnectorBlock": {
+    "account": "Compte client"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5172,28 +5172,6 @@ cozy-client@13.15.1:
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
-cozy-client@14.4.0:
-  version "14.4.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-14.4.0.tgz#4ea5026dfe33d81e97e86dfdc6f46c6761fcf794"
-  integrity sha512-H5Tzcj/5aHnUQfzduU2a68fOWJsS61tAb+Awkm56x6yc/1wAbQb88qoKX6C/VRdJZlJNUbdNb4ti6nj0Bh+ebg==
-  dependencies:
-    btoa "^1.2.1"
-    cozy-device-helper "^1.7.3"
-    cozy-logger "^1.6.0"
-    cozy-stack-client "^14.1.2"
-    isomorphic-fetch "^2.2.1"
-    lodash "^4.17.13"
-    microee "^0.0.6"
-    minilog "https://github.com/cozy/minilog.git#master"
-    open "^7.0.2"
-    prop-types "^15.6.2"
-    react-redux "^7.2.0"
-    redux "^3.7.2"
-    redux-thunk "^2.3.0"
-    server-destroy "^1.0.1"
-    sift "^6.0.0"
-    url-search-params-polyfill "^7.0.0"
-
 cozy-client@16.12.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-16.12.0.tgz#081bf9b6e4f5e55dba6614fd5e6cbc8ccfece9eb"
@@ -5226,6 +5204,28 @@ cozy-client@16.13.1:
     cozy-device-helper "^1.7.3"
     cozy-logger "^1.6.0"
     cozy-stack-client "^16.12.0"
+    lodash "^4.17.13"
+    microee "^0.0.6"
+    node-fetch "^2.6.1"
+    open "^7.0.2"
+    prop-types "^15.6.2"
+    react-redux "^7.2.0"
+    redux "^3.7.2"
+    redux-thunk "^2.3.0"
+    server-destroy "^1.0.1"
+    sift "^6.0.0"
+    url-search-params-polyfill "^7.0.0"
+
+cozy-client@16.17.0:
+  version "16.17.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-16.17.0.tgz#60721acc2fd7cb5cb09f69dc3dc433bfa4d74ae9"
+  integrity sha512-PicLBQJK73vmYMxaXUrOJopMWRnyBgkmWqp8k9rK6XJg0gNQweIGz74b/yjlb2sQacANR6ewcbxR4Kk0SJ8yng==
+  dependencies:
+    "@cozy/minilog" "1.0.0"
+    btoa "^1.2.1"
+    cozy-device-helper "^1.7.3"
+    cozy-logger "^1.6.0"
+    cozy-stack-client "^16.17.0"
     lodash "^4.17.13"
     microee "^0.0.6"
     node-fetch "^2.6.1"
@@ -5307,19 +5307,20 @@ cozy-stack-client@13.15.1, cozy-stack-client@^13.15.1:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^14.1.2:
-  version "14.1.2"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-14.1.2.tgz#606ce89cabf4def2875cb8749b28b3ee8b96d18f"
-  integrity sha512-0IyYvBQu+vuwN9qe6PHA7khXBQT8TGSjVia7SVTGQ88tEFSLLGXjfZe3pkZQ1ihBdJvmeon12dm0BWeEb+9KZw==
-  dependencies:
-    detect-node "^2.0.4"
-    mime "^2.4.0"
-    qs "^6.7.0"
-
 cozy-stack-client@^16.12.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-16.12.0.tgz#243d35058e2660f3923721ae91ae272a46d7e6ba"
   integrity sha512-oLWDSFMXbqKDjFAS9saj0U4X9LTfA45JZPPF6p5T2+mYAV4m7NW4pEdv3aYx43z0I9jhyRJyBhiI8E6GYLAjTA==
+  dependencies:
+    cozy-flags "^2.5.0"
+    detect-node "^2.0.4"
+    mime "^2.4.0"
+    qs "^6.7.0"
+
+cozy-stack-client@^16.17.0:
+  version "16.17.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-16.17.0.tgz#0b7e78473de86b81f6bf143b66b284ddbcc89544"
+  integrity sha512-tjpZrnjBcvFA/X9lcUxomfhxt3/BVJoEygSzWrBUJlrzi/lFYxSN9Rg75Q72Bd30+i3BuDFugZe6056yYjxVvg==
   dependencies:
     cozy-flags "^2.5.0"
     detect-node "^2.0.4"


### PR DESCRIPTION
On souhaite avoir un composant standalone qui permet d'afficher un bloc d'information sur le connecteur, afin entre autre d'agrémenter le Viewer augmenté.

Ceci est une première étape qui consiste à afficher le nom du connecteur avec un lien vers la popup d'harvest (il n'y a donc pas l'email ni le téléphone), ainsi que le compte client.

![image](https://user-images.githubusercontent.com/67680939/105859084-67016f80-5fec-11eb-9478-dcc83ab7f7a4.png)

