### PR TITLE
feat: Support for MAIF staging cozys to talk with the right BI endpoint

### DIFF
--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -88,6 +88,7 @@ export const getBIConfigForCozyURL = rawCozyURL => {
       return configsByMode['dev']
     case 'cozymaif.cloud':
     case 'cozy-maif-int.fr':
+    case 'cozy-maif-stg.fr':
       return configsByMode['devmaif']
     default:
       return configsByMode['prod']


### PR DESCRIPTION
Previously, we would target ask a temporary token to the banking
connector. The banking connector would reply with a *maif* BI enpoint
compatible token since it is configured via stack secrets. Then, our
front-end would try to talk to *our* BI prod on the front-end with the
previously fetched token. Since the token is specific to a BI endpoint,
the front-end had 401 responses.