### PR TITLE
feat: KonnectorBlock use its own fetchIcon func for AppIcon comp

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorBlock.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorBlock.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import get from 'lodash/get'
@@ -34,6 +34,16 @@ const KonnectorBlock = ({ file }) => {
   const { t } = useI18n()
   const slug = get(file, 'cozyMetadata.uploadedBy.slug')
   const sourceAccount = get(file, 'cozyMetadata.sourceAccount')
+
+  // TODO To be removed when UI's AppIcon use getIconURL from Cozy-Client
+  // instead of its own see https://github.com/cozy/cozy-ui/issues/1723
+  const fetchIcon = useCallback(() => {
+    return client.getStackClient().getIconURL({
+      type: 'konnector',
+      slug,
+      priority: 'registry'
+    })
+  }, [client, slug])
 
   useEffect(() => {
     const fetchKonnector = async ({ client, t, slug, sourceAccount }) => {
@@ -81,6 +91,7 @@ const KonnectorBlock = ({ file }) => {
             className={cx({
               'u-filter-gray-100 u-o-50': iconStatus === 'disabled'
             })}
+            fetchIcon={fetchIcon}
           />
         </ListItemIcon>
         <ListItemText


### PR DESCRIPTION
Les icons n’apparaissent pas en mobile avec le composant AppIcon.

Pour ne pas bloquer la release de Drive qu'on aimerait déployer asap, on applique ici le même patch qu'on a appliqué dans Drive : https://github.com/cozy/cozy-drive/pull/2229/files

Une autre PR va voir le jour pour corriger le souci dans UI : https://github.com/cozy/cozy-ui/pull/1775