### PR TITLE
feat(Harvest): Set the current app as default redirect slug for OAuth

### DIFF
--- a/packages/cozy-harvest-lib/src/helpers/oauth.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.js
@@ -3,6 +3,7 @@ import uuid from 'uuid/v4'
 import * as konnectors from './konnectors'
 import CozyClient from 'cozy-client'
 import CozyRealtime from 'cozy-realtime'
+import get from 'lodash/get'
 
 export const OAUTH_REALTIME_CHANNEL = 'oauth-popup'
 
@@ -101,7 +102,7 @@ export const getOAuthUrl = ({
   oAuthStateKey,
   oAuthConf,
   nonce,
-  redirectSlug,
+  redirectSlug = getAppSlug(),
   extraParams
 }) => {
   let oAuthUrl = `${cozyUrl}/accounts/${accountType}/start?state=${oAuthStateKey}&nonce=${nonce}`
@@ -126,6 +127,11 @@ export const getOAuthUrl = ({
   }
 
   return oAuthUrl
+}
+
+const getAppSlug = () => {
+  const root = document.querySelector('[role=application]')
+  return get(root, 'dataset.cozyAppSlug')
 }
 
 /**

--- a/packages/cozy-harvest-lib/src/helpers/oauth.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.js
@@ -102,7 +102,7 @@ export const getOAuthUrl = ({
   oAuthStateKey,
   oAuthConf,
   nonce,
-  redirectSlug = getAppSlug(),
+  redirectSlug,
   extraParams
 }) => {
   let oAuthUrl = `${cozyUrl}/accounts/${accountType}/start?state=${oAuthStateKey}&nonce=${nonce}`
@@ -129,9 +129,8 @@ export const getOAuthUrl = ({
   return oAuthUrl
 }
 
-const getAppSlug = () => {
-  const root = document.querySelector('[role=application]')
-  return get(root, 'dataset.cozyAppSlug')
+const getAppSlug = client => {
+  return get(client, 'appMetadata.slug')
 }
 
 /**
@@ -163,7 +162,7 @@ export const prepareOAuth = (client, konnector, redirectSlug, extraParams) => {
     oAuthStateKey,
     oAuthConf: oauth,
     nonce: Date.now(),
-    redirectSlug,
+    redirectSlug: redirectSlug || getAppSlug(client),
     extraParams
   })
 


### PR DESCRIPTION
After the OAuth dance, the stack redirects to the home application by
default.

This sets the current application as the default redirect