### PR TITLE
Feat/two steps confirmation

### DIFF
--- a/packages/cozy-sharing/jestHelpers/setup.js
+++ b/packages/cozy-sharing/jestHelpers/setup.js
@@ -1,5 +1,6 @@
 import Enzyme from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
+import '@testing-library/jest-dom/extend-expect'
 
 jest.mock('cozy-logger', () => ({
   namespace: () => () => {}

--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -1,4 +1,7 @@
 {
+  "loading": {
+    "sharing": "Loading in progress"
+  },
   "Share": {
     "status": {
       "owner": "Owner",
@@ -39,10 +42,13 @@
       "defaultDisplayName": "Anonymous"
     },
     "twoStepsConfirmation": {
+      "title": "Confirm contact",
       "confirm": "Confirm",
       "reject": "Reject",
+      "cancel": "Cancel",
       "contactAreWaitingForConfirmation": "Some contacts are waiting for your confirmation. Confirm their identities to allow them to access items you shared with them.||||%{smart_count} contacts are waiting for your confirmation. Confirm their identities to allow them to access items you shared with them."
     },
+    "loadingError": "Loading error"
   },
   "Sharings": {
     "unavailable": {

--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -360,6 +360,10 @@
         "isInSharedFolder": "is in a shared folder",
         "hasSharedFolder": "contains a shared folder"
       }
+    },
+    "fingerprint": {
+      "instruction": "Every Cozy is associated to a unique **fingerprint phrase**. For security reasons, please ask to %{userName} (%{userEmail}) if his Cozy's fingerprint phrase is corresponding to :",
+      "instruction2": "The fingerprint phrase of a Cozy is visible on top of the Cozy Pass' passwords list. This fingerprint phrase can also be accessed on **Parameters/Profile/Fingerprint phrase** from the mobile client or the browser extension."
     }
   }
 }

--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -40,7 +40,8 @@
     },
     "twoStepsConfirmation": {
       "confirm": "Confirm",
-      "reject": "Reject"
+      "reject": "Reject",
+      "contactAreWaitingForConfirmation": "Some contacts are waiting for your confirmation. Confirm their identities to allow them to access items you shared with them.||||%{smart_count} contacts are waiting for your confirmation. Confirm their identities to allow them to access items you shared with them."
     },
   },
   "Sharings": {

--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -37,7 +37,11 @@
         "success": "The application has access to your contacts"
       },
       "defaultDisplayName": "Anonymous"
-    }
+    },
+    "twoStepsConfirmation": {
+      "confirm": "Confirm",
+      "reject": "Reject"
+    },
   },
   "Sharings": {
     "unavailable": {

--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -43,10 +43,12 @@
     },
     "twoStepsConfirmation": {
       "title": "Confirm contact",
+      "titleReject": "Reject contact",
       "confirm": "Confirm",
       "reject": "Reject",
       "cancel": "Cancel",
-      "contactAreWaitingForConfirmation": "Some contacts are waiting for your confirmation. Confirm their identities to allow them to access items you shared with them.||||%{smart_count} contacts are waiting for your confirmation. Confirm their identities to allow them to access items you shared with them."
+      "contactAreWaitingForConfirmation": "Some contacts are waiting for your confirmation. Confirm their identities to allow them to access items you shared with them.||||%{smart_count} contacts are waiting for your confirmation. Confirm their identities to allow them to access items you shared with them.",
+      "confirmRejection": "Do you really want to reject contact %{userName} (%{userEmail})?"
     },
     "loadingError": "Loading error"
   },

--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -1,4 +1,7 @@
 {
+  "loading": {
+    "sharing": "Chargement en cours"
+  },
   "Share": {
     "status": {
       "owner": "Propriétaire",
@@ -39,10 +42,14 @@
       "defaultDisplayName": "Anonyme"
     },
     "twoStepsConfirmation": {
+      "title": "Confirmer le contact",
       "confirm": "Confirmer",
       "reject": "Refuser",
+      "cancel": "Annuler",
       "contactAreWaitingForConfirmation": "%{smart_count} contact en attente de confirmation. Confirmer son identité pour lui permettre d’accéder aux éléments que vous avez partagé avec lui.||||%{smart_count} contacts en attente de confirmation. Confirmer leur identité pour leur permettre d’accéder aux éléments que vous avez partagé avec eux."
     },
+    "loadingError": "Erreur de chargement"
+  },
   "Sharings": {
     "unavailable": {
       "title": "Ravi de vous revoir !",
@@ -151,7 +158,6 @@
       "sharedBy": "Partagé par %{name}",
       "shareByLink": {
         "subtitle": "Partager par lien",
-        "desc": "Chaque personne possédant le lien fourni peut voir et modifier votre note.",
         "create": "Générer un lien",
         "activated": "Lien activé",
         "copy": "Copier le lien",
@@ -232,7 +238,6 @@
       "sharedWithMe": "Partagé avec moi",
       "shareByLink": {
         "subtitle": "Ou partager par lien",
-        "desc": "Chaque personne possédant le lien fourni peut voir et télécharger vos photos.",
         "fetchFailed": "Oups ! Il semblerait que votre connexion internet soit limitée, réessayez plus tard quand le réseau sera meilleur.",
         "create": "Générer un lien",
         "activated": "Lien activé",

--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -360,6 +360,10 @@
         "isInSharedFolder": "se trouve dans un dossier partagé.",
         "hasSharedFolder": "contient un dossier partagé."
       }
+    },
+    "fingerprint": {
+      "instruction": "Chaque Cozy est associé **une phrase d’empreinte** unique. Par sécurité, merci de demander à %{userName} (%{userEmail}) si la phrase d’empreinte de son Cozy correspond bien à :",
+      "instruction2": "La phrase d’empreinte d’un Cozy est accessible **en haut de sa liste de mot de passes dans Cozy Pass**. Cette phrase d'empreinte est également accessible dans **Paramètres/Profil/Phrase d’empreinte** de son client mobile ou de son extension navigateur."
     }
   }
 }

--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -43,10 +43,12 @@
     },
     "twoStepsConfirmation": {
       "title": "Confirmer le contact",
+      "titleReject": "Refuser le contact",
       "confirm": "Confirmer",
       "reject": "Refuser",
       "cancel": "Annuler",
-      "contactAreWaitingForConfirmation": "%{smart_count} contact en attente de confirmation. Confirmer son identité pour lui permettre d’accéder aux éléments que vous avez partagé avec lui.||||%{smart_count} contacts en attente de confirmation. Confirmer leur identité pour leur permettre d’accéder aux éléments que vous avez partagé avec eux."
+      "contactAreWaitingForConfirmation": "%{smart_count} contact en attente de confirmation. Confirmer son identité pour lui permettre d’accéder aux éléments que vous avez partagé avec lui.||||%{smart_count} contacts en attente de confirmation. Confirmer leur identité pour leur permettre d’accéder aux éléments que vous avez partagé avec eux.",
+      "confirmRejection": "Êtes-vous sûr de vouloir refuser le contact %{userName} (%{userEmail})?"
     },
     "loadingError": "Erreur de chargement"
   },

--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -37,8 +37,11 @@
         "success": "L'application a accès à vos contacts"
       },
       "defaultDisplayName": "Anonyme"
