### PR TITLE
feat: Expose useSharingInfos hook as public API

### DIFF
--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -20,3 +20,4 @@ export {
   CozyPassFingerprintDialogContent
 } from './components/CozyPassFingerprintDialogContent'
 export { SharingBannerPlugin } from './SharingBanner'
+export { useSharingInfos } from './SharingBanner/hooks/useSharingInfos'


### PR DESCRIPTION
**Problem**: we need `useSharingInfos` in `cozy-drive`, there is no way around that.
**Solution**: no choice but to expose the hook in `cozy-sharing` in the public API.