### PR TITLE
feat: Harmonize `DropdownButton` typography

### DIFF
--- a/packages/cozy-sharing/src/components/Recipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient.jsx
@@ -216,7 +216,7 @@ export const Permissions = ({
             ref={buttonRef}
             className={modalStyles['aligned-dropdown-button']}
           >
-            {t(`Share.type.${type}`)}
+            <Typography variant="body1">{t(`Share.type.${type}`)}</Typography>
           </DropdownButton>
           {isMenuDisplayed && (
             <ActionMenu


### PR DESCRIPTION
Related to: https://trello.com/c/AiQg5Cjr/16-%F0%9F%93%9D-notes-partage-cozy-%C3%A0-cozy-notes-4j

Harmonize styling between cozy to cozy sharing button and by link sharing button, using the same `Typography `variant.