### PR TITLE
fix: KonnectorBlock now detect the correct language

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorBlock.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorBlock.jsx
@@ -18,9 +18,8 @@ import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
 import GlobeIcon from 'cozy-ui/transpiled/react/Icons/Globe'
 import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
 
+import withI18n from './hoc/withI18n'
 import Markdown from './Markdown'
-import withLocales from './hoc/withLocales'
-
 import { fetchKonnectorData } from '../helpers/konnectorBlock'
 
 /**
@@ -130,4 +129,4 @@ KonnectorBlock.propTypes = {
   file: PropTypes.object.isRequired
 }
 
-export default withLocales(KonnectorBlock)
+export default withI18n(KonnectorBlock)

--- a/packages/cozy-harvest-lib/src/components/hoc/withI18n.jsx
+++ b/packages/cozy-harvest-lib/src/components/hoc/withI18n.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import { useClient } from 'cozy-client'
+import I18n from 'cozy-ui/transpiled/react/I18n'
+
+const withI18n = Component => {
+  const WrappedComponent = props => {
+    const client = useClient()
+    const lang = client.instanceOptions.cozyLocale
+
+    return (
+      <I18n lang={lang} dictRequire={lang => require(`../../locales/${lang}`)}>
+        <Component {...props} />
+      </I18n>
+    )
+  }
+
+  return WrappedComponent
+}
+
+export default withI18n


### PR DESCRIPTION
`lang` récupéré via `useI18n()` était préalablement `undefined` et la solution de répli était la lang `en`. Ce qui fait que les traductions autre que FR n'était pas prise en compte.

Pour rappel on utilise ce composant KonnectorBlock directement dans l'application via un lien profond.