### PR TITLE
fix: Revert using named query for useAppLinkWithStoreFallback

### DIFF
--- a/packages/cozy-harvest-lib/src/components/hooks/useAppLinkWithStoreFallback.jsx
+++ b/packages/cozy-harvest-lib/src/components/hooks/useAppLinkWithStoreFallback.jsx
@@ -1,7 +1,5 @@
 import { useEffect, useState } from 'react'
-import { models } from 'cozy-client'
-
-import { appsConn } from '../../connections/apps'
+import { Q, models } from 'cozy-client'
 
 const { applications } = models
 
@@ -13,7 +11,7 @@ const useAppLinkWithStoreFallback = (slug, client, path = '') => {
   useEffect(() => {
     const load = async () => {
       try {
-        const apps = await client.query(appsConn.query, appsConn)
+        const apps = await client.query(Q('io.cozy.apps'))
         const appDocument = { slug }
         const appInstalled = applications.isInstalled(apps.data, appDocument)
         setIsInstalled(!!appInstalled)


### PR DESCRIPTION
revert this commit https://github.com/cozy/cozy-libs/commit/b9d1fad26ffbcfbf5cbbfe69e685519f837371f3 because of this issue https://github.com/cozy/cozy-client/issues/931

**Contexte :** sur la Home, le bouton "ouvrir les documents" de la modale d'un konnecteur ne fonctionne pas après ouverture/fermeture/ouverture de la modale. Ayant passé du temps pour identifier le problème précisément (et le contourner, voir https://github.com/cozy/cozy-libs/pull/1308), la solution retenue, pour l'instant, est finalement de revert l'utilisation de requête nommée.