### PR TITLE
Wait a little longer for realtime event

### DIFF
--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -68,7 +68,7 @@ const createTemporaryToken = async ({ client, konnector, account }) => {
   const jobResponse = await client.stackClient.jobs.create('konnector', {
     mode: 'getTemporaryToken',
     konnector: konnector.slug,
-    cozyBankId: cozyBankId
+    bankId: cozyBankId
   })
   const event = await waitForRealtimeEvent(
     client,

--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -73,7 +73,8 @@ const createTemporaryToken = async ({ client, konnector, account }) => {
   const event = await waitForRealtimeEvent(
     client,
     jobResponse.data.attributes,
-    'result'
+    'result',
+    30 * 1000
   )
   return event.data.result
 }

--- a/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
@@ -124,7 +124,8 @@ describe('createOrUpdateBIConnection', () => {
       {
         _id: 'job-id-1337'
       },
-      'result'
+      'result',
+      30000
     )
     expect(createBIConnection).toHaveBeenCalledWith(
       expect.any(Object),
@@ -152,7 +153,8 @@ describe('createOrUpdateBIConnection', () => {
       {
         _id: 'job-id-1337'
       },
-      'result'
+      'result',
+      30000
     )
     expect(createBIConnection).toHaveBeenCalledWith(
       expect.any(Object),
@@ -188,7 +190,8 @@ describe('createOrUpdateBIConnection', () => {
       {
         _id: 'job-id-1337'
       },
-      'result'
+      'result',
+      30000
     )
     expect(createBIConnection).not.toHaveBeenCalled()
     expect(updateBIConnection).toHaveBeenCalledWith(

--- a/packages/cozy-harvest-lib/src/services/jobUtils.js
+++ b/packages/cozy-harvest-lib/src/services/jobUtils.js
@@ -2,7 +2,12 @@ import CozyRealtime from 'cozy-realtime'
 
 const JOBS_DOCTYPE = 'io.cozy.jobs'
 
-export const waitForRealtimeEvent = (client, job, eventType) =>
+export const waitForRealtimeEvent = (
+  client,
+  job,
+  eventType,
+  timeout = 15 * 1000
+) =>
   new Promise((resolve, reject) => {
     const rt = new CozyRealtime({ client })
 
@@ -23,5 +28,5 @@ export const waitForRealtimeEvent = (client, job, eventType) =>
     rt.subscribe('notified', JOBS_DOCTYPE, id, handleNotification)
     setTimeout(() => {
       reject(new Error('Timeout for waitForRealtimeResult'))
-    }, 15 * 1000)
+    }, timeout)
   })


### PR DESCRIPTION
Instead of waiting 15s, we wait 30s, we've seen an instance of
reatime job taking 15s.

Fix https://github.com/cozy/cozy-libs/issues/1250