### PR TITLE
fix: Translate ShareByEmail success message

### DIFF
--- a/packages/cozy-sharing/src/components/ShareByEmail.jsx
+++ b/packages/cozy-sharing/src/components/ShareByEmail.jsx
@@ -92,7 +92,8 @@ export class ShareByEmail extends Component {
       onShare,
       createContact,
       documentType,
-      client
+      client,
+      t
     } = this.props
     const { recipients, selectedOption } = this.state
     if (recipients.length === 0) {
@@ -126,7 +127,7 @@ export class ShareByEmail extends Component {
       })
 
       Alerter.success(
-        ...getSuccessMessage(recipientsBefore, contacts, documentType)
+        t(...getSuccessMessage(recipientsBefore, contacts, documentType))
       )
       this.reset()
     } catch (err) {


### PR DESCRIPTION
Related to: https://trello.com/c/wRef7S3Z/85-%F0%9F%93%9D-notes-retour-il-manque-la-traduction-dans-lalerter-de-succ%C3%A8s-%C3%A0-lajout-dun-destinataire-dans-un-partage

It will translate the message instead of printing the key