### PR TITLE
Add linter for docs

### DIFF
--- a/.remarkignore
+++ b/.remarkignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "remark-preset-cozy"
+  ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
 script:
   - yarn build
   - yarn lint
+  - yarn lint:md -f
   - yarn test
 before_deploy:
   - git config --global user.email "npm@cozycloud.cc"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:doc:react": "styleguidist build --config docs/styleguidist.config.js",
     "deploy:doc": "git-directory-deploy --directory docs/build/ --branch gh-pages",
     "lint": "eslint --ext js,jsx .",
+    "lint:md": "remark . -o",
     "test": "lerna run --concurrency 1 test",
     "build": "lerna run --parallel build",
     "watch:doc:react": "styleguidist server --config docs/styleguidist.config.js",
@@ -33,6 +34,7 @@
     "lerna": "3.16.0",
     "mini-css-extract-plugin": "^0.5.0",
     "react-styleguidist": "^9.0.4",
+    "remark-cli": "^9.0.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2",
     "webpack": "4.41.2"

--- a/packages/babel-preset-cozy-app/README.md
+++ b/packages/babel-preset-cozy-app/README.md
@@ -132,7 +132,7 @@ See the options on the official docs :
  </div>
  </br>
 
-[Cozy] is a platform that brings all your web services in the same private space.  With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
+[Cozy][cozy] is a platform that brings all your web services in the same private space.  With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
 
 ### Get in touch
 

--- a/packages/babel-preset-cozy-app/README.md
+++ b/packages/babel-preset-cozy-app/README.md
@@ -99,8 +99,8 @@ the ability to prune unused module away. It works by configuring babel-preset-en
 
 You can have control on the options passed to `babel-preset-env` and `babel-plugin-transform-runtime`:
 
-* `presetEnv` will be passed to `babel-preset-env`
-* `transformRuntime` will be passed to `babel-plugin-transform-runtime`
+- `presetEnv` will be passed to `babel-preset-env`
+- `transformRuntime` will be passed to `babel-plugin-transform-runtime`
 
 ```json
 {
@@ -118,8 +118,8 @@ to be replaced by imports from `babel-runtime`.
 
 See the options on the official docs :
 
-https://babeljs.io/docs/en/babel-preset-env#modules
-https://babeljs.io/docs/en/babel-plugin-transform-runtime#helpers
+<https://babeljs.io/docs/en/babel-preset-env#modules>
+<https://babeljs.io/docs/en/babel-plugin-transform-runtime#helpers>
 
 ## Community
 
@@ -143,14 +143,16 @@ You can reach the Cozy Community by:
 - Posting issues on the [Github repos][github]
 - Say Hi! on [Twitter][twitter]
 
-
 ## License
 
 `babel-preset-cozy-app` is distributed under the MIT license.
 
-
 [cozy]: https://cozy.io "Cozy Cloud"
+
 [freenode]: http://webchat.freenode.net/?randomnick=1&channels=%23cozycloud&uio=d4
+
 [forum]: https://forum.cozy.io/
+
 [github]: https://github.com/cozy/
+
 [twitter]: https://twitter.com/cozycloud

--- a/packages/browserslist-config-cozy/README.md
+++ b/packages/browserslist-config-cozy/README.md
@@ -37,7 +37,11 @@ The maintainers for Browserslist Config Cozy are [CPatchane](https://github.com/
 `browserslist-config-cozy` is distributed under the MIT license.
 
 [cozy]: https://cozy.io "Cozy Cloud"
+
 [freenode]: http://webchat.freenode.net/?randomnick=1&channels=%23cozycloud&uio=d4
+
 [forum]: https://forum.cozy.io/
+
 [github]: https://github.com/cozy/
+
 [twitter]: https://twitter.com/cozycloud

--- a/packages/browserslist-config-cozy/README.md
+++ b/packages/browserslist-config-cozy/README.md
@@ -17,7 +17,7 @@
  </div>
  </br>
 
-[Cozy] is a platform that brings all your web services in the same private space.  With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
+[Cozy][cozy] is a platform that brings all your web services in the same private space.  With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
 
 ### Get in touch
 

--- a/packages/cli-tree/README.md
+++ b/packages/cli-tree/README.md
@@ -1,5 +1,4 @@
-CLI tree
-========
+# CLI tree
 
 CLI tree is a small package based on [argparse] to create a tree like CLI in a declarative
 way.
@@ -36,9 +35,8 @@ $ node examples/users.js users completion -h
 To properly handle completion in you program, you will have to add the completionHandler like in
 the [example]
 
-
-
-
 [example]: ./examples/users.js
+
 [argparse]: https://github.com/nodeca/argparse
+
 [tabtab]: https://www.npmjs.com/package/tabtab

--- a/packages/cli-tree/README.md
+++ b/packages/cli-tree/README.md
@@ -1,11 +1,11 @@
 # CLI tree
 
-CLI tree is a small package based on [argparse] to create a tree like CLI in a declarative
+CLI tree is a small package based on [argparse][] to create a tree like CLI in a declarative
 way.
 
 ## Usage
 
-See the [example].
+See the [example][].
 
 ## Automated help
 
@@ -24,7 +24,7 @@ Optional arguments:
 
 ## Command completion
 
-CLI tree uses [tabtab] to add command completion.
+CLI tree uses [tabtab][] to add command completion.
 
 Completion setup commands are automatically added and available like this :
 
@@ -33,7 +33,7 @@ $ node examples/users.js users completion -h
 ```
 
 To properly handle completion in you program, you will have to add the completionHandler like in
-the [example]
+the [example][].
 
 [example]: ./examples/users.js
 

