### PR TITLE
fix: Adjust DocumentQualification grid spacing

### DIFF
--- a/packages/cozy-scanner/src/DocumentQualification.jsx
+++ b/packages/cozy-scanner/src/DocumentQualification.jsx
@@ -156,7 +156,7 @@ export class DocumentQualification extends Component {
             </Typography>
           </div>
         )}
-        <Grid container spacing={8}>
+        <Grid container spacing={1}>
           <GridItem
             onClick={() => this.onSelect({ categoryLabel: null, item: null })}
           >

--- a/packages/cozy-scanner/src/__snapshots__/DocumentQualification.spec.jsx.snap
+++ b/packages/cozy-scanner/src/__snapshots__/DocumentQualification.spec.jsx.snap
@@ -53,7 +53,7 @@ exports[`DocumentQualification Initial render + selection + filename 1`] = `
     </h4>
   </div>
   <div
-    class="MuiGrid-root-31 MuiGrid-container-32 MuiGrid-spacing-xs-8-61"
+    class="MuiGrid-root-31 MuiGrid-container-32 MuiGrid-spacing-xs-1-54"
   >
     <div
       class="MuiGrid-root-31 styles__gridItem-container___387sO MuiGrid-item-33 MuiGrid-grid-xs-3-68 MuiGrid-grid-sm-2-81"
@@ -506,7 +506,7 @@ exports[`DocumentQualification Initial render + selection + filename 2`] = `
     </h4>
   </div>
   <div
-    class="MuiGrid-root-31 MuiGrid-container-32 MuiGrid-spacing-xs-8-61"
+    class="MuiGrid-root-31 MuiGrid-container-32 MuiGrid-spacing-xs-1-54"
   >
     <div
       class="MuiGrid-root-31 styles__gridItem-container___387sO MuiGrid-item-33 MuiGrid-grid-xs-3-68 MuiGrid-grid-sm-2-81"


### PR DESCRIPTION
to better fit with muiv4

**BEFORE :**
![image](https://user-images.githubusercontent.com/67680939/111965936-9d440280-8af6-11eb-9b4b-664c8ec22cfa.png)

**AFTER :**
![image](https://user-images.githubusercontent.com/67680939/111966004-b64cb380-8af6-11eb-8b09-cf5445bad89f.png)
