### PR TITLE
feat: Add u-success className to be forward compatible with cozy-ui

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountsList/Status.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountsList/Status.jsx
@@ -48,7 +48,7 @@ const Status = ({ t, trigger, konnector }) => {
           <Icon
             icon={CheckIcon}
             size={16}
-            className="u-flex-shrink-0 u-valid"
+            className="u-flex-shrink-0 u-valid u-success"
           />
         )
       }}


### PR DESCRIPTION
Since in a next version, cozy-ui will rename u-valid into u-success,
we add both classes to be compatible with every version of cozy-ui.

* There were no u-warn used (renamed to u-warning)
* There were no u-danger used (deprecated inf favor of u-error)