### PR TITLE
feat: Improve two steps confirmation user experience

### DIFF
--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -48,6 +48,7 @@
       "confirm": "Confirm",
       "reject": "Reject",
       "cancel": "Cancel",
+      "verify": "Verify",
       "contactAreWaitingForConfirmation": "Some contacts are waiting for your confirmation. Confirm their identities to allow them to access items you shared with them.||||%{smart_count} contacts are waiting for your confirmation. Confirm their identities to allow them to access items you shared with them.",
       "confirmRejection": "Do you really want to reject contact %{userName} (%{userEmail})?"
     },

--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -48,6 +48,7 @@
       "confirm": "Confirmer",
       "reject": "Refuser",
       "cancel": "Annuler",
+      "verify": "Vérifier",
       "contactAreWaitingForConfirmation": "%{smart_count} contact en attente de confirmation. Confirmer son identité pour lui permettre d’accéder aux éléments que vous avez partagé avec lui.||||%{smart_count} contacts en attente de confirmation. Confirmer leur identité pour leur permettre d’accéder aux éléments que vous avez partagé avec eux.",
       "confirmRejection": "Êtes-vous sûr de vouloir refuser le contact %{userName} (%{userEmail})?"
     },

--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -42,7 +42,7 @@
     "babel-plugin-css-modules-transform": "^1.6.2",
     "babel-plugin-inline-react-svg": "^1.1.0",
     "cozy-client": "23.19.1",
-    "cozy-ui": "51.6.0",
+    "cozy-ui": "54.0.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.6",
     "enzyme-to-json": "3.4.4",

