### PR TITLE
feat: Add redirection for geojson data

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/appLinksProps.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/appLinksProps.jsx
@@ -16,6 +16,11 @@ const appLinksProps = {
     slug: 'contacts',
     icon: 'team',
     iconColor: 'brightSun'
+  }),
+  coachco2: () => ({
+    slug: 'coachco2',
+    icon: 'location',
+    iconColor: 'brightSun'
   })
 }
 

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -97,6 +97,12 @@
         "description": "This service retrieves and keeps a complete record of your latest banking operations for you.",
         "button": "Access bank accounts",
         "install": "Discover Cozy Banks"
+      },
+      "coachco2": {
+        "title": "Your trips",
+        "description": "This service retrieves and keeps a complete record of your trips.",
+        "button": "Access trips",
+        "install": "Discover CoachCO2"
       }
     },
     "websiteLink": {

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -97,6 +97,12 @@
         "description": "Ce service récupère vos dernières lignes bancaires et en sauvegarde l'historique complet à votre place.",
         "button": "Accéder aux comptes bancaires",
         "install": "Découvrir Cozy Banks"
+      },
+      "coachco2": {
+        "title": "Vos déplacements",
+        "description": "Ce service récupère l'historique de vos trajets.",
+        "button": "Accéder aux déplacements",
+        "install": "Découvrir Coach CO2"
       }
     },
     "websiteLink": {

--- a/packages/cozy-harvest-lib/src/models/getRelatedAppsSlugs.js
+++ b/packages/cozy-harvest-lib/src/models/getRelatedAppsSlugs.js
@@ -7,6 +7,16 @@ import flag from 'cozy-flags'
  */
 export const relatedAppsConfiguration = [
   {
+    slug: 'coachco2',
+    priority: 3,
+    predicate: ({ konnectorManifest }) => {
+      return (
+        Array.isArray(konnectorManifest.data_types) &&
+        konnectorManifest.data_types.includes('geojson')
+      )
+    }
+  },
+  {
     slug: 'banks',
     priority: 2,
     predicate: ({ konnectorManifest }) => {


### PR DESCRIPTION
From a konnector retrieving geojson data (only Tracemob for now), we
add a redirect to the CoachCo2 app.