### PR TITLE
feat: Support two fa in launch mode

### DIFF
--- a/packages/cozy-harvest-lib/src/components/FlowProvider.jsx
+++ b/packages/cozy-harvest-lib/src/components/FlowProvider.jsx
@@ -5,14 +5,15 @@ import { translate } from 'cozy-ui/transpiled/react/I18n'
 
 import TwoFAModal from './TwoFAModal'
 import logger from '../logger'
-import ConnectionFlow, {
+import {
   ERROR_EVENT,
   SUCCESS_EVENT,
   LOGIN_SUCCESS_EVENT,
   TWO_FA_REQUEST_EVENT,
   TRIGGER_LAUNCH_EVENT,
   UPDATE_EVENT
-} from '../models/ConnectionFlow'
+} from '../models/flowEvents'
+import ConnectionFlow from '../models/ConnectionFlow'
 
 /**
  * FlowProvider instantiates a ConnectionFlow and provides it to its children.

--- a/packages/cozy-harvest-lib/src/components/FlowProvider.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/FlowProvider.spec.jsx
@@ -6,7 +6,7 @@ import {
   SUCCESS_EVENT,
   LOGIN_SUCCESS_EVENT,
   TWO_FA_REQUEST_EVENT
-} from 'models/ConnectionFlow'
+} from 'models/flowEvents'
 import TwoFAModal from 'components/TwoFAModal'
 
 const client = {

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -31,7 +31,7 @@ import {
 import DialogContent from '@material-ui/core/DialogContent'
 
 const DumbKonnectorDialog = ({
-  dismissAction,
+  onClose,
   konnector,
   addingAccount,
   account,
@@ -44,11 +44,11 @@ const DumbKonnectorDialog = ({
   const { dialogProps, dialogTitleProps } = useCozyDialog({
     size: 'medium',
     open: true,
-    onClose: dismissAction
+    onClose
   })
   return (
     <Dialog {...dialogProps}>
-      <DialogCloseButton onClick={dismissAction} />
+      <DialogCloseButton onClick={onClose} />
       <DialogTitle {...dialogTitleProps}>
         <div className="u-flex u-flex-row u-w-100 u-flex-items-center">
           <div className="u-w-3 u-h-3 u-mr-half">
@@ -70,7 +70,7 @@ const DumbKonnectorDialog = ({
           </div>
           <Button
             icon={<Icon icon={CrossIcon} size={'24'} />}
-            onClick={dismissAction}
+            onClick={onClose}
             iconOnly
             label={t('close')}
             subtle
@@ -86,7 +86,7 @@ const DumbKonnectorDialog = ({
 const DumbKonnectorDialogContent = props => {
   const { t } = useI18n()
   const {
-    dismissAction,
+    onClose,
     konnector,
     account,
     accountsAndTriggers,
@@ -156,7 +156,7 @@ const DumbKonnectorDialogContent = props => {
         konnector={konnector}
         initialTrigger={trigger}
         account={account}
-        onAccountDeleted={dismissAction}
+        onAccountDeleted={onClose}
         addAccount={requestAccountCreation}
         refetchTrigger={refetchTrigger}
       />
@@ -321,7 +321,7 @@ export class KonnectorModal extends PureComponent {
   }
 
   render() {
-    const { dismissAction, konnector } = this.props
+    const { onClose, konnector } = this.props
     const {
       account,
       accountsAndTriggers,
@@ -333,7 +333,7 @@ export class KonnectorModal extends PureComponent {
 
     return (
       <DumbKonnectorDialog
-        dismissAction={dismissAction}
+        onClose={onClose}
         konnector={konnector}
         account={account}
         accountsAndTriggers={accountsAndTriggers}
@@ -342,7 +342,7 @@ export class KonnectorModal extends PureComponent {
         requestAccountChange={this.requestAccountChange}
         content={
           <DumbKonnectorDialogContent
-            dismissAction={dismissAction}
+            onClose={onClose}
             konnector={konnector}
             account={account}
             accountsAndTriggers={accountsAndTriggers}
@@ -371,7 +371,7 @@ KonnectorModal.propTypes = {
       data: PropTypes.arrayOf(PropTypes.object)
     })
   }).isRequired,
-  dismissAction: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
   createAction: PropTypes.func,
   onAccountChange: PropTypes.func
 }

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.spec.jsx
@@ -42,7 +42,7 @@ describe('KonnectorModal', () => {
       }
     }
     props = {
-      dismissAction: jest.fn(),
+      onClose: jest.fn(),
       onSuccess: jest.fn(),
       konnector: mockKonnector,
       t

--- a/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
@@ -14,7 +14,7 @@ import accounts, {
   TWOFA_USER_INPUT
 } from '../helpers/accounts'
 
-import { TWO_FA_REQUEST_EVENT, UPDATE_EVENT } from '../models/ConnectionFlow'
+import { TWO_FA_REQUEST_EVENT, UPDATE_EVENT } from '../models/flowEvents'
 
 import { IllustrationDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 

--- a/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
@@ -69,12 +69,9 @@ export class TwoFAModal extends PureComponent {
     const code = this.state.twoFACode
 
     const konnectorPolicy = flow.getKonnectorPolicy()
-    if (konnectorPolicy.sendAdditionalInformation) {
-      const fields = flow.getAdditionalInformationNeeded()
-      const firstField = fields[0]
-      flow.sendAdditionalInformation({
-        [firstField.name]: code
-      })
+
+    if (konnectorPolicy.sendTwoFACode) {
+      konnectorPolicy.sendTwoFACode(flow, code)
     } else {
       flow.sendTwoFACode(code)
     }

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
@@ -5,12 +5,15 @@ import Button from 'cozy-ui/transpiled/react/Button'
 import Card from 'cozy-ui/transpiled/react/Card'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import Uppercase, { Text } from 'cozy-ui/transpiled/react/Text'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import { Text } from 'cozy-ui/transpiled/react/Text'
 import * as triggers from '../../helpers/triggers'
 import FlowProvider from '../FlowProvider'
 import { useFlowState } from '../../models/withConnectionFlow'
 
 import SyncIcon from 'cozy-ui/transpiled/react/Icons/Sync'
+
+const inlineStyle = { display: 'inline-block' }
 
 export const DumbLaunchTriggerCard = ({ flow, className, f, t, disabled }) => {
   const launch = flow.launch
@@ -24,9 +27,14 @@ export const DumbLaunchTriggerCard = ({ flow, className, f, t, disabled }) => {
       <div className="u-flex u-flex-column-s">
         <ul className="u-nolist u-m-0 u-mr-1 u-pl-0 u-flex-grow-1">
           <li className="u-mb-half">
-            <Uppercase tag="span" className="u-coolGrey u-mr-half u-fz-tiny">
+            <Typography
+              variant="caption"
+              component="span"
+              style={inlineStyle}
+              className="u-mr-half"
+            >
               {t('card.launchTrigger.lastSync.label')}
-            </Uppercase>
+            </Typography>
             <Text className="u-fz-tiny" tag="span">
               {running
                 ? t('card.launchTrigger.lastSync.syncing')
@@ -36,9 +44,14 @@ export const DumbLaunchTriggerCard = ({ flow, className, f, t, disabled }) => {
             </Text>
           </li>
           <li className="u-mb-half">
-            <Uppercase className="u-coolGrey u-mr-half u-fz-tiny" tag="span">
+            <Typography
+              variant="caption"
+              component="span"
+              style={inlineStyle}
+              className="u-mr-half"
+            >
               {t('card.launchTrigger.frequency.label')}
-            </Uppercase>
+            </Typography>
             <Text className="u-fz-tiny" tag="span">
               {t(
                 `card.launchTrigger.frequency.${triggers.getFrequency(

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
@@ -6,12 +6,11 @@ import Card from 'cozy-ui/transpiled/react/Card'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import Typography from 'cozy-ui/transpiled/react/Typography'
-import { Text } from 'cozy-ui/transpiled/react/Text'
+import SyncIcon from 'cozy-ui/transpiled/react/Icons/Sync'
+
 import * as triggers from '../../helpers/triggers'
 import FlowProvider from '../FlowProvider'
 import { useFlowState } from '../../models/withConnectionFlow'
-
-import SyncIcon from 'cozy-ui/transpiled/react/Icons/Sync'
 
 const inlineStyle = { display: 'inline-block' }
 
@@ -35,13 +34,13 @@ export const DumbLaunchTriggerCard = ({ flow, className, f, t, disabled }) => {
             >
               {t('card.launchTrigger.lastSync.label')}
             </Typography>
-            <Text className="u-fz-tiny" tag="span">
+            <Typography variant="caption" color="textPrimary" component="span">
               {running
                 ? t('card.launchTrigger.lastSync.syncing')
                 : lastSuccessDate
                 ? f(lastSuccessDate, t('card.launchTrigger.lastSync.format'))
                 : t('card.launchTrigger.lastSync.unknown')}
-            </Text>
+            </Typography>
           </li>
           <li className="u-mb-half">
             <Typography
@@ -52,13 +51,13 @@ export const DumbLaunchTriggerCard = ({ flow, className, f, t, disabled }) => {
             >
               {t('card.launchTrigger.frequency.label')}
             </Typography>
-            <Text className="u-fz-tiny" tag="span">
+            <Typography variant="caption" color="textPrimary" component="span">
               {t(
                 `card.launchTrigger.frequency.${triggers.getFrequency(
                   trigger
                 ) || 'undefined'}`
               )}
-            </Text>
+            </Typography>
           </li>
         </ul>
         <div>

--- a/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.jsx
@@ -4,14 +4,14 @@ import PropTypes from 'prop-types'
 import logger from '../../logger'
 import Card from 'cozy-ui/transpiled/react/Card'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
-import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import Link from '@material-ui/core/Link'
 import { Media, Img, Bd } from 'cozy-ui/transpiled/react/Media'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import palette from 'cozy-ui/transpiled/react/palette'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import GlobeIcon from 'cozy-ui/transpiled/react/Icons/Globe'
 
-import Typography from 'cozy-ui/transpiled/react/Typography'
+const linkStyle = { textTransform: 'lowercase' }
 
 const WebsiteLinkCard = ({ link }) => {
   const { t } = useI18n()
@@ -23,7 +23,6 @@ const WebsiteLinkCard = ({ link }) => {
     return null
   }
 
-  const linkStyle = { textTransform: 'lowercase' }
   const label = url.host
 
   return (
@@ -34,18 +33,19 @@ const WebsiteLinkCard = ({ link }) => {
       <Divider className="u-ml-0 u-maw-100" />
       <Media className="u-mt-1" align="top">
         <Img className="u-pr-1">
-          <Icon icon={GlobeIcon} color={palette['coolGrey']} />
+          <Typography color="textSecondary">
+            <Icon icon={GlobeIcon} />
+          </Typography>
         </Img>
         <Bd>
-          <ButtonLink
-            subtle
+          <Link
             target="_blank"
             href={link}
-            label={label}
-            theme="text"
-            className="u-primaryColor u-m-0"
+            className="u-m-0 u-fw-bold"
             style={linkStyle}
-          />
+          >
+            {label}
+          </Link>
           <Typography variant="caption" color="textSecondary">
             {t('card.websiteLink.description')}
           </Typography>

--- a/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.jsx
@@ -31,7 +31,7 @@ const WebsiteLinkCard = ({ link }) => {
         {t('card.websiteLink.title')}
       </Typography>
       <Divider className="u-ml-0 u-maw-100" />
-      <Media className="u-mt-1" align="top">
+      <Media className="u-mt-1">
         <Img className="u-pr-1">
           <Typography color="textSecondary">
             <Icon icon={GlobeIcon} />

--- a/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/WebsiteLinkCard.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { render } from '@testing-library/react'
 import I18n from 'cozy-ui/transpiled/react/I18n'
 
 import WebsiteLinkCard from './WebsiteLinkCard'
@@ -8,25 +8,21 @@ import enLocale from '../../locales/en'
 describe('WebsiteLinkCard', () => {
   it('should render', () => {
     const link = 'https://fc.assure.ameli.fr/FRCO-app/login'
-    const wrapper = mount(
+    const root = render(
       <I18n dictRequire={() => enLocale} lang="en">
         <WebsiteLinkCard link={link} />)
       </I18n>
     )
-    const component = wrapper.find(WebsiteLinkCard)
-    expect(component.find('ButtonLink').props().href).toEqual(link)
-    expect(component.find('ButtonLink').props().label).toEqual(
-      'fc.assure.ameli.fr'
-    )
+    const linkNode = root.getByText('fc.assure.ameli.fr')
+    expect(linkNode.getAttribute('href')).toEqual(link)
   })
   it('should ignore invalid urls', () => {
     const link = 'www.trainline.fr'
-    const wrapper = mount(
+    const root = render(
       <I18n dictRequire={() => enLocale} lang="en">
-        <WebsiteLinkCard link={link} />)
+        <WebsiteLinkCard link={link} />
       </I18n>
     )
-    const component = wrapper.find(WebsiteLinkCard)
-    expect(component.exists('ButtonLink')).toEqual(false)
+    expect(root.queryByText('www.trainline.fr')).toBeFalsy()
   })
 })

--- a/packages/cozy-harvest-lib/src/components/infos/KonnectorUpdateInfos.jsx
+++ b/packages/cozy-harvest-lib/src/components/infos/KonnectorUpdateInfos.jsx
@@ -2,8 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Typography from 'cozy-ui/transpiled/react/Typography'
 import Infos from 'cozy-ui/transpiled/react/Infos'
-import Text, { SubTitle } from 'cozy-ui/transpiled/react/Text'
 
 import KonnectorUpdateLinker from '../KonnectorUpdateLinker'
 
@@ -21,14 +21,14 @@ const KonnectorUpdateInfos = props => {
       theme={isBlocking ? 'danger' : 'secondary'}
       description={
         <>
-          <SubTitle className={isBlocking ? 'u-error' : ''}>
+          <Typography className={isBlocking ? 'u-error' : ''} variant="h5">
             {t('infos.konnectorUpdate.title')}
-          </SubTitle>
-          <Text>
+          </Typography>
+          <Typography variant="body1">
             {isBlocking
               ? t('infos.konnectorUpdate.body.blocking')
               : t('infos.konnectorUpdate.body.regular')}
-          </Text>
+          </Typography>
         </>
       }
       action={

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -572,7 +572,6 @@ export class ConnectionFlow {
   }
 
   getKonnectorPolicy() {
-    console.log('gkp')
     return findKonnectorPolicy(this.konnector)
   }
 

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -162,7 +162,7 @@ export class ConnectionFlow {
     this.getKonnectorSlug = this.getKonnectorSlug.bind(this)
     this.handleAccountUpdated = this.handleAccountUpdated.bind(this)
     this.handleJobUpdated = this.handleJobUpdated.bind(this)
-    this.handleTwoFA = this.handleTwoFA.bind(this)
+    this.handleAccountTwoFA = this.handleAccountTwoFA.bind(this)
     this.launch = this.launch.bind(this)
     this.sendTwoFACode = this.sendTwoFACode.bind(this)
     this.unwatch = this.unwatch.bind(this)
@@ -188,12 +188,16 @@ export class ConnectionFlow {
     return this.trigger.message.konnector
   }
 
-  handleTwoFA(prevAccount) {
+  handleAccountTwoFA(prevAccount) {
     const account = this.account
 
     const prevState = prevAccount && prevAccount.state
     const state = account.state
 
+    return this.handleTwoFAStateChange(state, prevState)
+  }
+
+  handleTwoFAStateChange(state, prevState = null) {
     if (prevState === state) {
       return
     }
@@ -439,7 +443,7 @@ export class ConnectionFlow {
     }
     const { state } = this.account
     if (accounts.isTwoFANeeded(state) || accounts.isTwoFARetry(state)) {
-      this.handleTwoFA(prevAccount)
+      this.handleAccountTwoFA(prevAccount)
     } else if (accounts.isLoginSuccessHandled(state)) {
       this.handleLoginSuccessHandled()
     } else if (accounts.isLoginSuccess(state)) {

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -24,32 +24,27 @@ import assert from '../assert'
 import * as accounts from '../helpers/accounts'
 import * as triggersModel from '../helpers/triggers'
 import sentryHub from '../sentry'
+import {
+  ERRORED,
+  ERROR_EVENT,
+  LOGIN_SUCCESS,
+  LOGIN_SUCCESS_EVENT,
+  SUCCESS,
+  SUCCESS_EVENT,
+  IDLE,
+  UPDATE_EVENT,
+  RUNNING_TWOFA,
+  TWO_FA_REQUEST,
+  TWO_FA_REQUEST_EVENT,
+  TWO_FA_MISMATCH,
+  TWO_FA_MISMATCH_EVENT,
+  WAITING_TWOFA,
+  CREATING_ACCOUNT,
+  PENDING,
+  JOB_EVENTS
+} from './flowEvents'
 
 const JOBS_DOCTYPE = 'io.cozy.jobs'
-
-// events
-export const ERROR_EVENT = 'error'
-export const LOGIN_SUCCESS_EVENT = 'loginSuccess'
-export const SUCCESS_EVENT = 'success'
-export const TRIGGER_LAUNCH_EVENT = 'TRIGGER_LAUNCH_EVENT'
-
-export const TWO_FA_REQUEST_EVENT = 'twoFARequest'
-export const TWO_FA_MISMATCH_EVENT = 'twoFAMismatch'
-export const UPDATE_EVENT = 'update'
-
-// statuses
-export const IDLE = 'IDLE'
-export const CREATING_ACCOUNT = 'CREATING_ACCOUNT'
-export const PENDING = 'PENDING'
-export const ERRORED = 'ERRORED'
-export const LOGIN_SUCCESS = 'LOGIN_SUCCESS'
-export const SUCCESS = 'SUCCESS'
-export const RUNNING_TWOFA = 'RUNNING_TWOFA'
-export const WAITING_TWOFA = 'WAITING_TWOFA'
-export const TWO_FA_MISMATCH = 'TWO_FA_MISMATCH'
-export const TWO_FA_REQUEST = 'TWO_FA_REQUEST'
-
-const JOB_EVENTS = [ERROR_EVENT, LOGIN_SUCCESS_EVENT, SUCCESS_EVENT]
 
 const eventToStatus = {
   [ERROR_EVENT]: ERRORED,
@@ -577,6 +572,7 @@ export class ConnectionFlow {
   }
 
   getKonnectorPolicy() {
+    console.log('gkp')
     return findKonnectorPolicy(this.konnector)
   }
 
@@ -586,6 +582,8 @@ export class ConnectionFlow {
       throw new Error(
         'A konnector policy is needed to be able to detect additional information'
       )
+    } else if (!konnectorPolicy.getAdditionalInformationNeeded) {
+      throw new Error('No getAdditionalInformationNeeded in konnector policy')
     } else {
       const fields = konnectorPolicy.getAdditionalInformationNeeded(this)
       return fields

--- a/packages/cozy-harvest-lib/src/models/flowEvents.js
+++ b/packages/cozy-harvest-lib/src/models/flowEvents.js
@@ -1,0 +1,23 @@
+// events
+export const ERROR_EVENT = 'error'
+export const LOGIN_SUCCESS_EVENT = 'loginSuccess'
+export const SUCCESS_EVENT = 'success'
+export const TRIGGER_LAUNCH_EVENT = 'TRIGGER_LAUNCH_EVENT'
+
+export const TWO_FA_REQUEST_EVENT = 'twoFARequest'
+export const TWO_FA_MISMATCH_EVENT = 'twoFAMismatch'
+export const UPDATE_EVENT = 'update'
+
+// statuses
+export const IDLE = 'IDLE'
+export const CREATING_ACCOUNT = 'CREATING_ACCOUNT'
+export const PENDING = 'PENDING'
+export const ERRORED = 'ERRORED'
+export const LOGIN_SUCCESS = 'LOGIN_SUCCESS'
+export const SUCCESS = 'SUCCESS'
+export const RUNNING_TWOFA = 'RUNNING_TWOFA'
+export const WAITING_TWOFA = 'WAITING_TWOFA'
+export const TWO_FA_MISMATCH = 'TWO_FA_MISMATCH'
+export const TWO_FA_REQUEST = 'TWO_FA_REQUEST'
+
+export const JOB_EVENTS = [ERROR_EVENT, LOGIN_SUCCESS_EVENT, SUCCESS_EVENT]

--- a/packages/cozy-harvest-lib/src/models/withConnectionFlow.jsx
+++ b/packages/cozy-harvest-lib/src/models/withConnectionFlow.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { UPDATE_EVENT } from './ConnectionFlow'
+import { UPDATE_EVENT } from './flowEvents'
 
 export const useFlowState = flow => {
   const [flowState, setFlowState] = useState(flow.getState())

--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -23,7 +23,7 @@ import {
 import assert from '../assert'
 import { mkConnAuth, biErrorMap } from 'cozy-bi-auth'
 import { KonnectorJobError } from '../helpers/konnectors'
-import { LOGIN_SUCCESS_EVENT } from '../models/ConnectionFlow'
+import { LOGIN_SUCCESS_EVENT } from '../models/flowEvents'
 import logger from '../logger'
 
 const DECOUPLED_ERROR = 'decoupled'

--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -351,6 +351,34 @@ export const onBIAccountCreation = async ({
   return account
 }
 
+export const sendTwoFaCode = (flow, code) => {
+  let fields
+
+  try {
+    // We can determine missing fields if we already have cached the
+    // connection on the frontend
+    fields = flow.getAdditionalInformationNeeded()
+  } catch (e) {
+    fields = null
+  }
+
+  if (fields) {
+    const firstField = fields[0]
+    // Update a new connection directly through the konnector policy
+    logger.debug('Sending two fa through web...')
+    flow.sendAdditionalInformation({
+      [firstField.name]: code
+    })
+  } else {
+    // If we are sending two fa for an existing connection, we do not
+    // have the connection cached on the front-end, but the connector
+    // knows the missing fields, we just have to send the two fa code
+    // through the connection flow
+    logger.debug('Sending two fa through connector...')
+    flow.sendTwoFACode(code)
+  }
+}
+
 export const getAdditionalInformationNeeded = flow => {
   const biConnection = flow.getData().biConnection
   assert(

--- a/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
@@ -19,7 +19,7 @@ import {
 import merge from 'lodash/merge'
 import ConnectionFlow from '../models/ConnectionFlow'
 import biPublicKeyProd from './bi-public-key-prod.json'
-import { LOGIN_SUCCESS_EVENT } from '../models/ConnectionFlow'
+import { LOGIN_SUCCESS_EVENT } from '../models/flowEvents'
 
 jest.mock('cozy-logger', () => ({
   namespace: () => () => {}

--- a/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
@@ -8,7 +8,8 @@ import {
   setSync,
   getBIConfig,
   saveBIConfig,
-  updateBIConnectionFromFlow
+  updateBIConnectionFromFlow,
+  sendTwoFaCode
 } from './budget-insight'
 import { waitForRealtimeEvent } from './jobUtils'
 import {
@@ -67,6 +68,9 @@ const konnector = {
   slug: 'boursorama83',
   parameters: {
     bankId: TEST_BANK_COZY_ID
+  },
+  partnership: {
+    domain: 'https://budget-insight.com'
   }
 }
 
@@ -721,5 +725,34 @@ describe('updateBIConnectionFromFlow', () => {
       { login: '1234' },
       'temporary-token'
     )
+  })
+})
+
+describe('sendTwoFaCode', () => {
+  it('should use flow.sendTwoFACode if fields are unknown', () => {
+    const client = new CozyClient({
+      uri: 'http://testcozy.mycozy.cloud'
+    })
+    const biConnId = 'conn-1337'
+    const account = { data: { auth: { bi: { connId: biConnId } } } }
+    const flow = new ConnectionFlow(client, null, konnector)
+    flow.account = account
+    jest.spyOn(flow, 'sendTwoFACode')
+    sendTwoFaCode(flow, 'abcde')
+    expect(flow.sendTwoFACode).toHaveBeenCalled()
+  })
+
+  it('should use flow.sendAdditionalInformation if fields are known', () => {
+    const client = new CozyClient({
+      uri: 'http://testcozy.mycozy.cloud'
+    })
+    const biConnId = 'conn-1337'
+    const account = { data: { auth: { bi: { connId: biConnId } } } }
+    const flow = new ConnectionFlow(client, null, konnector)
+    flow.account = account
+    flow.setData({ biConnection: { fields: ['sms'] } })
+    jest.spyOn(flow, 'sendAdditionalInformation')
+    sendTwoFaCode(flow, 'abcde')
+    expect(flow.sendAdditionalInformation).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Now, a user can launch the connector via the launch button and have the
two fa modals.

When launching the konnector, since we do not have the BI connection
cached (we do not launch a temporary token job, the front cannot access
budget-insight), we send the two fa codes to the konnector job via
the regular two fa APIs.