### PR TITLE
fix: Set `recipientsToBeConfirmed` default to `[]` on `WhoHasAccess`

### DIFF
--- a/packages/cozy-sharing/src/components/WhoHasAccess.jsx
+++ b/packages/cozy-sharing/src/components/WhoHasAccess.jsx
@@ -23,7 +23,7 @@ const RecipientWaitingForConfirmationAlert = ({ recipientsToBeConfirmed }) => {
 const WhoHasAccess = ({
   isOwner = false,
   recipients,
-  recipientsToBeConfirmed,
+  recipientsToBeConfirmed = [],
   document,
   documentType,
   onRevoke,


### PR DESCRIPTION
⚠️ this PR must not be merged on `feat/redesign_2steps_confirmation` but on `master`. The target branch will be edited after `feat/redesign_2steps_confirmation` merge

⚠️ this PR should not be merged before `feat/redesign_2steps_confirmation`
____

When WhoHasAccess is displayed from `SharingDetailsModal`, then no
`recipientsToBeConfirmed` is passed to the component