### PR TITLE
Approx number match improved

### DIFF
--- a/packages/cozy-doctypes/package.json
+++ b/packages/cozy-doctypes/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "lint": "cd ../../; yarn eslint --ext js,jsx packages/cozy-doctypes",
     "build": "babel src -d dist",
+    "watch": "yarn build --watch",
     "test": "jest src/",
     "encrypt-banking-tests": "cd src/banking/; make encrypted.tar.gz.gpg",
     "clean-banking-tests": "cd src/banking/; make clean",

--- a/packages/cozy-doctypes/src/banking/BankAccount.js
+++ b/packages/cozy-doctypes/src/banking/BankAccount.js
@@ -4,6 +4,7 @@ const merge = require('lodash/merge')
 const Document = require('../Document')
 const matching = require('./matching-accounts')
 const { getSlugFromInstitutionLabel } = require('./slug-account')
+const log = require('cozy-logger').namespace('BankAccount')
 
 class BankAccount extends Document {
   /**
@@ -12,6 +13,12 @@ class BankAccount extends Document {
   static reconciliate(fetchedAccounts, localAccounts) {
     const matchings = matching.matchAccounts(fetchedAccounts, localAccounts)
     return matchings.map(matching => {
+      log(
+        'info',
+        matching.match
+          ? `${matching.account.label} matched with ${matching.match.label} via ${matching.method}`
+          : `${matching.account.label} did not match with an existing account`
+      )
       return {
         ...matching.account,
         relationships: merge(

--- a/packages/cozy-doctypes/src/banking/label-slugs.js
+++ b/packages/cozy-doctypes/src/banking/label-slugs.js
@@ -18,6 +18,7 @@ module.exports = {
   '/Crédit du Nord.*/': 'cdngroup88',
   '/Crédit Maritime.*/': 'creditmaritime',
   '/Crédit Mutuel.*/': 'cic45',
+  '/Linxea/': 'linxea',
   Fortuneo: 'fortuneo84',
   'Hello bank!': 'hellobank145',
   'HSBC France': 'hsbc119',

--- a/packages/cozy-doctypes/src/banking/matching-accounts.js
+++ b/packages/cozy-doctypes/src/banking/matching-accounts.js
@@ -66,7 +66,8 @@ const approxNumberMatch = (account, existingAccount) => {
     existingAccount.number &&
     account.number &&
     (existingAccount.number.length === 11 || account.number.length === 11) &&
-    eitherIncludes(existingAccount.number, account.number)
+    eitherIncludes(existingAccount.number, account.number) &&
+    Math.min(existingAccount.number.length, account.number.length) >= 4
   )
 }
 
@@ -256,5 +257,6 @@ module.exports = {
   matchAccounts,
   normalizeAccountNumber,
   score,
-  creditCardMatch
+  creditCardMatch,
+  approxNumberMatch
 }

