### PR TITLE
fix(Harvest): Do not try to update decoupled bi connections

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@cozy/minilog": "^1.0.0",
     "@sentry/browser": "^6.0.1",
-    "cozy-bi-auth": "0.0.18",
+    "cozy-bi-auth": "0.0.19",
     "cozy-doctypes": "^1.78.0",
     "cozy-logger": "^1.7.0",
     "date-fns": "^1.30.1",

--- a/packages/cozy-harvest-lib/src/components/TwoFAModal.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/TwoFAModal.spec.jsx
@@ -63,7 +63,7 @@ describe('TwoFAModal', () => {
     expect(root.queryByPlaceholderText('')).toBeFalsy()
     expect(
       root.getByText(
-        `You need to open your provider's app and/or click on a notification to confirm your authentication.`
+        `You need to open your provider's app to confirm your authentication. In some cases, you will have to validate two times.`
       )
     )
   })

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -397,7 +397,7 @@
       "app_code": "Enter the code sent to you by your mobile application",
       "app": "Use your provider's app to continue authentication"
     },
-    "desc-2fa": "You need to open your provider's app and/or click on a notification to confirm your authentication.",
+    "desc-2fa": "You need to open your provider's app to confirm your authentication. In some cases, you will have to validate two times.",
     "desc_1": "This code enables you to finish your connexion.",
     "desc_2": "The second code received on your mobile phone or by email enables you to finalize your connexion.",
     "code": {

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -397,7 +397,7 @@
       "app_code": "Saisissez le code qui vous a été envoyé dans votre application mobile.",
       "app": "Utilisez l'application de votre service pour continuer à vous connecter"
     },
-    "desc-2fa": "Vous devez ouvrir l'application de votre banque et/ou cliquer sur une notification pour confirmer votre identité.",
+    "desc-2fa": " Vous devez ouvrir l'application de votre banque pour confirmer votre identité. Dans certains cas, vous devrez valider deux fois la demande.",
     "desc_1": "Ce code reçu sur votre mobile ou par email vous permet de valider votre connexion.",
     "desc_2": "Ce second code reçu sur votre mobile ou par email vous permet de finaliser votre connexion.",
     "code": {

--- a/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
@@ -363,6 +363,12 @@ describe('createOrUpdateBIConnection', () => {
 
   it('should update the BI connection if connection id in account', async () => {
     const { client, flow } = setup()
+    getBIConnection.mockReset().mockResolvedValue({
+      id: 'updated-bi-connection-id-789'
+    })
+    updateBIConnection.mockReset().mockResolvedValue({
+      id: 'updated-bi-connection-id-789'
+    })
     const connection = await createOrUpdateBIConnection({
       client,
       flow,
@@ -457,6 +463,7 @@ describe('createOrUpdateBIConnection', () => {
     const { client, flow } = setup()
     const err = new Error()
     err.code = 'wrongpass'
+    getBIConnection.mockReset().mockResolvedValueOnce({})
     updateBIConnection.mockReset().mockRejectedValue(err)
     await expect(
       createOrUpdateBIConnection({
@@ -480,6 +487,7 @@ describe('createOrUpdateBIConnection', () => {
     const { client, flow } = setup()
     const err = new Error()
     err.code = 'SCARequired'
+    getBIConnection.mockReset().mockResolvedValueOnce({})
     updateBIConnection.mockReset().mockRejectedValue(err)
     await expect(
       createOrUpdateBIConnection({

--- a/yarn.lock
+++ b/yarn.lock
@@ -5196,10 +5196,10 @@ cosmiconfig@^5.0.0, cosmiconfig@^5.0.7, cosmiconfig@^5.1.0, cosmiconfig@^5.2.0:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-cozy-bi-auth@0.0.18:
-  version "0.0.18"
-  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.18.tgz#d76353b7d134b5afdbd26973ba283a03225e206c"
-  integrity sha512-LhmfTlzz/h5mWJP+6kSPF2QQPRAsJeQXUKd2QjJZ+T//Cp6nk3mCokS6GT2OtypdcmKPQaNVot1z3Ua3GWPcsg==
+cozy-bi-auth@0.0.19:
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.19.tgz#536c4e33e804aa17a1340507f4e0d49ff6f62a3b"
+  integrity sha512-WgADGZqIVUH6kGwUcym44DlixpGtYfFEWwd46F/jJ13vZAOsfDaI7ajH07z6WJSsg+srx6+Ro8Mh6xYy1FgDdw==
   dependencies:
     cozy-logger "^1.3.0"
     lodash "^4.17.20"


### PR DESCRIPTION
BI does not allow to update fields of a decoupled connection

+ decoupled locales update
+ upgrade cozy-bi-auth