### PR TITLE
feat: Enable named query

### DIFF
--- a/packages/cozy-harvest-lib/src/components/hooks/useAppLinkWithStoreFallback.jsx
+++ b/packages/cozy-harvest-lib/src/components/hooks/useAppLinkWithStoreFallback.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react'
-import { Q, models } from 'cozy-client'
+import { models } from 'cozy-client'
+
+import { appsConn } from '../../connections/apps'
 
 const { applications } = models
 
@@ -11,7 +13,7 @@ const useAppLinkWithStoreFallback = (slug, client, path = '') => {
   useEffect(() => {
     const load = async () => {
       try {
-        const apps = await client.query(Q('io.cozy.apps'))
+        const apps = await client.query(appsConn.query, appsConn)
         const appDocument = { slug }
         const appInstalled = applications.isInstalled(apps.data, appDocument)
         setIsInstalled(!!appInstalled)


### PR DESCRIPTION
This commit revert the previous revert. Since
https://github.com/cozy/cozy-client/pull/935 we can now make
a call to client.query() with a fetchPolicy and get the right
results.

Needs: https://github.com/cozy/cozy-client/pull/935 & upgrade cozy-client devDep & peerDep

This reverts commit 06d0e9c5192cf75ffbcb0a108574e8cbfd6c9732.