--- a/packages/cozy-doctypes/src/banking/matching-accounts.js
+++ b/packages/cozy-doctypes/src/banking/matching-accounts.js
@@ -71,6 +71,9 @@ const approxNumberMatch = (account, existingAccount) => {
 }
 
 const creditCardMatch = (account, existingAccount) => {
+  if (account.type !== 'CreditCard' && existingAccount.type !== 'CreditCard') {
+    return false
+  }
   let ccAccount, lastDigits
   for (let acc of [account, existingAccount]) {
     const match = acc && acc.number && acc.number.match(redactedCreditCard)
@@ -83,6 +86,7 @@ const creditCardMatch = (account, existingAccount) => {
   if (other && other.number && other.number.slice(-4) === lastDigits) {
     return true
   }
+  return false
 }
 
 const slugMatch = (account, existingAccount) => {
@@ -97,6 +101,32 @@ const slugMatch = (account, existingAccount) => {
   )
 }
 
+const currencyMatch = (account, existingAccount) => {
+  if (!account.currency) {
+    return false
+  }
+  return (
+    (existingAccount.rawNumber &&
+      existingAccount.rawNumber.includes(account.currency)) ||
+    (existingAccount.label &&
+      existingAccount.label.includes(account.currency)) ||
+    (existingAccount.originalBankLabel &&
+      existingAccount.originalBankLabel.includes(account.currency))
+  )
+}
+
+const sameTypeMatch = (account, existingAccount) => {
+  return account.type === existingAccount.type
+}
+
+const rules = [
+  { rule: slugMatch, bonus: 0, malus: -1000 },
+  { rule: approxNumberMatch, bonus: 50, malus: -50, name: 'approx-number' },
+  { rule: sameTypeMatch, bonus: 50, malus: 0, name: 'same-type' },
+  { rule: creditCardMatch, bonus: 150, malus: 0, name: 'credit-card-number' },
+  { rule: currencyMatch, bonus: 50, malus: 0, name: 'currency' }
+]
+
 const score = (account, existingAccount) => {
   const methods = []
   const res = {
@@ -105,43 +135,19 @@ const score = (account, existingAccount) => {
   }
 
   let points = 0
-
-  /* To avoid accounts from different banks to be considered */
-  if (!slugMatch(account, existingAccount)) {
-    points -= 1000
-  }
-
-  if (approxNumberMatch(account, existingAccount)) {
-    points += 50
-    methods.push('approx-number')
-  } else {
-    points -= 50
-  }
-  if (account.type === existingAccount.type) {
-    points += 50
-    methods.push('same-type')
-  }
-  if (
-    (account.type === 'CreditCard' || existingAccount.type === 'CreditCard') &&
-    creditCardMatch(account, existingAccount)
-  ) {
-    points += 150
-    methods.push('credit-card-number')
-  }
-  if (account.currency) {
-    const sameCurrency =
-      (existingAccount.rawNumber &&
-        existingAccount.rawNumber.includes(account.currency)) ||
-      (existingAccount.label &&
-        existingAccount.label.includes(account.currency)) ||
-      (existingAccount.originalBankLabel &&
-        existingAccount.originalBankLabel.includes(account.currency))
-
-    if (sameCurrency) {
-      points += 50
-      methods.push('currency')
+  for (let { rule, bonus, malus, name } of rules) {
+    const ok = rule(account, existingAccount)
+    if (ok && bonus) {
+      points += bonus
+    }
+    if (!ok && malus) {
+      points += malus
+    }
+    if (name && ok) {
+      methods.push(name)
     }
   }
+
   res.points = points
   return res
 }

--- a/packages/cozy-doctypes/src/banking/matching-accounts.spec.js
+++ b/packages/cozy-doctypes/src/banking/matching-accounts.spec.js
@@ -4,7 +4,8 @@ const {
   matchAccounts,
   normalizeAccountNumber,
   score,
-  creditCardMatch
+  creditCardMatch,
+  approxNumberMatch
 } = require('./matching-accounts')
 
 const BANK_ACCOUNT_DOCTYPE = 'io.cozy.bank.accounts'
@@ -123,5 +124,30 @@ describe('creditCardMatch', () => {
         { number: '13002900002', type: 'CreditCard' }
       )
     ).toBe(false)
+  })
+})
+
+describe('approxNumberMatch', () => {
+  it('should not match when one of the number is too short', () => {
+    expect(
+      approxNumberMatch(
+        {
+          number: '90'
+        },
+        {
+          number: '01234567890'
+        }
+      )
+    ).toBe(false)
+    expect(
+      approxNumberMatch(
+        {
+          number: '7890'
+        },
+        {
+          number: '01234567890'
+        }
+      )
+    ).toBe(true)
   })
 })

--- a/packages/cozy-doctypes/src/banking/matching-accounts.spec.js
+++ b/packages/cozy-doctypes/src/banking/matching-accounts.spec.js
@@ -100,7 +100,7 @@ it('should normalize account number', () => {
 
 describe('creditCardMatch', () => {
   it('should not throw when an account does not have a number', () => {
-    expect(creditCardMatch).not.toThrow()
+    expect(() => creditCardMatch({}, {})).not.toThrow()
     // real paypal example
     expect(
       creditCardMatch(
@@ -120,8 +120,8 @@ describe('creditCardMatch', () => {
           vendorId: '230',
           institutionLabel: 'Paypal REST API'
         },
-        { number: '13002900002' }
+        { number: '13002900002', type: 'CreditCard' }
       )
-    ).toBe(undefined)
+    ).toBe(false)
   })
 })

--- a/packages/cozy-doctypes/src/banking/slug-account.js
+++ b/packages/cozy-doctypes/src/banking/slug-account.js
@@ -1,3 +1,4 @@
+const log = require('cozy-logger').namespace('slug-account')
 const labelSlugs = require('./label-slugs')
 
 const institutionLabelsCompiled = Object.entries(labelSlugs).map(
@@ -12,6 +13,7 @@ const institutionLabelsCompiled = Object.entries(labelSlugs).map(
 
 const getSlugFromInstitutionLabel = institutionLabel => {
   if (!institutionLabel) {
+    log('warn', 'No institution label, cannot compute slug')
     return
   }
   for (const [rx, slug] of institutionLabelsCompiled) {
@@ -24,6 +26,7 @@ const getSlugFromInstitutionLabel = institutionLabel => {
       return slug
     }
   }
+  log('warn', `Could not compute slug for ${institutionLabel}`)
 }
 
 module.exports = {


### PR DESCRIPTION
After a connector has fetched banking accounts, we use heuristics to match downloaded accounts with
the ones that are already stored. Here the heuristic led to a false positive and two unrelated
accounts were considered a match.

Say we have 1 account in database, { number: '01234567890' } and 1 downloaded account { number: '89' }.
Previously a="01234567890" would match b="89" since a.length == 11 and b is contained in a. This can lead to false positives: an account being matched with another account where they should not be matched.

We add a rule on the minimum length of account numbers for the approx-number rule.

To remedy this problem, we impose a minimum length on b, if its
length is inferior to 4, we do not generate a match.

- [x] Tested with encrypted matching tests