### PR TITLE
Fix OTP + 2FA flows

### DIFF
--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -114,7 +114,7 @@ export const createOrUpdateAccount = async ({
 
   if (onAccountCreation) {
     logger.debug(
-      `Using konnector policy "${konnectorPolicy.name}"'s custom  account creation`
+      `Using ${konnectorPolicy.name} konnector policy custom account creation`
     )
     accountToSave = await onAccountCreation({
       client,

--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -85,7 +85,7 @@ export const saveBIConfig = (flow, biConfig) =>
 
 export const getBIConfig = flow => {
   const data = flow.getData()
-  return data.tempToken
+  return data.biConfig
 }
 
 /**
@@ -221,7 +221,7 @@ export const updateBIConnectionFromFlow = async (flow, connectionData) => {
   const account = flow.account
 
   const connId = getBIConnectionIdFromAccount(account)
-  const { code: temporaryToken, config } = getBIConfig(flow)
+  const { code: temporaryToken, ...config } = getBIConfig(flow)
 
   logger.debug('Updating BI connection')
   const updatedConnection = await updateBIConnection(

--- a/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
@@ -378,7 +378,8 @@ describe('handleOAuthAccount', () => {
     const client = new CozyClient({
       uri: 'http://testcozy.mycozy.cloud'
     })
-    const flow = new ConnectionFlow(client, { konnector, account })
+    const flow = new ConnectionFlow(client, null, konnector)
+    flow.account = account
     flow.handleFormSubmit = jest.fn()
     flow.saveAccount = async account => account
     const account = { oauth: { query: { id_connection: ['12'] } } }
@@ -408,7 +409,8 @@ describe('setSync', () => {
     const client = new CozyClient({
       uri: 'http://testcozy.mycozy.cloud'
     })
-    const flow = new ConnectionFlow(client, { konnector, account })
+    const flow = new ConnectionFlow(client, null, konnector)
+    flow.account = account
     flow.handleFormSubmit = jest.fn()
     flow.saveAccount = async account => account
     const biConnId = 'conn-1337'


### PR DESCRIPTION
Correctly retrieve the bi config that has been saved in the
connection flow, after getTemporaryToken. The code has not
been modified to use biConfig after the update of 
getTemporaryToken to retrieve bi configuration along the
temporary token.