### PR TITLE
Fix : correctly update slide height of harvest modal

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
@@ -215,7 +215,9 @@ const ConfigurationTab = ({
         </NavigationListSection>
       </NavigationList>
       {showNewAccountButton ? (
-        <div className={cx('u-ta-right u-mt-1', isMobile ? 'u-ph-1' : null)}>
+        <div
+          className={cx('u-ta-right u-mt-1', isMobile ? 'u-ph-1 u-pb-1' : null)}
+        >
           <Button
             extension={isMobile ? 'full' : null}
             onClick={addAccount}

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
@@ -144,21 +144,28 @@ const ConfigurationTab = ({
 
   return (
     <div className={isMobile ? '' : 'u-pv-1-half'}>
+      {/**
+       * Use an extra div with padding instead of setting margins on TriggerErrorInfo since
+       * the offsetHeight of the parent does not take into account margins; slide content was
+       * cropped since SwipeableViews uses the offsetHeight of the first slide children when
+       * computing the height of the slide wrapper.
+       */}
       {shouldDisplayError && hasLoginError && (
-        <TriggerErrorInfo
-          className={isMobile ? 'u-mv-2' : 'u-mb-2'}
-          error={error}
-          konnector={konnector}
-          trigger={flow.trigger}
-          action={
-            error.isSolvableViaReconnect() ? (
-              <RedirectToAccountFormButton
-                konnector={konnector}
-                trigger={flow.trigger}
-              />
-            ) : null
-          }
-        />
+        <div className={isMobile ? 'u-pv-1' : 'u-pb-2'}>
+          <TriggerErrorInfo
+            error={error}
+            konnector={konnector}
+            trigger={flow.trigger}
+            action={
+              error.isSolvableViaReconnect() ? (
+                <RedirectToAccountFormButton
+                  konnector={konnector}
+                  trigger={flow.trigger}
+                />
+              ) : null
+            }
+          />
+        </div>
       )}
       <NavigationList style={isMobile ? tabMobileNavListStyle : null}>
         <ContractsForAccount konnector={konnector} account={account} />

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react'
+import React, { useState, useRef, useCallback } from 'react'
 import PropTypes from 'prop-types'
 
 import { makeStyles } from '@material-ui/core/styles'
@@ -10,6 +10,7 @@ import WarningIcon from 'cozy-ui/transpiled/react/Icons/Warning'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import SwipeableViews from 'react-swipeable-views'
 
+import useDOMMutations from '../hooks/useDOMMutations'
 import FlowProvider from '../FlowProvider'
 import DataTab from './DataTab'
 import ConfigurationTab from './ConfigurationTab'
@@ -70,6 +71,8 @@ export const KonnectorAccountTabsTabs = ({ tab, onChange, flowState }) => {
   )
 }
 
+const domMutationsConfig = { childList: true, subtree: true }
+
 const DumbKonnectorAccountTabs = props => {
   const {
     konnector,
@@ -100,6 +103,12 @@ const DumbKonnectorAccountTabs = props => {
   const swipeableActions = useRef()
   const nodeRef = useRef()
 
+  const updateSwiperHeight = useCallback(
+    () => swipeableActions.current.updateHeight(),
+    [swipeableActions]
+  )
+  useDOMMutations(nodeRef.current, domMutationsConfig, updateSwiperHeight)
+
   return (
     <div ref={nodeRef}>
       <KonnectorAccountTabsTabs
@@ -109,6 +118,7 @@ const DumbKonnectorAccountTabs = props => {
       />
       <Divider />
       <SwipeableViews
+        animateHeight={true}
         index={tab}
         disabled
         animateTransitions={isMobile}


### PR DESCRIPTION
Context:

1. the slides of the harvest konnector modal are in a swipeable
views.
2. content of slides can be dynamically computed
3. for slides of swipeable views to take the height of the current
child, we need to set animateHeight to true and watch for
subtree dom modifications

Bug:

A big white block was visible in the data tab when the content
of the configuration tab was much bigger (4). This is because a previous
commit removed the dom watching (necessary for 2) and thus the height
was not set dynamically (see 3).

The previous commit had removed updateHeight and animateHeight to
solve a bug where the content of the configuration was cropped
only when there was an error for the konnector. The fix meant
that the swipeable wrapper took the height of the tallest
slide, solving the cropping but introducing the bug 4.

To properly solve the bug, it is necessary to reintroduce the
animateHeight, the subtree modifications watching, and figure out
why swipeable views would compute the wrong height leading to cropped
content.

The cropped content appeared only when an error was shown.
The root cause was that the TriggerErrorInfo used
a *margin-top* to not be stuck to the tabs above. This margin was not
taken into account into the offsetHeight of the parent element
(only padding is taken into account) : swipeable views did not take
this margin when computing the height of the slide, leading to
cropped content.