### PR TITLE
fix: Change UI for geocard

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/appLinksProps.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/appLinksProps.jsx
@@ -19,7 +19,6 @@ const appLinksProps = {
   }),
   coachco2: () => ({
     slug: 'coachco2',
-    icon: 'location',
     iconColor: 'brightSun'
   })
 }

--- a/packages/cozy-harvest-lib/src/components/cards/AppLinkCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/AppLinkCard.jsx
@@ -60,13 +60,15 @@ const AppLinkCard = ({ slug, path, icon, iconColor }) => {
     <Card>
       <Stack>
         <Typography variant="h6" gutterBottom>
-          <Circle
-            size="small"
-            backgroundColor={palette[iconColor]}
-            className="u-mr-half"
-          >
-            <Icon icon={icon} color={palette['white']} />
-          </Circle>
+          {icon ? (
+            <Circle
+              size="small"
+              backgroundColor={palette[iconColor]}
+              className="u-mr-half"
+            >
+              <Icon icon={icon} color={palette['white']} />
+            </Circle>
+          ) : null}
           {t(`card.appLink.${slug}.title`)}
         </Typography>
         <Typography variant="body1">

--- a/packages/cozy-harvest-lib/src/datacards/GeoDataCard.jsx
+++ b/packages/cozy-harvest-lib/src/datacards/GeoDataCard.jsx
@@ -33,7 +33,7 @@ import FlagIcon from 'cozy-ui/transpiled/react/Icons/Flag'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Stack from 'cozy-ui/transpiled/react/Stack'
 
-import AppLinkCard, { AppLinkButton } from '../components/cards/AppLinkCard'
+import AppLinkCard from '../components/cards/AppLinkCard'
 import appLinksProps from '../components/KonnectorConfiguration/DataTab/appLinksProps'
 
 import useCycle from './useCycle'
@@ -261,11 +261,6 @@ const GeoDataCard = ({ trips, loading, konnector }) => {
       ) : (
         <TripsMap trips={trips} index={index} />
       )}
-      {flag('harvest.datacard.coachCO2') ? (
-        <div className="u-ta-right u-mv-half u-mh-1">
-          <AppLinkButton slug="coachco2" />
-        </div>
-      ) : null}
     </Card>
   )
 }
@@ -306,11 +301,16 @@ const DataGeoDataCard = ({ timeseriesCol, konnector }) => {
     return null
   }
   return (
-    <GeoDataCard
-      trips={ascendingTrips}
-      loading={isLoading}
-      konnector={konnector}
-    />
+    <>
+      <GeoDataCard
+        trips={ascendingTrips}
+        loading={isLoading}
+        konnector={konnector}
+      />
+      {flag('harvest.datacard.coachCO2') ? (
+        <AppLinkCard {...appLinksProps.coachco2()} />
+      ) : null}
+    </>
   )
 }
 

--- a/packages/cozy-harvest-lib/src/datacards/GeoDataCard.jsx
+++ b/packages/cozy-harvest-lib/src/datacards/GeoDataCard.jsx
@@ -214,7 +214,7 @@ const GeoDataCard = ({ trips, loading, konnector }) => {
   return (
     <Card className="u-ph-0 u-pb-0 u-ov-hidden">
       <div className="u-ph-1 u-mb-half">
-        <Typography variant="h5">{t('datacards.trips.title')}</Typography>
+        <Typography variant="h6">{t('datacards.trips.title')}</Typography>
         <Typography variant="caption">
           {t('datacards.trips.caption', { konnectorName: konnector.name })}
         </Typography>


### PR DESCRIPTION
We now:
- Do not display AppLinkButton for GeoCard
- Display the AppLinkCard below the DataGeoCard (it used to be above)