-    }
-  },
+    },
+    "twoStepsConfirmation": {
+      "confirm": "Confirmer",
+      "reject": "Refuser"
+    },
   "Sharings": {
     "unavailable": {
       "title": "Ravi de vous revoir !",

--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -40,7 +40,8 @@
     },
     "twoStepsConfirmation": {
       "confirm": "Confirmer",
-      "reject": "Refuser"
+      "reject": "Refuser",
+      "contactAreWaitingForConfirmation": "%{smart_count} contact en attente de confirmation. Confirmer son identité pour lui permettre d’accéder aux éléments que vous avez partagé avec lui.||||%{smart_count} contacts en attente de confirmation. Confirmer leur identité pour leur permettre d’accéder aux éléments que vous avez partagé avec eux."
     },
   "Sharings": {
     "unavailable": {

--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -32,7 +32,8 @@
     "cozy-doctypes": "^1.82.2",
     "lodash": "^4.17.19",
     "react-autosuggest": "^9.4.3",
-    "react-tooltip": "^3.11.1"
+    "react-tooltip": "^3.11.1",
+    "snarkdown": "^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.12.3",

--- a/packages/cozy-sharing/src/components/CozyPassFingerprintDialogContent.jsx
+++ b/packages/cozy-sharing/src/components/CozyPassFingerprintDialogContent.jsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import Paper from 'cozy-ui/transpiled/react/Paper'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import snarkdown from 'snarkdown'
+
+import cx from 'classnames'
+import styles from './CozyPassFingerprintDialogContent.styl'
+
+/**
+ * CozyPassFingerprintDialogContent can be use as a content for ShareModal when
+ * using 2 steps confirmation
+ *
+ * This should be the case when ShareModal is called from `cozy-pass-web`
+ */
+export const CozyPassFingerprintDialogContent = ({
+  recipientConfirmationData
+}) => {
+  const { t } = useI18n()
+
+  const instruction1 = snarkdown(
+    t(`Organizations.fingerprint.instruction`, {
+      userName: recipientConfirmationData.name,
+      userEmail: recipientConfirmationData.email
+    })
+  )
+
+  const instruction2 = snarkdown(t(`Organizations.fingerprint.instruction2`))
+
+  return (
+    <div className={cx(styles['share-modal-content'])}>
+      <p dangerouslySetInnerHTML={{ __html: instruction1 }}></p>
+      <Paper
+        className={cx(styles['cozy-pass-fingerprint-modal__fingerprint'])}
+        elevation={1}
+      >
+        <Typography variant="body1">
+          {recipientConfirmationData.fingerprintPhrase}
+        </Typography>
+      </Paper>
+      <p dangerouslySetInnerHTML={{ __html: instruction2 }}></p>
+    </div>
+  )
+}
+
+CozyPassFingerprintDialogContent.propTypes = {
+  recipientConfirmationData: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    email: PropTypes.string.isRequired,
+    fingerprintPhrase: PropTypes.string.isRequired
+  })
+}

--- a/packages/cozy-sharing/src/components/CozyPassFingerprintDialogContent.spec.jsx
+++ b/packages/cozy-sharing/src/components/CozyPassFingerprintDialogContent.spec.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import { createMockClient } from 'cozy-client'
+import AppLike from '../../test/AppLike'
+
+import { CozyPassFingerprintDialogContent } from './CozyPassFingerprintDialogContent'
+
+describe('CozyPassFingerprintDialogContent', () => {
+  const client = createMockClient({})
+  client.options = {
+    uri: 'foo.mycozy.cloud'
+  }
+
+  const setup = props => {
+    return render(
+      <AppLike client={client}>
+        <CozyPassFingerprintDialogContent {...props} />
+      </AppLike>
+    )
+  }
+
+  it('shoud show the fingerprint from recipientConfirmationData', async () => {
+    let props = {
+      recipientConfirmationData: {
+        name: 'SOME_NAME',
+        email: 'SOME_EMAIL',
+        fingerprintPhrase: 'SOME_FINGERPRINT'
+      }
+    }
+
+    const { getByText } = setup(props)
+
+    expect(getByText('SOME_FINGERPRINT')).toBeTruthy()
+  })
+})

--- a/packages/cozy-sharing/src/components/CozyPassFingerprintDialogContent.styl
+++ b/packages/cozy-sharing/src/components/CozyPassFingerprintDialogContent.styl
@@ -1,0 +1,7 @@
+.cozy-pass-fingerprint-modal
+    &__fingerprint
+        padding 16px
+        margin 24px 0
+        text-align center
+        p
+          color var(--secondaryColor)

--- a/packages/cozy-sharing/src/components/Recipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient.jsx
@@ -16,6 +16,8 @@ import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
 import EyeIcon from 'cozy-ui/transpiled/react/Icons/Eye'
 import PaperplaneIcon from 'cozy-ui/transpiled/react/Icons/Paperplane'
 import ToTheCloudIcon from 'cozy-ui/transpiled/react/Icons/ToTheCloud'
+import CheckCircleIcon from 'cozy-ui/transpiled/react/Icons/CheckCircle'
+import CrossCircleIcon from 'cozy-ui/transpiled/react/Icons/CrossCircle'
 
 import AvatarPlusX from './AvatarPlusX'
 import styles from './recipient.styl'
@@ -26,6 +28,7 @@ import Identity from './Identity'
 import LinkIcon from 'cozy-ui/transpiled/react/Icons/Link'
 
 import Typography from 'cozy-ui/transpiled/react/Typography'
+import Chip from 'cozy-ui/transpiled/react/Chip'
 
 export const MAX_DISPLAYED_RECIPIENTS = 3
 const DEFAULT_DISPLAY_NAME = 'Share.contacts.defaultDisplayName'
@@ -295,14 +298,82 @@ const Status = ({ status, isMe, instance }) => {
   )
 }
 
+/**
+ * Displays the confirmation interface that allows to confirm or reject a recipient
+ */
+const RecipientConfirm = ({
+  recipientConfirmationData,
+  rejectRecipient,
+  confirmRecipient
+}) => {
+  const { t } = useI18n()
+
+  const reject = () => {
+    rejectRecipient(recipientConfirmationData)
+  }
+
+  const confirm = () => {
+    confirmRecipient(recipientConfirmationData)
+  }
+
+  return (
+    <>
+      <Chip
+        className={cx(styles['recipient-confirm__action--confirm'])}
+        variant="outlined"
+        size="small"
+        onClick={confirm}
+      >
+        <Icon icon={CheckCircleIcon} className={'u-mr-half'} />
+        {t(`Share.twoStepsConfirmation.confirm`)}
+      </Chip>
+      <Chip.Round
+        className={cx(styles['recipient-confirm__action--cancel'])}
+        variant="outlined"
+        size="small"
+        onClick={reject}
+        aria-label={t(`Share.twoStepsConfirmation.reject`)}
+      >
+        <Icon icon={CrossCircleIcon} />
+      </Chip.Round>
+    </>
+  )
+}
+
+RecipientConfirm.propTypes = {
+  recipientConfirmationData: PropTypes.object.isRequired,
+  rejectRecipient: PropTypes.func.isRequired,
+  confirmRecipient: PropTypes.func.isRequired
+}
+
 const Recipient = props => {
   const { t } = useI18n()
   const client = useClient()
-  const { instance, isOwner, status, ...rest } = props
+
+  const {
+    instance,
+    isOwner,
+    status,
+    recipientConfirmationData,
+    rejectRecipient,
+    confirmRecipient,
+    ...rest
+  } = props
+
   const isMe =
     (isOwner && status === 'owner') || instance === client.options.uri
   const defaultDisplayName = t(DEFAULT_DISPLAY_NAME)
   const name = getDisplayName(rest, defaultDisplayName)
+
+  const RightPart = recipientConfirmationData ? (
+    <RecipientConfirm
+      recipientConfirmationData={recipientConfirmationData}
+      rejectRecipient={rejectRecipient}
+      confirmRecipient={confirmRecipient}
+    ></RecipientConfirm>
+  ) : (
+    <Permissions {...props} className="u-flex-shrink-0" />
+  )
 
   return (
     <CompositeRow
@@ -315,7 +386,7 @@ const Recipient = props => {
       }
       secondaryText={<Status status={status} isMe={isMe} instance={instance} />}
       image={<RecipientAvatar recipient={props} />}
-      right={<Permissions {...props} className="u-flex-shrink-0" />}
+      right={RightPart}
     />
   )
 }

