### PR TITLE
fix: Don't crash if there is no value inside a permission

### DIFF
--- a/packages/cozy-sharing/__tests__/fixtures.js
+++ b/packages/cozy-sharing/__tests__/fixtures.js
@@ -307,6 +307,22 @@ export const PERM_2 = {
   }
 }
 
+export const PERM_WITHOUT_DOC = {
+  type: 'io.cozy.permissions',
+  id: 'PERM_WITHOUT_DOC',
+  attributes: {
+    type: 'share',
+    permissions: {
+      rule0: {
+        type: 'io.cozy.files',
+        verbs: ['GET']
+      }
+    },
+    codes: { email: 'longcode' },
+    shortcodes: { email: 'shortcode' }
+  }
+}
+
 export const APPS = [
   {
     type: 'io.cozy.apps',

--- a/packages/cozy-sharing/src/state.js
+++ b/packages/cozy-sharing/src/state.js
@@ -367,7 +367,7 @@ export const hasSharedChild = (state, documentPath) => {
 }
 
 // helpers
-const getSharedDocIds = doc =>
+export const getSharedDocIds = doc =>
   doc.type === 'io.cozy.sharings'
     ? getSharingDocIds(doc)
     : getPermissionDocIds(doc)
@@ -384,9 +384,16 @@ export const getSharingDocIds = sharing => {
   return docs
 }
 
-const getPermissionDocIds = perm =>
+// Some permissions can not have values since they can
+// be on a global doctype. In that case, we can't sort
+// them by id
+export const getPermissionDocIds = perm =>
   Object.keys(perm.attributes.permissions)
-    .map(k => perm.attributes.permissions[k].values)
+    .map(k =>
+      perm.attributes.permissions[k].values
+        ? perm.attributes.permissions[k].values
+        : []
+    )
     .reduce((acc, val) => [...acc, ...val], [])
 
 const areAllRecipientsRevoked = sharing =>

--- a/packages/cozy-sharing/src/state.spec.js
+++ b/packages/cozy-sharing/src/state.spec.js
@@ -12,7 +12,8 @@ import reducer, {
   hasSharedParent,
   hasSharedChild,
   getSharedDocIdsBySharings,
-  getSharingType
+  getSharingType,
+  getPermissionDocIds
 } from './state'
 
 import {
@@ -22,6 +23,7 @@ import {
   SHARING_READ_ONLY,
   PERM_1,
   PERM_2,
+  PERM_WITHOUT_DOC,
   SHARING_NO_ACTIVE,
   SHARING_WITH_SHORTCUT,
   APPS
@@ -487,6 +489,16 @@ describe('getSharedDocIdsBySharings method', () => {
   })
 })
 
+describe('getPermissionDocIds method', () => {
+  it('should return the docs ids for the permission', () => {
+    const docs = getPermissionDocIds(PERM_2)
+    expect(docs).toEqual(['folder_2'])
+  })
+  it('should return nothing if there is no document', () => {
+    const docs = getPermissionDocIds(PERM_WITHOUT_DOC)
+    expect(docs).toEqual([])
+  })
+})
 describe('getSharingType selector', () => {
   it('should return false is this a sharingByLink', () => {
     const newState = reducer({}, addSharingLink(PERM_2))


### PR DESCRIPTION
We have an use case when a permission looks like the one added
 in the fixture. Resulting by trying to iterate on undefined...

So if there is no value, there is no need to iterate on it since we
can't sort documents by id... 

Since we don't know exactly how to deal with this issue yet, I 
returned an empty [] as a quick fix. 