### PR TITLE
fix: Label height for Account Form

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/Field.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/Field.jsx
@@ -3,7 +3,7 @@ import UIField from 'cozy-ui/transpiled/react/Field'
 
 const ObfuscateChar = () => {
   return (
-    <span style={{ fontSize: 0 }} aria-hidden="true">
+    <span style={{ display: 'none' }} aria-hidden="true">
       ·
     </span>
   )


### PR DESCRIPTION
Before, we set the fontSize to 0 in order to not display the
ObfuscateChar. But by doing so, I do know why, but the
height of the label is not the good one at least on Chromium's
based browser.

To avoid this issue, let's use display none. It will be easier

for Password manager to detect our trick, but we already have
an aria-label saying the same thing. So ...

Before
![before](https://user-images.githubusercontent.com/1107936/121721978-24e15200-cae5-11eb-88a7-7c3da47807f2.png)

After
![after](https://user-images.githubusercontent.com/1107936/121721975-23b02500-cae5-11eb-93ee-7bb35ae32b41.png)