--- a/packages/cozy-sharing/src/components/Recipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient.jsx
@@ -391,6 +391,15 @@ const Recipient = props => {
   )
 }
 
+Recipient.propTypes = {
+  instance: PropTypes.string,
+  isOwner: PropTypes.bool,
+  status: PropTypes.string,
+  recipientConfirmationData: PropTypes.object,
+  rejectRecipient: PropTypes.func,
+  confirmRecipient: PropTypes.func
+}
+
 export default Recipient
 
 export const RecipientWithoutStatus = ({ instance, ...rest }) => {

--- a/packages/cozy-sharing/src/components/Recipient.spec.jsx
+++ b/packages/cozy-sharing/src/components/Recipient.spec.jsx
@@ -95,6 +95,94 @@ describe('Recipient component', () => {
     expect(onRevoke).toBeCalled()
     expect(onRevokeSelf).not.toBeCalled()
   })
+
+  it('should render confirmation actions if recipient is waiting for confirmation', () => {
+    const confirmRecipient = jest.fn()
+    const rejectRecipient = jest.fn()
+
+    const { getByText } = setup({
+      instance: 'foo.mycozy.cloud',
+      status: 'ready',
+      type: 'two-way',
+      isOwner: false,
+      documentType: 'Organizations',
+      recipientConfirmationData: {
+        email: 'me@bob.cozy.localhost'
+      },
+      rejectRecipient,
+      confirmRecipient
+    })
+
+    expect(getByText('Confirm')).toBeTruthy()
+  })
+
+  it('should not render confirmation actions if no recipient is waiting for confirmation', () => {
+    const confirmRecipient = jest.fn()
+    const rejectRecipient = jest.fn()
+
+    const { queryByText } = setup({
+      instance: 'foo.mycozy.cloud',
+      status: 'ready',
+      type: 'two-way',
+      isOwner: false,
+      documentType: 'Organizations',
+      recipientConfirmationData: undefined,
+      rejectRecipient,
+      confirmRecipient
+    })
+
+    expect(queryByText('Confirm')).not.toBeInTheDocument()
+  })
+
+  it(`should call confirmRecipient when clicking 'confirm' button`, () => {
+    const confirmRecipient = jest.fn()
+    const rejectRecipient = jest.fn()
+
+    const { getByText } = setup({
+      instance: 'foo.mycozy.cloud',
+      status: 'ready',
+      type: 'two-way',
+      isOwner: false,
+      documentType: 'Organizations',
+      recipientConfirmationData: {
+        email: 'me@bob.cozy.localhost'
+      },
+      rejectRecipient,
+      confirmRecipient
+    })
+
+    fireEvent.click(getByText('Confirm'))
+
+    expect(confirmRecipient).toBeCalledWith({
+      email: 'me@bob.cozy.localhost'
+    })
+    expect(rejectRecipient).not.toBeCalled()
+  })
+
+  it(`should call rejectRecipient when clicking 'reject' button`, () => {
+    const confirmRecipient = jest.fn()
+    const rejectRecipient = jest.fn()
+
+    const { getByLabelText } = setup({
+      instance: 'foo.mycozy.cloud',
+      status: 'ready',
+      type: 'two-way',
+      isOwner: false,
+      documentType: 'Organizations',
+      recipientConfirmationData: {
+        email: 'me@bob.cozy.localhost'
+      },
+      rejectRecipient,
+      confirmRecipient
+    })
+
+    fireEvent.click(getByLabelText('Reject'))
+
+    expect(rejectRecipient).toBeCalledWith({
+      email: 'me@bob.cozy.localhost'
+    })
+    expect(confirmRecipient).not.toBeCalled()
+  })
 })
 
 describe('excludeMeAsOwnerFromRecipients', () => {

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
@@ -165,7 +165,13 @@ const ShareDialogCozyToCozy = ({
 }) => {
   const { t } = useI18n()
 
-  const [status, setStatus] = React.useState('loading')
+  const shouldGetRecipientsToBeConfirmed =
+    hasTwoStepsConfirmation &&
+    twoStepsConfirmationMethods?.getRecipientsToBeConfirmed
+
+  const [status, setStatus] = React.useState(
+    shouldGetRecipientsToBeConfirmed ? 'loading' : 'sharing'
+  )
   const [recipientsToBeConfirmed, setRecipientsToBeConfirmed] = useState([])
   const [recipientConfirmationData, setRecipientConfirmationData] = useState(
     undefined
@@ -187,10 +193,7 @@ const ShareDialogCozyToCozy = ({
   })
 
   const getRecipientsToBeConfirmed = useCallback(async () => {
-    if (
-      hasTwoStepsConfirmation &&
-      twoStepsConfirmationMethods?.getRecipientsToBeConfirmed
-    ) {
+    if (shouldGetRecipientsToBeConfirmed) {
       setStatus('loading')
 
       try {
@@ -210,7 +213,7 @@ const ShareDialogCozyToCozy = ({
     } else {
       setStatus('sharing')
     }
-  }, [hasTwoStepsConfirmation, twoStepsConfirmationMethods, document])
+  }, [shouldGetRecipientsToBeConfirmed, twoStepsConfirmationMethods, document])
 
   useEffect(() => {
     getRecipientsToBeConfirmed()

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
@@ -135,6 +135,43 @@ const ConfirmRecipientActions = ({ confirm, cancel }) => {
 }
 
 /**
+ * Displays the reject interface that can be used when ShareDialogCozyToCozy is in asking for
+ * confirmation after the user clicked on Reject button
+ */
+const RejectDialogContent = ({ recipientConfirmationData }) => {
+  const { t } = useI18n()
+
+  const question = t('Share.twoStepsConfirmation.confirmRejection', {
+    userName: recipientConfirmationData.name,
+    userEmail: recipientConfirmationData.email
+  })
+
+  return question
+}
+
+/**
+ * Displays actions that are available when rejecting a recipient
+ */
+const RejectRecipientActions = ({ reject, cancel }) => {
+  const { t } = useI18n()
+
+  return (
+    <>
+      <Button
+        theme="secondary"
+        label={t(`Share.twoStepsConfirmation.cancel`)}
+        onClick={cancel}
+      />
+      <Button
+        theme="primary"
+        label={t(`Share.twoStepsConfirmation.reject`)}
+        onClick={reject}
+      />
+    </>
+  )
+}
+
+/**
  * Displays a sharing dialog that allows to share a document between multiple Cozy users
  */
 const ShareDialogCozyToCozy = ({
@@ -219,8 +256,20 @@ const ShareDialogCozyToCozy = ({
     setStatus('confirmingRecipient')
   }
 
+  const showRejectDialog = recipientConfirmationData => {
+    setRecipientConfirmationData(recipientConfirmationData)
+    setStatus('rejectingRecipient')
+  }
+
   const onConfirmRecipient = () => {
     confirmRecipient(recipientConfirmationData).then(() => {
+      getRecipientsToBeConfirmed()
+    })
+  }
+
+  const onRejectRecipient = () => {
+    setStatus('loading')
+    rejectRecipient(recipientConfirmationData).then(() => {
       getRecipientsToBeConfirmed()
     })
   }
@@ -260,7 +309,7 @@ const ShareDialogCozyToCozy = ({
         showShareOnlyByLink={showShareOnlyByLink}
         showWhoHasAccess={showWhoHasAccess}
         recipientsToBeConfirmed={recipientsToBeConfirmed}
-        rejectRecipient={rejectRecipient}
+        rejectRecipient={showRejectDialog}
         confirmRecipient={showConfirmationDialog}
       />
     )
@@ -289,6 +338,21 @@ const ShareDialogCozyToCozy = ({
     dialogActions = (
       <ConfirmRecipientActions
         confirm={onConfirmRecipient}
+        cancel={closeConfirmationDialog}
+      />
+    )
+  } else if (status === 'rejectingRecipient') {
+    dialogTitle = t(`Share.twoStepsConfirmation.titleReject`)
+
+    dialogContent = (
+      <RejectDialogContent
+        recipientConfirmationData={recipientConfirmationData}
+      />
+    )
+
+    dialogActions = (
+      <RejectRecipientActions
+        reject={onRejectRecipient}
         cancel={closeConfirmationDialog}
       />
     )

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
@@ -8,6 +8,8 @@ import { default as DumbShareByLink } from './ShareByLink'
 import { default as DumbShareByEmail } from './ShareByEmail'
 import WhoHasAccess from './WhoHasAccess'
 
+import { useSafeState } from '../helpers/hooks'
+
 import cx from 'classnames'
 import styles from '../share.styl'
 
@@ -169,10 +171,10 @@ const ShareDialogCozyToCozy = ({
     hasTwoStepsConfirmation &&
     twoStepsConfirmationMethods?.getRecipientsToBeConfirmed
 
-  const [status, setStatus] = React.useState(
+  const [status, setStatus] = useSafeState(
     shouldGetRecipientsToBeConfirmed ? 'loading' : 'sharing'
   )
-  const [recipientsToBeConfirmed, setRecipientsToBeConfirmed] = useState([])
+  const [recipientsToBeConfirmed, setRecipientsToBeConfirmed] = useSafeState([])
   const [recipientConfirmationData, setRecipientConfirmationData] = useState(
     undefined
   )
@@ -183,15 +185,6 @@ const ShareDialogCozyToCozy = ({
     recipientConfirmationDialogContent: ConfirmationDialogContent
   } = twoStepsConfirmationMethods
 
-  const mountedRef = React.useRef(false)
-  useEffect(() => {
-    mountedRef.current = true
-
-    return () => {
-      mountedRef.current = false
-    }
-  })
-
   const getRecipientsToBeConfirmed = useCallback(async () => {
     if (shouldGetRecipientsToBeConfirmed) {
       setStatus('loading')
@@ -201,19 +194,21 @@ const ShareDialogCozyToCozy = ({
           document.id
         )
 
-        if (mountedRef.current) {
-          setRecipientsToBeConfirmed(result)
-          setStatus('sharing')
-        }
+        setRecipientsToBeConfirmed(result)
+        setStatus('sharing')
       } catch {
-        if (mountedRef.current) {
-          setStatus('error')
-        }
+        setStatus('error')
       }
     } else {
       setStatus('sharing')
     }
-  }, [shouldGetRecipientsToBeConfirmed, twoStepsConfirmationMethods, document])
+  }, [
+    shouldGetRecipientsToBeConfirmed,
+    twoStepsConfirmationMethods,
+    document,
+    setRecipientsToBeConfirmed,
+    setStatus
+  ])
 
   useEffect(() => {
     getRecipientsToBeConfirmed()

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
@@ -199,13 +199,11 @@ const ShareDialogCozyToCozy = ({
   showShareByLink,
   showShareOnlyByLink,
   showWhoHasAccess,
-  hasTwoStepsConfirmation = false,
   twoStepsConfirmationMethods = {}
 }) => {
   const { t } = useI18n()
 
   const shouldGetRecipientsToBeConfirmed =
-    hasTwoStepsConfirmation &&
     twoStepsConfirmationMethods?.getRecipientsToBeConfirmed
 
   const [status, setStatus] = useSafeState(

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
@@ -1,6 +1,8 @@
-import React from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { FixedDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Button from 'cozy-ui/transpiled/react/Button'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import { default as DumbShareByLink } from './ShareByLink'
 import { default as DumbShareByEmail } from './ShareByEmail'
@@ -8,6 +10,131 @@ import WhoHasAccess from './WhoHasAccess'
 
 import cx from 'classnames'
 import styles from '../share.styl'
+
+/**
+ * Displays a loader that can be used when ShareDialogCozyToCozy is in loading state
+ */
+const LoadingContent = () => {
+  return (
+    <div className={'u-ta-center'}>
+      <Spinner size="xxlarge" loadingType="sharing" />
+    </div>
+  )
+}
+
+/**
+ * Displays an error message that can be used when ShareDialogCozyToCozy is in error state
+ */
+const ErrorContent = () => {
+  const { t } = useI18n()
+
+  return <div>{t('Share.loadingError')}</div>
+}
+
+/**
+ * Displays the sharing interface that can be used when ShareDialogCozyToCozy is in sharing state
+ */
+const SharingContent = ({
+  contacts,
+  createContact,
+  document,
+  documentType,
+  groups,
+  hasSharedParent,
+  isOwner,
+  needsContactsPermission,
+  onRevoke,
+  onRevokeSelf,
+  onShare,
+  recipients,
+  sharing,
+  sharingDesc,
+  showShareByEmail,
+  showShareOnlyByLink,
+  showWhoHasAccess,
+  recipientsToBeConfirmed,
+  confirmRecipient,
+  rejectRecipient
+}) => {
+  const { t } = useI18n()
+
+  return (
+    <div className={cx(styles['share-modal-content'])}>
+      {showShareOnlyByLink && (
+        <div className={styles['share-byemail-onlybylink']}>
+          {t(`${documentType}.share.shareByEmail.onlyByLink`, {
+            type: t(
+              `${documentType}.share.shareByEmail.type.${
+                document.type === 'directory' ? 'folder' : 'file'
+              }`
+            )
+          })}{' '}
+          <strong>
+            {t(
+              `${documentType}.share.shareByEmail.${
+                hasSharedParent ? 'hasSharedParent' : 'hasSharedChild'
+              }`
+            )}
+          </strong>
+        </div>
+      )}
+      {showShareByEmail && (
+        <DumbShareByEmail
+          contacts={contacts}
+          createContact={createContact}
+          currentRecipients={recipients}
+          document={document}
+          documentType={documentType}
+          groups={groups}
+          needsContactsPermission={needsContactsPermission}
+          onShare={onShare}
+          sharing={sharing}
+          sharingDesc={sharingDesc}
+        />
+      )}
+      {showWhoHasAccess && (
+        <WhoHasAccess
+          className={'u-mt-1'}
+          document={document}
+          documentType={documentType}
+          isOwner={isOwner}
+          onRevoke={onRevoke}
+          onRevokeSelf={onRevokeSelf}
+          recipients={recipients}
+          recipientsToBeConfirmed={recipientsToBeConfirmed}
+          rejectRecipient={rejectRecipient}
+          confirmRecipient={confirmRecipient}
+        />
+      )}
+    </div>
+  )
+}
+
+/**
+ * Displays actions that are available when confirming a recipient
+ */
+const ConfirmRecipientActions = ({ confirm, cancel }) => {
+  const { t } = useI18n()
+
+  return (
+    <>
+      <Button
+        theme="secondary"
+        label={t(`Share.twoStepsConfirmation.cancel`)}
+        onClick={cancel}
+      />
+      <Button
+        theme="primary"
+        label={t(`Share.twoStepsConfirmation.confirm`)}
+        onClick={confirm}
+      />
+    </>
+  )
+}
+
+/**
+ * Displays a sharing dialog that allows to share a document between multiple Cozy users
+ */
 const ShareDialogCozyToCozy = ({
   contacts,
   createContact,
@@ -32,78 +159,151 @@ const ShareDialogCozyToCozy = ({
   showShareByEmail,
   showShareByLink,
   showShareOnlyByLink,
-  showWhoHasAccess
+  showWhoHasAccess,
+  hasTwoStepsConfirmation = false,
+  twoStepsConfirmationMethods = {}
 }) => {
   const { t } = useI18n()
+
+  const [status, setStatus] = React.useState('loading')
+  const [recipientsToBeConfirmed, setRecipientsToBeConfirmed] = useState([])
+  const [recipientConfirmationData, setRecipientConfirmationData] = useState(
+    undefined
+  )
+
+  const {
+    confirmRecipient,
+    rejectRecipient,
+    recipientConfirmationDialogContent: ConfirmationDialogContent
+  } = twoStepsConfirmationMethods
+
+  const mountedRef = React.useRef(false)
+  useEffect(() => {
+    mountedRef.current = true
+
+    return () => {
+      mountedRef.current = false
+    }
+  })
+
+  const getRecipientsToBeConfirmed = useCallback(async () => {
+    if (
+      hasTwoStepsConfirmation &&
+      twoStepsConfirmationMethods?.getRecipientsToBeConfirmed
+    ) {
+      setStatus('loading')
+
+      try {
+        const result = await twoStepsConfirmationMethods.getRecipientsToBeConfirmed(
+          document.id
+        )
+
+        if (mountedRef.current) {
+          setRecipientsToBeConfirmed(result)
+          setStatus('sharing')
+        }
+      } catch {
+        if (mountedRef.current) {
+          setStatus('error')
+        }
+      }
+    } else {
+      setStatus('sharing')
+    }
+  }, [hasTwoStepsConfirmation, twoStepsConfirmationMethods, document])
+
+  useEffect(() => {
+    getRecipientsToBeConfirmed()
+  }, [getRecipientsToBeConfirmed])
+
+  const showConfirmationDialog = recipientConfirmationData => {
+    setRecipientConfirmationData(recipientConfirmationData)
+    setStatus('confirmingRecipient')
+  }
+
+  const onConfirmRecipient = () => {
+    confirmRecipient(recipientConfirmationData).then(() => {
+      getRecipientsToBeConfirmed()
+    })
+  }
+
+  const closeConfirmationDialog = () => {
+    setStatus('sharing')
+  }
+
+  let dialogTitle = t(`${documentType}.share.title`, {
+    name: document.name || document.attributes?.name
+  })
+  let dialogContent = null
+  let dialogActions = null
+
+  if (status === 'error') {
+    dialogContent = <ErrorContent />
+  } else if (status === 'loading') {
+    dialogContent = <LoadingContent />
+  } else if (status === 'sharing') {
+    dialogContent = (
+      <SharingContent
+        contacts={contacts}
+        createContact={createContact}
+        document={document}
+        documentType={documentType}
+        groups={groups}
+        hasSharedParent={hasSharedParent}
+        isOwner={isOwner}
+        needsContactsPermission={needsContactsPermission}
+        onRevoke={onRevoke}
+        onRevokeSelf={onRevokeSelf}
+        onShare={onShare}
+        recipients={recipients}
+        sharing={sharing}
+        sharingDesc={sharingDesc}
+        showShareByEmail={showShareByEmail}
+        showShareOnlyByLink={showShareOnlyByLink}
+        showWhoHasAccess={showWhoHasAccess}
+        recipientsToBeConfirmed={recipientsToBeConfirmed}
+        rejectRecipient={rejectRecipient}
+        confirmRecipient={showConfirmationDialog}
+      />
+    )
+
+    dialogActions = showShareByLink ? (
+      <DumbShareByLink
+        checked={link !== null}
+        document={document}
+        documentType={documentType}
+        link={link}
+        onChangePermissions={onUpdateShareLinkPermissions}
+        onDisable={onRevokeLink}
+        onEnable={onShareByLink}
+        permissions={permissions}
+      />
+    ) : null
+  } else if (status === 'confirmingRecipient') {
+    dialogTitle = t(`Share.twoStepsConfirmation.title`)
+
+    dialogContent = (
+      <ConfirmationDialogContent
+        recipientConfirmationData={recipientConfirmationData}
+      />
+    )
+
+    dialogActions = (
+      <ConfirmRecipientActions
+        confirm={onConfirmRecipient}
+        cancel={closeConfirmationDialog}
+      />
+    )
+  }
+
   return (
     <FixedDialog
       disableEnforceFocus
       open={true}
       onClose={onClose}
-      title={t(`${documentType}.share.title`, {
-        name: document.name || document.attributes?.name
-      })}
-      content={
-        <div className={cx(styles['share-modal-content'])}>
-          {showShareOnlyByLink && (
-            <div className={styles['share-byemail-onlybylink']}>
-              {t(`${documentType}.share.shareByEmail.onlyByLink`, {
-                type: t(
-                  `${documentType}.share.shareByEmail.type.${
-                    document.type === 'directory' ? 'folder' : 'file'
-                  }`
-                )
-              })}{' '}
-              <strong>
-                {t(
-                  `${documentType}.share.shareByEmail.${
-                    hasSharedParent ? 'hasSharedParent' : 'hasSharedChild'
-                  }`
-                )}
-              </strong>
-            </div>
-          )}
-          {showShareByEmail && (
-            <DumbShareByEmail
-              contacts={contacts}
-              createContact={createContact}
-              currentRecipients={recipients}
-              document={document}
-              documentType={documentType}
-              groups={groups}
-              needsContactsPermission={needsContactsPermission}
-              onShare={onShare}
-              sharing={sharing}
-              sharingDesc={sharingDesc}
-            />
-          )}
-          {showWhoHasAccess && (
-            <WhoHasAccess
-              className={'u-mt-1'}
-              document={document}
-              documentType={documentType}
-              isOwner={isOwner}
-              onRevoke={onRevoke}
-              onRevokeSelf={onRevokeSelf}
-              recipients={recipients}
-            />
-          )}
-        </div>
-      }
-      actions={
-        showShareByLink ? (
-          <DumbShareByLink
-            checked={link !== null}
-            document={document}
-            documentType={documentType}
-            link={link}
-            onChangePermissions={onUpdateShareLinkPermissions}
-            onDisable={onRevokeLink}
-            onEnable={onShareByLink}
-            permissions={permissions}
-          />
-        ) : null
-      }
+      title={dialogTitle}
+      content={dialogContent}
+      actions={dialogActions}
     />
   )
 }

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
@@ -1,0 +1,381 @@
+import React from 'react'
+import ShareDialogCozyToCozy from './ShareDialogCozyToCozy'
+import AppLike from '../../test/AppLike'
+import { createMockClient } from 'cozy-client'
+import { render } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
+
+describe('ShareDialogCozyToCozy', () => {
+  const client = createMockClient({})
+  client.options = {
+    uri: 'foo.mycozy.cloud'
+  }
+
+  const setup = props => {
+    return render(
+      <AppLike client={client}>
+        <ShareDialogCozyToCozy {...props} />
+      </AppLike>
+    )
+  }
+
+  it('should show sharing dialog directly when hasTwoStepsConfirmation is set to false', () => {
+    let props = {
+      ...getMockProps(),
+      hasTwoStepsConfirmation: false
+    }
+
+    const { getByText } = setup(props)
+
+    expect(getByText('Owner')).toBeTruthy()
+  })
+
+  it('should show loading while calling getRecipientsToBeConfirmed', async () => {
+    const { promise, resolve } = deferablePromise()
+
+    let props = {
+      ...getMockProps(),
+      hasTwoStepsConfirmation: true,
+      twoStepsConfirmationMethods: {
+        getRecipientsToBeConfirmed: jest.fn(() => promise),
+        rejectRecipient: jest.fn()
+      }
+    }
+
+    const { getByText } = setup(props)
+
+    expect(getByText('Loading in progress')).toBeTruthy()
+
+    resolve([
+      {
+        name: recipientBob.public_name,
+        id: 'SOME_ID',
+        email: recipientBob.email
+      }
+    ])
+
+    await act(() => promise)
+
+    expect(getByText('Confirm')).toBeTruthy()
+  })
+
+  it('should ask to confirm 1 contact if 1 contact is waiting for confirmation', async () => {
+    const { promise, resolve } = deferablePromise()
+
+    let props = {
+      ...getMockProps(),
+      hasTwoStepsConfirmation: true,
+      twoStepsConfirmationMethods: {
+        getRecipientsToBeConfirmed: jest.fn(() => promise),
+        rejectRecipient: jest.fn()
+      }
+    }
+
+    const { getByText, getAllByText } = setup(props)
+
+    resolve([
+      {
+        name: recipientBob.public_name,
+        id: 'SOME_ID',
+        email: recipientBob.email
+      }
+    ])
+
+    await act(() => promise)
+
+    expect(getAllByText('Confirm')).toHaveLength(1)
+    expect(
+      getByText(/Some contacts are waiting for your confirmation/i)
+    ).toBeTruthy()
+  })
+
+  it('should ask to confirm 2 contacts if 2 contacts are waiting for confirmation', async () => {
+    const { promise, resolve } = deferablePromise()
+
+    let props = {
+      ...getMockProps(),
+      hasTwoStepsConfirmation: true,
+      twoStepsConfirmationMethods: {
+        getRecipientsToBeConfirmed: jest.fn(() => promise),
+        rejectRecipient: jest.fn()
+      }
+    }
+
+    const { getByText, getAllByText } = setup(props)
+
+    resolve([
+      {
+        name: recipientBob.public_name,
+        id: 'SOME_ID',
+        email: recipientBob.email
+      },
+      {
+        name: recipientClaude.public_name,
+        id: 'SOME_OTHER_ID',
+        email: recipientClaude.email
+      }
+    ])
+
+    await act(() => promise)
+
+    expect(getAllByText('Confirm')).toHaveLength(2)
+    expect(
+      getByText(/2 contacts are waiting for your confirmation/i)
+    ).toBeTruthy()
+  })
+
+  it('should not ask to confirm contacts if no contacts are waiting for confirmation', async () => {
+    const { promise, resolve } = deferablePromise()
+
+    let props = {
+      ...getMockProps(),
+      hasTwoStepsConfirmation: true,
+      twoStepsConfirmationMethods: {
+        getRecipientsToBeConfirmed: jest.fn(() => promise),
+        rejectRecipient: jest.fn()
+      }
+    }
+
+    const { queryByText } = setup(props)
+
+    resolve([])
+
+    await act(() => promise)
+
+    expect(queryByText('Confirm')).not.toBeInTheDocument()
+    expect(
+      queryByText(/waiting for your confirmation/i)
+    ).not.toBeInTheDocument()
+  })
+})
+
+const recipientAlice = {
+  status: 'owner',
+  public_name: 'Alice',
+  email: 'me@alice.cozy.localhost',
+  instance: 'http://alice.cozy.localhost:8080',
+  type: 'two-way',
+  sharingId: 'SOME_SHARING_ID',
+  index: 0,
+  avatarPath: '/sharings/SOME_SHARING_ID/recipients/0/avatar'
+}
+
+const recipientBob = {
+  status: 'ready',
+  public_name: 'Claude',
+  email: 'me@claude.cozy.localhost',
+  instance: 'http://claude.cozy.localhost:8080',
+  type: 'two-way',
+  sharingId: 'SOME_SHARING_ID',
+  index: 1,
+  avatarPath: '/sharings/SOME_SHARING_ID/recipients/1/avatar'
+}
+
+const recipientClaude = {
+  status: 'ready',
+  public_name: 'Bob',
+  email: 'me@bob.cozy.localhost',
+  instance: 'http://bob.cozy.localhost:8080',
+  type: 'two-way',
+  sharingId: 'SOME_SHARING_ID',
+  index: 2,
+  avatarPath: '/sharings/SOME_SHARING_ID/recipients/2/avatar'
+}
+
+const deferablePromise = () => {
+  let resolvePointer = undefined
+  let rejectPointer = undefined
+
+  let promise = new Promise((resolve, reject) => {
+    resolvePointer = resolve
+    rejectPointer = reject
+  })
+
+  return {
+    promise,
+    resolve: resolvePointer,
+    reject: rejectPointer
+  }
+}
+
+const getMockProps = () => {
+  return {
+    contacts: {
+      id: 'contacts',
+      definition: {
+        doctype: 'io.cozy.contacts',
+        selector: {
+          _id: {
+            $gt: null
+          }
+        },
+        indexedFields: ['_id'],
+        partialFilter: {
+          trashed: {
+            $or: [
+              {
+                $eq: false
+              },
+              {
+                $exists: false
+              }
+            ]
+          },
+          $or: [
+            {
+              cozy: {
+                $not: {
+                  $size: 0
+                }
+              }
+            },
+            {
+              email: {
+                $not: {
+                  $size: 0
+                }
+              }
+            }
+          ]
+        },
+        limit: 1000
+      },
+      fetchStatus: 'pending',
+      lastFetch: null,
+      lastUpdate: null,
+      lastErrorUpdate: null,
+      lastError: null,
+      hasMore: false,
+      count: 0,
+      data: [],
+      bookmark: null,
+      options: null
+    },
+    document: {
+      id: 'SOME_DOCUMENT_ID',
+      name: 'SOME_DOCUMENT_NAME',
+      _type: 'com.bitwarden.organizations',
+      _id: 'SOME_DOCUMENT_ID'
+    },
+    documentType: 'Organizations',
+    groups: {
+      id: 'groups',
+      definition: {
+        doctype: 'io.cozy.contacts.groups'
+      },
+      fetchStatus: 'pending',
+      lastFetch: null,
+      lastUpdate: null,
+      lastErrorUpdate: null,
+      lastError: null,
+      hasMore: false,
+      count: 0,
+      data: [],
+      bookmark: null,
+      options: null
+    },
+    hasSharedParent: null,
+    isOwner: true,
+    link: null,
+    permissions: [],
+    recipients: [
+      recipientAlice,
+      recipientBob,
+      recipientClaude,
+      {
+        status: 'pending',
+        email: 'me@ben.cozy.localhost',
+        type: 'two-way',
+        sharingId: 'SOME_SHARING_ID',
+        index: 3,
+        avatarPath: '/sharings/SOME_SHARING_ID/recipients/3/avatar'
+      }
+    ],
+    sharing: {
+      id: 'SOME_SHARING_ID',
+      _id: 'SOME_SHARING_ID',
+      _type: 'io.cozy.sharings',
+      type: 'io.cozy.sharings',
+      attributes: {
+        triggers: {
+          track_id: 'SOME_TRACK_ID',
+          replicate_id: 'SOME_REPLICATE_ID'
+        },
+        active: true,
+        owner: true,
+        open_sharing: true,
+        description: 'SOME_DOCUMENT_NAME',
+        app_slug: 'password',
+        created_at: '2021-08-13T16:51:28.562668+02:00',
+        updated_at: '2021-08-13T16:51:28.562668+02:00',
+        rules: [
+          {
+            title: 'SOME_DOCUMENT_NAME',
+            doctype: 'com.bitwarden.organizations',
+            values: ['SOME_DOCUMENT_ID'],
+            add: 'sync',
+            update: 'sync',
+            remove: 'sync'
+          },
+          {
+            title: 'Ciphers',
+            doctype: 'com.bitwarden.ciphers',
+            selector: 'organization_id',
+            values: ['SOME_DOCUMENT_ID'],
+            add: 'sync',
+            update: 'sync',
+            remove: 'sync'
+          }
+        ],
+        members: [
+          {
+            status: 'owner',
+            public_name: 'Alice',
+            email: 'me@alice.cozy.localhost',
+            instance: 'http://alice.cozy.localhost:8080'
+          },
+          {
+            status: 'ready',
+            public_name: 'Claude',
+            email: 'me@claude.cozy.localhost',
+            instance: 'http://claude.cozy.localhost:8080'
+          },
+          {
+            status: 'ready',
+            public_name: 'Bob',
+            email: 'me@bob.cozy.localhost',
+            instance: 'http://bob.cozy.localhost:8080'
+          },
+          {
+            status: 'pending',
+            email: 'me@ben.cozy.localhost'
+          }
+        ]
+      },
+      meta: {
+        rev: '12-136ad05bd33a80b6a1829a9ec3d918f0'
+      },
+      links: {
+        self: '/sharings/SOME_SHARING_ID'
+      },
+      relationships: {
+        shared_docs: {
+          data: [
+            {
+              id: 'SOME_DOCUMENT_ID',
+              type: 'com.bitwarden.organizations'
+            }
+          ]
+        }
+      }
+    },
+    sharingDesc: 'SOME_DOCUMENT_NAME',
+    showShareByEmail: true,
+    showShareByLink: false,
+    showShareOnlyByLink: null,
+    showWhoHasAccess: true,
+    onRevoke: jest.fn(),
+    onShare: jest.fn(),
+    createContact: jest.fn()
+  }
+}

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
@@ -19,10 +19,9 @@ describe('ShareDialogCozyToCozy', () => {
     )
   }
 
-  it('should show sharing dialog directly when hasTwoStepsConfirmation is set to false', () => {
+  it('should show sharing dialog directly when no twoStepsConfirmationMethods are provided', () => {
     let props = {
-      ...getMockProps(),
-      hasTwoStepsConfirmation: false
+      ...getMockProps()
     }
 
     const { getByText } = setup(props)
@@ -35,7 +34,6 @@ describe('ShareDialogCozyToCozy', () => {
 
     let props = {
       ...getMockProps(),
-      hasTwoStepsConfirmation: true,
       twoStepsConfirmationMethods: {
         getRecipientsToBeConfirmed: jest.fn(() => promise),
         rejectRecipient: jest.fn()
@@ -64,7 +62,6 @@ describe('ShareDialogCozyToCozy', () => {
 
     let props = {
       ...getMockProps(),
-      hasTwoStepsConfirmation: true,
       twoStepsConfirmationMethods: {
         getRecipientsToBeConfirmed: jest.fn(() => promise),
         rejectRecipient: jest.fn()
@@ -94,7 +91,6 @@ describe('ShareDialogCozyToCozy', () => {
 
     let props = {
       ...getMockProps(),
-      hasTwoStepsConfirmation: true,
       twoStepsConfirmationMethods: {
         getRecipientsToBeConfirmed: jest.fn(() => promise),
         rejectRecipient: jest.fn()
@@ -129,7 +125,6 @@ describe('ShareDialogCozyToCozy', () => {
 
     let props = {
       ...getMockProps(),
-      hasTwoStepsConfirmation: true,
       twoStepsConfirmationMethods: {
         getRecipientsToBeConfirmed: jest.fn(() => promise),
         rejectRecipient: jest.fn()
@@ -155,7 +150,6 @@ describe('ShareDialogCozyToCozy', () => {
 
     let props = {
       ...getMockProps(),
-      hasTwoStepsConfirmation: true,
       twoStepsConfirmationMethods: {
         getRecipientsToBeConfirmed: jest.fn(() => promise),
         rejectRecipient

--- a/packages/cozy-sharing/src/components/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal.jsx
@@ -27,7 +27,6 @@ export const ShareModal = ({
   recipients,
   sharing,
   sharingDesc,
-  hasTwoStepsConfirmation = false,
   twoStepsConfirmationMethods
 }) => {
   const showShareByEmail =
@@ -76,7 +75,6 @@ export const ShareModal = ({
           showShareByLink={showShareByLink}
           showShareOnlyByLink={showShareOnlyByLink}
           showWhoHasAccess={showWhoHasAccess}
-          hasTwoStepsConfirmation={hasTwoStepsConfirmation}
           twoStepsConfirmationMethods={twoStepsConfirmationMethods}
         />
       )}
@@ -106,7 +104,6 @@ ShareModal.propTypes = {
   permissions: PropTypes.array.isRequired,
   recipients: PropTypes.array.isRequired,
   sharingDesc: PropTypes.string,
-  hasTwoStepsConfirmation: PropTypes.bool,
   twoStepsConfirmationMethods: PropTypes.shape({
     getRecipientsToBeConfirmed: PropTypes.func,
     confirmRecipient: PropTypes.func,

--- a/packages/cozy-sharing/src/components/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal.jsx
@@ -26,7 +26,9 @@ export const ShareModal = ({
   permissions,
   recipients,
   sharing,
-  sharingDesc
+  sharingDesc,
+  hasTwoStepsConfirmation = false,
+  twoStepsConfirmationMethods
 }) => {
   const showShareByEmail =
     documentType !== 'Albums' && !hasSharedParent && !hasSharedChild
@@ -74,6 +76,8 @@ export const ShareModal = ({
           showShareByLink={showShareByLink}
           showShareOnlyByLink={showShareOnlyByLink}
           showWhoHasAccess={showWhoHasAccess}
+          hasTwoStepsConfirmation={hasTwoStepsConfirmation}
+          twoStepsConfirmationMethods={twoStepsConfirmationMethods}
         />
       )}
     </>
@@ -101,5 +105,12 @@ ShareModal.propTypes = {
   onUpdateShareLinkPermissions: PropTypes.func.isRequired,
   permissions: PropTypes.array.isRequired,
   recipients: PropTypes.array.isRequired,
-  sharingDesc: PropTypes.string
+  sharingDesc: PropTypes.string,
+  hasTwoStepsConfirmation: PropTypes.bool,
+  twoStepsConfirmationMethods: PropTypes.shape({
+    getRecipientsToBeConfirmed: PropTypes.func,
+    confirmRecipient: PropTypes.func,
+    rejectRecipient: PropTypes.func,
+    recipientConfirmationDialogContent: PropTypes.func
+  })
 }

--- a/packages/cozy-sharing/src/components/WhoHasAccess.jsx
+++ b/packages/cozy-sharing/src/components/WhoHasAccess.jsx
@@ -63,7 +63,11 @@ const WhoHasAccess = ({
 WhoHasAccess.propTypes = {
   isOwner: PropTypes.bool,
   recipients: PropTypes.array.isRequired,
-  recipientsToBeConfirmed: PropTypes.array,
+  recipientsToBeConfirmed: PropTypes.arrayOf(
+    PropTypes.shape({
+      email: PropTypes.string.isRequired
+    })
+  ),
   document: PropTypes.object.isRequired,
   documentType: PropTypes.string.isRequired,
   onRevoke: PropTypes.func.isRequired,

--- a/packages/cozy-sharing/src/components/WhoHasAccess.jsx
+++ b/packages/cozy-sharing/src/components/WhoHasAccess.jsx
@@ -1,37 +1,74 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Recipient from './Recipient'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+/**
+ * Displays a warning if some contacts are waiting for confirmation of their sharing
+ *
+ * This may happen in two steps confirmation scenario like when sharing passwords
+ */
+const RecipientWaitingForConfirmationAlert = ({ recipientsToBeConfirmed }) => {
+  const { t } = useI18n()
+
+  if (recipientsToBeConfirmed.length > 0) {
+    return t(`Share.twoStepsConfirmation.contactAreWaitingForConfirmation`, {
+      smart_count: recipientsToBeConfirmed.length
+    })
+  }
+
+  return null
+}
 
 const WhoHasAccess = ({
   isOwner = false,
   recipients,
+  recipientsToBeConfirmed,
   document,
   documentType,
   onRevoke,
   className,
-  onRevokeSelf
+  onRevokeSelf,
+  rejectRecipient,
+  confirmRecipient
 }) => (
   <div className={className}>
-    {recipients.map(recipient => (
-      <Recipient
-        {...recipient}
-        key={`key_r_${recipient.index}`}
-        isOwner={isOwner}
-        document={document}
-        documentType={documentType}
-        onRevoke={onRevoke}
-        onRevokeSelf={onRevokeSelf}
-      />
-    ))}
+    <RecipientWaitingForConfirmationAlert
+      recipientsToBeConfirmed={recipientsToBeConfirmed}
+    />
+
+    {recipients.map(recipient => {
+      const recipientConfirmationData = recipientsToBeConfirmed.find(
+        user => user.email === recipient.email
+      )
+
+      return (
+        <Recipient
+          {...recipient}
+          key={`key_r_${recipient.index}`}
+          isOwner={isOwner}
+          document={document}
+          documentType={documentType}
+          onRevoke={onRevoke}
+          onRevokeSelf={onRevokeSelf}
+          recipientConfirmationData={recipientConfirmationData}
+          rejectRecipient={rejectRecipient}
+          confirmRecipient={confirmRecipient}
+        />
+      )
+    })}
   </div>
 )
 
 WhoHasAccess.propTypes = {
   isOwner: PropTypes.bool,
   recipients: PropTypes.array.isRequired,
+  recipientsToBeConfirmed: PropTypes.array,
   document: PropTypes.object.isRequired,
   documentType: PropTypes.string.isRequired,
   onRevoke: PropTypes.func.isRequired,
-  onRevokeSelf: PropTypes.func
+  onRevokeSelf: PropTypes.func,
+  confirmRecipient: PropTypes.func,
+  rejectRecipient: PropTypes.func
 }
 export default WhoHasAccess

--- a/packages/cozy-sharing/src/components/recipient.styl
+++ b/packages/cozy-sharing/src/components/recipient.styl
@@ -75,3 +75,13 @@
     &--plusX,
     &--avatar
         margin-right -0.6rem
+
+.recipient-confirm
+    &__action
+        &--confirm
+            color var(--successColor)
+            border-color var(--successColor)
+
+        &--cancel
+            color var(--errorColor)
+            border-color var(--errorColor)

--- a/packages/cozy-sharing/src/helpers/hooks.js
+++ b/packages/cozy-sharing/src/helpers/hooks.js
@@ -1,0 +1,61 @@
+import React, { useCallback, useRef } from 'react'
+
+export const isServer = typeof window === 'undefined'
+
+/**
+ * based on : https://github.com/tannerlinsley/react-query/blob/79ad5a9ccbce1486c10e7e364d8fc28bef3fa19f/src/devtools/utils.ts#L61
+ */
+function useIsMounted() {
+  const mountedRef = useRef(false)
+  const isMounted = useCallback(() => mountedRef.current, [])
+
+  React[isServer ? 'useEffect' : 'useLayoutEffect'](() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  return isMounted
+}
+
+/**
+ * This hook is a safe useState version which schedules state updates in microtasks
+ * to prevent updating a component state while React is rendering different components
+ * or when the component is not mounted anymore.
+ *
+ * based on : https://github.com/tannerlinsley/react-query/blob/79ad5a9ccbce1486c10e7e364d8fc28bef3fa19f/src/devtools/utils.ts#L80
+ */
+export function useSafeState(initialState) {
+  const isMounted = useIsMounted()
+  const [state, setState] = React.useState(initialState)
+
+  const safeSetState = React.useCallback(
+    value => {
+      scheduleMicrotask(() => {
+        if (isMounted()) {
+          setState(value)
+        }
+      })
+    },
+    [isMounted]
+  )
+
+  return [state, safeSetState]
+}
+
+/**
+ * Schedules a microtask.
+ * This can be useful to schedule state updates after rendering.
+ *
+ * based on : https://github.com/tannerlinsley/react-query/blob/79ad5a9ccbce1486c10e7e364d8fc28bef3fa19f/src/devtools/utils.ts#L102
+ */
+function scheduleMicrotask(callback) {
+  Promise.resolve()
+    .then(callback)
+    .catch(error =>
+      setTimeout(() => {
+        throw error
+      })
+    )
+}

--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -16,3 +16,6 @@ export { ShareButton } from './ShareButton'
 export { ShareModal } from './ShareModal'
 export { RefreshableSharings } from './RefreshableSharings'
 export { useFetchDocumentPath } from './components/useFetchDocumentPath'
+export {
+  CozyPassFingerprintDialogContent
+} from './components/CozyPassFingerprintDialogContent'

--- a/yarn.lock
+++ b/yarn.lock
@@ -16480,6 +16480,11 @@ snarkdown@1.2.2, snarkdown@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/snarkdown/-/snarkdown-1.2.2.tgz#0cfe2f3012b804de120fc0c9f7791e869c59cc74"
 
+snarkdown@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/snarkdown/-/snarkdown-2.0.0.tgz#b1feb4db91b9f94a8ebbd7a50f3e99aee18b1e03"
+  integrity sha512-MgL/7k/AZdXCTJiNgrO7chgDqaB9FGM/1Tvlcenenb7div6obaDATzs16JhFyHHBGodHT3B7RzRc5qk8pFhg3A==
+
 sockjs-client@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.3.0.tgz#12fc9d6cb663da5739d3dc5fb6e8687da95cb177"


### PR DESCRIPTION
This PR adds support to `two steps confirmation` mechanisms

This mechanism is an opt-in mechanism and calling app should specify `hasTwoStepsConfirmation:true` in props. So this should not impact existing apps.

This mechanism is needed by `cozy-pass-web` : when Alice shares a folder to Bob, then B can accept this sharing from his emails, then Alice HAS to **confirm** Bob by displaying a fingerprint phrase. This mechanism ensures that Alice and Bob knows each others and that their encryption keys can be shared.

This mechanism has been implemented in a generic way so it can be adapted for future needs.

The only specific component is `CozyPassFingerprintDialogContent` but it should be passed as a prop to ShareDialog to be shown when the user click on `confirm`. So it will be possible to pass another component if needed.

Now when opening the `ShareModal` first thing that is done is to load eligible recipients. This action may not be processed by CozyClient and its realtime mechanisms. In the case of `cozy-pass-web` it is done on Angular side using Bitwarden http client.
This may introduce a latency in `ShareModal` so a loading spinner has been implemented and is called while `getRecipientsToBeConfirmed()` is being called.

This is may also introduce errors as this is a function passed from the exterior (i.e the app). So I implemented an "error" state that show the user that something wrong happened. This message is rudimentary as I don't have graphic specs, but also this should be a rare event.

Then, when fully loaded, user will be able to confirm or reject eligible recipients.

`confirmRecipient` and `rejectRecipient` are passed as props and should be handled by the calling app.

Here is a video of the new behaviour (loading spinner has been force to 3s for this demo but it is nearly instant in real env):

https://user-images.githubusercontent.com/1884255/130109871-4366c878-a1e5-41c5-8549-05e2b2b921f2.mp4

When an error happens then here is the displayed content:
![image](https://user-images.githubusercontent.com/1884255/130110066-2814159c-c3ca-425f-af8c-9847e8d582ab.png)

Notes :
-  UI is not definitive as @joel-costa still has some work to do on the specs
- Passphrase color is wrong as `cozy-ui` color palettes are not up to date (see: https://github.com/cozy/cozy-ui/issues/1865#issuecomment-894274954)
- Chips backgrounds are grey on hover this should be fixed later when I will finalise the UI
- `reject` Chip is not a perfect circle, I did not investigate yet if this is a bug or just a missing property