### PR TITLE
feat: Add sentry integration to harvest connection flow

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@cozy/minilog": "^1.0.0",
     "@material-ui/core": "3",
+    "@sentry/browser": "^6.0.1",
     "cozy-bi-auth": "0.0.16",
     "cozy-doctypes": "^1.75.2",
     "cozy-logger": "^1.6.0",

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -21,6 +21,7 @@ import { createOrUpdateCipher } from '../models/cipherUtils'
 import assert from '../assert'
 import * as accounts from '../helpers/accounts'
 import * as triggersModel from '../helpers/triggers'
+import sentryHub from '../sentry'
 
 const JOBS_DOCTYPE = 'io.cozy.jobs'
 
@@ -416,6 +417,10 @@ export class ConnectionFlow {
       logger.error(e)
       this.setState({ accountError: e })
       this.triggerEvent(ERROR_EVENT, e)
+      sentryHub.withScope(scope => {
+        scope.setTag('konnector', konnector.slug)
+        sentryHub.captureException(e)
+      })
       throw e
     }
   }

--- a/packages/cozy-harvest-lib/src/sentry.js
+++ b/packages/cozy-harvest-lib/src/sentry.js
@@ -1,0 +1,21 @@
+import * as Sentry from '@sentry/browser'
+
+/**
+ * Creates a Sentry client connected to the Harvest project
+ *
+ * @param {SentryClient}
+ */
+export const client = new Sentry.BrowserClient({
+  dsn: 'https://888abd94993a47a39e751598fc6be803@sentry.cozycloud.cc/145',
+  integrations: Sentry.defaultIntegrations,
+  beforeSend(event) {
+    if (process.env.NODE_ENV === 'production') {
+      return null
+    }
+    return event
+  }
+})
+
+export const hub = new Sentry.Hub(client)
+
+export default hub

--- a/yarn.lock
+++ b/yarn.lock
@@ -2680,6 +2680,58 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.4.tgz#11d5db19bd178936ec89cd84519c4de439574398"
   integrity sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg==
 
+"@sentry/browser@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.0.1.tgz#5d0b8e3bc893c1c7e55a9238e23ed47adf264fa2"
+  integrity sha512-iP8Bqxj4Ye8CXA4ja77buPZfXsKiZYUgHFzBQxVMihTHA8ZZLgBMPLQI6uFfHuJJW+1/yLzOf8BhvF2zknAebg==
+  dependencies:
+    "@sentry/core" "6.0.1"
+    "@sentry/types" "6.0.1"
+    "@sentry/utils" "6.0.1"
+    tslib "^1.9.3"
+
+"@sentry/core@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.0.1.tgz#4024b2b04e5ce78ce35d7795a283fbd235f37757"
+  integrity sha512-EoxgodyClasI8PA4GyU8Cp88W3R5ebpiLsE7fCcBcOU0DOBRkO8GAZ5IzfCDtYDJ50c9npivum5Oyj2wf8CXYw==
+  dependencies:
+    "@sentry/hub" "6.0.1"
+    "@sentry/minimal" "6.0.1"
+    "@sentry/types" "6.0.1"
+    "@sentry/utils" "6.0.1"
+    tslib "^1.9.3"
+
+"@sentry/hub@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.0.1.tgz#6a338522f62d6d6282822e16da4385a5a854f0a8"
+  integrity sha512-pGckNdhKcr7qYVXgSgA/QVGArATcmQu54YFAR5xTnkWVHpAwNmh0fc4CJCc4JBwS/LXSU1Y0nYiLQduVfnv8Cg==
+  dependencies:
+    "@sentry/types" "6.0.1"
+    "@sentry/utils" "6.0.1"
+    tslib "^1.9.3"
+
+"@sentry/minimal@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.0.1.tgz#f970a59b024d08e61e00d518081eb4b7591f3d77"
+  integrity sha512-TQ/M5A+OsxtQJ8dzHwrclxKXpJNdQeM1PUoYhff4BvsOXJScvZb7+Yn0OUEQXEc9pSMNt62tnQy4ct80iAMTHw==
+  dependencies:
+    "@sentry/hub" "6.0.1"
+    "@sentry/types" "6.0.1"
+    tslib "^1.9.3"
+
+"@sentry/types@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.0.1.tgz#4d1a281a4a79541b607361523e08058c6676409e"
+  integrity sha512-cEoe19vtam75Tf6eWmaobfbeV8XwBdr5FJoSVTomzcSsEiP2FHGOEhlE7kVBigzeH5Lri0aibiW6BDi1hIqHdg==
+
+"@sentry/utils@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.0.1.tgz#061ef604df519e1488960484e9bf0cbcb8d8c9a4"
+  integrity sha512-bjGuBYnG6fulZ8mLhPGBxttNu96DCN6d7Glw2sfLf4aurn1kjJ/58hP2c8dH0OqWO5e+rGYTsZ5Dr5kqVKNGTg==
+  dependencies:
+    "@sentry/types" "6.0.1"
+    tslib "^1.9.3"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.0.tgz#c8d68821a854c555bba172f3b06959a0039b236d"


### PR DESCRIPTION
First step in the integration of Sentry. Next step would be to
integrate a React error boundary connected to the hub, wrapping all
the Harvest routes. Since sentry React integration uses the global hub,
we cannot use directly.

We use a Hub instead of a global Sentry since harvest is used by other apps.