### PR TITLE
fix: Update cozy-authentication address placeholder in french

### DIFF
--- a/packages/cozy-authentication/src/locales/en.json
+++ b/packages/cozy-authentication/src/locales/en.json
@@ -18,8 +18,8 @@
         "domain_custom": "other",
         "button": "Next",
         "previous": "Previous",
-        "wrong_address_with_email": "You typed an email address. To connect on your cozy you must type its url, something like https://camillenimbus.mycozy.cloud",
-        "wrong_address_v2": "You have just entered the address of old Cozy version. This application is only compatible with the latest version. [Please refer to our site for more information.](https://blog.cozycloud.cc/post/2016/11/21/On-the-road-to-Cozy-version-3?lang=en)",
+        "wrong_address_with_email": "You typed an email address. To connect on your cozy you must type its url, something like https://claude.mycozy.cloud",
+        "wrong_address_v2": "You have just entered the address of old Cozy version. This application is only compatible with the latest version. Please contact support for more information.",
         "wrong_address": "This address doesn’t seem to be a cozy. Please check the address you provide.",
         "wrong_address_cosy": "Woops, the address is not correct. Try with \"cozy\" with a \"z\"!"
       },

--- a/packages/cozy-authentication/src/locales/en.json
+++ b/packages/cozy-authentication/src/locales/en.json
@@ -4,8 +4,8 @@
       "welcome": {
         "title": "%{appTitle}",
         "desc": "Create a Cozy or sign in to access %{appTitle}.",
-        "button": "Sign in",
-        "no_account_link": "I don't have a Cozy",
+        "button": "Sign in to your cozy",
+        "no_account_link": "No Cozy? Ask for one here.",
         "create_my_cozy": "Create my Cozy"
       },
       "server_selection": {

--- a/packages/cozy-authentication/src/locales/fr.json
+++ b/packages/cozy-authentication/src/locales/fr.json
@@ -19,8 +19,8 @@
         "domain_custom": "autre",
         "button": "Suivant",
         "previous": "Précédent",
-        "wrong_address_with_email": "Vous avez entré une adresse email. Pour vous connecter à votre Cozy vous devez entrer son url, sous la forme https://camillenimbus.mycozy.cloud",
-        "wrong_address_v2": "Vous avez entré l'adresse d'une Cozy v2. Cette application n'est compatible qu'avec la dernière version de Cozy. Rendez-vous sur [notre site](https://blog.cozycloud.cc/post/2016/11/21/On-the-road-to-Cozy-version-3?lang=fr) pour plus d'informations",
+        "wrong_address_with_email": "Vous avez entré une adresse email. Pour vous connecter à votre Cozy vous devez entrer son url, sous la forme https://claude.mycozy.cloud",
+        "wrong_address_v2": "Vous avez entré l'adresse d'une Cozy v2. Cette application n'est compatible qu'avec la dernière version de Cozy. Contactez notre assistance pour plus d'informations",
         "wrong_address": "Cette adresse ne semble pas correspondre à un Cozy.",
         "wrong_address_cosy": "Oups, ce n'est pas la bonne adresse. Essayez d'écrire \"cozy\" avec un \"z\" !"
       },

--- a/packages/cozy-authentication/src/locales/fr.json
+++ b/packages/cozy-authentication/src/locales/fr.json
@@ -4,17 +4,19 @@
       "welcome": {
         "title1": "Bienvenue sur Cozy",
         "title2": "Votre propre cloud personnel",
+        "desc": "Créer un Cozy ou connectez vous pour accéder à %{appTitle}.",
         "button": "Vous connecter à votre Cozy",
-        "no_account_link": "Vous n'avez pas de compte? Demandez-en un ici.",
-        "create_my_cozy": "Créer mon Cozy",
-        "desc": "Créer un Cozy ou connectez vous pour accéder à %{appTitle}."
+        "no_account_link": "Vous n'avez pas de compte ? Demandez-en un ici.",
+        "create_my_cozy": "Créer mon Cozy"
       },
       "server_selection": {
         "title": "Vous connecter à votre Cozy",
         "lostpwd": "[J'ai oublié l'adresse de mon Cozy](https://manager.cozycloud.cc/cozy/reminder)",
         "description": "Exemple: https://**claude**.mycozy.cloud\n",
         "label": "Entrez l'adresse de votre Cozy",
-        "cozy_address_placeholder": "claude.mycozy.cloud",
+        "cozy_address_placeholder": "claude",
+        "cozy_custom_address_placeholder": "claude.mycozy.cloud",
+        "domain_custom": "autre",
         "button": "Suivant",
         "previous": "Précédent",
         "wrong_address_with_email": "Vous avez entré une adresse email. Pour vous connecter à votre Cozy vous devez entrer son url, sous la forme https://camillenimbus.mycozy.cloud",


### PR DESCRIPTION
When using cozy-drive in french and connecting to your cozy, the address placeholder contains domain despite there is a separate domain input box, show the domain twice.

![image](https://user-images.githubusercontent.com/2768193/114522643-d7ab4600-9c43-11eb-80ce-0cec507bdbd0.png)

This PR updates french translation to fix this behaviour.
I also updated some unrelated english strings to make them coherent with french translation.
And I fixed missing space before question mark (french typography rules)