### PR TITLE
feat: Update preset config to target node 12

### DIFF
--- a/packages/babel-preset-cozy-app/index.js
+++ b/packages/babel-preset-cozy-app/index.js
@@ -21,7 +21,7 @@ const presetEnvBrowserOptions = {
 
 const presetEnvNodeOptions = {
   targets: {
-    node: 8
+    node: 12
   },
   // don't transform polyfills
   useBuiltIns: false


### PR DESCRIPTION
Node 8 is no longer maintained, we can safely target node 12 in babel preset.