### PR TITLE
feat: Map config errors to LOGIN_FAILED

### DIFF
--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -35,11 +35,23 @@ const getBIConnectionIdFromAccount = account =>
 const getBIIdFromContract = bankAccount => bankAccount.vendorId
 
 /**
+ * This error map is not in the bi-auth package since it is not really
+ * satisfying to have "config" mapped to LOGIN_FAILED. It might change.
+ * We should not have this error if we validate the fields in the
+ * front-end.
+ */
+const extraBIErrorMap = {
+  config: 'LOGIN_FAILED'
+}
+
+/**
  * Converts and chains error
  */
 const convertBIErrortoKonnectorJobError = error => {
   const errorCode = error ? error.code : null
-  const cozyErrorMessage = errorCode ? biErrorMap[errorCode] : null
+  const cozyErrorMessage = errorCode
+    ? biErrorMap[errorCode] || extraBIErrorMap[errorCode] || null
+    : null
   const errorMessage =
     cozyErrorMessage ||
     (errorCode ? `UNKNOWN_ERROR.${errorCode}` : 'UNKNOWN_ERROR')

--- a/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
@@ -487,6 +487,30 @@ describe('createOrUpdateBIConnection', () => {
     ).rejects.toEqual(new Error('LOGIN_FAILED'))
   })
 
+  it('should convert config correctly', async () => {
+    const { client, flow } = setup()
+    const err = new Error()
+    err.code = 'config'
+    getBIConnection.mockReset().mockResolvedValueOnce({})
+    updateBIConnection.mockReset().mockRejectedValue(err)
+    await expect(
+      createOrUpdateBIConnection({
+        client,
+        flow,
+        account: merge(account, {
+          data: {
+            auth: {
+              bi: {
+                connId: 1337
+              }
+            }
+          }
+        }),
+        konnector
+      })
+    ).rejects.toEqual(new Error('LOGIN_FAILED'))
+  })
+
   it('should convert SCARequired correctly', async () => {
     const { client, flow } = setup()
     const err = new Error()


### PR DESCRIPTION
BI expects field validation to be done front-side. If input does not
match the regex from BI, a "config" error is sent back to us, this is
why we map it to LOGIN_FAILED.

Ideally we would want to dynamically load validation rules from BI
side but it is complex since we have to handle

- Loading validation rules for agencies (biBankId not known until the user
has chosen an agency)
- Converting BI field names to cozy field names

Work on this has been started [here](https://github.com/cozy/cozy-libs/tree/dynamic-validation-rules) but it seems overly complicated and we're not sure with @fffflo that we want to manage this complexity, especially when we are thinking to use BI's webview to manage the lifecycle of connections in the future.