### PR TITLE
fix: BI Two FA naming error

### DIFF
--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -366,7 +366,7 @@ export const onBIAccountCreation = async ({
   return account
 }
 
-export const sendTwoFaCode = (flow, code) => {
+export const sendTwoFACode = (flow, code) => {
   let fields
 
   try {
@@ -509,6 +509,7 @@ export const konnectorPolicy = {
   saveInVault: false,
   onAccountCreation: onBIAccountCreation,
   sendAdditionalInformation: sendAdditionalInformation,
+  sendTwoFACode: sendTwoFACode,
   fetchExtraOAuthUrlParams: fetchExtraOAuthUrlParams,
   getAdditionalInformationNeeded,
   handleOAuthAccount,

--- a/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
@@ -9,7 +9,7 @@ import {
   getBIConfig,
   saveBIConfig,
   updateBIConnectionFromFlow,
-  sendTwoFaCode
+  sendTwoFACode
 } from './budget-insight'
 import { waitForRealtimeEvent } from './jobUtils'
 import {
@@ -752,7 +752,7 @@ describe('updateBIConnectionFromFlow', () => {
   })
 })
 
-describe('sendTwoFaCode', () => {
+describe('sendTwoFACode', () => {
   it('should use flow.sendTwoFACode if fields are unknown', () => {
     const client = new CozyClient({
       uri: 'http://testcozy.mycozy.cloud'
@@ -762,7 +762,7 @@ describe('sendTwoFaCode', () => {
     const flow = new ConnectionFlow(client, null, konnector)
     flow.account = account
     jest.spyOn(flow, 'sendTwoFACode')
-    sendTwoFaCode(flow, 'abcde')
+    sendTwoFACode(flow, 'abcde')
     expect(flow.sendTwoFACode).toHaveBeenCalled()
   })
 
@@ -776,7 +776,7 @@ describe('sendTwoFaCode', () => {
     flow.account = account
     flow.setData({ biConnection: { fields: ['sms'] } })
     jest.spyOn(flow, 'sendAdditionalInformation')
-    sendTwoFaCode(flow, 'abcde')
+    sendTwoFACode(flow, 'abcde')
     expect(flow.sendAdditionalInformation).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
There was an error in the naming of the sendTwoFa function
in the BI policy.
This caused 2FA codes not to be sent to BI and harvest was keeping
asking a new code indefinitely.