### PR TITLE
Sentry fixes

### DIFF
--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -411,7 +411,9 @@ export class ConnectionFlow {
       this.triggerEvent(ERROR_EVENT, e)
       sentryHub.withScope(scope => {
         scope.setTag('konnector', konnector.slug)
-        sentryHub.captureException(e)
+
+        // Capture the original exception instead of the user one
+        sentryHub.captureException(e.original || e)
       })
       throw e
     }

--- a/packages/cozy-harvest-lib/src/sentry.js
+++ b/packages/cozy-harvest-lib/src/sentry.js
@@ -9,7 +9,7 @@ export const client = new Sentry.BrowserClient({
   dsn: 'https://888abd94993a47a39e751598fc6be803@sentry.cozycloud.cc/145',
   integrations: Sentry.defaultIntegrations,
   beforeSend(event) {
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env.NODE_ENV !== 'production') {
       return null
     }
     return event


### PR DESCRIPTION
- Correctly send events in production
- Send original error instead of the konnector job error that is more for users