### PR TITLE
fix(Harvest): Get bi bank id in fetchExtraOAuthUrlParams

### DIFF
--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -59,7 +59,6 @@ const createTemporaryToken = async ({ client, konnector, account }) => {
     konnector.slug,
     'createTemporaryToken: konnector passed in options has no slug'
   )
-  assert(account, 'createTemporaryToken: No account passed in options')
   const cozyBankId = getCozyBankId({ konnector, account })
   assert(
     cozyBankId,

--- a/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
@@ -342,7 +342,9 @@ describe('fetchExtraOAuthUrlParams', () => {
         data: {
           result: {
             code: 'bi-temporary-access-token-121212',
-            biBankId: TEST_BANK_BI_ID
+            mode: 'prod',
+            biBankId: TEST_BANK_BI_ID,
+            bankId: TEST_BANK_COZY_ID
           }
         }
       }


### PR DESCRIPTION
createTemporaryToken results with cozy bank id (old linxo bank id). This bi
bank id is needed to calculate the webauth redirect url.

remove account assert in createTemporaryToken:
This function can be called without any account to calculate the webauth
redirect url, before any account creation.