### PR TITLE
fix: Handle undefined this.konnector for OAuth connectors

### DIFF
--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -1,4 +1,5 @@
 import MicroEE from 'microee'
+import get from 'lodash/get'
 
 import Realtime from 'cozy-realtime'
 import flag from 'cozy-flags'
@@ -483,7 +484,7 @@ export class ConnectionFlow {
    */
   async launch({ autoSuccessTimer = true } = {}) {
     const computedAutoSuccessTimer =
-      autoSuccessTimer && !this.konnector.clientSide
+      autoSuccessTimer && !get(this, 'konnector.clientSide')
 
     logger.info('ConnectionFlow: Launching job...')
     this.setState({ status: PENDING })
@@ -501,7 +502,7 @@ export class ConnectionFlow {
 
     this.job = await launchTrigger(this.client, this.trigger)
 
-    if (this.konnector.clientSide) {
+    if (get(this, 'konnector.clientSide')) {
       logger.info(
         'This connector can be run by the launcher',
         this.konnector.slug


### PR DESCRIPTION
In ConnectionFlow, this.konnector can be undefined.
I don't see any justification for that but it won't have any
other nagative effect on the connector exection.

This causes a fatal error on all applications using
harvest and trying to configure an OAuth connector

This is a hotfix.
We will check why this variable is undefined in later investigation
