### PR TITLE
feat: ShareAutosuggest can now handle with contact fullname

### DIFF
--- a/packages/cozy-sharing/src/components/ShareAutosuggest.jsx
+++ b/packages/cozy-sharing/src/components/ShareAutosuggest.jsx
@@ -9,7 +9,12 @@ import styles from './autosuggest.styl'
 import BoldCross from '../../assets/icons/icon-cross-bold.svg'
 
 import { getDisplayName, Contact } from '../models'
-import { cozyUrlMatch, emailMatch, groupNameMatch } from '../suggestionMatchers'
+import {
+  cozyUrlMatch,
+  emailMatch,
+  groupNameMatch,
+  fullnameMatch
+} from '../suggestionMatchers'
 import ContactSuggestion from './ContactSuggestion'
 import { extractEmails, validateEmail } from '../helpers/email'
 
@@ -30,12 +35,15 @@ export default class ShareAutocomplete extends Component {
   }
 
   computeSuggestions(value) {
+    const { contactsAndGroups } = this.props
     const inputValue = value.trim().toLowerCase()
+
     return inputValue.length === 0
       ? []
-      : this.props.contactsAndGroups.filter(
+      : contactsAndGroups.filter(
           contactOrGroup =>
             groupNameMatch(inputValue, contactOrGroup) ||
+            fullnameMatch(inputValue, contactOrGroup) ||
             emailMatch(inputValue, contactOrGroup) ||
             cozyUrlMatch(inputValue, contactOrGroup)
         )

--- a/packages/cozy-sharing/src/suggestionMatchers.js
+++ b/packages/cozy-sharing/src/suggestionMatchers.js
@@ -26,4 +26,10 @@ const groupNameMatch = (input, contactOrGroup) => {
   return nameInput.test(contactOrGroup.name)
 }
 
-export { emailMatch, cozyUrlMatch, groupNameMatch }
+const fullnameMatch = (input, contact) => {
+  if (!contact.fullname) return false
+  const fullnameInput = new RegExp(input, 'i')
+  return fullnameInput.test(contact.fullname)
+}
+
+export { emailMatch, cozyUrlMatch, groupNameMatch, fullnameMatch }

--- a/packages/cozy-sharing/src/suggestionMatchers.spec.js
+++ b/packages/cozy-sharing/src/suggestionMatchers.spec.js
@@ -94,4 +94,27 @@ describe('Suggestion matchers', () => {
       expect(result).toBe(false)
     })
   })
+
+  describe('fullnameMatch', () => {
+    it('should return false if no fullname or no match', () => {
+      const contact = {}
+      const result = matchers.fullnameMatch('jo', contact)
+      expect(result).toBeFalsy()
+
+      expect(
+        matchers.fullnameMatch('Matt', {
+          fullname: 'Jon'
+        })
+      ).toBeFalsy()
+    })
+
+    it('should return true if fullname matches', () => {
+      const contact = {
+        fullname: 'Jon Margaret Snow'
+      }
+      expect(matchers.fullnameMatch('jo', contact)).toBeTruthy()
+      expect(matchers.fullnameMatch('snow', contact)).toBeTruthy()
+      expect(matchers.fullnameMatch('MARG', contact)).toBeTruthy()
+    })
+  })
 })


### PR DESCRIPTION
On souhaite pouvoir récupérer un contact grâce à son fullname (nom, prénom, pré et suffixe de nom) dans la modale de partage