### PR TITLE
feat: Allow to pass onCreateOrUpdate error to bulkSave

### DIFF
--- a/packages/cozy-doctypes/src/Document.js
+++ b/packages/cozy-doctypes/src/Document.js
@@ -377,11 +377,20 @@ class Document {
 
     return parallelMap(
       documents,
-      doc => {
+      async doc => {
         if (logProgress) {
           logProgress(doc)
         }
-        return this.createOrUpdate(doc, createOrUpdateOptions)
+        try {
+          const newDoc = await this.createOrUpdate(doc, createOrUpdateOptions)
+          return newDoc
+        } catch (e) {
+          if (options.onCreateOrUpdateError) {
+            return options.onCreateOrUpdateError(e, doc)
+          } else {
+            throw e
+          }
+        }
       },
       concurrency
     )


### PR DESCRIPTION
This allows the user of bulkSave to decide what do to do with errors.
The onCreateOrUpdate callback receives (error, doc) as arguments and
its result will be put in the result array returned by bulkSave.
This way, the user can extract errors after the save and decide what
to do with them (maybe retry them)