### PR TITLE
feat: Allow email sharing in Notes

### DIFF
--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
@@ -40,7 +40,9 @@ const ShareDialogCozyToCozy = ({
       disableEnforceFocus
       open={true}
       onClose={onClose}
-      title={t(`${documentType}.share.title`, { name: document.name })}
+      title={t(`${documentType}.share.title`, {
+        name: document.name || document.attributes?.name
+      })}
       content={
         <div className={cx(styles['share-modal-content'])}>
           {showShareOnlyByLink && (

--- a/packages/cozy-sharing/src/components/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal.jsx
@@ -29,17 +29,14 @@ export const ShareModal = ({
   sharingDesc
 }) => {
   const showShareByEmail =
-    documentType !== 'Notes' &&
-    documentType !== 'Albums' &&
-    !hasSharedParent &&
-    !hasSharedChild
+    documentType !== 'Albums' && !hasSharedParent && !hasSharedChild
   const showShareByLink = documentType !== 'Organizations'
   const showShareOnlyByLink = hasSharedParent || hasSharedChild
   const showWhoHasAccess = documentType !== 'Albums'
 
   return (
     <>
-      {(documentType === 'Notes' || documentType === 'Albums') && (
+      {documentType === 'Albums' && (
         <ShareDialogOnlyByLink
           document={document}
           documentType={documentType}
@@ -51,7 +48,7 @@ export const ShareModal = ({
           permissions={permissions}
         />
       )}
-      {documentType !== 'Notes' && documentType !== 'Albums' && (
+      {documentType !== 'Albums' && (
         <ShareDialogCozyToCozy
           contacts={contacts}
           createContact={createContact}


### PR DESCRIPTION
Related to https://trello.com/c/AiQg5Cjr/16-%F0%9F%93%9D-notes-partage-cozy-%C3%A0-cozy-notes-4j

Notes Sharing modal can now use the email feature.