### PR TITLE
fix: Only check if vault is locked if konnectorPolicy says to save in vault

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -213,8 +213,13 @@ export class DumbTriggerManager extends Component {
       vaultClient
     } = this.props
     const konnectorPolicy = findKonnectorPolicy(konnector)
-    const isVaultLocked = await vaultClient.isLocked()
     if (konnectorPolicy.saveInVault) {
+      if (!vaultClient) {
+        throw new Error(
+          'Konnector policy `saveInVault` is true, but no vault has been passed in the context of the TriggerManager. You can wrap it the TriggerManager in a VaultUnlockProvider or VaultProvider (from cozy-keys-lib).'
+        )
+      }
+      const isVaultLocked = await vaultClient.isLocked()
       if (isVaultLocked) {
         showUnlockForm({
           onDismiss: onVaultDismiss,


### PR DESCRIPTION
We had an exception when the TriggerManager was not wrapped in a vault
context. It did not matter when the konnector that was dealt with did
not need to be saved in the vault (banking connectors for example).

After the fix, we do not need to wrap the TriggerManager in a vault ctx
if we are only dealing with konnectors that do not need to save in the
vault.

At the same time, crash with a helpful error if we deal with konnectors
that need to be saved in the vault while the TriggerManager has not
been wrapped in a VaultContext