### PR TITLE
Small improvements for Harvest

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
@@ -38,7 +38,6 @@ import { useTrackPage, useTracker } from '../../hoc/tracking'
 
 import RedirectToAccountFormButton from '../../RedirectToAccountFormButton'
 
-import tabSpecs from '../tabSpecs'
 import { ContractsForAccount } from './Contracts'
 
 const tabMobileNavListStyle = { borderTop: 'none' }
@@ -88,14 +87,8 @@ const ConfigurationTab = ({
   const flowState = flow.getState()
   const { error, running } = flowState
   const { showUnlockForm } = useVaultUnlockContext()
-  const shouldDisplayError = tabSpecs.configuration.errorShouldBeDisplayed(
-    error,
-    flowState
-  )
 
   useTrackPage('configuration')
-
-  const hasLoginError = error && error.isLoginError()
 
   const handleDeleteConfirm = async () => {
     setRequestDeletion(false)
@@ -143,15 +136,15 @@ const ConfigurationTab = ({
   }
 
   return (
-    <div className={isMobile ? '' : 'u-pv-1-half'}>
+    <div className={isMobile ? '' : 'u-pt-1 u-pb-1-half'}>
       {/**
        * Use an extra div with padding instead of setting margins on TriggerErrorInfo since
        * the offsetHeight of the parent does not take into account margins; slide content was
        * cropped since SwipeableViews uses the offsetHeight of the first slide children when
        * computing the height of the slide wrapper.
        */}
-      {shouldDisplayError && hasLoginError && (
-        <div className={isMobile ? 'u-pv-1' : 'u-pb-2'}>
+      {error && (
+        <div className={isMobile ? 'u-p-1' : 'u-pb-2'}>
           <TriggerErrorInfo
             error={error}
             konnector={konnector}

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.spec.jsx
@@ -125,22 +125,6 @@ describe('ConfigurationTab', () => {
       })
       expect(root.getByText('Reconnect')).toBeTruthy()
     })
-
-    it('should not show a reconnect button if error is not solvable by reconnecting through form)', () => {
-      const { root } = setup({
-        checkShouldUnlock: jest.fn().mockResolvedValue(false),
-        trigger: {
-          message: {
-            account: 'account-id-123',
-            konnector: 'konnector-slug'
-          }
-        },
-        flowState: {
-          error: new KonnectorJobError('USER_ACTION_NEEDED')
-        }
-      })
-      expect(root.queryByText('Reconnect')).toBeFalsy()
-    })
   })
 
   describe('deletion modal', () => {

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
@@ -14,7 +14,6 @@ import TriggerErrorInfo from '../../../components/infos/TriggerErrorInfo'
 import useMaintenanceStatus from '../../../components/hooks/useMaintenanceStatus'
 import getRelatedAppsSlugs from '../../../models/getRelatedAppsSlugs'
 import appLinksProps from '../../../components/KonnectorConfiguration/DataTab/appLinksProps'
-import tabSpecs from '../tabSpecs'
 import { useTrackPage } from '../../../components/hoc/tracking'
 import RedirectToAccountFormButton from '../../RedirectToAccountFormButton'
 import Datacards from '../../Datacards'
@@ -23,25 +22,12 @@ export const DataTab = ({ konnector, trigger, client, flow, account }) => {
   const { isMobile } = useBreakpoints()
   const flowState = flow.getState()
   const { error } = flowState
-  const hasLoginError = hasError && error.isLoginError()
   const hasError = !!error
 
   useTrackPage('donnees')
 
-  const shouldDisplayError = tabSpecs.data.errorShouldBeDisplayed(
-    error,
-    flowState
-  )
   const hasTermsVersionMismatchError =
     hasError && error.isTermsVersionMismatchError()
-  const isTermsVersionMismatchErrorWithVersionAvailable =
-    hasTermsVersionMismatchError &&
-    konnectorsModel.hasNewVersionAvailable(konnector)
-  const hasGenericError =
-    hasError &&
-    !hasLoginError &&
-    !isTermsVersionMismatchErrorWithVersionAvailable
-
   const appLinks = getRelatedAppsSlugs({
     konnectorManifest: konnector,
     trigger
@@ -68,7 +54,7 @@ export const DataTab = ({ konnector, trigger, client, flow, account }) => {
             isBlocking={hasTermsVersionMismatchError}
           />
         )}
-        {shouldDisplayError && hasGenericError && (
+        {hasError && (
           <TriggerErrorInfo
             error={error}
             konnector={konnector}

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
@@ -14,16 +14,6 @@ import useDOMMutations from '../hooks/useDOMMutations'
 import FlowProvider from '../FlowProvider'
 import DataTab from './DataTab'
 import ConfigurationTab from './ConfigurationTab'
-import tabSpecs from './tabSpecs'
-
-const WarningError = () => {
-  const { t } = useI18n()
-  return (
-    <span aria-label={t('badges.warning')}>
-      <Icon icon={WarningIcon} size={13} className="u-error u-ml-half" />
-    </span>
-  )
-}
 
 const tabIndexes = {
   data: 0,
@@ -41,32 +31,12 @@ const Tab = props => {
   return <UITab classes={classes} {...props} />
 }
 
-export const KonnectorAccountTabsTabs = ({ tab, onChange, flowState }) => {
+export const KonnectorAccountTabsTabs = ({ tab, onChange }) => {
   const { t } = useI18n()
-  const { error } = flowState
   return (
     <Tabs onChange={onChange} value={tab}>
-      <Tab
-        label={
-          <>
-            {t('modal.tabs.data')}
-            {tabSpecs.data.errorShouldBeDisplayed(error, flowState) && (
-              <WarningError />
-            )}
-          </>
-        }
-      />
-      <Tab
-        label={
-          <>
-            {t('modal.tabs.configuration')}
-            {tabSpecs.configuration.errorShouldBeDisplayed(
-              error,
-              flowState
-            ) && <WarningError />}
-          </>
-        }
-      />
+      <Tab label={<>{t('modal.tabs.data')}</>} />
+      <Tab label={<>{t('modal.tabs.configuration')}</>} />
     </Tabs>
   )
 }

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
@@ -3,10 +3,8 @@ import PropTypes from 'prop-types'
 
 import { makeStyles } from '@material-ui/core/styles'
 import { Tab as UITab, Tabs } from 'cozy-ui/transpiled/react/MuiTabs'
-import Icon from 'cozy-ui/transpiled/react/Icon'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
-import WarningIcon from 'cozy-ui/transpiled/react/Icons/Warning'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import SwipeableViews from 'react-swipeable-views'
 

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.spec.jsx
@@ -28,8 +28,5 @@ describe('Konnector account tabs', () => {
     const { root } = setup()
     expect(root.getByText('Data')).toBeTruthy()
     expect(root.getByText('Configuration')).toBeTruthy()
-    expect(
-      root.getByRole('tab', { name: 'Configuration Warning' })
-    ).toBeTruthy()
   })
 })

--- a/packages/cozy-harvest-lib/src/components/Markdown.jsx
+++ b/packages/cozy-harvest-lib/src/components/Markdown.jsx
@@ -3,17 +3,15 @@ import ReactMarkdown from 'react-markdown'
 
 export const reactMarkdownRendererOptions = {
   // eslint-disable-next-line react/display-name
-  Link: props => (
-    <a href={props.href} rel="noopener noreferrer" target="_blank">
-      {props.children}
-    </a>
-  ),
-  // eslint-disable-next-line react/display-name
   paragraph: props => <span className="u-db u-mv-0">{props.children}</span>
 }
 
 export const Markdown = ({ source }) => (
-  <ReactMarkdown source={source} renderers={reactMarkdownRendererOptions} />
+  <ReactMarkdown
+    source={source}
+    linkTarget="_blank"
+    renderers={reactMarkdownRendererOptions}
+  />
 )
 
 export default Markdown

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -112,7 +112,7 @@
     "reconnect-via-form": "Reconnect",
     "job": {
       "DISK_QUOTA_EXCEEDED": {
-        "title": "Cozy Storage full",
+        "title": "Storage full",
         "description": "This service cannot fetch your documents now. Please remove some files or go to **Settings > Storage** to get more free space."
       },
       "CHALLENGE_ASKED": {
@@ -382,7 +382,7 @@
     "button": {
       "label": "Close"
     },
-    "description": "Your data will be available in your Cozy in a few minutes and the next ones will follow automatically.",
+    "description": "Your data will be available in a few minutes and the next ones will follow automatically.",
     "figure": {
       "alt": "connected"
     },
@@ -410,7 +410,7 @@
   "account": {
     "success": {
       "title": "Successful configuration!",
-      "connect": "Your data will be available in your Cozy in a few minutes and the next ones will follow automatically.",
+      "connect": "Your data will be available in a few minutes and the next ones will follow automatically.",
       "banksLinkText": "See my accounts in %{appName}",
       "driveLinkText": "Open the folder in Cozy Drive",
       "button": "Close"
@@ -422,14 +422,14 @@
   },
   "suggestions": {
     "title": "Import your data from %{name}",
-    "data": "Installing %{name} will automatically import the following data into your cozy:",
+    "data": "Installing %{name} will automatically import the following data:",
     "why": "Why is %{name} suggested to me?",
     "reason_bank": "%{name} has been detected in one of your bank transactions. Don't worry, no one else can access this information",
     "install": "Install",
     "silence": "Don't suggest it again"
   },
   "dataType": {
-    "none": "%{name} won't access any data in your Cozy",
+    "none": "%{name} won't access any of your personal data",
     "activity": "Your activities",
     "appointment": "Your appointments",
     "bankTransactions": "Your bank transactions",

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -112,8 +112,8 @@
     "reconnect-via-form": "Se reconnecter",
     "job": {
       "DISK_QUOTA_EXCEEDED": {
-        "title": "Espace Cozy plein",
-        "description": "Actuellement, le service ne peut plus récupérer vos documents.\nLibérez de l'espace en supprimant des fichiers ou rendez-vous dans **Paramètres > Stockage** pour augmenter l'espace de stockage de votre Cozy"
+        "title": "Espace Disque plein",
+        "description": "Actuellement, le service ne peut plus récupérer vos documents.\nLibérez de l'espace en supprimant des fichiers ou rendez-vous dans **Paramètres > Stockage** pour augmenter votre espace de stockage."
       },
       "CHALLENGE_ASKED": {
         "title": "Second facteur d’authentification demandé",
@@ -121,7 +121,7 @@
       },
       "LOGIN_FAILED": {
         "title": "Identifiants erronés ou expirés",
-        "description": "Votre identifiant et/ou mot de passe ne sont pas corrects. Vous pouvez les vérifier directement sur le site [%{name}](%{link}) avant de réessayer"
+        "description": "Votre identifiant et/ou mot de passe ne semblent pas corrects. Merci de les vérifier sur le site [%{name}](%{link}) avant de réessayer."
       },
       "LOGIN_FAILED.NEEDS_SECRET": {
         "title": "Information additionnelle requise",
@@ -149,7 +149,7 @@
       },
       "USER_ACTION_NEEDED": {
         "title": "Action nécessaire chez le fournisseur",
-        "description": "Il semble que le site [%{name}](%{link}) ait besoin que vous vous y authentifiez pour réaliser une action spécifique. Merci de relancer une connexion manuelle une fois cette action effectuée."
+        "description": "Il semble que [%{name}](%{link}) ait besoin de revérifier votre connexion. Connectez-vous sur [%{name}](%{link}) puis cliquez sur \"Mettre à jour\" dans l'onglet données."
       },
       "USER_ACTION_NEEDED.OAUTH_OUTDATED": {
         "title": "Renouvellement de l’authentification requis",
@@ -169,7 +169,7 @@
       },
       "USER_ACTION_NEEDED.SCA_REQUIRED": {
         "title": "Renouvellement d'authentification demandé",
-        "description": "Il semble que %{name} ait besoin de revérifier votre connexion avant d'autoriser Cozy à synchroniser vos comptes. Merci de relancer le connecteur, cela déclenchera la demande auprès de votre banque. Vous recevrez un code à usage unique ou une demande sur l'espace client ou l'application de votre banque."
+        "description": "Il semble que %{name} ait besoin de revérifier votre connexion afin d'autoriser une nouvelle synchronisation de vos comptes. Merci de relancer le connecteur, cela déclenchera la demande auprès de votre banque. Vous recevrez un code à usage unique ou une demande sur l'espace client ou l'application de votre banque."
       },
       "USER_ACTION_NEEDED.TWOFA_EXPIRED": {
         "title": "Renouvellement de l’authentification demandé",
@@ -177,7 +177,7 @@
       },
       "USER_ACTION_NEEDED.WEBAUTH_REQUIRED": {
         "title": "Authentification sur le site web demandée",
-        "description": "Il semble que [%{name}](%{link}) ait besoin que vous vous authentifiiez à leur site web pour que la connexion à Cozy refonctionne. Merci de relancer le connecteur une fois cette action effectuée."
+        "description": "Il semble que [%{name}](%{link}) ait besoin que vous vous authentifiiez à leur site web pour que la synchronisation refonctionne. Merci de relancer le connecteur une fois cette action effectuée."
       },
       "USER_ACTION_NEEDED.WRONG_TWOFA_CODE": {
         "title": "Le code fourni ne semble pas correct",
@@ -382,7 +382,7 @@
     "button": {
       "label": "Fermer"
     },
-    "description": "Vos données existantes seront disponibles dans votre Cozy dans quelques minutes et les prochaines suivront automatiquement.",
+    "description": "Vos données existantes seront disponibles dans quelques minutes et les prochaines suivront automatiquement.",
     "figure": {
       "alt": "Connecté"
     },
@@ -410,9 +410,9 @@
   "account": {
     "success": {
       "title": "Configuration réussie !",
-      "connect": "Vos données existantes seront disponibles dans votre Cozy dans quelques minutes et les prochaines suivront automatiquement.",
+      "connect": "Vos données existantes seront disponibles dans quelques minutes et les prochaines suivront automatiquement.",
       "banksLinkText": "Voir mes comptes dans %{appName}",
-      "driveLinkText": "Ouvrir le dossier dans Cozy Drive",
+      "driveLinkText": "Ouvrir le dossier dans %{appName}",
       "button": "Fermer"
     }
   },
@@ -422,14 +422,14 @@
   },
   "suggestions": {
     "title": "Importer mes données %{name}",
-    "data": "Installer %{name} importera automatiquement les données suivantes dans votre cozy :",
+    "data": "Installer %{name} importera automatiquement les données suivantes :",
     "why": "Pourquoi %{name} m’est proposé ?",
     "reason_bank": "%{name} a été détecté à partir de vos dépenses bancaires. Pas d’inquiétude, personne à part vous ne peut avoir accès à cette  information.",
     "install": "Installer",
     "silence": "Ne plus me proposer"
   },
   "dataType": {
-    "none": "%{name} n'accèdera à aucune donnée de votre Cozy",
+    "none": "%{name} n'accèdera à aucune de vos données personnelles.",
     "activity": "Vos activités",
     "appointment": "Vos rendez-vous",
     "bankTransactions": "Vos mouvements bancaires",

--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -323,7 +323,10 @@ export const finishConnection = async ({ flow }) => {
 }
 
 /**
- * Used in the custom konnector policy for BI
+ * When a BI io.cozy.accounts is created, we create a connection on BI
+ * side and store its credentials inside the io.cozy.accounts
+ *
+ * Creates the BI connection from the front-end
  */
 export const onBIAccountCreation = async ({
   account: fullAccount,


### PR DESCRIPTION
feat: Remove references to "cozy" in harvest locales
Makes it easier to customize and whitelabel the UI

Show konnector error in both data and configuration tab in harvest

Open external links in a new tab not to lose the Cozy context