### PR TITLE
fix(Harvest): Recreate non existing BI connection saved in account

### DIFF
--- a/packages/cozy-harvest-lib/src/services/bi-http.js
+++ b/packages/cozy-harvest-lib/src/services/bi-http.js
@@ -20,6 +20,11 @@ const softJSONParse = maybeJSONData => {
 }
 
 /**
+ * @typedef {Object} BIConfig
+ * @priority {string} url
+ */
+
+/**
  * Handles BI HTTP Error
  *
  * - "code" attribute: wrongpass, actionNeeded etc..
@@ -87,6 +92,32 @@ export const updateBIUserConfig = async (config, userConfig, biAccessToken) => {
   )
 }
 
+/**
+ * Get a bi connection given it's id
+ *
+ * @param  {BIConfig} config
+ * @param  {number} connId
+ * @param  {string} biAccessToken
+ * @return {BIConnection}
+ */
+export const getBIConnection = async (config, connId, biAccessToken) => {
+  return await biRequest(
+    'GET',
+    `/users/me/connections/${connId}`,
+    config,
+    null,
+    biAccessToken
+  )
+}
+
+/**
+ * Create a BI connection
+ *
+ * @param  {BIConfig} config
+ * @param  {Object} encryptedAuth
+ * @param  {string} biAccessToken
+ * @return {BIConnection}
+ */
 export const createBIConnection = async (
   config,
   encryptedAuth,
@@ -101,10 +132,19 @@ export const createBIConnection = async (
   )
 }
 
+/**
+ * Update an existing BI connection
+ *
+ * @param  {BIConfig} config
+ * @param  {number} connId
+ * @param  {Object} encryptedAuth
+ * @param  {string} biAccessToken
+ * @return {BIConnection}
+ */
 export const updateBIConnection = async (
   config,
   connId,
-  data,
+  encryptedAuth,
   biAccessToken
 ) => {
   assert(
@@ -115,7 +155,7 @@ export const updateBIConnection = async (
     'POST',
     `/users/me/connections/${connId}`,
     config,
-    encodeToForm(data),
+    encodeToForm(encryptedAuth),
     biAccessToken
   )
 
@@ -131,6 +171,14 @@ export const updateBIConnection = async (
   }
 }
 
+/**
+ * Resume a blocked BI connection
+ *
+ * @param  {BIConfig} config
+ * @param  {number} connId
+ * @param  {string} biAccessToken
+ * @return {BIConnection}
+ */
 export const resumeBIConnection = async (config, connId, biAccessToken) => {
   assert(
     connId,


### PR DESCRIPTION
In case of outdated, non existing connection id defined in the account.
The connection would fail with an unknown error caused by harvest trying
to update a non existing bi connection -> 404

This case is not supposed to happen but still happend because we do not
handle a double decoupled 2FA, which will be fixed in another PR. And
the user is blocked trying to authenticate his bank account and failing
miserably.

Now, we first check if the connection id is valid and create a new
connection if the connection id is not valid