### PR TITLE
fix: Informations on readme

### DIFF
--- a/packages/cozy-flags/README.md
+++ b/packages/cozy-flags/README.md
@@ -45,10 +45,11 @@ The `FlagSwitcher` shows all flags in use and displays all
 flags in use.
 
 ```js
-import flag, { FlagSwitcher } from 'cozy-flags'
+import flag from 'cozy-flags'
+import FlagSwitcher from 'cozy-flags/dist/FlagSwitcher'
 
 if (process.env.NODE_ENV !== 'production'
-    && flag('switcher') === undefined) {
+    && flag('switcher') === null) {
     flag('switcher', true) // set default flag in dev mode
 }
 


### PR DESCRIPTION
- Import of FlagSwitcher:
  We could re-export from the index, to match the current doc, but that would cause a Breaking Change.
  I don't know if it's really better

- Condition of flag('switcher'):
  The condition does not return `undefined` but rather `null`
  (see: https://github.com/cozy/cozy-libs/blob/master/packages/cozy-flags/src/store.js#L35)