### PR TITLE
fix: Use menuPosition fixed to handle overflow

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/AccountField.jsx
@@ -130,7 +130,9 @@ export class AccountField extends PureComponent {
           />
         )
       case 'dropdown':
-        return <Field {...sanitizeSelectProps(fieldProps)} />
+        return (
+          <Field {...sanitizeSelectProps(fieldProps)} menuPosition={'fixed'} />
+        )
       case 'password':
         return (
           <Field
@@ -151,11 +153,6 @@ export class AccountField extends PureComponent {
 }
 
 AccountField.propTypes = {
-  /**
-   * The element wrapping the <Field /> component.
-   * Passed to <SelectBox /> component.
-   */
-  container: PropTypes.instanceOf(Element),
   /**
    * Indicates if the <Field /> should be rendered with an error style.
    */

--- a/packages/cozy-harvest-lib/src/components/AccountForm/AccountFields.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/AccountFields.jsx
@@ -22,7 +22,6 @@ const parse = type => value => {
 export class AccountFields extends PureComponent {
   render() {
     const {
-      container,
       disabled,
       fields,
       hasError,
@@ -54,7 +53,6 @@ export class AccountFields extends PureComponent {
                 <AccountField
                   {...field}
                   {...input}
-                  container={container}
                   hasError={hasError}
                   disabled={disabled}
                   initialValue={
@@ -75,11 +73,6 @@ export class AccountFields extends PureComponent {
 }
 
 AccountFields.propTypes = {
-  /**
-   * The element wrapping the <AccountFields /> component.
-   * Passed to <Field /> component.
-   */
-  container: PropTypes.instanceOf(Element),
   /**
    * Indicates if all the fields are disabled
    * @type {Boolean}

--- a/packages/cozy-harvest-lib/src/components/AccountForm/Field.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/Field.jsx
@@ -28,7 +28,6 @@ const ObfuscatedLabel = ({ label }) => {
 
 export const Field = ({ label, type, ...props }) => {
   let Component = type === 'password' ? PasswordField : UIField
-
   return (
     <Component
       {...props}

--- a/packages/cozy-harvest-lib/src/components/AccountForm/__snapshots__/index.spec.jsx.snap
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/__snapshots__/index.spec.jsx.snap
@@ -6,7 +6,6 @@ exports[`AccountForm should not render error 1`] = `
   onKeyUp={[Function]}
 >
   <AccountFields
-    container={null}
     fields={
       Object {
         "passphrase": Object {
@@ -43,7 +42,6 @@ exports[`AccountForm should render 1`] = `
   onKeyUp={[Function]}
 >
   <AccountFields
-    container={null}
     fields={
       Object {
         "passphrase": Object {
@@ -95,7 +93,6 @@ exports[`AccountForm should render error 1`] = `
     }
   />
   <AccountFields
-    container={null}
     fields={
       Object {
         "passphrase": Object {

--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -228,7 +228,6 @@ export class AccountForm extends PureComponent {
       sanitizedFields[identifier].type = 'hidden'
     }
 
-    let container = null
     const isLoginError =
       error instanceof KonnectorJobError && error.isLoginError()
 
@@ -250,9 +249,6 @@ export class AccountForm extends PureComponent {
               })
             }
             onFocusCapture={this.handleFocus}
-            ref={element => {
-              container = element
-            }}
           >
             {error && showError && (
               <TriggerErrorInfo
@@ -273,7 +269,6 @@ export class AccountForm extends PureComponent {
               />
             )}
             <AccountFields
-              container={container}
               disabled={submitting}
               fields={sanitizedFields}
               hasError={error && isLoginError}

--- a/packages/cozy-harvest-lib/src/components/__snapshots__/AccountField.spec.js.snap
+++ b/packages/cozy-harvest-lib/src/components/__snapshots__/AccountField.spec.js.snap
@@ -116,6 +116,7 @@ exports[`AccountField render a dropdown field 1`] = `
       "aria-label": "fields.multiple.label",
     }
   }
+  menuPosition="fixed"
   name="multiple"
   options={
     Array [


### PR DESCRIPTION
In previous attempt to handle the overflow, we
decided to calculate the size of the select box
by measuring the size of the Select's container
and calculating the available space.

See #240

But if the SelectBox is near to the bottom of the
container, its size is not big enough.

To fix that issue, we use the fixed position of
ReactSelect to overflow the content and use a
default max-height to 300px.

Since the "container" props was added by the PR
we "revert", I removed them.



After: 
<img width="719" alt="Capture d’écran 2021-05-04 à 10 40 31" src="https://user-images.githubusercontent.com/1107936/116979382-3a34b680-acc5-11eb-81c2-d7a4e323f477.png">
