### PR TITLE
fix: Revert change on removal of browser

### DIFF
--- a/packages/cozy-flags/package.json
+++ b/packages/cozy-flags/package.json
@@ -3,6 +3,7 @@
   "version": "2.7.1",
   "description": "Flag library used in Cozy",
   "main": "dist/index.js",
+  "browser": "dist/index.browser.js",
   "author": "Cozy",
   "license": "MIT",
   "homepage": "https://github.com/cozy/cozy-libs/blob/master/packages/cozy-flags/README.md",


### PR DESCRIPTION
The browser entrypoint was removed by error in a unrelated commit.
The commit in question a0856a5fc4b1701376dddabe9065b521a6a0294a

This had the consequence that we could not access browser only methods
after updating cozy-flags.