### PR TITLE
feat(cozy-doctypes): Avoid a log for each transaction

### DIFF
--- a/packages/cozy-doctypes/src/banking/BankingReconciliator.js
+++ b/packages/cozy-doctypes/src/banking/BankingReconciliator.js
@@ -28,6 +28,26 @@ class BankingReconciliator {
     return { savedAccounts, reconciliatedAccounts }
   }
 
+  /**
+   * @typedef ReconciliatorResponse
+   * @attribute {Array<BankAccount>} accounts
+   * @attribute {Array<BankTransactions>} transactions
+   */
+
+  /**
+   * @typedef ReconciliatorSaveOptions
+   * @attribute {Function} logProgress
+   */
+
+  /**
+   * Save new accounts and transactions
+   *
+   * @param {Array<BankAccount>} fetchedAccounts
+   * @param {Array<BankTransactions>} fetchedTransactions
+   * @param  {ReconciliatorSaveOptions} options
+   * @returns {ReconciliatorResponse}
+   *
+   */
   async save(fetchedAccounts, fetchedTransactions, options = {}) {
     const { BankAccount, BankTransaction } = this.options
 
@@ -74,12 +94,13 @@ class BankingReconciliator {
 
     log('info', 'Saving transactions...')
     let i = 1
-    const logProgress = doc => {
+    const logProgressFn = doc => {
       log('debug', `[bulkSave] ${i++} Saving ${doc.date} ${doc.label}`)
     }
     const savedTransactions = await BankTransaction.bulkSave(transactions, {
       concurrency: 30,
-      logProgress,
+      logProgress:
+        options.logProgress !== undefined ? options.logProgress : logProgressFn,
       handleDuplicates: 'remove'
     })
     return {


### PR DESCRIPTION
In some cases (ex nestor connector with many transactions), the banking
reconciliator can generate a lot of logs, which is suspected to case
memory errors in connector's worker.

This logProgress added option allows to not log each transaction with
the `null` value and this option can be chosen by the connector.