### PR TITLE
feat: Reword contact confirmation dialog

### DIFF
--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -43,7 +43,7 @@
       "defaultDisplayName": "Anonymous"
     },
     "twoStepsConfirmation": {
-      "title": "Confirm contact",
+      "title": "Confirm contact's identity",
       "titleReject": "Reject contact",
       "confirm": "Confirm",
       "reject": "Reject",
@@ -381,8 +381,8 @@
       }
     },
     "fingerprint": {
-      "instruction": "Every Cozy is associated to a unique **fingerprint phrase**. For security reasons, please ask to %{userName} (%{userEmail}) if his Cozy's fingerprint phrase is corresponding to :",
-      "instruction2": "The fingerprint phrase of a Cozy is visible on top of the Cozy Pass' passwords list. This fingerprint phrase can also be accessed on **Parameters/Profile/Fingerprint phrase** from the mobile client or the browser extension."
+      "instruction": "For security reasons, please verify **%{userName} (%{userEmail})**'s identity. To do this, contact **%{userName}** via the means of communication of your choice (call, text message, instant messaging app...) and verify their security code.<br><br>Every Cozy user has a security code that they can find using their web application. Their security code must correspond to:",
+      "instruction2": "If it is the case, then you can confirm this contact who will be considered as secure for your next sharings."
     }
   }
 }

--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -43,7 +43,7 @@
       "defaultDisplayName": "Anonyme"
     },
     "twoStepsConfirmation": {
-      "title": "Confirmer le contact",
+      "title": "Confirmer l'identité du contact",
       "titleReject": "Refuser le contact",
       "confirm": "Confirmer",
       "reject": "Refuser",
@@ -380,8 +380,8 @@
       }
     },
     "fingerprint": {
-      "instruction": "Chaque Cozy est associé **une phrase d’empreinte** unique. Par sécurité, merci de demander à %{userName} (%{userEmail}) si la phrase d’empreinte de son Cozy correspond bien à :",
-      "instruction2": "La phrase d’empreinte d’un Cozy est accessible **en haut de sa liste de mot de passes dans Cozy Pass**. Cette phrase d'empreinte est également accessible dans **Paramètres/Profil/Phrase d’empreinte** de son client mobile ou de son extension navigateur."
+      "instruction": "Par sécurité, nous vous proposons de vérifier l'identité de **%{userName} (%{userEmail})**. Pour cela, contactez **%{userName}** par le moyen de votre choix (Appel, SMS, messagerie instantanée, ...) afin de vérifier son code de sécurité.<br><br>Chaque Cozy a une phrase de sécurité qu'il peut retrouver dans son interface web. Sa phrase de sécurité doit correspondre à :",
+      "instruction2": "Si c'est bien le cas, vous pouvez confirmer ce contact qui sera alors vu comme sécurisé pour vos prochains partages."
     }
   }
 }


### PR DESCRIPTION
`Fingerprint phrase` is replaced by `Security code` and 2steps-confirmation instructions have been simplified