### PR TITLE
feat: Change AppLinkCard behaviour for geojson data

### DIFF
--- a/packages/cozy-harvest-lib/src/datacards/GeoDataCard.jsx
+++ b/packages/cozy-harvest-lib/src/datacards/GeoDataCard.jsx
@@ -19,6 +19,7 @@ import CozyClient, {
   isQueryLoading,
   hasQueryBeenLoaded
 } from 'cozy-client'
+import flag from 'cozy-flags'
 
 import Card from 'cozy-ui/transpiled/react/Card'
 import Icon from 'cozy-ui/transpiled/react/Icon'
@@ -31,6 +32,9 @@ import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
 import FlagIcon from 'cozy-ui/transpiled/react/Icons/Flag'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Stack from 'cozy-ui/transpiled/react/Stack'
+
+import AppLinkCard, { AppLinkButton } from '../components/cards/AppLinkCard'
+import appLinksProps from '../components/KonnectorConfiguration/DataTab/appLinksProps'
 
 import useCycle from './useCycle'
 import {
@@ -257,6 +261,11 @@ const GeoDataCard = ({ trips, loading, konnector }) => {
       ) : (
         <TripsMap trips={trips} index={index} />
       )}
+      {flag('harvest.datacard.coachCO2') ? (
+        <div className="u-ta-right u-mv-half u-mh-1">
+          <AppLinkButton slug="coachco2" />
+        </div>
+      ) : null}
     </Card>
   )
 }
@@ -288,7 +297,15 @@ const DataGeoDataCard = ({ timeseriesCol, konnector }) => {
   const noTimeseries =
     hasQueryBeenLoaded(timeseriesCol) && timeseries.length == 0
   const isLoading = isQueryLoading(timeseriesCol)
-  return noTimeseries ? null : (
+
+  if (noTimeseries && flag('harvest.datacard.coachCO2')) {
+    // This is hidden between a flag as long as the CoachCO2 app is not in the store
+    return <AppLinkCard {...appLinksProps.coachco2()} />
+  }
+  if (noTimeseries) {
+    return null
+  }
+  return (
     <GeoDataCard
       trips={ascendingTrips}
       loading={isLoading}

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -103,9 +103,9 @@
         "install": "Discover Cozy Banks"
       },
       "coachco2": {
-        "title": "Your trips",
-        "description": "This service retrieves and keeps a complete record of your trips.",
-        "button": "Access trips",
+        "title": "Apps to go further",
+        "description": "The following apps are able to use privately this kind of data inside your Cozy.",
+        "button": "Coach CO2",
         "install": "Discover CoachCO2"
       }
     },

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -103,9 +103,9 @@
         "install": "Découvrir Cozy Banks"
       },
       "coachco2": {
-        "title": "Vos déplacements",
-        "description": "Ce service récupère l'historique de vos trajets.",
-        "button": "Accéder aux déplacements",
+        "title": "Applications pour aller plus loin",
+        "description": "Les applications suivantes proposent d'utiliser ces données en toute confidentialité au sein de votre Cozy",
+        "button": "Coach CO2",
         "install": "Découvrir Coach CO2"
       }
     },

--- a/packages/cozy-harvest-lib/src/models/getRelatedAppsSlugs.js
+++ b/packages/cozy-harvest-lib/src/models/getRelatedAppsSlugs.js
@@ -7,16 +7,6 @@ import flag from 'cozy-flags'
  */
 export const relatedAppsConfiguration = [
   {
-    slug: 'coachco2',
-    priority: 3,
-    predicate: ({ konnectorManifest }) => {
-      return (
-        Array.isArray(konnectorManifest.data_types) &&
-        konnectorManifest.data_types.includes('geojson')
-      )
-    }
-  },
-  {
     slug: 'banks',
     priority: 2,
     predicate: ({ konnectorManifest }) => {


### PR DESCRIPTION
We introduce here a 'harvest.datacard.coachCO2' flag, used to display
the AppLinkCard or AppLinkButton for the CoachCO2 app.

The display rules are the following:
- When there is no data and the flag is enabled: show the AppLinkCard
- When there is no data  and the flag is not enabled: show nothing
- When there is data and the flag is enabled: show the AppLinkButton