### PR TITLE
fix: ShareByLink z-index on iOS

### DIFF
--- a/packages/cozy-sharing/src/components/ShareByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareByLink.jsx
@@ -123,6 +123,7 @@ class ShareByLink extends React.Component {
           </Typography>
           {!checked && (
             <Button
+              style={{ position: 'initial' }} // fix z-index bug on iOS when under a BottomDrawer due to relative position
               theme="text"
               className={styles['aligned-dropdown-button']}
               onClick={async () => {


### PR DESCRIPTION
Le bouton "générer un lien" se met par-dessus le bottomDrawer de l'action menu sur iOS.

![image](https://user-images.githubusercontent.com/67680939/113998925-d0f28c80-9859-11eb-9986-72e4bc687713.png)


Le bug n'est présent que sur iOS, cela fonctionnait sur Safari web (tout comme avec les autres browser).

La modification n'impacte pas les autres navigateurs. Je n'ai pas trouvé d'autre solution pour corriger le problème.
J'ai essayé de jouer avec les z-index et position sur les overlay/dialog/action menu, j'ai essayé de modifier le type de button également...

Une autre approche serait de ne pas utiliser de `Button` mais un `<button>` plus classique, mais on perd le bénéfice de l'api (notamment le busy) et de la cohérence du style - ça ferait un composant spécifique à maintenir, je n'ai donc pas retenu cette approche.