### PR TITLE
feat: Add verror in cozy-app-publish dependencies

### DIFF
--- a/packages/cozy-app-publish/package.json
+++ b/packages/cozy-app-publish/package.json
@@ -28,7 +28,8 @@
     "node-fetch": "^2.6.1",
     "prompt": "^1.0.0",
     "request": "^2.88.0",
-    "tar": "^4.4.13"
+    "tar": "^4.4.13",
+    "verror": "^1.10.1"
   },
   "files": [
     "index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18113,6 +18113,15 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+verror@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.1.tgz#4bf09eeccf4563b109ed4b3d458380c972b0cdeb"
+  integrity sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==
+  dependencies:
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
+
 vfile-location@^2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.5.tgz#c83eb02f8040228a8d2b3f10e485be3e3433e0a2"


### PR DESCRIPTION
cozy-app-publish uses `verror` package but until today it was installed
from some dependencies of dependencies

This commit force verror installation to ensure it will be available
even if it is removed from dependencies's dependencies


_________

This PR is needed to fix cozy-pass-web CI as it calls `yarn add cozy-app-publish` during the CI and there is no `yarn.lock` file for this project (it uses a npm-lock file instead).