### PR TITLE
Improve 2FA process

### DIFF
--- a/packages/cozy-harvest-lib/README.md
+++ b/packages/cozy-harvest-lib/README.md
@@ -84,7 +84,7 @@ For now it is possible to instanciate a `<TriggerManager />` which will allow to
 As this component uses CozyClient, it must be wrapped at some point into a [`<CozyProvider />`](https://github.com/cozy/cozy-client/blob/master/docs/getting-started.md#wrapping-the-app-in-a-cozyprovider).
 
 ```js
-import CozyClient, { CozyProvider } from 'cozy-client'
+import CozyClient, { CozyProvider, Q } from 'cozy-client'
 import { TriggerManager } from 'cozy-harvest-lib'
 
 const client = new CozyClient({
@@ -93,8 +93,8 @@ const client = new CozyClient({
 
 ReactDOM.render(
   <CozyProvider client={client}>
-    <Query query={client => client.get('io.cozy.apps', 'my-konnector-id')}>
-      {konnector => (
+    <Query query={()=> Q('io.cozy.apps').getById('my-konnector-id')}>
+      {({ data: konnector }) => (
         <TriggerManager
           konnector={konnector}
           onSuccessLogin={() => alert('logged in')}

--- a/packages/cozy-harvest-lib/src/components/FlowProvider.jsx
+++ b/packages/cozy-harvest-lib/src/components/FlowProvider.jsx
@@ -25,7 +25,7 @@ import ConnectionFlow, {
  * <FlowProvider initialTrigger={trigger}>
  *   {({ flow }) => {
  *     const flowState = flow.getState()
- *     return <Button onClick={() => flow.launch(trigger)} disabled={running} />
+ *     return <Button onClick={() => flow.launch()} disabled={running} />
  *    }}
  * </FlowProvider>
  * ```

--- a/packages/cozy-harvest-lib/src/components/FlowProvider.jsx
+++ b/packages/cozy-harvest-lib/src/components/FlowProvider.jsx
@@ -4,6 +4,7 @@ import { withClient } from 'cozy-client'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 
 import TwoFAModal from './TwoFAModal'
+import logger from '../logger'
 import ConnectionFlow, {
   ERROR_EVENT,
   SUCCESS_EVENT,
@@ -60,7 +61,9 @@ export class FlowProvider extends Component {
   }
 
   handleFlowUpdate() {
-    this.setState({ flowState: this.flow.getState() })
+    const flowState = this.flow.getState()
+    logger.info('FlowProvider: Handle flow update', flowState)
+    this.setState({ flowState })
   }
 
   stopWatchingConnectionFlow() {
@@ -78,19 +81,23 @@ export class FlowProvider extends Component {
   }
 
   handleTriggerLaunch(trigger) {
+    logger.info('FlowProvider: Dismissing two fa modal')
     const { onLaunch } = this.props
     if (typeof onLaunch === 'function') onLaunch(trigger)
   }
 
   dismissTwoFAModal() {
+    logger.info('FlowProvider: Dismissing two fa modal')
     this.setState({ showTwoFAModal: false })
   }
 
   displayTwoFAModal() {
+    logger.info('FlowProvider: Show two fa modal')
     this.setState({ showTwoFAModal: true })
   }
 
   handleError(error) {
+    logger.info('FlowProvider: Handle error')
     if (this.state.showTwoFAModal) {
       this.dismissTwoFAModal()
     }
@@ -109,6 +116,7 @@ export class FlowProvider extends Component {
    *
    */
   handleSuccess() {
+    logger.info('FlowProvider: Handle success')
     if (this.state.showTwoFAModal) {
       this.dismissTwoFAModal()
     }
@@ -118,6 +126,7 @@ export class FlowProvider extends Component {
   }
 
   handleLoginSuccess() {
+    logger.info('FlowProvider: Handle success')
     if (this.state.showTwoFAModal) {
       this.dismissTwoFAModal()
     }

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
@@ -36,6 +36,8 @@ import TriggerErrorInfo from '../../infos/TriggerErrorInfo'
 import { MountPointContext } from '../../MountPointContext'
 import { useTrackPage, useTracker } from '../../hoc/tracking'
 
+import RedirectToAccountFormButton from '../../RedirectToAccountFormButton'
+
 import tabSpecs from '../tabSpecs'
 import { ContractsForAccount } from './Contracts'
 
@@ -147,6 +149,15 @@ const ConfigurationTab = ({
           className={isMobile ? 'u-mv-2' : 'u-mb-2'}
           error={error}
           konnector={konnector}
+          trigger={flow.trigger}
+          action={
+            error.isSolvableViaReconnect() ? (
+              <RedirectToAccountFormButton
+                konnector={konnector}
+                trigger={flow.trigger}
+              />
+            ) : null
+          }
         />
       )}
       <NavigationList style={isMobile ? tabMobileNavListStyle : null}>

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.spec.jsx
@@ -100,86 +100,88 @@ describe('ConfigurationTab', () => {
     expect(root.getByText('Identifiers')).toBeTruthy()
   })
 
-  it('should display deletion modal when clicking on disconnect this account (vault does not need to be unlocked)', async () => {
-    const { root } = setup({
-      checkShouldUnlock: jest.fn().mockResolvedValue(false)
+  describe('deletion modal', () => {
+    it('should display deletion modal when clicking on disconnect this account (vault does not need to be unlocked)', async () => {
+      const { root } = setup({
+        checkShouldUnlock: jest.fn().mockResolvedValue(false)
+      })
+      useVaultClient.mockReturnValue({
+        isLocked: jest.fn().mockResolvedValue(false)
+      })
+      findKonnectorPolicy.mockReturnValue({ saveInVault: true })
+      const btn = root.getByText('Disconnect this account')
+      const modalText =
+        'Your account will be disconnected, but already imported data will be kept.'
+      expect(root.queryByText(modalText)).toBeFalsy()
+      fireEvent.click(btn)
+      expect(root.getByText(modalText))
+      expect(deleteAccount).not.toHaveBeenCalled()
+      const confirmBtn = root.getByText('Disconnect')
+      await act(async () => {
+        fireEvent.click(confirmBtn)
+      })
+      expect(deleteAccount).toHaveBeenCalled()
     })
-    useVaultClient.mockReturnValue({
-      isLocked: jest.fn().mockResolvedValue(false)
-    })
-    findKonnectorPolicy.mockReturnValue({ saveInVault: true })
-    const btn = root.getByText('Disconnect this account')
-    const modalText =
-      'Your account will be disconnected, but already imported data will be kept.'
-    expect(root.queryByText(modalText)).toBeFalsy()
-    fireEvent.click(btn)
-    expect(root.getByText(modalText))
-    expect(deleteAccount).not.toHaveBeenCalled()
-    const confirmBtn = root.getByText('Disconnect')
-    await act(async () => {
-      fireEvent.click(confirmBtn)
-    })
-    expect(deleteAccount).toHaveBeenCalled()
-  })
 
-  it('should display deletion modal when clicking on disconnect this account (vault needs to be unlocked, connector policy does not save in vault)', async () => {
-    findKonnectorPolicy.mockReturnValue({ saveInVault: false })
-    const { root } = setup({
-      checkShouldUnlock: jest.fn().mockResolvedValue(true)
-    })
-    const btn = root.getByText('Disconnect this account')
-    expect(
-      root.queryByText(
-        'Your account will be disconnected, but already imported data will be kept.'
+    it('should display deletion modal when clicking on disconnect this account (vault needs to be unlocked, connector policy does not save in vault)', async () => {
+      findKonnectorPolicy.mockReturnValue({ saveInVault: false })
+      const { root } = setup({
+        checkShouldUnlock: jest.fn().mockResolvedValue(true)
+      })
+      const btn = root.getByText('Disconnect this account')
+      expect(
+        root.queryByText(
+          'Your account will be disconnected, but already imported data will be kept.'
+        )
+      ).toBeFalsy()
+      fireEvent.click(btn)
+      expect(
+        root.getByText(
+          'Your account will be disconnected, but already imported data will be kept.'
+        )
       )
-    ).toBeFalsy()
-    fireEvent.click(btn)
-    expect(
-      root.getByText(
-        'Your account will be disconnected, but already imported data will be kept.'
-      )
-    )
-    expect(deleteAccount).not.toHaveBeenCalled()
-    const confirmBtn = root.getByText('Disconnect')
-    await act(async () => {
-      fireEvent.click(confirmBtn)
+      expect(deleteAccount).not.toHaveBeenCalled()
+      const confirmBtn = root.getByText('Disconnect')
+      await act(async () => {
+        fireEvent.click(confirmBtn)
+      })
+      expect(deleteAccount).toHaveBeenCalled()
     })
-    expect(deleteAccount).toHaveBeenCalled()
-  })
 
-  it('should display deletion modal when clicking on disconnect this account (vault needs to be unlocked, connector policy saves in vault)', async () => {
-    findKonnectorPolicy.mockReturnValue({ saveInVault: true })
-    useVaultClient.mockReturnValue({
-      isLocked: jest.fn().mockResolvedValue(true)
-    })
-    const { root } = setup({
-      checkShouldUnlock: jest.fn().mockResolvedValue(true)
-    })
-    const btn = root.getByText('Disconnect this account')
-    expect(
-      root.queryByText(
-        'Your account will be disconnected, but already imported data will be kept.'
+    it('should display deletion modal when clicking on disconnect this account (vault needs to be unlocked, connector policy saves in vault)', async () => {
+      findKonnectorPolicy.mockReturnValue({ saveInVault: true })
+      useVaultClient.mockReturnValue({
+        isLocked: jest.fn().mockResolvedValue(true)
+      })
+      const { root } = setup({
+        checkShouldUnlock: jest.fn().mockResolvedValue(true)
+      })
+      const btn = root.getByText('Disconnect this account')
+      expect(
+        root.queryByText(
+          'Your account will be disconnected, but already imported data will be kept.'
+        )
+      ).toBeFalsy()
+      fireEvent.click(btn)
+      expect(
+        root.getByText(
+          'Your account will be disconnected, but already imported data will be kept.'
+        )
       )
-    ).toBeFalsy()
-    fireEvent.click(btn)
-    expect(
-      root.getByText(
-        'Your account will be disconnected, but already imported data will be kept.'
-      )
-    )
-    expect(deleteAccount).not.toHaveBeenCalled()
-    const confirmBtn = root.getByText('Disconnect')
-    await act(async () => {
-      fireEvent.click(confirmBtn)
-    })
-    expect(deleteAccount).not.toHaveBeenCalled()
+      expect(deleteAccount).not.toHaveBeenCalled()
+      const confirmBtn = root.getByText('Disconnect')
+      await act(async () => {
+        fireEvent.click(confirmBtn)
+      })
+      expect(deleteAccount).not.toHaveBeenCalled()
 
-    // Since the konnector saves the cipher in the vault, we need to unlock the
-    // vault, for the cipher to be correctly unshared from the vault
-    await act(async () => {
-      fireEvent.click(root.getByText('Unlock'))
+      // Since the konnector saves the cipher in the vault, we need to unlock the
+      // vault, for the cipher to be correctly unshared from the vault
+      await act(async () => {
+        fireEvent.click(root.getByText('Unlock'))
+      })
+      expect(deleteAccount).toHaveBeenCalled()
     })
-    expect(deleteAccount).toHaveBeenCalled()
   })
 
   it('should not render identifiers for oauth konnectors', () => {

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { withClient } from 'cozy-client'
-
 import Stack from 'cozy-ui/transpiled/react/Stack'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
@@ -17,6 +16,7 @@ import getRelatedAppsSlugs from '../../../models/getRelatedAppsSlugs'
 import appLinksProps from '../../../components/KonnectorConfiguration/DataTab/appLinksProps'
 import tabSpecs from '../tabSpecs'
 import { useTrackPage } from '../../../components/hoc/tracking'
+import RedirectToAccountFormButton from '../../RedirectToAccountFormButton'
 
 export const DataTab = ({ konnector, trigger, client, flow }) => {
   const { isMobile } = useBreakpoints()
@@ -68,7 +68,18 @@ export const DataTab = ({ konnector, trigger, client, flow }) => {
           />
         )}
         {shouldDisplayError && hasGenericError && (
-          <TriggerErrorInfo error={error} konnector={konnector} />
+          <TriggerErrorInfo
+            error={error}
+            konnector={konnector}
+            action={
+              error.isSolvableViaReconnect() ? (
+                <RedirectToAccountFormButton
+                  konnector={konnector}
+                  trigger={trigger}
+                />
+              ) : null
+            }
+          />
         )}
         <LaunchTriggerCard flow={flow} disabled={isInMaintenance} />
         {appLinks.map(({ slug, ...otherProps }) => (

--- a/packages/cozy-harvest-lib/src/components/RedirectToAccountFormButton.jsx
+++ b/packages/cozy-harvest-lib/src/components/RedirectToAccountFormButton.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { withRouter } from 'react-router'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Button from 'cozy-ui/transpiled/react/Button'
+import { getAccountId } from '../helpers/triggers'
+
+const RedirectToAccountFormButton = ({ konnector, trigger, history }) => {
+  const { t } = useI18n()
+  const accountId = getAccountId(trigger)
+  return (
+    <Button
+      className="u-ml-0"
+      theme="secondary"
+      label={t('error.reconnect-via-form')}
+      onClick={() =>
+        history.push(`/connected/${konnector.slug}/accounts/${accountId}/edit`)
+      }
+    />
+  )
+}
+
+export default withRouter(RedirectToAccountFormButton)

--- a/packages/cozy-harvest-lib/src/components/cards/AppLinkCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/AppLinkCard.jsx
@@ -41,7 +41,7 @@ const AppLinkCard = ({ slug, path, icon, iconColor }) => {
         <Typography variant="body1">
           {t(`card.appLink.${slug}.description`)}
         </Typography>
-        <AppLinker slug={slug} nativePath={path} href={url}>
+        <AppLinker slug={slug} nativePath={path} href={url || '#'}>
           {({ onClick, href }) => (
             <ButtonLink
               onClick={fetchStatus !== 'loaded' ? onClick : null}

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
@@ -56,7 +56,7 @@ export const DumbLaunchTriggerCard = ({ flow, className, f, t, disabled }) => {
             icon={<Icon focusable="false" icon={SyncIcon} spin={running} />}
             className="u-mh-0 u-mv-0"
             disabled={running || disabled}
-            onClick={() => launch(trigger)}
+            onClick={() => launch({ autoSuccessTimer: false })}
             subtle
             style={{ lineHeight: '1.4' }}
           />

--- a/packages/cozy-harvest-lib/src/components/infos/TriggerErrorInfo.jsx
+++ b/packages/cozy-harvest-lib/src/components/infos/TriggerErrorInfo.jsx
@@ -19,11 +19,12 @@ import Markdown from '../Markdown'
  */
 export class TriggerErrorInfo extends PureComponent {
   render() {
-    const { className, error, konnector, t } = this.props
+    const { className, error, konnector, t, action } = this.props
     return (
       <Infos
         className={className}
         theme="danger"
+        action={action}
         description={
           <>
             <Typography className="u-error" variant="h6" gutterBottom>

--- a/packages/cozy-harvest-lib/src/helpers/konnectors.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectors.js
@@ -95,6 +95,10 @@ export class KonnectorJobError extends Error {
   isTermsVersionMismatchError() {
     return this.type === TERMS_VERSION_MISMATCH
   }
+
+  isSolvableViaReconnect() {
+    return this.type === LOGIN_FAILED || this.type === CHALLENGE_ASKED
+  }
 }
 
 /**

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -109,6 +109,7 @@
     "baseDir": "/Administrative"
   },
   "error": {
+    "reconnect-via-form": "Reconnect",
     "job": {
       "DISK_QUOTA_EXCEEDED": {
         "title": "Cozy Storage full",

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -109,6 +109,7 @@
     "baseDir": "/Administratif"
   },
   "error": {
+    "reconnect-via-form": "Se reconnecter",
     "job": {
       "DISK_QUOTA_EXCEEDED": {
         "title": "Espace Cozy plein",

--- a/packages/cozy-harvest-lib/src/logger.js
+++ b/packages/cozy-harvest-lib/src/logger.js
@@ -1,10 +1,9 @@
 import minilog_ from '@cozy/minilog'
 
 const inBrowser = typeof window !== 'undefined'
+
 const minilog = (inBrowser && window.minilog) || minilog_
 
 const logger = minilog('harvest')
-
-minilog.suggest.deny('harvest', 'info')
 
 export default logger

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -205,12 +205,12 @@ export class ConnectionFlow {
   }
 
   triggerEvent(eventName, ...args) {
-    logger.debug(`TriggerEvent ${eventName}`, args)
+    logger.debug(`ConnectionFlow: triggerEvent ${eventName}`, args)
     if (isStepEvent(eventName)) {
       this.setState({ [eventName]: true })
     }
     if (eventToStatus[eventName]) {
-      logger.debug(`Setting status ${eventToStatus[eventName]}`)
+      logger.debug(`ConnectionFlow: Setting status ${eventToStatus[eventName]}`)
       this.setState({ status: eventToStatus[eventName] })
     }
     if (eventName === ERROR_EVENT) {
@@ -248,7 +248,7 @@ export class ConnectionFlow {
    *
    */
   waitForTwoFA() {
-    logger.info('Waiting for two FA')
+    logger.info('ConnectionFlow: Waiting for two FA')
     return new Promise(rawResolve => {
       const accountId = this.account._id
       assert(accountId, 'Cannot wait for two fa on account without id')
@@ -288,18 +288,20 @@ export class ConnectionFlow {
    * Saves and updates internal account
    */
   async saveAccount(updatedAccount) {
-    logger.debug('Saving account')
+    logger.debug('ConnectionFlow: Saving account')
     this.account = await saveAccount(
       this.client,
       this.konnector,
       updatedAccount
     )
-    logger.info('Saved account')
+    logger.info('ConnectionFlow: Saved account')
     return this.account
   }
 
   flushTwoFAWaiters() {
-    logger.debug(`Flushing ${this.twoFAWaiters.length} two fa waiters`)
+    logger.debug(
+      `ConnectionFlow: Flushing ${this.twoFAWaiters.length} two fa waiters`
+    )
     for (const callback of this.twoFAWaiters) {
       callback()
     }
@@ -324,7 +326,7 @@ export class ConnectionFlow {
   async sendTwoFACode(code) {
     this.setState({ status: RUNNING_TWOFA })
     try {
-      logger.debug(`Sending two fa code ${code}`)
+      logger.debug(`ConnectionFlow: Sending two fa code ${code}`)
       await this.saveAccount(accounts.updateTwoFaCode(this.account, code))
     } catch (error) {
       // eslint-disable-next-line no-console
@@ -366,7 +368,7 @@ export class ConnectionFlow {
       assert(client, 'No client')
       const konnectorPolicy = findKonnectorPolicy(konnector)
       logger.log(
-        `Handling submit, with konnector policy ${konnectorPolicy.name}`
+        `ConnectionFlow: Handling submit, with konnector policy ${konnectorPolicy.name}`
       )
 
       let cipher
@@ -378,11 +380,11 @@ export class ConnectionFlow {
         })
       } else {
         logger.info(
-          'Bypassing cipher creation because of konnector account policy'
+          'ConnectionFlow: Bypassing cipher creation because of konnector account policy'
         )
       }
 
-      logger.debug('Creating/updating account...', account)
+      logger.debug('ConnectionFlow: Creating/updating account...', account)
 
       account = await createOrUpdateAccount({
         account,
@@ -396,7 +398,7 @@ export class ConnectionFlow {
 
       this.account = account
 
-      logger.info(`Saved account ${account._id}`)
+      logger.info(`ConnectionFlow: Saved account ${account._id}`)
 
       await this.ensureTriggerAndLaunch(client, {
         trigger,
@@ -440,7 +442,7 @@ export class ConnectionFlow {
   }
 
   async handleJobUpdated() {
-    logger.debug('Handling update from job')
+    logger.debug('ConnectionFlow: Handling update from job')
     await this.refetchTrigger()
   }
 
@@ -448,7 +450,7 @@ export class ConnectionFlow {
     if (!this.trigger) {
       return null
     }
-    logger.debug(`Refetching trigger  ${this.trigger._id}`)
+    logger.debug(`ConnectionFlow: Refetching trigger  ${this.trigger._id}`)
     const trigger = await fetchTrigger(this.client, this.trigger._id)
     logger.debug(`Refetched trigger`, trigger)
     this.trigger = trigger
@@ -456,7 +458,7 @@ export class ConnectionFlow {
   }
 
   async ensureTriggerAndLaunch(client, { trigger, account, konnector, t }) {
-    logger.debug('Ensuring trigger...')
+    logger.debug('ConnectionFlow: Ensuring trigger...')
     this.t = t
     const ensuredTrigger = await ensureTrigger(client, {
       trigger,
@@ -474,7 +476,7 @@ export class ConnectionFlow {
    * Launches the job and sets everything up to follow execution.
    */
   async launch() {
-    logger.info('Launching job...')
+    logger.info('ConnectionFlow: Launching job...')
     this.setState({ status: PENDING })
 
     this.account = await prepareTriggerAccount(this.client, this.trigger)
@@ -484,7 +486,9 @@ export class ConnectionFlow {
       this.account._id,
       this.handleAccountUpdated
     )
-    logger.info(`Subscribed to ${ACCOUNTS_DOCTYPE}:${this.account._id}`)
+    logger.info(
+      `ConnectionFlow: Subscribed to ${ACCOUNTS_DOCTYPE}:${this.account._id}`
+    )
 
     this.job = await launchTrigger(this.client, this.trigger)
     this.realtime.subscribe(
@@ -494,7 +498,7 @@ export class ConnectionFlow {
       this.handleJobUpdated.bind(this)
     )
     this.jobWatcher = watchKonnectorJob(this.client, this.job)
-    logger.info(`Subscribed to ${JOBS_DOCTYPE}:${this.job._id}`)
+    logger.info(`ConnectionFlow: Subscribed to ${JOBS_DOCTYPE}:${this.job._id}`)
 
     for (const ev of JOB_EVENTS) {
       this.jobWatcher.on(ev, (...args) => this.triggerEvent(ev, ...args))

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -249,6 +249,10 @@ export class ConnectionFlow {
    */
   waitForTwoFA() {
     logger.info('ConnectionFlow: Waiting for two FA')
+    if (this.jobWatcher) {
+      this.jobWatcher.disableSuccessTimer()
+    }
+
     return new Promise(rawResolve => {
       const accountId = this.account._id
       assert(accountId, 'Cannot wait for two fa on account without id')

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -475,7 +475,7 @@ export class ConnectionFlow {
   /**
    * Launches the job and sets everything up to follow execution.
    */
-  async launch() {
+  async launch({ autoSuccessTimer = true } = {}) {
     logger.info('ConnectionFlow: Launching job...')
     this.setState({ status: PENDING })
 
@@ -497,7 +497,9 @@ export class ConnectionFlow {
       this.job._id,
       this.handleJobUpdated.bind(this)
     )
-    this.jobWatcher = watchKonnectorJob(this.client, this.job)
+    this.jobWatcher = watchKonnectorJob(this.client, this.job, {
+      autoSuccessTimer
+    })
     logger.info(`ConnectionFlow: Subscribed to ${JOBS_DOCTYPE}:${this.job._id}`)
 
     for (const ev of JOB_EVENTS) {

--- a/packages/cozy-harvest-lib/src/models/konnector/KonnectorJobWatcher.js
+++ b/packages/cozy-harvest-lib/src/models/konnector/KonnectorJobWatcher.js
@@ -79,6 +79,7 @@ export class KonnectorJobWatcher {
 
   disableSuccessTimer() {
     if (this.successTimer) {
+      logger.info(`KonnectorJobWatcher: Disabling auto success timer`)
       clearTimeout(this.successTimer)
       this.successTimer = null
     }


### PR DESCRIPTION
- Add a button for the user to reconnect easily in case of LOGIN_FAILED
  or CHALLENGE_ASKED

The button is displayed in the error info card. This way, the user
is brought to the form to reconnect, and will not be mistaken into
clicking the "launch" button that only restarts the job without
doing the client-side process with budget-insight.

- Deactivate auto success when clicking the launch button

We do not want auto success in this case, auto success is only
when connecting for the first time.

- Add logs

Logs are helpful when debugging. A good next step would be to store
the logs in memory and for the user to have a way to send them easily in case
of a problem. Could this be done via Sentry ?