### PR TITLE
fix: Harvest Konnector translation

### DIFF
--- a/packages/cozy-harvest-lib/src/components/hoc/withKonnectorLocales.jsx
+++ b/packages/cozy-harvest-lib/src/components/hoc/withKonnectorLocales.jsx
@@ -6,13 +6,6 @@ import { extend } from 'cozy-ui/transpiled/react/I18n'
 import { getDisplayName } from './utils'
 
 /**
- * Index of konnectors which locales have already extended the I18n.
- * For now we are not supposed to update konnector locales at runtime and we
- * should just load them once for all.
- */
-const loadedKonnectors = []
-
-/**
  * HOC which ensures that a component get extended I18n with locales data from
  * konnector manifest.
  */
@@ -21,15 +14,11 @@ export const withKonnectorLocales = Component => {
     constructor(props, context) {
       super(props, context)
       const { konnector, lang } = this.props
-      if (loadedKonnectors.includes(konnector.slug)) return
-
       const { locales } = konnector
       if (locales && lang) {
         extend(locales[lang])
-        loadedKonnectors.push(konnector.slug)
       }
     }
-
     render() {
       return <Component {...this.props} />
     }


### PR DESCRIPTION
Relying on of non "lifecycled" react variable
is pretty always a bad idea.

Here, we have a bad sync between runtime variable
and react state.

Now the I18n stuff is unmounted when we close the
Modal, but we didn't remove the konnector from
the already loaded konnector. The result was that
when we opened again the modal after having
closed it once, we didn't have the translation loaded.

Let's remove this stuff.