### PR TITLE
feat: Include owners in Contracts query

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/Contracts.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/Contracts.jsx
@@ -29,7 +29,10 @@ const makeContractsConn = ({ account }) => {
   const doctype = 'io.cozy.bank.accounts'
   return {
     query: () =>
-      Q(doctype).where({ 'relationships.connection.data._id': account._id }),
+      Q(doctype)
+        .where({ 'relationships.connection.data._id': account._id })
+        .include(['owners'])
+        .indexFields(['relationships.connection.data._id']),
     as: `connection-${account._id}/contracts`,
     fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000)
   }


### PR DESCRIPTION
We need to fetch the owner when fetching the contracts.
Otherwise the owner is not correctly shown in the contract edit
screen.