### PR TITLE
fix: Display Recipient's initials if no avatarPath or status is provided

### DIFF
--- a/packages/cozy-sharing/src/components/Recipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient.jsx
@@ -126,18 +126,24 @@ export const RecipientsAvatars = ({
 
 export const RecipientAvatar = ({ recipient, ...rest }) => {
   const client = useClient()
+
+  /**
+   * avatarPath is always the same for a recipient, but image
+   * can be different since the stack generate it on the fly.
+   * It can be "gray" during the first load depending of the
+   * status' sharing, but can become active (from the realtime)
+   * so we need a way to "refresh" the image. Passing the
+   * status in the url force the refresh of the image when the
+   * status changes
+   */
+  const image =
+    recipient.avatarPath && recipient.status
+      ? `${client.options.uri}${recipient.avatarPath}?v=${recipient.status}`
+      : null
+
   return (
     <Avatar
-      /**
-       * avatarPath is always the same for a recipient, but image
-       * can be different since the stack generate it on the fly.
-       * It can be "gray" during the first load depending of the
-       * status' sharing, but can become active (from the realtime)
-       * so we need a way to "refresh" the image. Passing the
-       * status in the url force the refresh of the image when the
-       * status changes
-       */
-      image={`${client.options.uri}${recipient.avatarPath}?v=${recipient.status}`}
+      image={image}
       text={getInitials(recipient)}
       textId={getDisplayName(recipient)}
       disabled={


### PR DESCRIPTION
`<Recipient>` may now be used in not sharing related contexts

This is the case on cozy-pass where the user can display a list of
users that are waiting for identity confirmation (this uses
`ConfirmTrustedRecipientsDialog`)

In this scenario, there is no `avatarPath` to provide as the stack only
supports avatars on the
`/sharings/${sharing.id}/recipients/${recipient.id}/avatar` route

So we want to set `null` image in props instead of an url formatted
with missing attributes. By setting `null` image, then the `Avatar`
component will display the text attribute instead