### PR TITLE
fix: When no number or null, use id attribute

### DIFF
--- a/packages/cozy-doctypes/src/banking/matching-accounts.js
+++ b/packages/cozy-doctypes/src/banking/matching-accounts.js
@@ -71,6 +71,23 @@ const approxNumberMatch = (account, existingAccount) => {
   )
 }
 
+/**
+ * If there is no "number" attribute or null, "id" attribute is used
+ * in the other, it's not a match
+ *
+ * @param account
+ * @param existingAccount
+ * @returns {boolean}
+ */
+const noNumberMatch = (account, existingAccount) => {
+  const accNumber = account.number || String(account.id)
+  const existingAccNumber = existingAccount.number || String(existingAccount.id)
+  if (!account.number || !existingAccount.number) {
+    return eitherIncludes(accNumber, existingAccNumber)
+  }
+  return false
+}
+
 const creditCardMatch = (account, existingAccount) => {
   if (account.type !== 'CreditCard' && existingAccount.type !== 'CreditCard') {
     return false
@@ -123,6 +140,7 @@ const sameTypeMatch = (account, existingAccount) => {
 const rules = [
   { rule: slugMatch, bonus: 0, malus: -1000 },
   { rule: approxNumberMatch, bonus: 50, malus: -50, name: 'approx-number' },
+  { rule: noNumberMatch, bonus: 10, malus: -10, name: 'no-number-attr' },
   { rule: sameTypeMatch, bonus: 50, malus: 0, name: 'same-type' },
   { rule: creditCardMatch, bonus: 150, malus: 0, name: 'credit-card-number' },
   { rule: currencyMatch, bonus: 50, malus: 0, name: 'currency' }

--- a/packages/cozy-doctypes/src/banking/matching-accounts.spec.js
+++ b/packages/cozy-doctypes/src/banking/matching-accounts.spec.js
@@ -91,6 +91,65 @@ describe('slug match', () => {
   })
 })
 
+describe('no "number" attribute match', () => {
+  const acc = {
+    id: 1337,
+    balance: 1337,
+    label: 'Test account',
+    number: null,
+    type: 'pee',
+    institutionLabel: "Plan·d'Epargne·Entreprise"
+  }
+
+  it('should not match the same account (id) without number attribute', () => {
+    const newAcc = {
+      ...acc,
+      id: 1234
+    }
+
+    expect(score(acc, newAcc).points).toBeLessThan(0)
+  })
+
+  it('should match even if there are not the same id', () => {
+    const acc1 = {
+      ...acc,
+      id: 1234,
+      number: '13371337133'
+    }
+    const acc2 = {
+      ...acc,
+      id: 1337,
+      number: '13371337133'
+    }
+
+    expect(score(acc1, acc2).points).toBeGreaterThan(0)
+  })
+
+  it('should not match even if there are same id', () => {
+    const acc1 = {
+      ...acc,
+      id: 1234,
+      number: '13371337133'
+    }
+    const acc2 = {
+      ...acc,
+      id: 1234,
+      number: '12341234123'
+    }
+
+    expect(score(acc1, acc2).points).toBeLessThan(0)
+  })
+
+  it('should match the same account (id) without number attribute', () => {
+    const acc2 = {
+      ...acc,
+      id: 1337,
+      number: null
+    }
+    expect(score(acc, acc2).points).toBeGreaterThan(0)
+  })
+})
+
 it('should normalize account number', () => {
   expect(normalizeAccountNumber('LEO-385248377-EUR')).toBe('385248377')
   expect(normalizeAccountNumber('385248377EUR')).toBe('385248377')


### PR DESCRIPTION
In the Natixis example, there is no value
in the number attribute of the account.

And so when matching the accounts the score
was 0 (no matching).
As a result we had duplicate accounts.

A “rule” has been added which allows to take into
account the case where the "number" attribute
is null.

In this case we use the account ID which
allows for a correspondence.