### PR TITLE
Improvements

### DIFF
--- a/packages/cozy-harvest-lib/src/components/RedirectToAccountFormButton.jsx
+++ b/packages/cozy-harvest-lib/src/components/RedirectToAccountFormButton.jsx
@@ -1,22 +1,24 @@
-import React from 'react'
-import { withRouter } from 'react-router'
+import React, { useContext, useCallback } from 'react'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Button from 'cozy-ui/transpiled/react/Button'
 import { getAccountId } from '../helpers/triggers'
+import { MountPointContext } from './MountPointContext'
 
-const RedirectToAccountFormButton = ({ konnector, trigger, history }) => {
+const RedirectToAccountFormButton = ({ trigger }) => {
   const { t } = useI18n()
   const accountId = getAccountId(trigger)
+  const { pushHistory } = useContext(MountPointContext)
+  const handleClick = useCallback(() => {
+    pushHistory(`/accounts/${accountId}/edit`)
+  }, [accountId, pushHistory])
   return (
     <Button
       className="u-ml-0"
       theme="secondary"
       label={t('error.reconnect-via-form')}
-      onClick={() =>
-        history.push(`/connected/${konnector.slug}/accounts/${accountId}/edit`)
-      }
+      onClick={handleClick}
     />
   )
 }
 
-export default withRouter(RedirectToAccountFormButton)
+export default RedirectToAccountFormButton

--- a/packages/cozy-harvest-lib/src/components/RedirectToAccountFormButton.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/RedirectToAccountFormButton.spec.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import { MountPointContext } from './MountPointContext'
+import RedirectToAccountFormButton from './RedirectToAccountFormButton'
+import AppLike from '../../test/AppLike'
+
+describe('redirect to account form button', () => {
+  it('should use pushHistory to navigate', () => {
+    const pushHistory = jest.fn()
+    const mountPointContextValue = {
+      pushHistory
+    }
+    const trigger = {
+      message: {
+        account: 'account-id-1337'
+      }
+    }
+    const root = render(
+      <AppLike>
+        <MountPointContext.Provider value={mountPointContextValue}>
+          <RedirectToAccountFormButton trigger={trigger} />
+        </MountPointContext.Provider>
+      </AppLike>
+    )
+    fireEvent.click(root.getByText('Reconnect'))
+    expect(pushHistory).toHaveBeenCalledWith('/accounts/account-id-1337/edit')
+  })
+})

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -1,6 +1,7 @@
 import MicroEE from 'microee'
 
 import Realtime from 'cozy-realtime'
+import flag from 'cozy-flags'
 
 import {
   fetchReusableAccount,
@@ -14,6 +15,7 @@ import {
   fetchTrigger,
   ensureTrigger
 } from '../connections/triggers'
+import { KonnectorJobError } from '../helpers/konnectors'
 import { watchKonnectorJob } from '../models/konnector/KonnectorJobWatcher'
 import logger from '../logger'
 import { findKonnectorPolicy } from '../konnector-policies'
@@ -528,6 +530,12 @@ export class ConnectionFlow {
     this.emit(UPDATE_EVENT)
   }
 
+  getMockError() {
+    return flag('harvest.force-last-error')
+      ? new KonnectorJobError(flag('harvest.force-last-error'))
+      : null
+  }
+
   getDerivedState() {
     const trigger = this.trigger
     const { status, accountError } = this.state
@@ -539,7 +547,7 @@ export class ConnectionFlow {
       triggerError: triggerError,
       trigger,
       accountError,
-      error: accountError || triggerError,
+      error: this.getMockError() || accountError || triggerError,
       konnectorRunning: triggersModel.isKonnectorRunning(trigger)
     }
   }


### PR DESCRIPTION
* Add flag to easily mock a trigger error

Allows to easily test for LOGIN_FAILED for example
You can use `flag('harvest.force-trigger-error, "LOGIN_FAILED")`
in this case.

* Use pushHistory instead of history.push

In harvest, we have to use a special context provided method
instead of directly using history.push. This is because harvest
can be mounted differently depending on the application. The
bug here was that when clicking on the button in banks, since
we did not have `history` in context, the method did not work.