--- a/packages/cozy-sharing/src/components/Recipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient.jsx
@@ -6,6 +6,7 @@ import { useClient } from 'cozy-client'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Avatar from 'cozy-ui/transpiled/react/Avatar'
+import Button from 'cozy-ui/transpiled/react/Button'
 import CompositeRow from 'cozy-ui/transpiled/react/CompositeRow'
 import DropdownButton from 'cozy-ui/transpiled/react/DropdownButton'
 import ActionMenu, { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu'
@@ -16,8 +17,6 @@ import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
 import EyeIcon from 'cozy-ui/transpiled/react/Icons/Eye'
 import PaperplaneIcon from 'cozy-ui/transpiled/react/Icons/Paperplane'
 import ToTheCloudIcon from 'cozy-ui/transpiled/react/Icons/ToTheCloud'
-import CheckCircleIcon from 'cozy-ui/transpiled/react/Icons/CheckCircle'
-import CrossCircleIcon from 'cozy-ui/transpiled/react/Icons/CrossCircle'
 
 import AvatarPlusX from './AvatarPlusX'
 import styles from './recipient.styl'
@@ -28,7 +27,6 @@ import Identity from './Identity'
 import LinkIcon from 'cozy-ui/transpiled/react/Icons/Link'
 
 import Typography from 'cozy-ui/transpiled/react/Typography'
-import Chip from 'cozy-ui/transpiled/react/Chip'
 
 export const MAX_DISPLAYED_RECIPIENTS = 3
 const DEFAULT_DISPLAY_NAME = 'Share.contacts.defaultDisplayName'
@@ -301,49 +299,29 @@ const Status = ({ status, isMe, instance }) => {
 /**
  * Displays the confirmation interface that allows to confirm or reject a recipient
  */
-const RecipientConfirm = ({
-  recipientConfirmationData,
-  rejectRecipient,
-  confirmRecipient
-}) => {
+const RecipientConfirm = ({ recipientConfirmationData, verifyRecipient }) => {
   const { t } = useI18n()
 
-  const reject = () => {
-    rejectRecipient(recipientConfirmationData)
-  }
-
-  const confirm = () => {
-    confirmRecipient(recipientConfirmationData)
+  const verify = () => {
+    verifyRecipient(recipientConfirmationData)
   }
 
   return (
     <>
-      <Chip
-        className={cx(styles['recipient-confirm__action--confirm'])}
-        variant="outlined"
-        size="small"
-        onClick={confirm}
-      >
-        <Icon icon={CheckCircleIcon} className={'u-mr-half'} />
-        {t(`Share.twoStepsConfirmation.confirm`)}
-      </Chip>
-      <Chip.Round
-        className={cx(styles['recipient-confirm__action--cancel'])}
-        variant="outlined"
-        size="small"
-        onClick={reject}
-        aria-label={t(`Share.twoStepsConfirmation.reject`)}
-      >
-        <Icon icon={CrossCircleIcon} />
-      </Chip.Round>
+      <Button
+        style={{ position: 'initial' }} // fix z-index bug on iOS when under a BottomDrawer due to relative position
+        theme="text"
+        className={modalStyles['aligned-dropdown-button']}
+        onClick={verify}
+        label={t(`Share.twoStepsConfirmation.verify`)}
+      />
     </>
   )
 }
 
 RecipientConfirm.propTypes = {
   recipientConfirmationData: PropTypes.object.isRequired,
-  rejectRecipient: PropTypes.func.isRequired,
-  confirmRecipient: PropTypes.func.isRequired
+  verifyRecipient: PropTypes.func.isRequired
 }
 
 const Recipient = props => {
@@ -355,8 +333,7 @@ const Recipient = props => {
     isOwner,
     status,
     recipientConfirmationData,
-    rejectRecipient,
-    confirmRecipient,
+    verifyRecipient,
     ...rest
   } = props
 
@@ -368,8 +345,7 @@ const Recipient = props => {
   const RightPart = recipientConfirmationData ? (
     <RecipientConfirm
       recipientConfirmationData={recipientConfirmationData}
-      rejectRecipient={rejectRecipient}
-      confirmRecipient={confirmRecipient}
+      verifyRecipient={verifyRecipient}
     ></RecipientConfirm>
   ) : (
     <Permissions {...props} className="u-flex-shrink-0" />
@@ -396,8 +372,7 @@ Recipient.propTypes = {
   isOwner: PropTypes.bool,
   status: PropTypes.string,
   recipientConfirmationData: PropTypes.object,
-  rejectRecipient: PropTypes.func,
-  confirmRecipient: PropTypes.func
+  verifyRecipient: PropTypes.func
 }
 
 export default Recipient

--- a/packages/cozy-sharing/src/components/Recipient.spec.jsx
+++ b/packages/cozy-sharing/src/components/Recipient.spec.jsx
@@ -113,7 +113,7 @@ describe('Recipient component', () => {
       confirmRecipient
     })
 
-    expect(getByText('Confirm')).toBeTruthy()
+    expect(getByText('Verify')).toBeTruthy()
   })
 
   it('should not render confirmation actions if no recipient is waiting for confirmation', () => {
@@ -131,12 +131,11 @@ describe('Recipient component', () => {
       confirmRecipient
     })
 
-    expect(queryByText('Confirm')).not.toBeInTheDocument()
+    expect(queryByText('Verify')).not.toBeInTheDocument()
   })
 
-  it(`should call confirmRecipient when clicking 'confirm' button`, () => {
-    const confirmRecipient = jest.fn()
-    const rejectRecipient = jest.fn()
+  it(`should call verifyRecipient when clicking 'verify' button`, () => {
+    const verifyRecipient = jest.fn()
 
     const { getByText } = setup({
       instance: 'foo.mycozy.cloud',
@@ -147,41 +146,14 @@ describe('Recipient component', () => {
       recipientConfirmationData: {
         email: 'me@bob.cozy.localhost'
       },
-      rejectRecipient,
-      confirmRecipient
+      verifyRecipient
     })
 
-    fireEvent.click(getByText('Confirm'))
+    fireEvent.click(getByText('Verify'))
 
-    expect(confirmRecipient).toBeCalledWith({
+    expect(verifyRecipient).toBeCalledWith({
       email: 'me@bob.cozy.localhost'
     })
-    expect(rejectRecipient).not.toBeCalled()
-  })
-
-  it(`should call rejectRecipient when clicking 'reject' button`, () => {
-    const confirmRecipient = jest.fn()
-    const rejectRecipient = jest.fn()
-
-    const { getByLabelText } = setup({
-      instance: 'foo.mycozy.cloud',
-      status: 'ready',
-      type: 'two-way',
-      isOwner: false,
-      documentType: 'Organizations',
-      recipientConfirmationData: {
-        email: 'me@bob.cozy.localhost'
-      },
-      rejectRecipient,
-      confirmRecipient
-    })
-
-    fireEvent.click(getByLabelText('Reject'))
-
-    expect(rejectRecipient).toBeCalledWith({
-      email: 'me@bob.cozy.localhost'
-    })
-    expect(confirmRecipient).not.toBeCalled()
   })
 })
 

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
@@ -288,6 +288,7 @@ const ShareDialogCozyToCozy = ({
   })
   let dialogContent = null
   let dialogActions = null
+  let onBack = null
 
   if (status === 'error') {
     dialogContent = <ErrorContent />
@@ -346,6 +347,8 @@ const ShareDialogCozyToCozy = ({
         reject={showRejectDialog}
       />
     )
+
+    onBack = closeConfirmationDialog
   } else if (status === 'rejectingRecipient') {
     dialogTitle = t(`Share.twoStepsConfirmation.titleReject`)
 
@@ -361,6 +364,8 @@ const ShareDialogCozyToCozy = ({
         cancel={closeRejectDialog}
       />
     )
+
+    onBack = closeRejectDialog
   }
 
   return (
@@ -368,6 +373,7 @@ const ShareDialogCozyToCozy = ({
       disableEnforceFocus
       open={true}
       onClose={onClose}
+      onBack={onBack}
       title={dialogTitle}
       content={dialogContent}
       actions={dialogActions}

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
@@ -1,37 +1,14 @@
-import React, { useCallback, useEffect, useState } from 'react'
-import { FixedDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import React from 'react'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
-import Button from 'cozy-ui/transpiled/react/Button'
-import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import { default as DumbShareByLink } from './ShareByLink'
 import { default as DumbShareByEmail } from './ShareByEmail'
 import WhoHasAccess from './WhoHasAccess'
 
-import { useSafeState } from '../helpers/hooks'
-
 import cx from 'classnames'
 import styles from '../share.styl'
 
-/**
- * Displays a loader that can be used when ShareDialogCozyToCozy is in loading state
- */
-const LoadingContent = () => {
-  return (
-    <div className={'u-ta-center'}>
-      <Spinner size="xxlarge" loadingType="sharing" />
-    </div>
-  )
-}
-
-/**
- * Displays an error message that can be used when ShareDialogCozyToCozy is in error state
- */
-const ErrorContent = () => {
-  const { t } = useI18n()
-
-  return <div>{t('Share.loadingError')}</div>
-}
+import ShareDialogTwoStepsConfirmationContainer from './ShareDialogTwoStepsConfirmationContainer'
 
 /**
  * Displays the sharing interface that can be used when ShareDialogCozyToCozy is in sharing state
@@ -111,272 +88,36 @@ const SharingContent = ({
 }
 
 /**
- * Displays actions that are available when confirming a recipient
+ * Displays the dialog's title that can be used when ShareDialogCozyToCozy is in sharing state
  */
-const ConfirmRecipientActions = ({ confirm, reject, cancel }) => {
-  const { t } = useI18n()
+const SharingTitleFunction = ({ documentType, document }) =>
+  function SharingTitle() {
+    const { t } = useI18n()
 
-  return (
-    <>
-      <Button
-        theme="secondary"
-        label={t(`Share.twoStepsConfirmation.cancel`)}
-        onClick={cancel}
-      />
-      <Button
-        theme="danger-outline"
-        label={t(`Share.twoStepsConfirmation.reject`)}
-        onClick={reject}
-      />
-      <Button
-        theme="primary"
-        label={t(`Share.twoStepsConfirmation.confirm`)}
-        onClick={confirm}
-      />
-    </>
-  )
-}
+    const title = t(`${documentType}.share.title`, {
+      name: document.name || document.attributes?.name
+    })
 
-/**
- * Displays the reject interface that can be used when ShareDialogCozyToCozy is in asking for
- * confirmation after the user clicked on Reject button
- */
-const RejectDialogContent = ({ recipientConfirmationData }) => {
-  const { t } = useI18n()
-
-  const question = t('Share.twoStepsConfirmation.confirmRejection', {
-    userName: recipientConfirmationData.name,
-    userEmail: recipientConfirmationData.email
-  })
-
-  return question
-}
-
-/**
- * Displays actions that are available when rejecting a recipient
- */
-const RejectRecipientActions = ({ reject, cancel }) => {
-  const { t } = useI18n()
-
-  return (
-    <>
-      <Button
-        theme="secondary"
-        label={t(`Share.twoStepsConfirmation.cancel`)}
-        onClick={cancel}
-      />
-      <Button
-        theme="primary"
-        label={t(`Share.twoStepsConfirmation.reject`)}
-        onClick={reject}
-      />
-    </>
-  )
-}
+    return title
+  }
 
 /**
  * Displays a sharing dialog that allows to share a document between multiple Cozy users
  */
 const ShareDialogCozyToCozy = ({
-  contacts,
-  createContact,
-  document,
-  documentType,
-  groups,
-  hasSharedParent,
-  isOwner,
-  link,
-  needsContactsPermission,
-  onClose,
-  onRevoke,
-  onRevokeLink,
-  onRevokeSelf,
-  onShare,
-  onShareByLink,
-  onUpdateShareLinkPermissions,
-  permissions,
-  recipients,
-  sharing,
-  sharingDesc,
-  showShareByEmail,
   showShareByLink,
-  showShareOnlyByLink,
-  showWhoHasAccess,
-  twoStepsConfirmationMethods = {}
+  documentType,
+  document,
+  ...props
 }) => {
-  const { t } = useI18n()
-
-  const shouldGetRecipientsToBeConfirmed =
-    twoStepsConfirmationMethods?.getRecipientsToBeConfirmed
-
-  const [status, setStatus] = useSafeState(
-    shouldGetRecipientsToBeConfirmed ? 'loading' : 'sharing'
-  )
-  const [recipientsToBeConfirmed, setRecipientsToBeConfirmed] = useSafeState([])
-  const [recipientConfirmationData, setRecipientConfirmationData] = useState(
-    undefined
-  )
-
-  const {
-    confirmRecipient,
-    rejectRecipient,
-    recipientConfirmationDialogContent: ConfirmationDialogContent
-  } = twoStepsConfirmationMethods
-
-  const getRecipientsToBeConfirmed = useCallback(async () => {
-    if (shouldGetRecipientsToBeConfirmed) {
-      setStatus('loading')
-
-      try {
-        const result = await twoStepsConfirmationMethods.getRecipientsToBeConfirmed(
-          document.id
-        )
-
-        setRecipientsToBeConfirmed(result)
-        setStatus('sharing')
-      } catch {
-        setStatus('error')
-      }
-    } else {
-      setStatus('sharing')
-    }
-  }, [
-    shouldGetRecipientsToBeConfirmed,
-    twoStepsConfirmationMethods,
-    document,
-    setRecipientsToBeConfirmed,
-    setStatus
-  ])
-
-  useEffect(() => {
-    getRecipientsToBeConfirmed()
-  }, [getRecipientsToBeConfirmed])
-
-  const showConfirmationDialog = recipientConfirmationData => {
-    setRecipientConfirmationData(recipientConfirmationData)
-    setStatus('confirmingRecipient')
-  }
-
-  const showRejectDialog = () => {
-    setRecipientConfirmationData(recipientConfirmationData)
-    setStatus('rejectingRecipient')
-  }
-
-  const onConfirmRecipient = () => {
-    confirmRecipient(recipientConfirmationData).then(() => {
-      getRecipientsToBeConfirmed()
-    })
-  }
-
-  const onRejectRecipient = () => {
-    setStatus('loading')
-    rejectRecipient(recipientConfirmationData).then(() => {
-      getRecipientsToBeConfirmed()
-    })
-  }
-
-  const closeConfirmationDialog = () => {
-    setStatus('sharing')
-  }
-
-  const closeRejectDialog = () => {
-    setStatus('confirmingRecipient')
-  }
-
-  let dialogTitle = t(`${documentType}.share.title`, {
-    name: document.name || document.attributes?.name
-  })
-  let dialogContent = null
-  let dialogActions = null
-  let onBack = null
-
-  if (status === 'error') {
-    dialogContent = <ErrorContent />
-  } else if (status === 'loading') {
-    dialogContent = <LoadingContent />
-  } else if (status === 'sharing') {
-    dialogContent = (
-      <SharingContent
-        contacts={contacts}
-        createContact={createContact}
-        document={document}
-        documentType={documentType}
-        groups={groups}
-        hasSharedParent={hasSharedParent}
-        isOwner={isOwner}
-        needsContactsPermission={needsContactsPermission}
-        onRevoke={onRevoke}
-        onRevokeSelf={onRevokeSelf}
-        onShare={onShare}
-        recipients={recipients}
-        sharing={sharing}
-        sharingDesc={sharingDesc}
-        showShareByEmail={showShareByEmail}
-        showShareOnlyByLink={showShareOnlyByLink}
-        showWhoHasAccess={showWhoHasAccess}
-        recipientsToBeConfirmed={recipientsToBeConfirmed}
-        verifyRecipient={showConfirmationDialog}
-      />
-    )
-
-    dialogActions = showShareByLink ? (
-      <DumbShareByLink
-        checked={link !== null}
-        document={document}
-        documentType={documentType}
-        link={link}
-        onChangePermissions={onUpdateShareLinkPermissions}
-        onDisable={onRevokeLink}
-        onEnable={onShareByLink}
-        permissions={permissions}
-      />
-    ) : null
-  } else if (status === 'confirmingRecipient') {
-    dialogTitle = t(`Share.twoStepsConfirmation.title`)
-
-    dialogContent = (
-      <ConfirmationDialogContent
-        recipientConfirmationData={recipientConfirmationData}
-      />
-    )
-
-    dialogActions = (
-      <ConfirmRecipientActions
-        confirm={onConfirmRecipient}
-        cancel={closeConfirmationDialog}
-        reject={showRejectDialog}
-      />
-    )
-
-    onBack = closeConfirmationDialog
-  } else if (status === 'rejectingRecipient') {
-    dialogTitle = t(`Share.twoStepsConfirmation.titleReject`)
-
-    dialogContent = (
-      <RejectDialogContent
-        recipientConfirmationData={recipientConfirmationData}
-      />
-    )
-
-    dialogActions = (
-      <RejectRecipientActions
-        reject={onRejectRecipient}
-        cancel={closeRejectDialog}
-      />
-    )
-
-    onBack = closeRejectDialog
-  }
-
   return (
-    <FixedDialog
-      disableEnforceFocus
-      open={true}
-      onClose={onClose}
-      onBack={onBack}
-      title={dialogTitle}
-      content={dialogContent}
-      actions={dialogActions}
+    <ShareDialogTwoStepsConfirmationContainer
+      {...props}
+      documentType={documentType}
+      document={document}
+      dialogContentOnShare={SharingContent}
+      dialogActionsOnShare={showShareByLink ? DumbShareByLink : null}
+      dialogTitleOnShare={SharingTitleFunction({ documentType, document })}
     />
   )
 }

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
@@ -55,8 +55,7 @@ const SharingContent = ({
   showShareOnlyByLink,
   showWhoHasAccess,
   recipientsToBeConfirmed,
-  confirmRecipient,
-  rejectRecipient
+  verifyRecipient
 }) => {
   const { t } = useI18n()
 
@@ -104,8 +103,7 @@ const SharingContent = ({
           onRevokeSelf={onRevokeSelf}
           recipients={recipients}
           recipientsToBeConfirmed={recipientsToBeConfirmed}
-          rejectRecipient={rejectRecipient}
-          confirmRecipient={confirmRecipient}
+          verifyRecipient={verifyRecipient}
         />
       )}
     </div>
@@ -115,7 +113,7 @@ const SharingContent = ({
 /**
  * Displays actions that are available when confirming a recipient
  */
-const ConfirmRecipientActions = ({ confirm, cancel }) => {
+const ConfirmRecipientActions = ({ confirm, reject, cancel }) => {
   const { t } = useI18n()
 
   return (
@@ -124,6 +122,11 @@ const ConfirmRecipientActions = ({ confirm, cancel }) => {
         theme="secondary"
         label={t(`Share.twoStepsConfirmation.cancel`)}
         onClick={cancel}
+      />
+      <Button
+        theme="danger-outline"
+        label={t(`Share.twoStepsConfirmation.reject`)}
+        onClick={reject}
       />
       <Button
         theme="primary"
@@ -254,7 +257,7 @@ const ShareDialogCozyToCozy = ({
     setStatus('confirmingRecipient')
   }
 
-  const showRejectDialog = recipientConfirmationData => {
+  const showRejectDialog = () => {
     setRecipientConfirmationData(recipientConfirmationData)
     setStatus('rejectingRecipient')
   }
@@ -274,6 +277,10 @@ const ShareDialogCozyToCozy = ({
 
   const closeConfirmationDialog = () => {
     setStatus('sharing')
+  }
+
+  const closeRejectDialog = () => {
+    setStatus('confirmingRecipient')
   }
 
   let dialogTitle = t(`${documentType}.share.title`, {
@@ -307,8 +314,7 @@ const ShareDialogCozyToCozy = ({
         showShareOnlyByLink={showShareOnlyByLink}
         showWhoHasAccess={showWhoHasAccess}
         recipientsToBeConfirmed={recipientsToBeConfirmed}
-        rejectRecipient={showRejectDialog}
-        confirmRecipient={showConfirmationDialog}
+        verifyRecipient={showConfirmationDialog}
       />
     )
 
@@ -337,6 +343,7 @@ const ShareDialogCozyToCozy = ({
       <ConfirmRecipientActions
         confirm={onConfirmRecipient}
         cancel={closeConfirmationDialog}
+        reject={showRejectDialog}
       />
     )
   } else if (status === 'rejectingRecipient') {
@@ -351,7 +358,7 @@ const ShareDialogCozyToCozy = ({
     dialogActions = (
       <RejectRecipientActions
         reject={onRejectRecipient}
-        cancel={closeConfirmationDialog}
+        cancel={closeRejectDialog}
       />
     )
   }

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import ShareDialogCozyToCozy from './ShareDialogCozyToCozy'
+import { CozyPassFingerprintDialogContent } from './CozyPassFingerprintDialogContent'
 import AppLike from '../../test/AppLike'
 import { createMockClient } from 'cozy-client'
-import { render, fireEvent } from '@testing-library/react'
-import { act } from 'react-dom/test-utils'
+import { act, render, fireEvent } from '@testing-library/react'
 
 describe('ShareDialogCozyToCozy', () => {
   const client = createMockClient({})
@@ -54,7 +54,7 @@ describe('ShareDialogCozyToCozy', () => {
 
     await act(() => promise)
 
-    expect(getByText('Confirm')).toBeTruthy()
+    expect(getByText('Verify')).toBeTruthy()
   })
 
   it('should ask to confirm 1 contact if 1 contact is waiting for confirmation', async () => {
@@ -80,7 +80,7 @@ describe('ShareDialogCozyToCozy', () => {
 
     await act(() => promise)
 
-    expect(getAllByText('Confirm')).toHaveLength(1)
+    expect(getAllByText('Verify')).toHaveLength(1)
     expect(
       getByText(/Some contacts are waiting for your confirmation/i)
     ).toBeTruthy()
@@ -114,7 +114,7 @@ describe('ShareDialogCozyToCozy', () => {
 
     await act(() => promise)
 
-    expect(getAllByText('Confirm')).toHaveLength(2)
+    expect(getAllByText('Verify')).toHaveLength(2)
     expect(
       getByText(/2 contacts are waiting for your confirmation/i)
     ).toBeTruthy()
@@ -137,7 +137,7 @@ describe('ShareDialogCozyToCozy', () => {
 
     await act(() => promise)
 
-    expect(queryByText('Confirm')).not.toBeInTheDocument()
+    expect(queryByText('Verify')).not.toBeInTheDocument()
     expect(
       queryByText(/waiting for your confirmation/i)
     ).not.toBeInTheDocument()
@@ -152,11 +152,12 @@ describe('ShareDialogCozyToCozy', () => {
       ...getMockProps(),
       twoStepsConfirmationMethods: {
         getRecipientsToBeConfirmed: jest.fn(() => promise),
-        rejectRecipient
+        rejectRecipient,
+        recipientConfirmationDialogContent: CozyPassFingerprintDialogContent
       }
     }
 
-    const { getByText, getByLabelText } = setup(props)
+    const { getByText } = setup(props)
 
     resolve([
       {
@@ -168,7 +169,11 @@ describe('ShareDialogCozyToCozy', () => {
 
     await act(() => promise)
 
-    const rejectButton = getByLabelText('Reject')
+    const verifyButton = getByText('Verify')
+
+    await act(() => fireEvent.click(verifyButton))
+
+    const rejectButton = getByText('Reject')
 
     await act(() => fireEvent.click(rejectButton))
 

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
@@ -44,15 +44,16 @@ describe('ShareDialogCozyToCozy', () => {
 
     expect(getByText('Loading in progress')).toBeTruthy()
 
-    resolve([
-      {
-        name: recipientBob.public_name,
-        id: 'SOME_ID',
-        email: recipientBob.email
-      }
-    ])
-
-    await act(() => promise)
+    await act(async () => {
+      resolve([
+        {
+          name: recipientBob.public_name,
+          id: 'SOME_ID',
+          email: recipientBob.email
+        }
+      ])
+      await promise
+    })
 
     expect(getByText('Verify')).toBeTruthy()
   })
@@ -70,15 +71,16 @@ describe('ShareDialogCozyToCozy', () => {
 
     const { getByText, getAllByText } = setup(props)
 
-    resolve([
-      {
-        name: recipientBob.public_name,
-        id: 'SOME_ID',
-        email: recipientBob.email
-      }
-    ])
-
-    await act(() => promise)
+    await act(async () => {
+      resolve([
+        {
+          name: recipientBob.public_name,
+          id: 'SOME_ID',
+          email: recipientBob.email
+        }
+      ])
+      await promise
+    })
 
     expect(getAllByText('Verify')).toHaveLength(1)
     expect(
@@ -99,20 +101,21 @@ describe('ShareDialogCozyToCozy', () => {
 
     const { getByText, getAllByText } = setup(props)
 
-    resolve([
-      {
-        name: recipientBob.public_name,
-        id: 'SOME_ID',
-        email: recipientBob.email
-      },
-      {
-        name: recipientClaude.public_name,
-        id: 'SOME_OTHER_ID',
-        email: recipientClaude.email
-      }
-    ])
-
-    await act(() => promise)
+    await act(async () => {
+      resolve([
+        {
+          name: recipientBob.public_name,
+          id: 'SOME_ID',
+          email: recipientBob.email
+        },
+        {
+          name: recipientClaude.public_name,
+          id: 'SOME_OTHER_ID',
+          email: recipientClaude.email
+        }
+      ])
+      await promise
+    })
 
     expect(getAllByText('Verify')).toHaveLength(2)
     expect(
@@ -133,9 +136,10 @@ describe('ShareDialogCozyToCozy', () => {
 
     const { queryByText } = setup(props)
 
-    resolve([])
-
-    await act(() => promise)
+    await act(async () => {
+      resolve([])
+      await promise
+    })
 
     expect(queryByText('Verify')).not.toBeInTheDocument()
     expect(
@@ -159,23 +163,25 @@ describe('ShareDialogCozyToCozy', () => {
 
     const { getByText } = setup(props)
 
-    resolve([
-      {
-        name: recipientBob.public_name,
-        id: 'SOME_ID',
-        email: recipientBob.email
-      }
-    ])
-
-    await act(() => promise)
+    await act(async () => {
+      resolve([
+        {
+          name: recipientBob.public_name,
+          id: 'SOME_ID',
+          email: recipientBob.email,
+          fingerprintPhrase: 'SOME_FINGERPRINT_PHRASE'
+        }
+      ])
+      await promise
+    })
 
     const verifyButton = getByText('Verify')
 
-    await act(() => fireEvent.click(verifyButton))
+    await act(async () => fireEvent.click(verifyButton))
 
     const rejectButton = getByText('Reject')
 
-    await act(() => fireEvent.click(rejectButton))
+    await act(async () => fireEvent.click(rejectButton))
 
     expect(
       getByText(
@@ -184,7 +190,7 @@ describe('ShareDialogCozyToCozy', () => {
     ).toBeTruthy()
 
     const confirmRejectButton = getByText('Reject')
-    await act(() => fireEvent.click(confirmRejectButton))
+    await act(async () => fireEvent.click(confirmRejectButton))
 
     expect(rejectRecipient).toBeCalled()
   })

--- a/packages/cozy-sharing/src/components/ShareDialogTwoStepsConfirmationContainer.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogTwoStepsConfirmationContainer.jsx
@@ -1,0 +1,296 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { FixedDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Button from 'cozy-ui/transpiled/react/Button'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+
+import { useSafeState } from '../helpers/hooks'
+
+/**
+ * Displays a loader that can be used when ShareDialogTwoStepsConfirmationContainer is in loading state
+ */
+const LoadingContent = () => {
+  return (
+    <div className={'u-ta-center'}>
+      <Spinner size="xxlarge" loadingType="sharing" />
+    </div>
+  )
+}
+
+/**
+ * Displays an error message that can be used when ShareDialogTwoStepsConfirmationContainer is in error state
+ */
+const ErrorContent = () => {
+  const { t } = useI18n()
+
+  return <div>{t('Share.loadingError')}</div>
+}
+
+/**
+ * Displays actions that are available when confirming a recipient
+ */
+const ConfirmRecipientActions = ({ confirm, reject }) => {
+  const { t } = useI18n()
+
+  return (
+    <>
+      <Button
+        theme="danger-outline"
+        label={t(`Share.twoStepsConfirmation.reject`)}
+        onClick={reject}
+      />
+      <Button
+        theme="primary"
+        label={t(`Share.twoStepsConfirmation.confirm`)}
+        onClick={confirm}
+      />
+    </>
+  )
+}
+
+/**
+ * Displays the reject interface that can be used when ShareDialogTwoStepsConfirmationContainer is in asking for
+ * confirmation after the user clicked on Reject button
+ */
+const RejectDialogContent = ({ recipientConfirmationData }) => {
+  const { t } = useI18n()
+
+  const question = t('Share.twoStepsConfirmation.confirmRejection', {
+    userName: recipientConfirmationData.name,
+    userEmail: recipientConfirmationData.email
+  })
+
+  return question
+}
+
+/**
+ * Displays actions that are available when rejecting a recipient
+ */
+const RejectRecipientActions = ({ reject, cancel }) => {
+  const { t } = useI18n()
+
+  return (
+    <>
+      <Button
+        theme="secondary"
+        label={t(`Share.twoStepsConfirmation.cancel`)}
+        onClick={cancel}
+      />
+      <Button
+        theme="primary"
+        label={t(`Share.twoStepsConfirmation.reject`)}
+        onClick={reject}
+      />
+    </>
+  )
+}
+
+/**
+ * Displays a sharing dialog that allows to share a document between multiple Cozy users
+ */
+const ShareDialogTwoStepsConfirmationContainer = ({
+  contacts,
+  createContact,
+  document,
+  documentType,
+  groups,
+  hasSharedParent,
+  isOwner,
+  link,
+  needsContactsPermission,
+  onClose,
+  onRevoke,
+  onRevokeLink,
+  onRevokeSelf,
+  onShare,
+  onShareByLink,
+  onUpdateShareLinkPermissions,
+  permissions,
+  recipients,
+  sharing,
+  sharingDesc,
+  showShareByEmail,
+  showShareOnlyByLink,
+  showWhoHasAccess,
+  twoStepsConfirmationMethods = {},
+  dialogContentOnShare: DialogContentOnShare,
+  dialogActionsOnShare: DialogActionsOnShare,
+  dialogTitleOnShare: DialogTitleOnShare
+}) => {
+  const { t } = useI18n()
+
+  const shouldGetRecipientsToBeConfirmed =
+    twoStepsConfirmationMethods?.getRecipientsToBeConfirmed
+
+  const [status, setStatus] = useSafeState(
+    shouldGetRecipientsToBeConfirmed ? 'loading' : 'sharing'
+  )
+  const [recipientsToBeConfirmed, setRecipientsToBeConfirmed] = useSafeState([])
+  const [recipientConfirmationData, setRecipientConfirmationData] = useState(
+    undefined
+  )
+
+  const {
+    confirmRecipient,
+    rejectRecipient,
+    recipientConfirmationDialogContent: ConfirmationDialogContent
+  } = twoStepsConfirmationMethods
+
+  const getRecipientsToBeConfirmed = useCallback(async () => {
+    if (shouldGetRecipientsToBeConfirmed) {
+      setStatus('loading')
+
+      try {
+        const result = await twoStepsConfirmationMethods.getRecipientsToBeConfirmed(
+          document.id
+        )
+
+        setRecipientsToBeConfirmed(result)
+        setStatus('sharing')
+      } catch {
+        setStatus('error')
+      }
+    } else {
+      setStatus('sharing')
+    }
+  }, [
+    shouldGetRecipientsToBeConfirmed,
+    twoStepsConfirmationMethods,
+    document,
+    setRecipientsToBeConfirmed,
+    setStatus
+  ])
+
+  useEffect(() => {
+    getRecipientsToBeConfirmed()
+  }, [getRecipientsToBeConfirmed])
+
+  const showConfirmationDialog = recipientConfirmationData => {
+    setRecipientConfirmationData(recipientConfirmationData)
+    setStatus('confirmingRecipient')
+  }
+
+  const showRejectDialog = () => {
+    setRecipientConfirmationData(recipientConfirmationData)
+    setStatus('rejectingRecipient')
+  }
+
+  const onConfirmRecipient = () => {
+    confirmRecipient(recipientConfirmationData).then(() => {
+      getRecipientsToBeConfirmed()
+    })
+  }
+
+  const onRejectRecipient = () => {
+    setStatus('loading')
+    rejectRecipient(recipientConfirmationData).then(() => {
+      getRecipientsToBeConfirmed()
+    })
+  }
+
+  const closeConfirmationDialog = () => {
+    setStatus('sharing')
+  }
+
+  const closeRejectDialog = () => {
+    setStatus('confirmingRecipient')
+  }
+
+  let dialogTitle = (
+    <DialogTitleOnShare recipientsToBeConfirmed={recipientsToBeConfirmed} />
+  )
+  let dialogContent = null
+  let dialogActions = null
+  let onBack = null
+
+  if (status === 'error') {
+    dialogContent = <ErrorContent />
+  } else if (status === 'loading') {
+    dialogContent = <LoadingContent />
+  } else if (status === 'sharing') {
+    dialogContent = (
+      <DialogContentOnShare
+        contacts={contacts}
+        createContact={createContact}
+        document={document}
+        documentType={documentType}
+        groups={groups}
+        hasSharedParent={hasSharedParent}
+        isOwner={isOwner}
+        needsContactsPermission={needsContactsPermission}
+        onRevoke={onRevoke}
+        onRevokeSelf={onRevokeSelf}
+        onShare={onShare}
+        recipients={recipients}
+        sharing={sharing}
+        sharingDesc={sharingDesc}
+        showShareByEmail={showShareByEmail}
+        showShareOnlyByLink={showShareOnlyByLink}
+        showWhoHasAccess={showWhoHasAccess}
+        recipientsToBeConfirmed={recipientsToBeConfirmed}
+        verifyRecipient={showConfirmationDialog}
+      />
+    )
+
+    dialogActions = DialogActionsOnShare ? (
+      <DialogActionsOnShare
+        checked={link !== null}
+        document={document}
+        documentType={documentType}
+        link={link}
+        onChangePermissions={onUpdateShareLinkPermissions}
+        onDisable={onRevokeLink}
+        onEnable={onShareByLink}
+        permissions={permissions}
+      />
+    ) : null
+  } else if (status === 'confirmingRecipient') {
+    dialogTitle = t(`Share.twoStepsConfirmation.title`)
+
+    dialogContent = (
+      <ConfirmationDialogContent
+        recipientConfirmationData={recipientConfirmationData}
+      />
+    )
+
+    dialogActions = (
+      <ConfirmRecipientActions
+        confirm={onConfirmRecipient}
+        reject={showRejectDialog}
+      />
+    )
+
+    onBack = closeConfirmationDialog
+  } else if (status === 'rejectingRecipient') {
+    dialogTitle = t(`Share.twoStepsConfirmation.titleReject`)
+
+    dialogContent = (
+      <RejectDialogContent
+        recipientConfirmationData={recipientConfirmationData}
+      />
+    )
+
+    dialogActions = (
+      <RejectRecipientActions
+        reject={onRejectRecipient}
+        cancel={closeRejectDialog}
+      />
+    )
+
+    onBack = closeRejectDialog
+  }
+
+  return (
+    <FixedDialog
+      disableEnforceFocus
+      open={true}
+      onClose={onClose}
+      onBack={onBack}
+      title={dialogTitle}
+      content={dialogContent}
+      actions={dialogActions}
+    />
+  )
+}
+
+export default ShareDialogTwoStepsConfirmationContainer

--- a/packages/cozy-sharing/src/components/ShareDialogTwoStepsConfirmationContainer.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogTwoStepsConfirmationContainer.jsx
@@ -141,9 +141,7 @@ const ShareDialogTwoStepsConfirmationContainer = ({
       setStatus('loading')
 
       try {
-        const result = await twoStepsConfirmationMethods.getRecipientsToBeConfirmed(
-          document.id
-        )
+        const result = await twoStepsConfirmationMethods.getRecipientsToBeConfirmed()
 
         setRecipientsToBeConfirmed(result)
         setStatus('sharing')
@@ -156,7 +154,6 @@ const ShareDialogTwoStepsConfirmationContainer = ({
   }, [
     shouldGetRecipientsToBeConfirmed,
     twoStepsConfirmationMethods,
-    document,
     setRecipientsToBeConfirmed,
     setStatus
   ])

--- a/packages/cozy-sharing/src/components/ShareDialogTwoStepsConfirmationContainer.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogTwoStepsConfirmationContainer.spec.jsx
@@ -1,0 +1,463 @@
+import React from 'react'
+import ShareDialogTwoStepsConfirmationContainer from './ShareDialogTwoStepsConfirmationContainer'
+import { CozyPassFingerprintDialogContent } from './CozyPassFingerprintDialogContent'
+import AppLike from '../../test/AppLike'
+import { createMockClient } from 'cozy-client'
+import { act, render, fireEvent } from '@testing-library/react'
+
+const FakeSharingContent = ({ recipientsToBeConfirmed, verifyRecipient }) => {
+  const verify = recipientConfirmationData => () => {
+    verifyRecipient(recipientConfirmationData)
+  }
+
+  if (recipientsToBeConfirmed.length === 0) {
+    return 'NO RECIPIENT'
+  }
+
+  return (
+    <>
+      {recipientsToBeConfirmed.map(recipientConfirmationData => {
+        return (
+          <button
+            key={`key_r_${recipientConfirmationData.index}`}
+            data-test-id={`modal-verify-button-${recipientConfirmationData.index}`}
+            onClick={verify(recipientConfirmationData)}
+          >
+            Verify
+          </button>
+        )
+      })}
+    </>
+  )
+}
+
+const FakeSharingTitle = ({ recipientsToBeConfirmed }) => {
+  return `FakeSharingTitle ${recipientsToBeConfirmed}`
+}
+
+const FakeDialogActionsOnShare = () => {
+  return `FakeDialogActionsOnShare`
+}
+
+describe('ShareDialogTwoStepsConfirmationContainer', () => {
+  const client = createMockClient({})
+  client.options = {
+    uri: 'foo.mycozy.cloud'
+  }
+
+  const setup = props => {
+    return render(
+      <AppLike client={client}>
+        <ShareDialogTwoStepsConfirmationContainer
+          {...props}
+          dialogContentOnShare={FakeSharingContent}
+          dialogActionsOnShare={FakeDialogActionsOnShare}
+          dialogTitleOnShare={FakeSharingTitle}
+        />
+      </AppLike>
+    )
+  }
+
+  it('should show sharing dialog directly when no twoStepsConfirmationMethods are provided', () => {
+    let props = {
+      ...getMockProps()
+    }
+
+    const { getByText } = setup(props)
+
+    expect(getByText('NO RECIPIENT')).toBeTruthy()
+  })
+
+  it('should show loading while calling getRecipientsToBeConfirmed', async () => {
+    const { promise, resolve } = deferablePromise()
+
+    let props = {
+      ...getMockProps(),
+      twoStepsConfirmationMethods: {
+        getRecipientsToBeConfirmed: jest.fn(() => promise),
+        rejectRecipient: jest.fn()
+      }
+    }
+
+    const { getByText } = setup(props)
+
+    expect(getByText('Loading in progress')).toBeTruthy()
+
+    await act(async () => {
+      resolve([
+        {
+          name: recipientBob.public_name,
+          id: 'SOME_ID',
+          index: 0,
+          email: recipientBob.email
+        }
+      ])
+      await promise
+    })
+
+    expect(getByText('Verify')).toBeTruthy()
+  })
+
+  it('should ask to confirm 1 contact if 1 contact is waiting for confirmation', async () => {
+    const { promise, resolve } = deferablePromise()
+
+    let props = {
+      ...getMockProps(),
+      twoStepsConfirmationMethods: {
+        getRecipientsToBeConfirmed: jest.fn(() => promise),
+        rejectRecipient: jest.fn()
+      }
+    }
+
+    const { getAllByText } = setup(props)
+
+    await act(async () => {
+      resolve([
+        {
+          name: recipientBob.public_name,
+          id: 'SOME_ID',
+          index: 0,
+          email: recipientBob.email
+        }
+      ])
+      await promise
+    })
+
+    expect(getAllByText('Verify')).toHaveLength(1)
+  })
+
+  it('should ask to confirm 2 contacts if 2 contacts are waiting for confirmation', async () => {
+    const { promise, resolve } = deferablePromise()
+
+    let props = {
+      ...getMockProps(),
+      twoStepsConfirmationMethods: {
+        getRecipientsToBeConfirmed: jest.fn(() => promise),
+        rejectRecipient: jest.fn()
+      }
+    }
+
+    const { getAllByText } = setup(props)
+
+    await act(async () => {
+      resolve([
+        {
+          name: recipientBob.public_name,
+          id: 'SOME_ID',
+          index: 0,
+          email: recipientBob.email
+        },
+        {
+          name: recipientClaude.public_name,
+          id: 'SOME_OTHER_ID',
+          index: 1,
+          email: recipientClaude.email
+        }
+      ])
+      await promise
+    })
+
+    expect(getAllByText('Verify')).toHaveLength(2)
+  })
+
+  it('should not ask to confirm contacts if no contacts are waiting for confirmation', async () => {
+    const { promise, resolve } = deferablePromise()
+
+    let props = {
+      ...getMockProps(),
+      twoStepsConfirmationMethods: {
+        getRecipientsToBeConfirmed: jest.fn(() => promise),
+        rejectRecipient: jest.fn()
+      }
+    }
+
+    const { queryByText } = setup(props)
+
+    await act(async () => {
+      resolve([])
+      await promise
+    })
+
+    expect(queryByText('Verify')).not.toBeInTheDocument()
+  })
+
+  it(`should display confirmation of 'contact rejection' when user click on the 'reject' button`, async () => {
+    const { promise, resolve } = deferablePromise()
+
+    const rejectRecipient = jest.fn(() => Promise.resolve())
+
+    let props = {
+      ...getMockProps(),
+      twoStepsConfirmationMethods: {
+        getRecipientsToBeConfirmed: jest.fn(() => promise),
+        rejectRecipient,
+        recipientConfirmationDialogContent: CozyPassFingerprintDialogContent
+      }
+    }
+
+    const { getByText } = setup(props)
+
+    await act(async () => {
+      resolve([
+        {
+          name: recipientBob.public_name,
+          id: 'SOME_ID',
+          index: 0,
+          email: recipientBob.email,
+          fingerprintPhrase: 'SOME_FINGERPRINT_PHRASE'
+        }
+      ])
+      await promise
+    })
+
+    const verifyButton = getByText('Verify')
+
+    await act(async () => fireEvent.click(verifyButton))
+
+    const rejectButton = getByText('Reject')
+
+    await act(async () => fireEvent.click(rejectButton))
+
+    expect(
+      getByText(
+        `Do you really want to reject contact ${recipientBob.public_name} (${recipientBob.email})?`
+      )
+    ).toBeTruthy()
+
+    const confirmRejectButton = getByText('Reject')
+    await act(async () => fireEvent.click(confirmRejectButton))
+
+    expect(rejectRecipient).toBeCalled()
+  })
+})
+
+const recipientAlice = {
+  status: 'owner',
+  public_name: 'Alice',
+  email: 'me@alice.cozy.localhost',
+  instance: 'http://alice.cozy.localhost:8080',
+  type: 'two-way',
+  sharingId: 'SOME_SHARING_ID',
+  index: 0,
+  avatarPath: '/sharings/SOME_SHARING_ID/recipients/0/avatar'
+}
+
+const recipientBob = {
+  status: 'ready',
+  public_name: 'Claude',
+  email: 'me@claude.cozy.localhost',
+  instance: 'http://claude.cozy.localhost:8080',
+  type: 'two-way',
+  sharingId: 'SOME_SHARING_ID',
+  index: 1,
+  avatarPath: '/sharings/SOME_SHARING_ID/recipients/1/avatar'
+}
+
+const recipientClaude = {
+  status: 'ready',
+  public_name: 'Bob',
+  email: 'me@bob.cozy.localhost',
+  instance: 'http://bob.cozy.localhost:8080',
+  type: 'two-way',
+  sharingId: 'SOME_SHARING_ID',
+  index: 2,
+  avatarPath: '/sharings/SOME_SHARING_ID/recipients/2/avatar'
+}
+
+const deferablePromise = () => {
+  let resolvePointer = undefined
+  let rejectPointer = undefined
+
+  let promise = new Promise((resolve, reject) => {
+    resolvePointer = resolve
+    rejectPointer = reject
+  })
+
+  return {
+    promise,
+    resolve: resolvePointer,
+    reject: rejectPointer
+  }
+}
+
+const getMockProps = () => {
+  return {
+    contacts: {
+      id: 'contacts',
+      definition: {
+        doctype: 'io.cozy.contacts',
+        selector: {
+          _id: {
+            $gt: null
+          }
+        },
+        indexedFields: ['_id'],
+        partialFilter: {
+          trashed: {
+            $or: [
+              {
+                $eq: false
+              },
+              {
+                $exists: false
+              }
+            ]
+          },
+          $or: [
+            {
+              cozy: {
+                $not: {
+                  $size: 0
+                }
+              }
+            },
+            {
+              email: {
+                $not: {
+                  $size: 0
+                }
+              }
+            }
+          ]
+        },
+        limit: 1000
+      },
+      fetchStatus: 'pending',
+      lastFetch: null,
+      lastUpdate: null,
+      lastErrorUpdate: null,
+      lastError: null,
+      hasMore: false,
+      count: 0,
+      data: [],
+      bookmark: null,
+      options: null
+    },
+    document: {
+      id: 'SOME_DOCUMENT_ID',
+      name: 'SOME_DOCUMENT_NAME',
+      _type: 'com.bitwarden.organizations',
+      _id: 'SOME_DOCUMENT_ID'
+    },
+    documentType: 'Organizations',
+    groups: {
+      id: 'groups',
+      definition: {
+        doctype: 'io.cozy.contacts.groups'
+      },
+      fetchStatus: 'pending',
+      lastFetch: null,
+      lastUpdate: null,
+      lastErrorUpdate: null,
+      lastError: null,
+      hasMore: false,
+      count: 0,
+      data: [],
+      bookmark: null,
+      options: null
+    },
+    hasSharedParent: null,
+    isOwner: true,
+    link: null,
+    permissions: [],
+    recipients: [
+      recipientAlice,
+      recipientBob,
+      recipientClaude,
+      {
+        status: 'pending',
+        email: 'me@ben.cozy.localhost',
+        type: 'two-way',
+        sharingId: 'SOME_SHARING_ID',
+        index: 3,
+        avatarPath: '/sharings/SOME_SHARING_ID/recipients/3/avatar'
+      }
+    ],
+    sharing: {
+      id: 'SOME_SHARING_ID',
+      _id: 'SOME_SHARING_ID',
+      _type: 'io.cozy.sharings',
+      type: 'io.cozy.sharings',
+      attributes: {
+        triggers: {
+          track_id: 'SOME_TRACK_ID',
+          replicate_id: 'SOME_REPLICATE_ID'
+        },
+        active: true,
+        owner: true,
+        open_sharing: true,
+        description: 'SOME_DOCUMENT_NAME',
+        app_slug: 'password',
+        created_at: '2021-08-13T16:51:28.562668+02:00',
+        updated_at: '2021-08-13T16:51:28.562668+02:00',
+        rules: [
+          {
+            title: 'SOME_DOCUMENT_NAME',
+            doctype: 'com.bitwarden.organizations',
+            values: ['SOME_DOCUMENT_ID'],
+            add: 'sync',
+            update: 'sync',
+            remove: 'sync'
+          },
+          {
+            title: 'Ciphers',
+            doctype: 'com.bitwarden.ciphers',
+            selector: 'organization_id',
+            values: ['SOME_DOCUMENT_ID'],
+            add: 'sync',
+            update: 'sync',
+            remove: 'sync'
+          }
+        ],
+        members: [
+          {
+            status: 'owner',
+            public_name: 'Alice',
+            email: 'me@alice.cozy.localhost',
+            instance: 'http://alice.cozy.localhost:8080'
+          },
+          {
+            status: 'ready',
+            public_name: 'Claude',
+            email: 'me@claude.cozy.localhost',
+            instance: 'http://claude.cozy.localhost:8080'
+          },
+          {
+            status: 'ready',
+            public_name: 'Bob',
+            email: 'me@bob.cozy.localhost',
+            instance: 'http://bob.cozy.localhost:8080'
+          },
+          {
+            status: 'pending',
+            email: 'me@ben.cozy.localhost'
+          }
+        ]
+      },
+      meta: {
+        rev: '12-136ad05bd33a80b6a1829a9ec3d918f0'
+      },
+      links: {
+        self: '/sharings/SOME_SHARING_ID'
+      },
+      relationships: {
+        shared_docs: {
+          data: [
+            {
+              id: 'SOME_DOCUMENT_ID',
+              type: 'com.bitwarden.organizations'
+            }
+          ]
+        }
+      }
+    },
+    sharingDesc: 'SOME_DOCUMENT_NAME',
+    showShareByEmail: true,
+    showShareByLink: false,
+    showShareOnlyByLink: null,
+    showWhoHasAccess: true,
+    onRevoke: jest.fn(),
+    onShare: jest.fn(),
+    createContact: jest.fn()
+  }
+}

--- a/packages/cozy-sharing/src/components/WhoHasAccess.jsx
+++ b/packages/cozy-sharing/src/components/WhoHasAccess.jsx
@@ -29,8 +29,7 @@ const WhoHasAccess = ({
   onRevoke,
   className,
   onRevokeSelf,
-  rejectRecipient,
-  confirmRecipient
+  verifyRecipient
 }) => (
   <div className={className}>
     <RecipientWaitingForConfirmationAlert
@@ -52,8 +51,7 @@ const WhoHasAccess = ({
           onRevoke={onRevoke}
           onRevokeSelf={onRevokeSelf}
           recipientConfirmationData={recipientConfirmationData}
-          rejectRecipient={rejectRecipient}
-          confirmRecipient={confirmRecipient}
+          verifyRecipient={verifyRecipient}
         />
       )
     })}
@@ -72,7 +70,6 @@ WhoHasAccess.propTypes = {
   documentType: PropTypes.string.isRequired,
   onRevoke: PropTypes.func.isRequired,
   onRevokeSelf: PropTypes.func,
-  confirmRecipient: PropTypes.func,
-  rejectRecipient: PropTypes.func
+  verifyRecipient: PropTypes.func
 }
 export default WhoHasAccess

--- a/packages/cozy-sharing/src/components/recipient.styl
+++ b/packages/cozy-sharing/src/components/recipient.styl
@@ -76,12 +76,3 @@
     &--avatar
         margin-right -0.6rem
 
-.recipient-confirm
-    &__action
-        &--confirm
-            color var(--successColor)
-            border-color var(--successColor)
-
-        &--cancel
-            color var(--errorColor)
-            border-color var(--errorColor)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5791,10 +5791,10 @@ cozy-ui@44.1.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@51.6.0:
-  version "51.6.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-51.6.0.tgz#8dca7b428e87b0403ff95dfdd29568500d603b5a"
-  integrity sha512-q+VkWkWyIi3QAvrq/aY/aUQ2NpI3e3HOy8lUaTh6OFO17z/bxKeFoD1ai1jZUN5m1+PN0LNKcvJ7qkz1LUnPSQ==
+cozy-ui@54.0.0:
+  version "54.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-54.0.0.tgz#16c12ef7d180e59c5f504f39c34b8b1e3a136b60"
+  integrity sha512-tl4brtnqDUnxx/7y95+4M02JRSsdXCfOctRIYpED9+Jat76o05mVTdlmd7NQDNEcp52ECkJBr/0r09vSUroxHg==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"


### PR DESCRIPTION
~~⚠️  this PR cannot be merged yet as it depends on https://github.com/cozy/cozy-ui/pull/1905~~

Instead of displaying `confirm` and `reject` buttons, now a `verify`
button is displayed

The opened dialog now allows to accept or reject the user

![image](https://user-images.githubusercontent.com/1884255/133136517-83bdce50-2651-4752-8383-4a202036794f.png)
![image](https://user-images.githubusercontent.com/1884255/133136539-5f888825-6b61-4aca-a63d-75d2ec2d8d63.png)
