### PR TITLE
fix: Sharing type for recipients in sharing modal

### DIFF
--- a/packages/cozy-sharing/__tests__/fixtures.js
+++ b/packages/cozy-sharing/__tests__/fixtures.js
@@ -228,6 +228,7 @@ export const SHARING_READ_ONLY = {
     }
   }
 }
+
 export const SHARING_WITH_SHORTCUT = {
   type: 'io.cozy.sharings',
   id: 'sharing_5',

--- a/packages/cozy-sharing/src/state.spec.js
+++ b/packages/cozy-sharing/src/state.spec.js
@@ -13,7 +13,8 @@ import reducer, {
   hasSharedChild,
   getSharedDocIdsBySharings,
   getSharingType,
-  getPermissionDocIds
+  getPermissionDocIds,
+  getDocumentSharingType
 } from './state'
 
 import {
@@ -344,6 +345,7 @@ describe('Sharing state', () => {
           avatarPath: '/sharings/sharing_3/recipients/1/avatar'
         }
       ])
+
       expect(getRecipients(state, 'shortcut_id')).toEqual([
         {
           email: 'jane@doe.com',
@@ -499,6 +501,7 @@ describe('getPermissionDocIds method', () => {
     expect(docs).toEqual([])
   })
 })
+
 describe('getSharingType selector', () => {
   it('should return false is this a sharingByLink', () => {
     const newState = reducer({}, addSharingLink(PERM_2))
@@ -518,6 +521,7 @@ describe('getSharingType selector', () => {
       getSharingType(newState, SHARING_3.attributes.rules[0].values[0], '')
     ).toBe('two-way')
   })
+
   it('should return one-way if the sharing is one-way', () => {
     const newState = reducer(
       {},
@@ -530,6 +534,82 @@ describe('getSharingType selector', () => {
         newState,
         SHARING_READ_ONLY.attributes.rules[0].values[0],
         ''
+      )
+    ).toBe('one-way')
+  })
+})
+
+describe('getDocumentSharingType', () => {
+  it('should return null if no sharing', () => {
+    expect(getDocumentSharingType()).toBeNull()
+  })
+
+  it('should return one-way or two-way according to the rules', () => {
+    expect(
+      getDocumentSharingType(
+        {
+          attributes: {
+            rules: [
+              {
+                values: ['folder_1'],
+                update: 'sync',
+                remove: 'sync'
+              }
+            ]
+          }
+        },
+        'folder_1'
+      )
+    ).toBe('two-way')
+
+    expect(
+      getDocumentSharingType(
+        {
+          attributes: {
+            rules: [
+              {
+                values: ['file_1'],
+                update: 'sync',
+                remove: 'revoke'
+              }
+            ]
+          }
+        },
+        'file_1'
+      )
+    ).toBe('two-way')
+
+    expect(
+      getDocumentSharingType(
+        {
+          attributes: {
+            rules: [
+              {
+                values: ['folder_1'],
+                update: 'revoke',
+                remove: 'revoke'
+              }
+            ]
+          }
+        },
+        'folder_1'
+      )
+    ).toBe('one-way')
+
+    expect(
+      getDocumentSharingType(
+        {
+          attributes: {
+            rules: [
+              {
+                values: ['folder_1'],
+                update: 'revoke',
+                remove: 'sync'
+              }
+            ]
+          }
+        },
+        'folder_1'
       )
     ).toBe('one-way')
   })


### PR DESCRIPTION
Lors d'un partage en "can change" c'est à dire "two-way", le destinataire était affiché étant en "can view" c'est à dire "one-way" dans la liste des destinataires.

C'est maintenant corrigé.

**Attention** on ne change pas le comportement pour le destinataire lors sur un lien de partage non approuvé. Dans ce cas, on a toujours "one-way" pour le destinataire, même si l'expéditeur a choisi "two-way". Car on se base sur les rules pour définir si on est en "one-way" ou "two-way", or il n'y a pas de rule pur un partage non approuvé. Pour ça il faudrait se baser sur les `read_only` des membres plutôt que les rules. Issue https://github.com/cozy/cozy-libs/issues/1229#issuecomment-780410677

![image](https://user-images.githubusercontent.com/67680939/107943938-ae48a380-6f8d-11eb-91c9-985ed1f1090a.png)

![image](https://user-images.githubusercontent.com/67680939/107943967-bbfe2900-6f8d-11eb-9714-0615d2777b71.png)

