### PR TITLE
feat: Add new connectors mapping in harvest

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@cozy/minilog": "^1.0.0",
     "@sentry/browser": "^6.0.1",
-    "cozy-bi-auth": "0.0.23",
+    "cozy-bi-auth": "0.0.24",
     "cozy-doctypes": "^1.83.0",
     "cozy-logger": "^1.7.0",
     "date-fns": "^1.30.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5485,10 +5485,10 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-cozy-bi-auth@0.0.23:
-  version "0.0.23"
-  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.23.tgz#fcbf6b710622c50fad20573b3ca6cac64102b65f"
-  integrity sha512-UXzLlEeq1+g7Q7qQyDzdsIPE+4CbFmNbFVmgel7PlvBols6AunCS2SOptwAmcdCr3jI6CXSv/0TS57jmDPdukg==
+cozy-bi-auth@0.0.24:
+  version "0.0.24"
+  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.24.tgz#b9232e5c5a9828e59c88b6130a8d50043ed050b0"
+  integrity sha512-7Dr08b6uE81x1jjO8jZfy2738mvaQpUS4N+tfZthpO1MB7kSeB0RPlULG+IEMBll+NDlixypjcmVPdJ8ZJUkNA==
   dependencies:
     cozy-logger "^1.3.0"
     lodash "^4.17.20"


### PR DESCRIPTION
Updating cozy-bi-auth in harvest to add 3 new mapping of connecteurs (2 maif/socram and nalo)