### PR TITLE
fix: Change timeout to get BI temporary token

### DIFF
--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -28,6 +28,7 @@ import logger from '../logger'
 
 const DECOUPLED_ERROR = 'decoupled'
 const ADDITIONAL_INFORMATION_NEEDED_ERROR = 'additionalInformationNeeded'
+const TEMP_TOKEN_TIMOUT_S = 60
 
 const getBIConnectionIdFromAccount = account =>
   get(account, 'data.auth.bi.connId')
@@ -86,7 +87,7 @@ const createTemporaryToken = async ({ client, konnector, account }) => {
     client,
     jobResponse.data.attributes,
     'result',
-    30 * 1000
+    TEMP_TOKEN_TIMOUT_S * 1000
   )
   return event.data.result
 }

--- a/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
@@ -321,7 +321,7 @@ describe('createOrUpdateBIConnection', () => {
         _id: 'job-id-1337'
       },
       'result',
-      30000
+      60000
     )
     expect(createBIConnection).toHaveBeenCalledWith(
       expect.any(Object),
@@ -350,7 +350,7 @@ describe('createOrUpdateBIConnection', () => {
         _id: 'job-id-1337'
       },
       'result',
-      30000
+      60000
     )
     expect(createBIConnection).toHaveBeenCalledWith(
       expect.any(Object),
@@ -393,7 +393,7 @@ describe('createOrUpdateBIConnection', () => {
         _id: 'job-id-1337'
       },
       'result',
-      30000
+      60000
     )
     expect(createBIConnection).not.toHaveBeenCalled()
     expect(updateBIConnection).toHaveBeenCalledWith(
@@ -440,7 +440,7 @@ describe('createOrUpdateBIConnection', () => {
         _id: 'job-id-1337'
       },
       'result',
-      30000
+      60000
     )
     expect(updateBIConnection).not.toHaveBeenCalled()
     expect(createBIConnection).toHaveBeenCalledWith(


### PR DESCRIPTION
In some (too many) case, BI can take more than 30s to give response.
This leads to timeout error message to the user which occur in their
first connection or when renewing their connection.
And since these errors occur in the browser, they are not visible
in our usual connector error dashboard.

We saw that when BI is long to respond, it takes usually 35s to 40s but
in most cases it takes 2s to 3s.
