### PR TITLE
fix: Use useQuery instead of client.query in useAppLinkWithStoreFallback

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/BanksLink.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/BanksLink.jsx
@@ -9,9 +9,9 @@ import withLocales from '../../hoc/withLocales'
 
 import OpenwithIcon from 'cozy-ui/transpiled/react/Icons/Openwith'
 
-const BanksLinkRedirectStore = ({ client, t }) => {
+const BanksLinkRedirectStore = ({ t }) => {
   const slug = 'banks'
-  const { fetchStatus, url } = useAppLinkWithStoreFallback(slug, client)
+  const { fetchStatus, url } = useAppLinkWithStoreFallback(slug)
 
   if (fetchStatus === 'loaded') {
     return (

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/DriveLink.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/DriveLink.jsx
@@ -8,10 +8,10 @@ import useAppLinkWithStoreFallback from '../../hooks/useAppLinkWithStoreFallback
 
 import OpenwithIcon from 'cozy-ui/transpiled/react/Icons/Openwith'
 
-const DriveLink = memo(({ folderId, client, t }) => {
+const DriveLink = memo(({ folderId, t }) => {
   const slug = 'drive'
   const path = `#/files/${folderId}`
-  const { fetchStatus, url } = useAppLinkWithStoreFallback(slug, client, path)
+  const { fetchStatus, url } = useAppLinkWithStoreFallback(slug, path)
 
   if (fetchStatus === 'loaded') {
     return (

--- a/packages/cozy-harvest-lib/src/components/cards/AppLinkCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/AppLinkCard.jsx
@@ -21,7 +21,6 @@ export const AppLinkButton = ({ slug, path }) => {
   const cozyURL = new URL(client.getStackClient().uri)
   const { fetchStatus, url, isInstalled } = useAppLinkWithStoreFallback(
     slug,
-    client,
     path
   )
   return (


### PR DESCRIPTION
Suite à un `apps.data` on catchait une erreur `data is undefined` car le `client.query()` ne retourne aucune data lors d'un fetch en cache (fetchPolicy)

voir https://github.com/cozy/cozy-client/issues/931