### PR TITLE
feat: Correctly update relationships when reconciliating accounts

### DIFF
--- a/packages/cozy-doctypes/src/banking/BankAccount.js
+++ b/packages/cozy-doctypes/src/banking/BankAccount.js
@@ -16,8 +16,8 @@ class BankAccount extends Document {
         ...matching.account,
         relationships: merge(
           {},
-          matching.account.relationships,
-          matching.match ? matching.match.relationships : null
+          matching.match ? matching.match.relationships : null,
+          matching.account.relationships
         ),
         _id: matching.match ? matching.match._id : undefined
       }

--- a/packages/cozy-doctypes/src/banking/BankAccount.spec.js
+++ b/packages/cozy-doctypes/src/banking/BankAccount.spec.js
@@ -1,30 +1,32 @@
 const BankAccount = require('./BankAccount')
 
 describe('account reconciliation', () => {
-  const localAccounts = [
-    {
-      _id: 'a1',
-      number: '1',
-      balance: 50,
-      relationships: { aRelationship: { _id: 'fake-id', _type: 'fake-type' } }
-    }
-  ]
-  const remoteAccounts = [
+  const newAccounts = [
     {
       number: '1',
       balance: 100,
       relationships: {
-        aRelationship: { _id: 'old-fake-id', _type: 'old-fake-type' },
+        aRelationship: { _id: 'fake-id', _type: 'fake-type' },
         anotherRelationship: { _id: 'fake-id2', _type: 'fake-type2' }
       }
     },
     { number: '2', balance: 200 }
   ]
+  const currentAccounts = [
+    {
+      _id: 'a1',
+      number: '1',
+      balance: 50,
+      relationships: {
+        aRelationship: { _id: 'old-fake-id', _type: 'old-fake-type' }
+      }
+    }
+  ]
 
   it('should correctly match linxo accounts to cozy accounts through number', () => {
     const matchedAccounts = BankAccount.reconciliate(
-      remoteAccounts,
-      localAccounts
+      newAccounts,
+      currentAccounts
     )
 
     const accountA1 = matchedAccounts.find(x => x.number === '1')


### PR DESCRIPTION
When merging relationships, we would kept the relationships items
of the old document due to an ordering typo.

This caused a bug where when updating the relationships.connection of a banking account, it would keep the old connection. This means that if a user disconnects and reconnects a banking connection, its accounts would show as "Disconnected" in Banks UI since the connection id in the banking accounts was not updated.