--- a/packages/commitlint-config-cozy/README.md
+++ b/packages/commitlint-config-cozy/README.md
@@ -11,6 +11,7 @@
 
 - Add the library on your dev dependency (`yarn add commitlint-config-cozy --dev --exact`)
 - Add configuration on your `package.json` ([see an example](https://github.com/cozy/cozy-banks/blob/85572b6827cdaa45c1ed44d6922829ba6480b3c9/package.json#L242-L246)):
+
 ```json
 "commitlint": {
   "extends": [
@@ -18,7 +19,9 @@
   ]
 }
 ```
+
 - Add verification during a commit with husky (> 1.0.0) on your `package.json` ([see an example](https://github.com/cozy/cozy-libs/blob/ea325a4ea2b5bf0067875f625b5ad0a5b320e7e9/package.json#L24-L28)):
+
 ```
 "husky": {
   "hooks": {
@@ -58,7 +61,11 @@ The maintainer for Commitlint Config Cozy is [kosssi](https://github.com/kosssi)
 `commitlint-config-cozy` is distributed under the MIT license.
 
 [cozy]: https://cozy.io "Cozy Cloud"
+
 [freenode]: http://webchat.freenode.net/?randomnick=1&channels=%23cozycloud&uio=d4
+
 [forum]: https://forum.cozy.io/
+
 [github]: https://github.com/cozy/
+
 [twitter]: https://twitter.com/cozycloud

--- a/packages/commitlint-config-cozy/README.md
+++ b/packages/commitlint-config-cozy/README.md
@@ -41,7 +41,7 @@
  </div>
  </br>
 
-[Cozy] is a platform that brings all your web services in the same private space.  With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
+[Cozy][cozy] is a platform that brings all your web services in the same private space.  With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
 
 ### Get in touch
 

--- a/packages/cozy-app-publish/README.md
+++ b/packages/cozy-app-publish/README.md
@@ -1,4 +1,5 @@
 # Cozy App Publish
+
 ![https://npmjs.org/package/cozy-app-publish](https://img.shields.io/npm/v/cozy-app-publish.svg)
 ![https://github.com/cozy/cozy-libs/blob/master/packages//LICENSE](https://img.shields.io/npm/l/cozy-app-publish.svg)
 ![https://npmcharts.com/compare/cozy-app-publish](https://img.shields.io/npm/dm/cozy-app-publish.svg)
@@ -9,7 +10,7 @@
 
 #### Requirements
 
- - Node.js version 8 or higher;
+- Node.js version 8 or higher;
 
 ### Install
 
@@ -24,12 +25,14 @@ You can find more information about the registry and how to prepare an applicati
 ### Usage via Travis CI (recommended)
 
 First of all, don't forget to build the application:
+
 ```
 # build the application (in the ./build folder here)
 yarn build
 ```
 
 Then, just publish it using the Travis CI workflow:
+
 ```
 # publish it, REGISTRY_TOKEN should be
 # encrypted and provided via Travis CI environment
@@ -42,12 +45,14 @@ yarn cozy-app-publish \
 ### Manual usage (not recommended)
 
 First of all, don't forget to build the application:
+
 ```
 # build the application (in the ./build folder here)
 yarn build
 ```
 
 Then, just publish it using:
+
 ```
 yarn cozy-app-publish \
 --token $REGISTRY_TOKEN \
@@ -80,6 +85,7 @@ In the manual mode, we don't have a way to compute the version like in the Travi
 #### `--prepublish <script_path>`
 
 Specify custom prepublish hook to manage how the app archive is generated and uploaded. The script must export a asynchronous function which has the following signature:
+
 ```js
 module.exports = async ({
   appBuildUrl,
@@ -98,18 +104,17 @@ module.exports = async ({
 
 This function must return an object containing the same options given as parameter, which can have been updated. For example, you may specifiy a new appBuildUrl in the hook. Here's a description of the different options:
 
-|Options|Description|
-|-|-|
-| `appBuildUrl` | The url where the build can be retrieved. For example, `http://github.com/cozy/cozy-foo/archives/cozy-foo.tar.gz`|
-| `appSlug` | The slug of the application, as defined in the manifest. Should not be mutated |
-| `appType` | `webapp` or `konnector` |
-| `appVersion` | App version, as defined in the manifest. Should not be mutated. |
-| `buildCommit` | sha of the commit, should not be mutated. |
-| `registryUrl` | URL of the Cozy registry, should not be mutated. |
-| `registryEditor` | Editor as it appears in the Cozy registry. |
-| `registryToken` | Registry Token. See [registry documentation](https://docs.cozy.io/en/cozy-stack/registry-publish/). Should not be mutated. |
-| `spaceName` | Space name in the Cozy registry. |
-
+| Options          | Description                                                                                                                |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `appBuildUrl`    | The url where the build can be retrieved. For example, `http://github.com/cozy/cozy-foo/archives/cozy-foo.tar.gz`          |
+| `appSlug`        | The slug of the application, as defined in the manifest. Should not be mutated                                             |
+| `appType`        | `webapp` or `konnector`                                                                                                    |
+| `appVersion`     | App version, as defined in the manifest. Should not be mutated.                                                            |
+| `buildCommit`    | sha of the commit, should not be mutated.                                                                                  |
+| `registryUrl`    | URL of the Cozy registry, should not be mutated.                                                                           |
+| `registryEditor` | Editor as it appears in the Cozy registry.                                                                                 |
+| `registryToken`  | Registry Token. See [registry documentation](https://docs.cozy.io/en/cozy-stack/registry-publish/). Should not be mutated. |
+| `spaceName`      | Space name in the Cozy registry.                                                                                           |
 
 #### `--postpublish <script_path>`
 
@@ -169,7 +174,7 @@ Sends a message to a mattermost channel to notify of the app's deployment. Requi
 
 #### `--registry-url <url>`
 
-The url of the registry, by default it will be https://staging-apps-registry.cozycloud.cc.
+The url of the registry, by default it will be <https://staging-apps-registry.cozycloud.cc>.
 
 #### `--space <space-name>`
 

--- a/packages/cozy-authentication/README.md
+++ b/packages/cozy-authentication/README.md
@@ -1,32 +1,26 @@
-[Cozy] Authentication component
-==================
+# [Cozy] Authentication component
 
-What's cozy-authentication
-----------------
+## What's cozy-authentication
 
 Cozy-Authentication is a React component used to authenticate to a Cozy. It acts as a login page.
 
-What's Cozy?
-------------
+## What's Cozy?
 
 ![Cozy Logo](https://cdn.rawgit.com/cozy/cozy-guidelines/master/templates/cozy_logo_small.svg)
 
 [Cozy] is a platform that brings all your web services in the same private space.  With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
 
-Contribute
-----------
+## Contribute
 
 If you want to work on cozy-authentication itself and submit code modifications, feel free to open pull-requests! See the [contributing guide][contribute] for more information about this repository structure, testing, linting and how to properly open pull-requests.
 
-Docs related to authentication process
---------------------------------------
+## Docs related to authentication process
 
-https://gitlab.cozycloud.cc/cloudery/backend-cozy/blob/master/doc/onboarding_mobile.mmdc
+<https://gitlab.cozycloud.cc/cloudery/backend-cozy/blob/master/doc/onboarding_mobile.mmdc>
 
-https://paper.dropbox.com/doc/Connexion-apres-creation--Ab117hm3s4nvwa6eQctXmIWzAg-Sr76PG8FfCNrVNsb19pCf
+<https://paper.dropbox.com/doc/Connexion-apres-creation--Ab117hm3s4nvwa6eQctXmIWzAg-Sr76PG8FfCNrVNsb19pCf>
 
-Community
----------
+## Community
 
 ### Get in touch
 
@@ -37,17 +31,20 @@ You can reach the Cozy Community by:
 - Posting issues on the [Github repos][github]
 - Say Hi! on [Twitter][twitter]
 
-
-Licence
--------
+## Licence
 
 cozy-authentication is developed by Cozy Cloud and distributed under the [MIT].
 
-
 [cozy]: https://cozy.io "Cozy Cloud"
+
 [MIT]: https://opensource.org/licenses/MIT
+
 [contribute]: CONTRIBUTING.md
+
 [freenode]: http://webchat.freenode.net/?randomnick=1&channels=%23cozycloud&uio=d4
+
 [forum]: https://forum.cozy.io/
+
 [github]: https://github.com/cozy/
+
 [twitter]: https://twitter.com/mycozycloud

--- a/packages/cozy-authentication/README.md
+++ b/packages/cozy-authentication/README.md
@@ -1,4 +1,4 @@
-# [Cozy] Authentication component
+# [Cozy][cozy] Authentication component
 
 ## What's cozy-authentication
 
@@ -8,7 +8,7 @@ Cozy-Authentication is a React component used to authenticate to a Cozy. It acts
 
 ![Cozy Logo](https://cdn.rawgit.com/cozy/cozy-guidelines/master/templates/cozy_logo_small.svg)
 
-[Cozy] is a platform that brings all your web services in the same private space.  With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
+[Cozy][cozy] is a platform that brings all your web services in the same private space.  With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
 
 ## Contribute
 
@@ -33,7 +33,7 @@ You can reach the Cozy Community by:
 
 ## Licence
 
-cozy-authentication is developed by Cozy Cloud and distributed under the [MIT].
+cozy-authentication is developed by Cozy Cloud and distributed under the [MIT][].
 
 [cozy]: https://cozy.io "Cozy Cloud"
 

--- a/packages/cozy-codemods/README.md
+++ b/packages/cozy-codemods/README.md
@@ -14,6 +14,7 @@ for
 See [here][jscodeshift-docs] for more information on codeshifts.
 
 [jscodeshift]: https://github.com/facebook/jscodeshift
+
 [jscodeshift-docs]: https://github.com/facebook/jscodeshift/wiki/jscodeshift-Documentation
 
 ### Installation
@@ -78,7 +79,6 @@ After
 - Replace a HOC with a hook with [`hoc-replacer.js`](./src/hoc-replacer.js)
 - Remove unused imports with [`remove-unused-imports.js`](./src/remove-unused-imports.js)
 
-
 ## API
 
 ## Functions
@@ -103,53 +103,58 @@ JSX identifiers are counted as React usage.</p>
 <a name="removeUnusedImports"></a>
 
 ## removeUnusedImports(root, j)
+
 Removes unused imports by counting usage.
 JSX identifiers are counted as React usage.
 
 **Kind**: global function
 
-| Param | Type |
-| --- | --- |
-| root | <code>PathNode</code> |
-| j | <code>Object</code> |
+| Param | Type                  |
+| ----- | --------------------- |
+| root  | <code>PathNode</code> |
+| j     | <code>Object</code>   |
 
 <a name="isBlockLike"></a>
 
 ## isBlockLike(path) ⇒ <code>Boolean</code>
+
 Returns true if path is Program or a Block
 
 **Kind**: global function
 
-| Param | Type |
-| --- | --- |
-| path | <code>PathNode</code> |
+| Param | Type                  |
+| ----- | --------------------- |
+| path  | <code>PathNode</code> |
 
 <a name="flatReplace"></a>
 
 ## flatReplace(path, newNode)
+
 Replaces `path.node` with `newNode` without keeping blocks, flattening
 `newNode` into `path`. Useful when removing `if`/`else`.
 
 **Kind**: global function
 
-| Param | Type |
-| --- | --- |
-| path | <code>PathNode</code> |
-| newNode | <code>Node</code> |
+| Param   | Type                  |
+| ------- | --------------------- |
+| path    | <code>PathNode</code> |
+| newNode | <code>Node</code>     |
 
 <a name="simplifyConditions"></a>
 
 ## simplifyConditions(root, j)
+
 Statically evaluates boolean conditions
 
 **Kind**: global function
 
-| Param | Type |
-| --- | --- |
-| root | <code>NodePath</code> |
-| j | <code>Object</code> |
+| Param | Type                  |
+| ----- | --------------------- |
+| root  | <code>NodePath</code> |
+| j     | <code>Object</code>   |
 
 **Example**
+
 ```js
 `if (true) { foo } else { bar }` -> `foo`
 
@@ -157,4 +162,3 @@ Statically evaluates boolean conditions
 
 `!true ? foo : bar` -> `bar`
 ```
-

--- a/packages/cozy-codemods/README.md
+++ b/packages/cozy-codemods/README.md
@@ -2,7 +2,7 @@
 
 ## Cozy codeshifts
 
-A collection of utils and transforms for [jscodeshift].
+A collection of utils and transforms for [jscodeshift][].
 
 Codeshifts are automatic transformations of Javascript code. They can be used
 for

--- a/packages/cozy-doctypes/README.md
+++ b/packages/cozy-doctypes/README.md
@@ -133,7 +133,7 @@ The `package.json` has both `main` and `browser` fields. This allows
 - browser runtimes to use transpiled code
 
 The only caveat here is that we must pay attention to features that we use that are not supported yet
-in nodeJS, for example 
+in nodeJS, for example
 
 - the lack of ES6 module support in nodeJS, we have to use `module.exports`
 - class properties: must bind the methods in the constructor

--- a/packages/cozy-doctypes/README.md
+++ b/packages/cozy-doctypes/README.md
@@ -128,7 +128,7 @@ The created document will have a `cozyMetadata` property like this:
 The `package.json` has both `main` and `browser` fields. This allows
 
 - a nodeJS runtime to run the non transpiled code (async/await are for example
-supported in nodeJS) which allows for easier to read stacktraces.
+  supported in nodeJS) which allows for easier to read stacktraces.
 
 - browser runtimes to use transpiled code
 
@@ -138,6 +138,6 @@ in nodeJS, for example
 - the lack of ES6 module support in nodeJS, we have to use `module.exports`
 - class properties: must bind the methods in the constructor
 
-webpack doc for browser field: https://webpack.js.org/configuration/resolve/#resolvealiasfields
+webpack doc for browser field: <https://webpack.js.org/configuration/resolve/#resolvealiasfields>
 
-package.json doc for browser field: https://docs.npmjs.com/files/package.json#browser
+package.json doc for browser field: <https://docs.npmjs.com/files/package.json#browser>

--- a/packages/cozy-doctypes/src/banking/README.md
+++ b/packages/cozy-doctypes/src/banking/README.md
@@ -9,7 +9,7 @@ Account matching necessitates real world data for its tests. After
 anonymizing the data, it has been encrypted to further increase
 security and privacy.
 
-To run the tests (you'll need a password for the decryption step): 
+To run the tests (you'll need a password for the decryption step):
 
 ```bash
 cd packages/cozy-doctypes

--- a/packages/cozy-flags/README.md
+++ b/packages/cozy-flags/README.md
@@ -14,7 +14,7 @@ npm install --save cozy-flags
 # or yarn add cozy-flags
 ```
 
-A CozyClient plugin is exported that 
+A CozyClient plugin is exported that
 
 - initializes flags on client's login
 - resets them on client's logout
@@ -24,7 +24,7 @@ import flag from 'cozy-flags'
 client.registerPlugin(flag.plugin)
 ```
 
-ℹ️ It will fetch server flags for consumption by the app 
+ℹ️ It will fetch server flags for consumption by the app
 
 - either from DOM data (if `data-cozy={{ .CozyData }}` or `data-flags={{ .Flags }}`, on web
 - or by fetching data from the server (on mobile)

--- a/packages/cozy-flags/README.md
+++ b/packages/cozy-flags/README.md
@@ -1,5 +1,4 @@
-Flags
-=====
+# Flags
 
 Use and manage cozy feature flags.
 Flags can be toggled for a cozy instance, a context or globally.
@@ -69,7 +68,6 @@ const App = () => {
 The `FlagSwitcher` component helps toggling the flags.
 
 <img src='https://user-images.githubusercontent.com/1606068/43769674-93301fa4-9a3a-11e8-9d2a-93a6ab4f1a07.gif' />
-
 
 ### Flags enabled at build time
 

--- a/packages/cozy-harvest-lib/README.md
+++ b/packages/cozy-harvest-lib/README.md
@@ -113,4 +113,4 @@ See the [Styleguidist](https://docs.cozy.io/cozy-libs/cozy-harvest-lib/).
 
 # Doc and example about manifests
 
-https://docs.cozy.io/en/tutorials/konnector/#the-manifest
+<https://docs.cozy.io/en/tutorials/konnector/#the-manifest>

--- a/packages/cozy-interapp/README.md
+++ b/packages/cozy-interapp/README.md
@@ -58,7 +58,7 @@ intents.create('EDIT', 'io.cozy.apps')
 
 If `intentId` and `window` parameters are not provided the method will try to retrieve them automatically.
 
-It returns a _service_ object, which provides the following methods :
+It returns a *service* object, which provides the following methods :
 
 - `compose(action, doctype, data)`: request the client to make a second intent. This returns a promise fulfilled with the second intent result.
 

--- a/packages/cozy-interapp/README.md
+++ b/packages/cozy-interapp/README.md
@@ -4,7 +4,6 @@ Library to create intents : actions that need to be fullfilled by another app th
 
 See cozy-stack [documentation](https://docs.cozy.io/en/cozy-stack/intents/) for more details.
 
-
 ### Initialization
 
 ```js
@@ -19,7 +18,7 @@ const intents = new Intents({ client })
 
 `intents.create(action, doctype [, data, permissions])` create an intent. It returns a modified Promise for the intent document, having a custom `start(element)` method. This method interacts with the DOM to append an iframe to the given HTML element. This iframe will provide an access to an app, which will serve a service page able to manage the intent action for the intent doctype. The `start(element)` method returns a promise for the result document provided by intent service.
 
-> __On Intent ready callback:__ This `start` method also takes a second optional argument which is a callback function (`start(element, onReadyCallback)`). When provided, this function will be run when the intent iframe will be completely loaded (using the `onload` iframe listener). This callback could be useful to run a client code only when the intent iframe is ready and loaded.
+> **On Intent ready callback:** This `start` method also takes a second optional argument which is a callback function (`start(element, onReadyCallback)`). When provided, this function will be run when the intent iframe will be completely loaded (using the `onload` iframe listener). This callback could be useful to run a client code only when the intent iframe is ready and loaded.
 
 An intent has to be created everytime an app need to perform an action over a doctype for wich it does not have permission. For example, the Cozy Drive app should create an intent to `pick` a `io.cozy.contacts` document. The cozy-stack will determines which app can offer a service to resolve the intent. It's this service's URL that will be passed to the iframe `src` property.
 
@@ -59,37 +58,38 @@ intents.create('EDIT', 'io.cozy.apps')
 
 If `intentId` and `window` parameters are not provided the method will try to retrieve them automatically.
 
-It returns a *service* object, which provides the following methods :
- * `compose(action, doctype, data)`: request the client to make a second intent. This returns a promise fulfilled with the second intent result.
+It returns a _service_ object, which provides the following methods :
+
+- `compose(action, doctype, data)`: request the client to make a second intent. This returns a promise fulfilled with the second intent result.
 
 ```js
 // ...
 const app = await service.compose('INSTALL', 'io.cozy.apps', { slug: 'drive' })
- ```
+```
 
- * `getData()`: returns the data passed to the service by the client.
- * `getIntent()`: returns the intent
- * `resizeClient(doc, transitionProperty)`: forces the size of the intent modale to a given width, maxWidth, height, maxHeight, or dimensions of a given element. The second optional argument `transitionProperty` can be used to add a CSS transition property on the intent in order to 'animate' the resizing.
+- `getData()`: returns the data passed to the service by the client.
+- `getIntent()`: returns the intent
+- `resizeClient(doc, transitionProperty)`: forces the size of the intent modale to a given width, maxWidth, height, maxHeight, or dimensions of a given element. The second optional argument `transitionProperty` can be used to add a CSS transition property on the intent in order to 'animate' the resizing.
 
- ```js
- // resize the client ot 300 pixels max height
- service.resizeClient({
-    maxHeight: 300
-}, '.2s linear') // will be in css -> transition: .2s linear;
- // or
- service.resizeClient({
-    element: document.querySelector('.class')
- })
- ```
+  ```js
+  // resize the client ot 300 pixels max height
+  service.resizeClient({
+     maxHeight: 300
+  }, '.2s linear') // will be in css -> transition: .2s linear;
+  // or
+  service.resizeClient({
+     element: document.querySelector('.class')
+  })
+  ```
 
-> __On intent size:__ If an intent is used by multiple applications, we don't use resizeClient(), since each application can have his own layout. You have to define the size of the intent in your application
+> **On intent size:** If an intent is used by multiple applications, we don't use resizeClient(), since each application can have his own layout. You have to define the size of the intent in your application
 
+- `terminate(doc)`: ends the intent process by passing to the client the resulting document `doc`. An intent service may only be terminated once.
+  > If a boolean `exposeIntentFrameRemoval` is found as `true` in the data sent by the client, the `terminate()` method will return an object with as properties a function named `removeIntentFrame` to remove the iframe DOM node (in order to be run by the client later on) and the resulting document `doc`. This could be useful to animate an intent closing and remove the iframe node at the animation ending.
 
- * `terminate(doc)`: ends the intent process by passing to the client the resulting document `doc`. An intent service may only be terminated once.
-   > If a boolean `exposeIntentFrameRemoval` is found as `true` in the data sent by the client, the `terminate()` method will return an object with as properties a function named `removeIntentFrame` to remove the iframe DOM node (in order to be run by the client later on) and the resulting document `doc`. This could be useful to animate an intent closing and remove the iframe node at the animation ending.
+- `cancel()`: ends the intent process by passing a `null` value to the client. This method terminate the intent service the same way that `terminate()`.
 
- * `cancel()`: ends the intent process by passing a `null` value to the client. This method terminate the intent service the same way that `terminate()`.
- * `throw(error)`: throw an error to client and causes the intent promise rejection.
+- `throw(error)`: throw an error to client and causes the intent promise rejection.
 
 #### Example
 

--- a/packages/cozy-logger/README.md
+++ b/packages/cozy-logger/README.md
@@ -7,6 +7,6 @@ It is starting to be usable by apps but the code is still in NodeJS (with requir
 Depending on NODE_ENV, it will either :
 
 - log with colors in a human friendly way switch (`NODE_ENV` == "developement" || "standalone" || "test")
-- log in JSON for logs to be picked up by the [stack] (`NODE_ENV` == "production")
+- log in JSON for logs to be picked up by the [stack] \(`NODE_ENV` == "production")
 
 [stack]: https://github.com/cozy/cozy-stack

--- a/packages/cozy-logger/README.md
+++ b/packages/cozy-logger/README.md
@@ -7,6 +7,6 @@ It is starting to be usable by apps but the code is still in NodeJS (with requir
 Depending on NODE_ENV, it will either :
 
 - log with colors in a human friendly way switch (`NODE_ENV` == "developement" || "standalone" || "test")
-- log in JSON for logs to be picked up by the [stack] \(`NODE_ENV` == "production")
+- log in JSON for logs to be picked up by the [stack][] (`NODE_ENV` == "production")
 
 [stack]: https://github.com/cozy/cozy-stack

--- a/packages/cozy-mjml/README.md
+++ b/packages/cozy-mjml/README.md
@@ -76,8 +76,8 @@ There are no props for this component.
 
 #### Available props
 
-- `mycozy`: bool, default `false` - Displays a header with _MyCozy_ logo instead of _CozyCloud_ logo
-- `locale`: `en`\|`fr`, default `en` - Displays the _MyCozy_ logo in english or french
+- `mycozy`: bool, default `false` - Displays a header with *MyCozy* logo instead of *CozyCloud* logo
+- `locale`: `en`|`fr`, default `en` - Displays the *MyCozy* logo in english or french
 
 ```xml
 <mj-header></mj-header>
@@ -88,7 +88,7 @@ There are no props for this component.
 
 #### Available props
 
-- `locale`: `en`\|`fr`, default `en` - Displays the footer texts & urls in english or french
+- `locale`: `en`|`fr`, default `en` - Displays the footer texts & urls in english or french
 - `instance`: `string` - Displays the user's instance text & link instead of Cozy logo
 
 ```xml

--- a/packages/cozy-mjml/README.md
+++ b/packages/cozy-mjml/README.md
@@ -1,5 +1,4 @@
-Cozy-MJML
-=========
+# Cozy-MJML
 
 Cozy-MJML is used for emails. It brings some custom components for MJML that we
 want to share between several projects (cozy-stack, clouderery, notifications,
@@ -64,6 +63,7 @@ To apply those classes, your must add an attribute `mj-class` to your MJML eleme
 ```
 
 #### Available props
+
 There are no props for this component.
 
 ```xml
@@ -75,8 +75,9 @@ There are no props for this component.
 ### `<mj-header>`
 
 #### Available props
-- `mycozy`: bool, default `false` - Displays a header with *MyCozy* logo instead of *CozyCloud* logo
-- `locale`: `en`|`fr`, default `en` - Displays the *MyCozy* logo in english or french
+
+- `mycozy`: bool, default `false` - Displays a header with _MyCozy_ logo instead of _CozyCloud_ logo
+- `locale`: `en`\|`fr`, default `en` - Displays the _MyCozy_ logo in english or french
 
 ```xml
 <mj-header></mj-header>
@@ -86,7 +87,8 @@ There are no props for this component.
 ### `<mj-footer>`
 
 #### Available props
-- `locale`: `en`|`fr`, default `en` - Displays the footer texts & urls in english or french
+
+- `locale`: `en`\|`fr`, default `en` - Displays the footer texts & urls in english or french
 - `instance`: `string` - Displays the user's instance text & link instead of Cozy logo
 
 ```xml

--- a/packages/cozy-notifications/README.md
+++ b/packages/cozy-notifications/README.md
@@ -73,7 +73,6 @@ The mobile channels consists of a push notification. Its title will be
 the result of the `getTitle` method and its content will be the result
 of `getPushContent`.
 
-
 ### mail
 
 Emails need more markup and thus will need the `template` class attribute.
@@ -193,7 +192,7 @@ MyNotificationView.template = template
 email will not be sent directly to the stack, but only rendered parts will be
 sent; in other words, only `appURL`, `topLogo`, `content` etc... will be sent,
 instead of the whole content). This is why `cozy-notifications` needs to know
-our *uncompiled* partials. We can destructure `parts` to access rendered parts.
+our _uncompiled_ partials. We can destructure `parts` to access rendered parts.
 
 ```
 import { renderer } from 'cozy-notifications'
@@ -205,7 +204,7 @@ const { parts } = render({ template, data })
 ## Built-in helpers
 
 - `t` will be passed automatically as a helper in templates. We must pass
- the `locales` object when instantiating the NotificationView.
+  the `locales` object when instantiating the NotificationView.
 
 ```javascript
 const locales = {

--- a/packages/cozy-notifications/README.md
+++ b/packages/cozy-notifications/README.md
@@ -192,7 +192,7 @@ MyNotificationView.template = template
 email will not be sent directly to the stack, but only rendered parts will be
 sent; in other words, only `appURL`, `topLogo`, `content` etc... will be sent,
 instead of the whole content). This is why `cozy-notifications` needs to know
-our _uncompiled_ partials. We can destructure `parts` to access rendered parts.
+our *uncompiled* partials. We can destructure `parts` to access rendered parts.
 
 ```
 import { renderer } from 'cozy-notifications'

--- a/packages/cozy-procedures/README.md
+++ b/packages/cozy-procedures/README.md
@@ -4,7 +4,7 @@
 
 # What's cozy-procedures?
 
-A simple way to manipulate `io.cozy.files` administrative documents. 
+A simple way to manipulate `io.cozy.files` administrative documents.
 
 With Cozy-Procedure, you can fetch documents that match the rules you define. See [this template](./src/templates/creditApplicationTemplate.js) for an creditApplication example.
 

--- a/packages/cozy-procedures/README.md
+++ b/packages/cozy-procedures/README.md
@@ -10,7 +10,7 @@ With Cozy-Procedure, you can fetch documents that match the rules you define. Se
 
 It also helps to enhance the file you manipulate by adding the corresponsing metadata automatically.
 
-See https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.files_metadata/#administrative-documents for more information about administrative documents.
+See <https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.files_metadata/#administrative-documents> for more information about administrative documents.
 
 ## Setup
 

--- a/packages/cozy-realtime/README.md
+++ b/packages/cozy-realtime/README.md
@@ -31,7 +31,7 @@ yarn add cozy-realtime
 
 ### Example
 
-CozyRealtime comes with a plugin for CozyClient. This is the recommended way to use it: 
+CozyRealtime comes with a plugin for CozyClient. This is the recommended way to use it:
 
 ```js
 import CozyClient from 'cozy-client'

--- a/packages/cozy-release/README.md
+++ b/packages/cozy-release/README.md
@@ -71,7 +71,7 @@ git tag -a x.y.z
  </div>
  </br>
 
-[Cozy] is a platform that brings all your web services in the same private space. With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
+[Cozy][cozy] is a platform that brings all your web services in the same private space. With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
 
 ### Get in touch
 

--- a/packages/cozy-release/README.md
+++ b/packages/cozy-release/README.md
@@ -89,3 +89,13 @@ The maintainers for Cozy Release are [Gregory](https://github.com/gregorylegarec
 ## License
 
 `cozy-release` is distributed under the MIT license.
+
+[cozy]: https://cozy.io "Cozy Cloud"
+
+[freenode]: http://webchat.freenode.net/?randomnick=1&channels=%23cozycloud&uio=d4
+
+[forum]: https://forum.cozy.io/
+
+[github]: https://github.com/cozy/
+
+[twitter]: https://twitter.com/cozycloud

--- a/packages/cozy-sharing/README.md
+++ b/packages/cozy-sharing/README.md
@@ -65,7 +65,7 @@ Cozy apps let users [share documents from cozy to cozy](https://github.com/cozy/
 Meet Alice and Bob.
 Alice wants to share a folder with Bob.
 Alice clicks on the share button and fills in the email input with Bob's email address.
-Bob receives an email with a _« Accept the sharing »_ button.
+Bob receives an email with a *« Accept the sharing »* button.
 Bob clicks on that button and is redirected to Alice's cozy to enter his own cozy url to link both cozys.
 Bob sees Alice's shared folder in his own cozy.
 
@@ -85,10 +85,10 @@ If you develop with the [cozy-stack CLI](https://github.com/cozy/cozy-stack/blob
 ./cozy-stack serve --appdir drive:../cozy-drive/build,settings:../cozy-settings/build --mail-disable-tls --mail-port 1025
 ```
 
-_This commands assumes you `git clone` [cozy-drive](https://github.com/cozy/cozy-drive) and [cozy-settings](https://github.com/cozy/cozy-settings) in the same folder than you `git clone` [cozy-stack](https://github.com/cozy/cozy-stack)._
+*This commands assumes you `git clone` [cozy-drive](https://github.com/cozy/cozy-drive) and [cozy-settings](https://github.com/cozy/cozy-settings) in the same folder than you `git clone` [cozy-stack](https://github.com/cozy/cozy-stack).*
 
 Then simply run `mailhog` and open <http://cozy.tools:8025/>.
 
 ## Retrieve sent emails
 
-With MailHog, **every email** sent by cozy-stack is caught. That means the email address _does not have to be a real one_, ie. `bob@cozy`, `bob@cozy.tools` are perfectly fine. It _could be a real one_, but the email will not reach the real recipient's inbox, say `contact@cozycloud.cc`.
+With MailHog, **every email** sent by cozy-stack is caught. That means the email address *does not have to be a real one*, ie. `bob@cozy`, `bob@cozy.tools` are perfectly fine. It *could be a real one*, but the email will not reach the real recipient's inbox, say `contact@cozycloud.cc`.

--- a/packages/cozy-sharing/README.md
+++ b/packages/cozy-sharing/README.md
@@ -75,7 +75,7 @@ Bob sees Alice's shared folder in his own cozy.
 
 If you develop with the [cozy-app-dev docker image](https://github.com/cozy/cozy-stack/blob/master/docs/client-app-dev.md#with-docker), [MailHog](https://github.com/mailhog/MailHog) is running inside it to catch emails.
 
-If cozy-stack has to send an email, MailHog catches it and exposes it on its web interface on http://cozy.tools:8025/.
+If cozy-stack has to send an email, MailHog catches it and exposes it on its web interface on <http://cozy.tools:8025/>.
 
 ## With the binary cozy-stack
 
@@ -87,7 +87,7 @@ If you develop with the [cozy-stack CLI](https://github.com/cozy/cozy-stack/blob
 
 _This commands assumes you `git clone` [cozy-drive](https://github.com/cozy/cozy-drive) and [cozy-settings](https://github.com/cozy/cozy-settings) in the same folder than you `git clone` [cozy-stack](https://github.com/cozy/cozy-stack)._
 
-Then simply run `mailhog` and open http://cozy.tools:8025/.
+Then simply run `mailhog` and open <http://cozy.tools:8025/>.
 
 ## Retrieve sent emails
 

--- a/packages/eslint-config-cozy-app/README.md
+++ b/packages/eslint-config-cozy-app/README.md
@@ -95,7 +95,7 @@ Configuration for Vue applications (basics configuration included). To use in yo
  </div>
  </br>
 
-[Cozy] is a platform that brings all your web services in the same private space.  With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
+[Cozy][cozy] is a platform that brings all your web services in the same private space.  With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
 
 ### Get in touch
 

--- a/packages/eslint-config-cozy-app/README.md
+++ b/packages/eslint-config-cozy-app/README.md
@@ -84,7 +84,6 @@ Configuration for Vue applications (basics configuration included). To use in yo
 }
 ```
 
-
 ## Community
 
 ### What's Cozy?
@@ -107,14 +106,16 @@ You can reach the Cozy Community by:
 - Posting issues on the [Github repos][github]
 - Say Hi! on [Twitter][twitter]
 
-
 ## License
 
 `eslint-config-cozy-app` is distributed under the MIT license.
 
-
 [cozy]: https://cozy.io "Cozy Cloud"
+
 [freenode]: http://webchat.freenode.net/?randomnick=1&channels=%23cozycloud&uio=d4
+
 [forum]: https://forum.cozy.io/
+
 [github]: https://github.com/cozy/
+
 [twitter]: https://twitter.com/cozycloud

--- a/packages/playgrounds/README.md
+++ b/packages/playgrounds/README.md
@@ -17,7 +17,7 @@ You need to launch your browser with disabled CORS, for example on macOS (the im
 ```
 
 And on the connexion page, you need to indicate the full domain for your cozy when reaching
-http&#x3A;//localhost:1234/index.html:
+http://localhost:1234/index.html:
 
 ```
 http://cozy.tools:8080

--- a/packages/playgrounds/README.md
+++ b/packages/playgrounds/README.md
@@ -4,7 +4,7 @@
 yarn start
 ```
 
-If you work on a local cozy and you don't have https enabled you have to define a global `ALLOW_HTTP` var at start to be able to login (see this line in cozy-authentication https://github.com/cozy/cozy-libs/blob/master/packages/cozy-authentication/src/steps/SelectServer.jsx#L111). With `parcel` you can use the `--global` option to do so
+If you work on a local cozy and you don't have https enabled you have to define a global `ALLOW_HTTP` var at start to be able to login (see this line in cozy-authentication <https://github.com/cozy/cozy-libs/blob/master/packages/cozy-authentication/src/steps/SelectServer.jsx#L111>). With `parcel` you can use the `--global` option to do so
 
 ```
 yarn start --global __ALLOW_HTTP__
@@ -17,7 +17,7 @@ You need to launch your browser with disabled CORS, for example on macOS (the im
 ```
 
 And on the connexion page, you need to indicate the full domain for your cozy when reaching
-http://localhost:1234/index.html:
+http&#x3A;//localhost:1234/index.html:
 
 ```
 http://cozy.tools:8080

--- a/packages/renovate-config-cozy/README.md
+++ b/packages/renovate-config-cozy/README.md
@@ -6,7 +6,7 @@ To easily develop renovate configs, it is recommended to
 
 - install globally the `renovate` npm package
 - test the changes inside one repo
-- backport the changes to the config renovate 
+- backport the changes to the config renovate
 
 ```bash
 yarn global add renovate

--- a/packages/repo-doctor/README.md
+++ b/packages/repo-doctor/README.md
@@ -29,7 +29,6 @@ to mattermost.
 - If no repository is detected, it will run repo-doctor on all the repositories
   of the config
 
-
 ```bash
 # Download an example config
 $ curl -o ~/.config/repo-doctor.json https://raw.githubusercontent.com/cozy/cozy-libs/master/packages/repo-doctor/examples/repo-doctor.json
@@ -70,7 +69,6 @@ See [the example config](./examples/repo-doctor.json).
 
 For the mattermost reporter, you'll need to set up the `MATTERMOST_HOOK` env
 variable with the URL of the incoming hook that you've set up in mattermost.
-
 
 ## How to write a rule
 

--- a/packages/webpack-expose-package-info-plugin/README.md
+++ b/packages/webpack-expose-package-info-plugin/README.md
@@ -1,5 +1,4 @@
-Expose package information
-======================
+# Expose package information
 
 This plugin is useful if you want to expose chosen package information to
 a bundle created via webpack.
@@ -19,7 +18,7 @@ new PackageInfoPlugin({
 
 #### Exposed variable
 
-By default the exposed variable is __PACKAGES__ but it can be customized
+By default the exposed variable is **PACKAGES** but it can be customized
 via the `varName` option.
 
 ```patch

--- a/yarn.lock
+++ b/yarn.lock
@@ -2885,6 +2885,13 @@
     csstype "^2.0.0"
     indefinite-observable "^1.0.1"
 
+"@types/mdast@^3.0.0":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.3.tgz#2d7d671b1cd1ea3deb306ea75036c2a0407d2deb"
+  integrity sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==
+  dependencies:
+    "@types/unist" "*"
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -4493,6 +4500,21 @@ chokidar@^1.6.1:
   optionalDependencies:
     fsevents "^1.0.0"
 
+chokidar@^3.0.0:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
+  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.3.1"
+
 chokidar@^3.4.0:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.3.tgz#c1df38231448e45ca4ac588e6c79573ba6a57d5b"
@@ -5881,6 +5903,13 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.2.5, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.0.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
@@ -7097,6 +7126,13 @@ fastparse@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
 
+fault@^1.0.0, fault@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.4.tgz#eafcfc0a6d214fc94601e170df29954a4f842f13"
+  integrity sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==
+  dependencies:
+    format "^0.2.0"
+
 faye-websocket@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.10.0.tgz#4e492f8d04dfb6f89003507f6edbf2d501e7c6f4"
@@ -7142,6 +7178,13 @@ figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+figures@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
 
@@ -7373,6 +7416,11 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+format@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
+  integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
+
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
@@ -7451,6 +7499,11 @@ fsevents@^2.1.2, fsevents@~2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+
+fsevents@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -8281,6 +8334,11 @@ ignore@^4.0.3, ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
 
+ignore@^5.0.0:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
+  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
 ignore@^5.1.1:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
@@ -8646,6 +8704,11 @@ is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
 
+is-empty@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-empty/-/is-empty-1.2.0.tgz#de9bb5b278738a05a0b09a57e1fb4d4a341a9f6b"
+  integrity sha1-3pu1snhzigWgsJpX4ftNSjQan2s=
+
 is-equal-shallow@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#2238098fc221de0bcfa5d9eac4c45d638aa1c534"
@@ -8781,6 +8844,11 @@ is-path-inside@^2.1.0:
 is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+
+is-plain-obj@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
@@ -9830,6 +9898,14 @@ js-yaml@^3.10.0, js-yaml@^3.13.0, js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.6.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
+  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
@@ -10069,6 +10145,13 @@ json5@^1.0.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
   dependencies:
     minimist "^1.2.0"
+
+json5@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
+  dependencies:
+    minimist "^1.2.5"
 
 json5@^2.1.0, json5@^2.1.2:
   version "2.1.3"
@@ -10340,6 +10423,15 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+libnpmconfig@^1.0.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/libnpmconfig/-/libnpmconfig-1.2.1.tgz#c0c2f793a74e67d4825e5039e7a02a0044dfcbc0"
+  integrity sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==
+  dependencies:
+    figgy-pudding "^3.5.1"
+    find-up "^3.0.0"
+    ini "^1.3.5"
+
 lie@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
@@ -10399,6 +10491,14 @@ load-json-file@^5.3.0:
     pify "^4.0.1"
     strip-bom "^3.0.0"
     type-fest "^0.3.0"
+
+load-plugin@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/load-plugin/-/load-plugin-3.0.0.tgz#8f3ce57cf4e5111639911012487bc1c2ba3d0e6c"
+  integrity sha512-od7eKCCZ62ITvFf8nHHrIiYmgOHb4xVNDRDqxBWSaao5FZyyZVX8OmRCbwjDGPrSrgIulwPNyBsWCGnhiDC0oQ==
+  dependencies:
+    libnpmconfig "^1.0.0"
+    resolve-from "^5.0.0"
 
 loader-runner@^2.4.0:
   version "2.4.0"
@@ -10627,6 +10727,11 @@ long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
+longest-streak@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
+  integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
+
 longest-streak@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.3.tgz#3de7a3f47ee18e9074ded8575b5c091f5d0a4105"
@@ -10768,6 +10873,11 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.3.tgz#6155e10416efaafab665d466ce598216375195f5"
   integrity sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw==
 
+markdown-extensions@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/markdown-extensions/-/markdown-extensions-1.1.1.tgz#fea03b539faeaee9b4ef02a3769b455b189f7fc3"
+  integrity sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==
+
 markdown-it-anchor@^5.0.2:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-5.2.4.tgz#d39306fe4c199705b4479d3036842cf34dcba24f"
@@ -10830,15 +10940,43 @@ mdast-util-compact@^1.0.0:
   dependencies:
     unist-util-visit "^1.1.0"
 
+mdast-util-from-markdown@^0.8.0:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz#d1ef2ca42bc377ecb0463a987910dae89bd9a28c"
+  integrity sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-string "^2.0.0"
+    micromark "~2.11.0"
+    parse-entities "^2.0.0"
+    unist-util-stringify-position "^2.0.0"
+
 mdast-util-heading-style@^1.0.2:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/mdast-util-heading-style/-/mdast-util-heading-style-1.0.6.tgz#6410418926fd5673d40f519406b35d17da10e3c5"
   integrity sha512-8ZuuegRqS0KESgjAGW8zTx4tJ3VNIiIaGFNEzFpRSAQBavVc7AvOo9I4g3crcZBfYisHs4seYh0rAVimO6HyOw==
 
+mdast-util-to-markdown@^0.6.0:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz#b33f67ca820d69e6cc527a93d4039249b504bebe"
+  integrity sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    longest-streak "^2.0.0"
+    mdast-util-to-string "^2.0.0"
+    parse-entities "^2.0.0"
+    repeat-string "^1.0.0"
+    zwitch "^1.0.0"
+
 mdast-util-to-string@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz#27055500103f51637bd07d01da01eb1967a43527"
   integrity sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==
+
+mdast-util-to-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz#b8cfe6a713e1091cb5b728fc48885a4767f8b97b"
+  integrity sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==
 
 mdn-data@2.0.4:
   version "2.0.4"
@@ -10965,6 +11103,14 @@ microevent.ts@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
   integrity sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==
+
+micromark@~2.11.0:
+  version "2.11.4"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-2.11.4.tgz#d13436138eea826383e822449c9a5c50ee44665a"
+  integrity sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==
+  dependencies:
+    debug "^4.0.0"
+    parse-entities "^2.0.0"
 
 micromatch@^2.1.5:
   version "2.3.11"
@@ -11527,7 +11673,7 @@ ms@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
-ms@^2.0.0, ms@^2.1.1:
+ms@2.1.2, ms@^2.0.0, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -12449,6 +12595,18 @@ parse-entities@^1.0.2, parse-entities@^1.1.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"
   integrity sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
+parse-entities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-2.0.0.tgz#53c6eb5b9314a1f4ec99fa0fdf7ce01ecda0cbe8"
+  integrity sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==
   dependencies:
     character-entities "^1.0.0"
     character-entities-legacy "^1.0.0"
@@ -14410,6 +14568,15 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
+remark-cli@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/remark-cli/-/remark-cli-9.0.0.tgz#6f7951e7a72217535f2e32b7a6d3f638fe182f86"
+  integrity sha512-y6kCXdwZoMoh0Wo4Och1tDW50PmMc86gW6GpF08v9d+xUCEJE2wwXdQ+TnTaUamRnfFdU+fE+eNf2PJ53cyq8g==
+  dependencies:
+    markdown-extensions "^1.1.0"
+    remark "^13.0.0"
+    unified-args "^8.0.0"
+
 remark-lint-final-newline@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/remark-lint-final-newline/-/remark-lint-final-newline-1.0.5.tgz#666f609a91f97c44f5ab7facf1fb3c5b3ffe398f"
@@ -14617,6 +14784,13 @@ remark-parse@^6.0.0:
     vfile-location "^2.0.0"
     xtend "^4.0.1"
 
+remark-parse@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-9.0.0.tgz#4d20a299665880e4f4af5d90b7c7b8a935853640"
+  integrity sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==
+  dependencies:
+    mdast-util-from-markdown "^0.8.0"
+
 remark-preset-lint-recommended@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/remark-preset-lint-recommended/-/remark-preset-lint-recommended-4.0.1.tgz#2077b38706759277c0eb304c57453ebfa3e63207"
@@ -14658,6 +14832,13 @@ remark-stringify@^6.0.0:
     unherit "^1.0.4"
     xtend "^4.0.1"
 
+remark-stringify@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-9.0.1.tgz#576d06e910548b0a7191a71f27b33f1218862894"
+  integrity sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==
+  dependencies:
+    mdast-util-to-markdown "^0.6.0"
+
 remark@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/remark/-/remark-10.0.1.tgz#3058076dc41781bf505d8978c291485fe47667df"
@@ -14665,6 +14846,15 @@ remark@^10.0.1:
     remark-parse "^6.0.0"
     remark-stringify "^6.0.0"
     unified "^7.0.0"
+
+remark@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/remark/-/remark-13.0.0.tgz#d15d9bf71a402f40287ebe36067b66d54868e425"
+  integrity sha512-HDz1+IKGtOyWN+QgBiAT0kn+2s6ovOxHyPAFGKVE81VSzJ+mq7RwHFledEvB5F1p4iJvOah/LOKdFuzvRnNLCA==
+  dependencies:
+    remark-parse "^9.0.0"
+    remark-stringify "^9.0.0"
+    unified "^9.1.0"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -14674,7 +14864,7 @@ repeat-element@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
 
-repeat-string@^1.5.2, repeat-string@^1.5.4, repeat-string@^1.6.1:
+repeat-string@^1.0.0, repeat-string@^1.5.0, repeat-string@^1.5.2, repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -15672,7 +15862,7 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.1.0, string-width@^4.2.0:
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
   integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
@@ -15855,7 +16045,7 @@ stylus@^0.54.5, stylus@^0.54.7:
     semver "^6.0.0"
     source-map "^0.7.3"
 
-supports-color@6.1.0, supports-color@^6.1.0:
+supports-color@6.1.0, supports-color@^6.0.0, supports-color@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
   dependencies:
@@ -16228,6 +16418,14 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+to-vfile@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/to-vfile/-/to-vfile-6.1.0.tgz#5f7a3f65813c2c4e34ee1f7643a5646344627699"
+  integrity sha512-BxX8EkCxOAZe+D/ToHdDsJcVI4HqQfmw0tCkp31zf3dNP/XWIAjU4CmeuSwsSoOzOTqHPOL0KUzyZqJplkD0Qw==
+  dependencies:
+    is-buffer "^2.0.0"
+    vfile "^4.0.0"
+
 toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
@@ -16473,6 +16671,43 @@ unicode-trie@^0.3.1:
     pako "^0.2.5"
     tiny-inflate "^1.0.0"
 
+unified-args@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/unified-args/-/unified-args-8.1.0.tgz#a27dbe996a49fbbf3d9f5c6a98008ab9b0ee6ae5"
+  integrity sha512-t1HPS1cQPsVvt/6EtyWIbQGurza5684WGRigNghZRvzIdHm3LPgMdXPyGx0npORKzdiy5+urkF0rF5SXM8lBuQ==
+  dependencies:
+    camelcase "^5.0.0"
+    chalk "^3.0.0"
+    chokidar "^3.0.0"
+    fault "^1.0.2"
+    json5 "^2.0.0"
+    minimist "^1.2.0"
+    text-table "^0.2.0"
+    unified-engine "^8.0.0"
+
+unified-engine@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/unified-engine/-/unified-engine-8.0.0.tgz#e3996ff6eaecc6ca3408af92b70e25691192d17d"
+  integrity sha512-vLUezxCnjzz+ya4pYouRQVMT8k82Rk4fIj406UidRnSFJdGXFaQyQklAnalsQHJrLqAlaYPkXPUa1upfVSHGCA==
+  dependencies:
+    concat-stream "^2.0.0"
+    debug "^4.0.0"
+    fault "^1.0.0"
+    figures "^3.0.0"
+    glob "^7.0.3"
+    ignore "^5.0.0"
+    is-buffer "^2.0.0"
+    is-empty "^1.0.0"
+    is-plain-obj "^2.0.0"
+    js-yaml "^3.6.1"
+    load-plugin "^3.0.0"
+    parse-json "^5.0.0"
+    to-vfile "^6.0.0"
+    trough "^1.0.0"
+    unist-util-inspect "^5.0.0"
+    vfile-reporter "^6.0.0"
+    vfile-statistics "^1.1.0"
+
 unified-lint-rule@^1.0.0:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/unified-lint-rule/-/unified-lint-rule-1.0.6.tgz#b4ab801ff93c251faa917a8d1c10241af030de84"
@@ -16512,6 +16747,18 @@ unified@^7.0.0:
     vfile "^3.0.0"
     x-is-string "^0.1.0"
 
+unified@^9.1.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.0.tgz#67a62c627c40589edebbf60f53edfd4d822027f8"
+  integrity sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-buffer "^2.0.0"
+    is-plain-obj "^2.0.0"
+    trough "^1.0.0"
+    vfile "^4.0.0"
+
 union-value@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
@@ -16547,6 +16794,13 @@ unist-util-generated@^1.1.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.5.tgz#1e903e68467931ebfaea386dae9ea253628acd42"
   integrity sha512-1TC+NxQa4N9pNdayCYA1EGUOCAO0Le3fVp7Jzns6lnua/mYgwHo0tz5WUAfrdpNch1RZLHc61VZ1SDgrtNXLSw==
+
+unist-util-inspect@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-inspect/-/unist-util-inspect-5.0.1.tgz#168c8770a99902318ca268f8c391e294bcf44540"
+  integrity sha512-fPNWewS593JSmg49HbnE86BJKuBi1/nMWhDSccBvbARfxezEuJV85EaARR9/VplveiwCoLm2kWq+DhP8TBaDpw==
+  dependencies:
+    is-empty "^1.0.0"
 
 unist-util-is@^3.0.0:
   version "3.0.0"
@@ -16833,6 +17087,36 @@ vfile-message@^1.0.0:
   dependencies:
     unist-util-stringify-position "^1.1.1"
 
+vfile-message@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-2.0.4.tgz#5b43b88171d409eae58477d13f23dd41d52c371a"
+  integrity sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-stringify-position "^2.0.0"
+
+vfile-reporter@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/vfile-reporter/-/vfile-reporter-6.0.2.tgz#cbddaea2eec560f27574ce7b7b269822c191a676"
+  integrity sha512-GN2bH2gs4eLnw/4jPSgfBjo+XCuvnX9elHICJZjVD4+NM0nsUrMTvdjGY5Sc/XG69XVTgLwj7hknQVc6M9FukA==
+  dependencies:
+    repeat-string "^1.5.0"
+    string-width "^4.0.0"
+    supports-color "^6.0.0"
+    unist-util-stringify-position "^2.0.0"
+    vfile-sort "^2.1.2"
+    vfile-statistics "^1.1.0"
+
+vfile-sort@^2.1.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/vfile-sort/-/vfile-sort-2.2.2.tgz#720fe067ce156aba0b411a01bb0dc65596aa1190"
+  integrity sha512-tAyUqD2R1l/7Rn7ixdGkhXLD3zsg+XLAeUDUhXearjfIcpL1Hcsj5hHpCoy/gvfK/Ws61+e972fm0F7up7hfYA==
+
+vfile-statistics@^1.1.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/vfile-statistics/-/vfile-statistics-1.1.4.tgz#b99fd15ecf0f44ba088cc973425d666cb7a9f245"
+  integrity sha512-lXhElVO0Rq3frgPvFBwahmed3X03vjPF8OcjKMy8+F1xU/3Q3QU3tKEDp743SFtb74PdF0UWpxPvtOP0GCLheA==
+
 vfile@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
@@ -16850,6 +17134,16 @@ vfile@^3.0.0:
     replace-ext "1.0.0"
     unist-util-stringify-position "^1.0.0"
     vfile-message "^1.0.0"
+
+vfile@^4.0.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-4.2.1.tgz#03f1dce28fc625c625bc6514350fbdb00fa9e624"
+  integrity sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    is-buffer "^2.0.0"
+    unist-util-stringify-position "^2.0.0"
+    vfile-message "^2.0.0"
 
 vlq@^0.2.2:
   version "0.2.3"
@@ -17509,6 +17803,11 @@ yargs@^8.0.2:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^7.0.0"
+
+zwitch@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-1.0.5.tgz#d11d7381ffed16b742f6af7b3f223d5cd9fe9920"
+  integrity sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==
 
 zxcvbn@^4.4.2:
   version "4.4.2"


### PR DESCRIPTION
- Brings coherence to the way we write markdown
- Catches easy to miss errors like missing break lines before a
  code block (works on GitHub, not on mkdocs)