### PR TITLE
feat: Upgrade cozy-bi-auth with some new banking connectors

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -29,7 +29,7 @@
     "@cozy/minilog": "^1.0.0",
     "@material-ui/core": "3",
     "@sentry/browser": "^6.0.1",
-    "cozy-bi-auth": "0.0.16",
+    "cozy-bi-auth": "0.0.17",
     "cozy-doctypes": "^1.77.0",
     "cozy-logger": "^1.6.0",
     "date-fns": "^1.30.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5132,10 +5132,10 @@ cosmiconfig@^5.0.0, cosmiconfig@^5.0.7, cosmiconfig@^5.1.0, cosmiconfig@^5.2.0:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-cozy-bi-auth@0.0.16:
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.16.tgz#82ac022b3a7a76aa9cce28cc2827e79a4c35a671"
-  integrity sha512-XC9hkmND7YA/qFLy8KTTqZMhRFNWsuU5ys2st3ZuvB+EXqAferMamWlfgPl6ogIDpt8zr4ldqf9U3dX2S79GKg==
+cozy-bi-auth@0.0.17:
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.17.tgz#dea325731c67b12b73e9e9c60febfa3c8e16b934"
+  integrity sha512-8wKKDgz6Mm8IWn6IAf5QNYInnRPWQa6SEizX54JnqaboBeo8j4WlK5jQ6+4jYEJ2+8FpJwVzjFp2uFJJhgMHdw==
   dependencies:
     cozy-logger "^1.3.0"
     lodash "^4.17.20"


### PR DESCRIPTION
Upgrade the cozy-bi-auth package to 0.0.17 with some new mapping for 14 futures connectors.

