### PR TITLE
fix: esc touch does the same as the back button.

### DIFF
--- a/packages/cozy-harvest-lib/src/datacards/FileDataCard.jsx
+++ b/packages/cozy-harvest-lib/src/datacards/FileDataCard.jsx
@@ -12,6 +12,8 @@ import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemIcon from '@material-ui/core/ListItemIcon'
 import Slide from '@material-ui/core/Slide'
+import Modal from '@material-ui/core/Modal'
+
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 
 import palette from 'cozy-ui/transpiled/react/palette'
@@ -19,7 +21,6 @@ import { Media, Bd, Img } from 'cozy-ui/transpiled/react/Media'
 import Circle from 'cozy-ui/transpiled/react/Circle'
 import Portal from 'cozy-ui/transpiled/react/Portal'
 import Viewer from 'cozy-ui/transpiled/react/Viewer'
-import Overlay from 'cozy-ui/transpiled/react/Overlay'
 import Card from 'cozy-ui/transpiled/react/Card'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import FileIcon from 'cozy-ui/transpiled/react/Icons/File'
@@ -148,14 +149,14 @@ const FileCard = ({ files, loading, konnector, trigger }) => {
       </List>
       {viewerIndex !== null && (
         <Portal into="body">
-          <Overlay style={{ zIndex: 10000 }}>
+          <Modal open={true}>
             <Viewer
               files={files}
               currentIndex={viewerIndex}
               onCloseRequest={handleCloseViewer}
               onChangeRequest={handleFileChange}
             />
-          </Overlay>
+          </Modal>
         </Portal>
       )}
       <div className="u-ta-right u-mv-half u-mh-1">


### PR DESCRIPTION
The bug was: after opened the viewer, if I touch the "ESC" we close the
"first modal" aka the Harvest one (containing herself this Overlay).

We can pass an `onEscape` props on the `Overlay` component, but in fact
Overlay is below the `Harvest Modal` as you can see we cheated with a
zIndex to display it in top. Since the Modal is "first", then when we
espace, we close the modal (and since the modal contains the Overlay
it closes all the stuff).

To fix that, we use the Modal component from M-UI. Like that, M-UI
handles the "stack component" for us, so the latest opened modal get the
priority for events.

I now import Modal from m-ui itself, but like that I do not need to
update UI. Will do that later.