### PR TITLE
feat: KonnectorBlock handles konnector errors

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorBlock.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorBlock.jsx
@@ -1,11 +1,13 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import get from 'lodash/get'
+import flow from 'lodash/flow'
+import { withStyles } from '@material-ui/core/styles'
 
-import { useQuery, useClient } from 'cozy-client'
+import { useClient } from 'cozy-client'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
-import { generateUniversalLink } from 'cozy-ui/transpiled/react/AppLinker'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
+import Typography from 'cozy-ui/transpiled/react/Typography'
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
 import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
@@ -17,25 +19,39 @@ import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
 import GlobeIcon from 'cozy-ui/transpiled/react/Icons/Globe'
 import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
 
+import Markdown from './Markdown'
 import withLocales from './hoc/withLocales'
-import { buildKonnectorQuery } from '../helpers/queries'
 
-const KonnectorBlock = ({ file }) => {
+import { fetchKonnectorData } from '../helpers/konnectorBlock'
+
+const customStyles = () => ({
+  disabled: {
+    filter: 'grayscale(1)',
+    opacity: 0.5
+  }
+})
+
+const KonnectorBlock = ({ classes, file }) => {
+  const [konnector, setKonnector] = useState()
   const client = useClient()
   const { t } = useI18n()
-
   const slug = get(file, 'cozyMetadata.uploadedBy.slug')
+  const sourceAccount = get(file, 'cozyMetadata.sourceAccount')
 
-  const konnectorQuery = buildKonnectorQuery(slug)
-  const konnectorQueryDef = konnectorQuery.definition()
-  konnectorQueryDef.sources = ['stack', 'registry']
+  useEffect(() => {
+    const fetchKonnector = async ({ client, t, slug, sourceAccount }) => {
+      const konnector = await fetchKonnectorData({
+        client,
+        t,
+        slug,
+        sourceAccount
+      })
+      setKonnector(konnector)
+    }
+    fetchKonnector({ client, t, slug, sourceAccount })
+  }, [client, t, slug, sourceAccount])
 
-  const { data, fetchStatus } = useQuery(
-    konnectorQueryDef,
-    konnectorQuery.options
-  )
-
-  if (fetchStatus !== 'loaded' || !data.length > 0) {
+  if (!konnector) {
     return (
       <div data-testid="KonnectorBlock-spinner">
         <Spinner className="u-flex u-flex-justify-center u-p-2" size="large" />
@@ -43,24 +59,29 @@ const KonnectorBlock = ({ file }) => {
     )
   }
 
-  const sourceAccount = get(file, 'cozyMetadata.sourceAccount')
-  const link = generateUniversalLink({
-    cozyUrl: client.getStackClient().uri,
-    slug: 'home',
-    subDomainType: client.getInstanceOptions().cozySubdomainType,
-    nativePath: `connected/${slug}/accounts/${sourceAccount}`
-  })
-  const konnector = data[0].attributes
+  const { name, link, vendorLink, iconStatus, message, fatalError } = konnector
+
+  if (fatalError) {
+    return (
+      <Typography className="u-pv-1-half u-ph-2" variant="body1">
+        <Markdown source={fatalError} />
+      </Typography>
+    )
+  }
 
   return (
     <List>
       <ListItem className="u-ph-2 u-h-3" button component="a" href={link}>
         <ListItemIcon>
-          <AppIcon app={konnector.slug} />
+          <AppIcon app={slug} className={classes[iconStatus]} />
         </ListItemIcon>
         <ListItemText
-          primary={konnector.name}
+          primary={name}
           primaryTypographyProps={{ variant: 'h6' }}
+          secondary={get(message, 'text')}
+          secondaryTypographyProps={
+            get(message, 'color') && { color: message.color }
+          }
         />
         <ListItemSecondaryAction>
           <Icon
@@ -73,19 +94,13 @@ const KonnectorBlock = ({ file }) => {
 
       <Divider component="li" />
 
-      <ListItem
-        className="u-ph-2"
-        button
-        component="a"
-        href={konnector.vendor_link}
-        target="_blank"
-      >
+      <ListItem className="u-ph-2" button {...vendorLink}>
         <ListItemIcon>
           <Icon icon={GlobeIcon} color="var(--primaryTextColor)" />
         </ListItemIcon>
         <ListItemText
           primary={t('konnectorBlock.account')}
-          secondary={konnector.vendor_link}
+          secondary={get(vendorLink, 'href')}
         />
       </ListItem>
     </List>
@@ -96,4 +111,7 @@ KonnectorBlock.propTypes = {
   file: PropTypes.object.isRequired
 }
 
-export default withLocales(KonnectorBlock)
+export default flow(
+  withLocales,
+  withStyles(customStyles)
+)(KonnectorBlock)

--- a/packages/cozy-harvest-lib/src/helpers/konnectorBlock.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectorBlock.js
@@ -1,0 +1,273 @@
+import { triggers } from 'cozy-client/dist/models/trigger'
+import { generateUniversalLink } from 'cozy-ui/transpiled/react/AppLinker'
+import get from 'lodash/get'
+
+import logger from '../logger'
+import sentryHub from '../sentry'
+
+import {
+  buildKonnectorQuery,
+  buildAccountQuery,
+  buildTriggersQuery,
+  buildTriggersByIdQuery
+} from './queries'
+import { hasNewVersionAvailable } from './konnectors'
+
+const formatKonnector = ({
+  client,
+  konnector,
+  universalLink,
+  iconStatus,
+  message
+}) => {
+  const link = generateUniversalLink({
+    cozyUrl: client.getStackClient().uri,
+    slug: universalLink.slug,
+    subDomainType: client.getInstanceOptions().cozySubdomainType,
+    nativePath: universalLink.nativePath
+  })
+
+  return {
+    name: konnector.name,
+    link,
+    vendorLink: konnector.vendor_link && {
+      component: 'a',
+      href: konnector.vendor_link,
+      target: '_blank'
+    },
+    iconStatus,
+    message
+  }
+}
+
+// TODO should be in cozy-client as a new method of client
+// see https://github.com/cozy/cozy-client/issues/867#issuecomment-773907266
+const fetchDataFromState = async (client, query) => {
+  try {
+    await client.query(query.definition, query.options)
+    const { data } = client.getQueryFromState(query.options.as)
+    return data[0]
+  } catch (error) {
+    throw error
+  }
+}
+
+const fetchKonnector = (client, query) => fetchDataFromState(client, query)
+
+const isAccountConnected = async (client, sourceAccount) => {
+  const query = buildAccountQuery(sourceAccount)
+  const data = await fetchDataFromState(client, query)
+  return !!data
+}
+
+// Only konnectors from the registry have a maintenance status
+// so we need to fetch registry to get this information
+const isInMaintenance = async (client, slug) => {
+  const konnector = await konnectorBlock.fetchKonnector(
+    client,
+    buildKonnectorQuery(slug, 'registry')
+  )
+  return get(konnector, 'maintenance_activated', false)
+}
+
+const isInError = async ({ client, slug, sourceAccount }) => {
+  const query = buildTriggersQuery(slug, sourceAccount)
+  const data = await fetchDataFromState(client, query)
+  const triggerId = get(data, 'id')
+
+  const triggersByIdQuery = buildTriggersByIdQuery(triggerId)
+  const trigger = await fetchDataFromState(client, triggersByIdQuery)
+
+  const inError = get(trigger, 'current_state.status') === 'errored'
+
+  if (!inError) {
+    return { error: null }
+  }
+
+  const message = get(trigger, 'current_state.last_error')
+
+  const isActionable = triggers.hasActionableError(trigger)
+
+  return { error: { message, isActionable } }
+}
+
+const not404Error = ({ t, slug, error }) => {
+  logger.error(error)
+  sentryHub.withScope(scope => {
+    scope.setTag('konnectorBlock with konnector', slug)
+
+    // Capture the original exception instead of the user one
+    sentryHub.captureException(error.original || error)
+  })
+  return {
+    not404Error: t('konnectorBlock.not404Error', {
+      name: 'support@cozycloud.cc',
+      link: 'mailto:support@cozycloud.cc'
+    })
+  }
+}
+
+const statusToFormatOptions = {
+  noAccountConnected: ({ client, konnector, slug, t }) =>
+    formatKonnector({
+      client,
+      konnector: konnector.attributes,
+      universalLink: {
+        slug: 'home',
+        nativePath: `connected/${slug}/new`
+      },
+      iconStatus: 'disabled',
+      message: {
+        text: t('konnectorBlock.disconnected')
+      }
+    }),
+  inMaintenance: ({ client, konnector, slug, t }) =>
+    formatKonnector({
+      client,
+      konnector: konnector.attributes,
+      universalLink: {
+        slug: 'home',
+        nativePath: `connected/${slug}`
+      },
+      iconStatus: 'disabled',
+      message: {
+        text: t('konnectorBlock.inMaintenance')
+      }
+    }),
+  inError: ({ client, konnector, slug, t, error }) => {
+    const color =
+      error.isActionable || hasNewVersionAvailable(konnector)
+        ? 'error'
+        : 'textSecondary'
+    return formatKonnector({
+      client,
+      konnector: konnector.attributes,
+      universalLink: {
+        slug: 'home',
+        nativePath: `connected/${slug}`
+      },
+      iconStatus: 'disabled',
+      message: {
+        text: t(`error.job.${error.message}.title`),
+        color
+      }
+    })
+  },
+  hasNewVersionAvailable: ({ client, konnector, slug, t }) =>
+    formatKonnector({
+      client,
+      konnector: konnector.attributes,
+      universalLink: {
+        slug: 'home',
+        nativePath: `connected/${slug}`
+      },
+      message: {
+        text: t('konnectorBlock.hasNewVersionAvailable'),
+        color: 'primary'
+      }
+    }),
+  default: ({ client, konnector, slug, sourceAccount }) =>
+    formatKonnector({
+      client,
+      konnector: konnector.attributes,
+      universalLink: {
+        slug: 'home',
+        nativePath: `connected/${slug}/accounts/${sourceAccount}`
+      }
+    }),
+  stackNotFound: ({ client, konnector, slug }) =>
+    formatKonnector({
+      client,
+      konnector: konnector.attributes,
+      universalLink: {
+        slug: 'store',
+        nativePath: `discover/${slug}`
+      },
+      iconStatus: 'disabled'
+    }),
+  not404Error: ({ t, slug, error }) => not404Error({ t, slug, error })
+}
+
+const fetchKonnectorStatus = async ({ client, slug, sourceAccount }) => {
+  try {
+    const konnector = await konnectorBlock.fetchKonnector(
+      client,
+      buildKonnectorQuery(slug, 'stack')
+    )
+
+    const accountConnected = await konnectorBlock.isAccountConnected(
+      client,
+      sourceAccount
+    )
+    if (!accountConnected) {
+      return { konnector, status: 'noAccountConnected' }
+    }
+
+    const inMaintenance = await konnectorBlock.isInMaintenance(client, slug)
+    if (inMaintenance) {
+      return { konnector, status: 'inMaintenance' }
+    }
+
+    const { error } = await konnectorBlock.isInError({
+      client,
+      slug,
+      sourceAccount
+    })
+    if (error) {
+      return { konnector, status: 'inError', error }
+    }
+
+    if (hasNewVersionAvailable(konnector)) {
+      return { konnector, status: 'hasNewVersionAvailable' }
+    }
+
+    return { konnector, status: 'default' }
+  } catch (error) {
+    // The konnector can be uninstalled and returned 404
+    if (error.status === 404) {
+      try {
+        const konnector = await konnectorBlock.fetchKonnector(
+          client,
+          buildKonnectorQuery(slug, 'registry')
+        )
+
+        return { konnector, status: 'stackNotFound' }
+      } catch (error) {
+        return { status: 'not404Error', error }
+      }
+    }
+    return { status: 'not404Error', error }
+  }
+}
+
+export const fetchKonnectorData = async ({
+  client,
+  t,
+  slug,
+  sourceAccount
+}) => {
+  const { konnector, status, error } = await fetchKonnectorStatus({
+    client,
+    slug,
+    sourceAccount
+  })
+
+  return statusToFormatOptions[status]({
+    client,
+    konnector,
+    slug,
+    t,
+    sourceAccount,
+    error
+  })
+}
+
+const konnectorBlock = {
+  fetchKonnectorData,
+  fetchKonnector,
+  isAccountConnected,
+  isInError,
+  isInMaintenance
+}
+
+export default konnectorBlock

--- a/packages/cozy-harvest-lib/src/helpers/konnectorBlock.spec.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectorBlock.spec.js
@@ -1,0 +1,206 @@
+import { createMockClient } from 'cozy-client'
+
+import konnectorBlock from './konnectorBlock'
+
+const client = createMockClient({})
+client.getStackClient = jest.fn(() => ({ uri: 'http://cozy.tools:8080' }))
+client.fetchJSON = jest.fn()
+client.query = jest.fn()
+client.getQueryFromState = jest.fn()
+
+const setup = async ({
+  isAccountConnected = true,
+  isInMaintenance = false,
+  isInError = { error: null }
+} = {}) => {
+  jest
+    .spyOn(konnectorBlock, 'isAccountConnected')
+    .mockResolvedValue(isAccountConnected)
+  jest
+    .spyOn(konnectorBlock, 'isInMaintenance')
+    .mockResolvedValue(isInMaintenance)
+  jest.spyOn(konnectorBlock, 'isInError').mockResolvedValue(isInError)
+
+  return await konnectorBlock.fetchKonnectorData({
+    client,
+    t: jest.fn(x => x),
+    slug: 'pajemploi',
+    sourceAccount: '012345'
+  })
+}
+
+describe('fetchKonnectorData', () => {
+  let konnector = {
+    attributes: {
+      name: 'Pajemploi',
+      vendor_link: 'https://www.pajemploi.urssaf.fr/'
+    }
+  }
+
+  beforeEach(() => {
+    jest.spyOn(konnectorBlock, 'fetchKonnector').mockResolvedValue(konnector)
+  })
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return appropriate response if nothing goes wrong', async () => {
+    const res = await setup()
+
+    expect(res).toMatchObject({
+      name: 'Pajemploi',
+      link:
+        'https://links.mycozy.cloud/home/connected/pajemploi/accounts/012345?fallback=http%3A%2F%2Fcozy-home.tools%3A8080%2F%23%2Fconnected%2Fpajemploi%2Faccounts%2F012345',
+      vendorLink: {
+        component: 'a',
+        href: 'https://www.pajemploi.urssaf.fr/',
+        target: '_blank'
+      },
+      iconStatus: undefined,
+      message: undefined
+    })
+  })
+
+  it('should return appropriate response if everything goes wrong', async () => {
+    const error = new Error('Not Found')
+    error.status = 404
+    jest.spyOn(konnectorBlock, 'fetchKonnector').mockRejectedValue(error)
+
+    const res = await setup()
+    expect(res).toMatchObject({ not404Error: 'konnectorBlock.not404Error' })
+  })
+
+  it('should return appropriate response if stack returns other error than 404', async () => {
+    const error = new Error('Not Found')
+    error.status = 403
+    jest.spyOn(konnectorBlock, 'fetchKonnector').mockRejectedValue(error)
+
+    const res = await setup()
+    expect(res).toMatchObject({ not404Error: 'konnectorBlock.not404Error' })
+  })
+
+  it('should return appropriate response from the registry', async () => {
+    const error = new Error('Not Found')
+    error.status = 404
+    const spy = jest.spyOn(konnectorBlock, 'fetchKonnector')
+    spy.mockRejectedValueOnce(error).mockResolvedValue(konnector)
+
+    const res = await setup()
+    const firstResponseArg = spy.mock.calls[0][1]
+    expect(firstResponseArg.definition.sources).toStrictEqual(['stack'])
+    const secondResponseArg = spy.mock.calls[1][1]
+    expect(secondResponseArg.definition.sources).toStrictEqual(['registry'])
+    expect(res).toMatchObject({
+      name: 'Pajemploi',
+      link:
+        'https://links.mycozy.cloud/store/discover/pajemploi?fallback=http%3A%2F%2Fcozy-store.tools%3A8080%2F%23%2Fdiscover%2Fpajemploi',
+      vendorLink: {
+        component: 'a',
+        href: 'https://www.pajemploi.urssaf.fr/',
+        target: '_blank'
+      },
+      iconStatus: 'disabled',
+      message: undefined
+    })
+  })
+
+  it('should return appropriate response if account is not connected', async () => {
+    const res = await setup({ isAccountConnected: false })
+
+    expect(res).toMatchObject({
+      name: 'Pajemploi',
+      link:
+        'https://links.mycozy.cloud/home/connected/pajemploi/new?fallback=http%3A%2F%2Fcozy-home.tools%3A8080%2F%23%2Fconnected%2Fpajemploi%2Fnew',
+      vendorLink: {
+        component: 'a',
+        href: 'https://www.pajemploi.urssaf.fr/',
+        target: '_blank'
+      },
+      iconStatus: 'disabled',
+      message: { text: 'konnectorBlock.disconnected' }
+    })
+  })
+
+  it('should return appropriate response if konnector is in maintenance', async () => {
+    const res = await setup({ isInMaintenance: true })
+
+    expect(res).toMatchObject({
+      name: 'Pajemploi',
+      link:
+        'https://links.mycozy.cloud/home/connected/pajemploi?fallback=http%3A%2F%2Fcozy-home.tools%3A8080%2F%23%2Fconnected%2Fpajemploi',
+      vendorLink: {
+        component: 'a',
+        href: 'https://www.pajemploi.urssaf.fr/',
+        target: '_blank'
+      },
+      iconStatus: 'disabled',
+      message: { text: 'konnectorBlock.inMaintenance' }
+    })
+  })
+
+  it('should return appropriate response if konnector has actionable error', async () => {
+    const res = await setup({
+      isInError: { error: { message: 'errorMessage', isActionable: true } }
+    })
+
+    expect(res).toMatchObject({
+      name: 'Pajemploi',
+      link:
+        'https://links.mycozy.cloud/home/connected/pajemploi?fallback=http%3A%2F%2Fcozy-home.tools%3A8080%2F%23%2Fconnected%2Fpajemploi',
+      vendorLink: {
+        component: 'a',
+        href: 'https://www.pajemploi.urssaf.fr/',
+        target: '_blank'
+      },
+      iconStatus: 'disabled',
+      message: { text: 'error.job.errorMessage.title', color: 'error' }
+    })
+  })
+
+  it('should return appropriate response if konnector has not actionable error', async () => {
+    const res = await setup({
+      isInError: { error: { message: 'errorMessage', isActionable: false } }
+    })
+
+    expect(res).toMatchObject({
+      name: 'Pajemploi',
+      link:
+        'https://links.mycozy.cloud/home/connected/pajemploi?fallback=http%3A%2F%2Fcozy-home.tools%3A8080%2F%23%2Fconnected%2Fpajemploi',
+      vendorLink: {
+        component: 'a',
+        href: 'https://www.pajemploi.urssaf.fr/',
+        target: '_blank'
+      },
+      iconStatus: 'disabled',
+      message: { text: 'error.job.errorMessage.title', color: 'textSecondary' }
+    })
+  })
+
+  it('should return appropriate response if konnector has a new version available', async () => {
+    jest.spyOn(konnectorBlock, 'fetchKonnector').mockResolvedValue({
+      attributes: {
+        name: 'Pajemploi',
+        vendor_link: 'https://www.pajemploi.urssaf.fr/'
+      },
+      available_version: true
+    })
+
+    const res = await setup()
+
+    expect(res).toMatchObject({
+      name: 'Pajemploi',
+      link:
+        'https://links.mycozy.cloud/home/connected/pajemploi?fallback=http%3A%2F%2Fcozy-home.tools%3A8080%2F%23%2Fconnected%2Fpajemploi',
+      vendorLink: {
+        component: 'a',
+        href: 'https://www.pajemploi.urssaf.fr/',
+        target: '_blank'
+      },
+      iconStatus: undefined,
+      message: {
+        color: 'primary',
+        text: 'konnectorBlock.hasNewVersionAvailable'
+      }
+    })
+  })
+})

--- a/packages/cozy-harvest-lib/src/helpers/queries.js
+++ b/packages/cozy-harvest-lib/src/helpers/queries.js
@@ -1,15 +1,49 @@
 import CozyClient, { Q } from 'cozy-client'
 
-const DEFAULT_CACHE_TIMEOUT_QUERIES = 9 * 60 * 1000
+const DEFAULT_CACHE_TIMEOUT_QUERIES = 10 * 60 * 1000
 const defaultFetchPolicy = CozyClient.fetchPolicies.olderThan(
   DEFAULT_CACHE_TIMEOUT_QUERIES
 )
 
-export const buildKonnectorQuery = slug => ({
-  definition: () =>
-    Q('io.cozy.konnectors').getById(`io.cozy.konnectors/${slug}`),
+export const buildKonnectorQuery = (slug, source) => {
+  const query = {
+    definition: () =>
+      Q('io.cozy.konnectors').getById(`io.cozy.konnectors/${slug}`),
+    options: {
+      as: `io.cozy.konnectors/${slug}-${source}`,
+      fetchPolicy: defaultFetchPolicy
+    }
+  }
+  const queryDef = query.definition()
+  queryDef.sources = [source]
+
+  return { definition: queryDef, options: query.options }
+}
+
+export const buildAccountQuery = accountId => ({
+  definition: Q('io.cozy.accounts').getById(accountId),
   options: {
-    as: `konnector-${slug}`,
+    as: `io.cozy.accounts/${accountId}`,
+    fetchPolicy: defaultFetchPolicy
+  }
+})
+
+export const buildTriggersQuery = (konnectorSlug, accountId) => ({
+  definition: Q('io.cozy.triggers').where({
+    type: '@cron',
+    'message.account': accountId,
+    'message.konnector': konnectorSlug
+  }),
+  options: {
+    as: `triggers-${konnectorSlug}-${accountId}`,
+    fetchPolicy: defaultFetchPolicy
+  }
+})
+
+export const buildTriggersByIdQuery = id => ({
+  definition: Q('io.cozy.triggers').getById(id),
+  options: {
+    as: `io.cozy.triggers/${id}`,
     fetchPolicy: defaultFetchPolicy
   }
 })

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -479,6 +479,10 @@
     "disconnected-help": "This account is disconnected. Your data has been kept. If you want to restart the synchronisation, please reconfigure your account with the \"Add a bank\" button."
   },
   "konnectorBlock": {
-    "account": "Customer account"
+    "account": "Customer account",
+    "disconnected": "Disconnected",
+    "inMaintenance": "In maintenance",
+    "hasNewVersionAvailable": "New version available",
+    "not404Error": "An error occurred while recovering the service. If this problem persists, do not hesitate to contact us at [%{name}](%{link})"
   }
 }


### PR DESCRIPTION
On souhaite gérer dans KonnectorBlock les erreurs renvoyées par le connecteur et afficher différents messages selon différents cas : 
- connecteur désinstallé
- compte déconnecté
- connecteur en maintenance
- compte en erreur
- mise à jour disponible

Chaque cas renvoie un résultat différent et affiche donc le bloc de connecteur selon un certaine manière.