### PR TITLE
feat: Add client side connector launcher

### DIFF
--- a/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
@@ -70,11 +70,19 @@ const NewAccountModal = ({ konnector, onDismiss }) => {
             konnector={konnector}
             onLoginSuccess={trigger => {
               const accountId = triggersModel.getAccountId(trigger)
-              pushHistory(`/accounts/${accountId}/success`)
+              let path = `/accounts/${accountId}`
+              if (trigger.worker !== 'client') {
+                path += '/success'
+              }
+              pushHistory(path)
             }}
             onSuccess={trigger => {
               const accountId = triggersModel.getAccountId(trigger)
-              pushHistory(`/accounts/${accountId}/success`)
+              let path = `/accounts/${accountId}`
+              if (trigger.worker !== 'client') {
+                path += '/success'
+              }
+              pushHistory(path)
             }}
             onVaultDismiss={onDismiss}
             fieldOptions={fieldOptions}

--- a/packages/cozy-harvest-lib/src/components/NewAccountModal.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/NewAccountModal.spec.jsx
@@ -1,0 +1,103 @@
+/* eslint-env jest */
+import React from 'react'
+
+import { render } from '@testing-library/react'
+import AppLike from '../../test/AppLike'
+import NewAccountModal from './NewAccountModal'
+import { MountPointContext } from './MountPointContext'
+
+let onLoginSuccessFn
+let onSuccessFn
+jest.mock('./TriggerManager', () => ({ onLoginSuccess, onSuccess }) => {
+  onLoginSuccessFn = onLoginSuccess
+  onSuccessFn = onSuccess
+  return null
+})
+jest.mock('./DialogContext', () => {
+  return {
+    useDialogContext: () => {
+      return {
+        dialogTitleProps: {
+          className: 'class'
+        }
+      }
+    }
+  }
+})
+
+describe('NewAccountModal', () => {
+  const pushHistory = jest.fn()
+  const mountPointContextValue = {
+    pushHistory
+  }
+  const konnectorTrigger = {
+    worker: 'konnector',
+    message: {
+      account: 'accountNumber'
+    }
+  }
+
+  const clientTrigger = {
+    worker: 'client',
+    message: {
+      account: 'accountNumberClient'
+    }
+  }
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+  it('should redirect to success route on login success for non client triggers', () => {
+    render(
+      <AppLike client={{}}>
+        <MountPointContext.Provider value={mountPointContextValue}>
+          <NewAccountModal
+            konnector={{ slug: 'konnectorslug', name: 'konnector slug' }}
+          />
+        </MountPointContext.Provider>
+      </AppLike>
+    )
+    onLoginSuccessFn(konnectorTrigger)
+    expect(pushHistory).toHaveBeenCalledWith('/accounts/accountNumber/success')
+  })
+  it('should redirect to route without success on login success for client triggers', () => {
+    render(
+      <AppLike client={{}}>
+        <MountPointContext.Provider value={mountPointContextValue}>
+          <NewAccountModal
+            konnector={{ slug: 'konnectorslug', name: 'konnector slug' }}
+          />
+        </MountPointContext.Provider>
+      </AppLike>
+    )
+    onLoginSuccessFn(clientTrigger)
+    expect(pushHistory).toHaveBeenCalledWith('/accounts/accountNumberClient')
+  })
+
+  it('should redirect to success route on success for non client triggers', () => {
+    render(
+      <AppLike client={{}}>
+        <MountPointContext.Provider value={mountPointContextValue}>
+          <NewAccountModal
+            konnector={{ slug: 'konnectorslug', name: 'konnector slug' }}
+          />
+        </MountPointContext.Provider>
+      </AppLike>
+    )
+    onSuccessFn(konnectorTrigger)
+    expect(pushHistory).toHaveBeenCalledWith('/accounts/accountNumber/success')
+  })
+  it('should redirect to route without success on success for client triggers', () => {
+    render(
+      <AppLike client={{}}>
+        <MountPointContext.Provider value={mountPointContextValue}>
+          <NewAccountModal
+            konnector={{ slug: 'konnectorslug', name: 'konnector slug' }}
+          />
+        </MountPointContext.Provider>
+      </AppLike>
+    )
+    onSuccessFn(clientTrigger)
+    expect(pushHistory).toHaveBeenCalledWith('/accounts/accountNumberClient')
+  })
+})

--- a/packages/cozy-harvest-lib/src/helpers/triggers.js
+++ b/packages/cozy-harvest-lib/src/helpers/triggers.js
@@ -27,12 +27,16 @@ export const buildAttributes = ({
     message['folder_to_save'] = folder._id
   }
 
-  return {
-    type: '@cron',
-    arguments: cron,
+  const result = {
     worker: 'konnector',
     message
   }
+
+  const options = konnector.clientSide
+    ? { type: '@client' }
+    : { type: '@cron', arguments: cron }
+
+  return { ...result, ...options }
 }
 
 export const getAccountId = trigger => {

--- a/packages/cozy-harvest-lib/src/helpers/triggers.spec.js
+++ b/packages/cozy-harvest-lib/src/helpers/triggers.spec.js
@@ -12,7 +12,7 @@ describe('Triggers Helper', () => {
     const konnector = { slug: 'konnectest' }
     const account = { _id: '963a51f6cdd34401b0904de32cc5578d' }
 
-    it('build attributes', () => {
+    it('builds attributes', () => {
       expect(buildAttributes({ konnector, account })).toEqual({
         arguments: '0 0 0 * * 0',
         type: '@cron',
@@ -24,11 +24,25 @@ describe('Triggers Helper', () => {
       })
     })
 
-    it('build attributes with cron', () => {
+    it('builds attributes with cron', () => {
       const cron = '0 0 0 * * 2'
       expect(buildAttributes({ konnector, account, cron })).toEqual({
         arguments: '0 0 0 * * 2',
         type: '@cron',
+        worker: 'konnector',
+        message: {
+          account: '963a51f6cdd34401b0904de32cc5578d',
+          konnector: 'konnectest'
+        }
+      })
+    })
+
+    it('builds for client side connectors', () => {
+      const clientSideConnector = { ...konnector, clientSide: true }
+      expect(
+        buildAttributes({ konnector: clientSideConnector, account })
+      ).toEqual({
+        type: '@client',
         worker: 'konnector',
         message: {
           account: '963a51f6cdd34401b0904de32cc5578d',

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -496,6 +496,7 @@ export class ConnectionFlow {
    */
   async launch({ autoSuccessTimer = true } = {}) {
     const konnector = this.withClientSide(this.konnector)
+    const computedAutoSuccessTimer = autoSuccessTimer && !konnector.clientSide
 
     logger.info('ConnectionFlow: Launching job...')
     this.setState({ status: PENDING })
@@ -541,7 +542,7 @@ export class ConnectionFlow {
       this.handleJobUpdated.bind(this)
     )
     this.jobWatcher = watchKonnectorJob(this.client, this.job, {
-      autoSuccessTimer
+      autoSuccessTimer: computedAutoSuccessTimer
     })
     logger.info(`ConnectionFlow: Subscribed to ${JOBS_DOCTYPE}:${this.job._id}`)
 

--- a/packages/cozy-harvest-lib/src/services/softDeleteOrRestoreAccounts.js
+++ b/packages/cozy-harvest-lib/src/services/softDeleteOrRestoreAccounts.js
@@ -57,7 +57,7 @@ const softDeleteOrRestoreAccounts = async (
   const decryptedPassword = await decrypt(encryptedPassword)
   const decryptedUsername = await decrypt(encryptedUsername)
   if (decryptedPassword === null || decryptedUsername === null) {
-    // Something wrong occured dujring the credentials encryption
+    // Something wrong occured during the credentials encryption
     // and/or decryption
     throw new Error('DECRYPT_FAILED')
   }

--- a/packages/cozy-harvest-lib/src/services/utils.js
+++ b/packages/cozy-harvest-lib/src/services/utils.js
@@ -76,8 +76,9 @@ export const fetchKonnectorFromAccount = async (cozyClient, account) => {
 export const fetchTriggersFromAccount = async (cozyClient, account) => {
   const triggers = await cozyClient.queryAll(
     Q('io.cozy.triggers').where({
-      worker: 'konnector',
-      type: '@cron',
+      worker: {
+        $in: ['konnector', 'client']
+      },
       'message.account': account._id
     })
   )
@@ -105,8 +106,9 @@ export const fetchLoginFailedTriggersForAccountsIds = async (
 ) => {
   const triggers = await cozyClient.queryAll(
     Q('io.cozy.triggers').where({
-      worker: 'konnector',
-      type: '@cron',
+      worker: {
+        $in: ['konnector', 'client']
+      },
       'message.account': {
         $in: accountsIds
       }

--- a/packages/cozy-harvest-lib/src/services/utils.spec.js
+++ b/packages/cozy-harvest-lib/src/services/utils.spec.js
@@ -175,8 +175,9 @@ describe('fetchLoginFailedTriggersForAccountsIds', () => {
       expect.objectContaining({
         selector: {
           'message.account': { $in: ['acc1', 'acc2'] },
-          type: '@cron',
-          worker: 'konnector'
+          worker: {
+            $in: ['konnector', 'client']
+          }
         }
       })
     )

--- a/packages/cozy-harvest-lib/test/fixtures.js
+++ b/packages/cozy-harvest-lib/test/fixtures.js
@@ -14,6 +14,18 @@ const fixtures = {
       }
     }
   },
+  clientKonnector: {
+    slug: 'konnectest',
+    clientSide: true,
+    fields: {
+      username: {
+        type: 'text'
+      },
+      passphrase: {
+        type: 'password'
+      }
+    }
+  },
   konnectorWithFolder: {
     _type: 'io.cozy.konnectors',
     name: 'myBills',


### PR DESCRIPTION
This adds a call to any react native launcher if :

1. the window.cozy.clientSideSlugs property contains a value corresponding to the current connector slug
2. window.ClientConnectorLauncher is initialized with `react-native` value

1) Won't be needed when the stack will handle the "clientSide" attribute in the manifest.

The call to the launcher provides the following values : 

- connector manifest
- account
- trigger
- job

Another addition : for client side connectors, the redirect to the success modale is deactivated when the connector finishes or sends the LOGIN_OK signal