### PR TITLE
feat: Use configured support address in UNKNOWN_ERROR message

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/__snapshots__/index.spec.jsx.snap
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/__snapshots__/index.spec.jsx.snap
@@ -80,7 +80,7 @@ exports[`AccountForm should render error 1`] = `
   onFocusCapture={[Function]}
   onKeyUp={[Function]}
 >
-  <withI18n(withKonnectorLocales(TriggerErrorInfo)
+  <withI18n(withClient(withKonnectorLocales(TriggerErrorInfo))
     className="u-mb-1"
     error={[Error: Test error]}
     konnector={

--- a/packages/cozy-harvest-lib/src/components/infos/TriggerErrorInfo.jsx
+++ b/packages/cozy-harvest-lib/src/components/infos/TriggerErrorInfo.jsx
@@ -4,8 +4,9 @@ import PropTypes from 'prop-types'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import Infos from 'cozy-ui/transpiled/react/Infos'
 import Typography from 'cozy-ui/transpiled/react/Typography'
+import { withClient } from 'cozy-client'
 
-import { getErrorLocale } from '../../helpers/konnectors'
+import { getErrorLocale, fetchSupportMail } from '../../helpers/konnectors'
 import withKonnectorLocales from '../hoc/withKonnectorLocales'
 import Markdown from '../Markdown'
 
@@ -18,8 +19,20 @@ import Markdown from '../Markdown'
  * deals mainly with translation concerns.
  */
 export class TriggerErrorInfo extends PureComponent {
+  state = {
+    supportMail: null
+  }
+  async componentDidMount() {
+    await this.loadSupportMail()
+  }
+  async loadSupportMail() {
+    const { client } = this.props
+    const supportMail = await fetchSupportMail(client)
+    this.setState({ supportMail })
+  }
   render() {
     const { className, error, konnector, t, action } = this.props
+    const { supportMail } = this.state
     return (
       <Infos
         className={className}
@@ -30,11 +43,19 @@ export class TriggerErrorInfo extends PureComponent {
             <Typography className="u-error" variant="h6" gutterBottom>
               {getErrorLocale(error, konnector, t, 'title')}
             </Typography>
-            <Typography variant="body1" component="div">
-              <Markdown
-                source={getErrorLocale(error, konnector, t, 'description')}
-              />
-            </Typography>
+            {supportMail ? (
+              <Typography variant="body1" component="div">
+                <Markdown
+                  source={getErrorLocale(
+                    error,
+                    konnector,
+                    t,
+                    'description',
+                    supportMail
+                  )}
+                />
+              </Typography>
+            ) : null}
           </>
         }
       />
@@ -48,4 +69,4 @@ TriggerErrorInfo.proptTypes = {
   t: PropTypes.func.isRequired
 }
 
-export default translate()(withKonnectorLocales(TriggerErrorInfo))
+export default translate()(withClient(withKonnectorLocales(TriggerErrorInfo)))

--- a/packages/cozy-harvest-lib/src/components/infos/TriggerErrorInfo.spec.js
+++ b/packages/cozy-harvest-lib/src/components/infos/TriggerErrorInfo.spec.js
@@ -33,7 +33,7 @@ describe('TriggerErrorInfo', () => {
 
   const setup = ({ props: optionProps } = {}) => {
     fakeClient = {
-      query: jest.fn()
+      fetchQueryAndGetFromState: jest.fn()
     }
     const root = render(
       <AppLike client={fakeClient}>
@@ -58,8 +58,8 @@ describe('TriggerErrorInfo', () => {
   })
 
   it('should render unknown error with configured mail support if any', () => {
-    fakeClient.query.mockResolvedValue({
-      data: { attributes: { support_address: 'test@address' } }
+    fakeClient.fetchQueryAndGetFromState.mockResolvedValue({
+      data: [{ attributes: { support_address: 'test@address' } }]
     })
     const { root } = setup({
       props: {

--- a/packages/cozy-harvest-lib/src/components/infos/TriggerErrorInfo.spec.js
+++ b/packages/cozy-harvest-lib/src/components/infos/TriggerErrorInfo.spec.js
@@ -16,6 +16,7 @@ const fixtures = {
 const tMock = jest.fn().mockImplementation(key => key)
 
 describe('TriggerErrorInfo', () => {
+  let fakeClient
   beforeAll(() => {
     jest.spyOn(console, 'error').mockImplementation(() => {})
   })
@@ -31,7 +32,9 @@ describe('TriggerErrorInfo', () => {
   }
 
   const setup = ({ props: optionProps } = {}) => {
-    const fakeClient = {}
+    fakeClient = {
+      query: jest.fn()
+    }
     const root = render(
       <AppLike client={fakeClient}>
         <TriggerErrorInfo {...props} {...optionProps} />
@@ -52,5 +55,17 @@ describe('TriggerErrorInfo', () => {
       }
     })
     expect(root.findByText('An unknown error has occurred.')).toBeTruthy()
+  })
+
+  it('should render unknown error with configured mail support if any', () => {
+    fakeClient.query.mockResolvedValue({
+      data: { attributes: { support_address: 'test@address' } }
+    })
+    const { root } = setup({
+      props: {
+        error: new Error('Something is undefined')
+      }
+    })
+    expect(root.findByText('test@address')).toBeTruthy()
   })
 })

--- a/packages/cozy-harvest-lib/src/helpers/konnectors.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectors.js
@@ -3,7 +3,11 @@ import has from 'lodash/has'
 import trim from 'lodash/trim'
 import { getBoundT } from '../locales'
 
+import { Q } from 'cozy-client'
+
 import * as accounts from './accounts'
+
+const DEFAULT_SUPPORT_MAIL = 'claude@cozycloud.cc'
 
 // Default name for base directory
 const DEFAULT_LOCALIZED_BASE_DIR = 'Administrative'
@@ -130,11 +134,18 @@ export class KonnectorJobError extends Error {
  * @param  {Func} suffixKey   What part of the error message should be returned, title or description
  * @return {String}           The error locale
  */
-export const getErrorLocale = (error, konnector, t, suffixKey) => {
+export const getErrorLocale = (
+  error,
+  konnector,
+  t,
+  suffixKey,
+  supportMail = DEFAULT_SUPPORT_MAIL
+) => {
   const defaultKey = 'error.job.UNKNOWN_ERROR'
   const translationVariables = {
     name: konnector.name || '',
-    link: konnector.vendor_link || ''
+    link: konnector.vendor_link || '',
+    supportMail
   }
 
   // not handled errors
@@ -156,9 +167,20 @@ export const getErrorLocale = (error, konnector, t, suffixKey) => {
   })
 }
 
-export const getErrorLocaleBound = (error, konnector, lang, suffixKey) => {
+export const fetchSupportMail = async client => {
+  const result = await client.query(Q('io.cozy.settings').getById('context'))
+  return get(result, 'data.attributes.support_address', DEFAULT_SUPPORT_MAIL)
+}
+
+export const getErrorLocaleBound = (
+  error,
+  konnector,
+  lang,
+  suffixKey,
+  supportMail
+) => {
   const t = getBoundT(lang)
-  return getErrorLocale(error, konnector, t, suffixKey)
+  return getErrorLocale(error, konnector, t, suffixKey, supportMail)
 }
 
 /**
@@ -364,5 +386,7 @@ export default {
   getLauncher,
   isRunnable,
   hasNewVersionAvailable,
-  needsFolder
+  needsFolder,
+  fetchSupportMail,
+  DEFAULT_SUPPORT_MAIL
 }

--- a/packages/cozy-harvest-lib/src/helpers/konnectors.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectors.js
@@ -3,7 +3,7 @@ import has from 'lodash/has'
 import trim from 'lodash/trim'
 import { getBoundT } from '../locales'
 
-import { Q } from 'cozy-client'
+import { Q, fetchPolicies } from 'cozy-client'
 
 import * as accounts from './accounts'
 
@@ -168,8 +168,14 @@ export const getErrorLocale = (
 }
 
 export const fetchSupportMail = async client => {
-  const result = await client.query(Q('io.cozy.settings').getById('context'))
-  return get(result, 'data.attributes.support_address', DEFAULT_SUPPORT_MAIL)
+  const result = await client.fetchQueryAndGetFromState({
+    definition: Q('io.cozy.settings').getById('context'),
+    options: {
+      as: 'contextSupportMail',
+      fetchPolicy: fetchPolicies.olderThan(60 * 60 * 1000)
+    }
+  })
+  return get(result, 'data[0].attributes.support_address', DEFAULT_SUPPORT_MAIL)
 }
 
 export const getErrorLocaleBound = (

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -155,7 +155,7 @@
       },
       "UNKNOWN_ERROR": {
         "title": "Connection error",
-        "description": "An unknown error has occurred. You can try to update your data. If the problem persists, please contact us at [claude@cozycloud.cc](mailto:claude@cozycloud.cc)."
+        "description": "An unknown error has occurred. You can try to update your data. If the problem persists, please contact us at [%{supportMail}](mailto:%{supportMail})."
       },
       "USER_ACTION_NEEDED": {
         "title": "Action needed on the provider's website",

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -151,7 +151,7 @@
       },
       "TERMS_VERSION_MISMATCH": {
         "title": "Latest Terms of Service non accepted",
-        "description": "%{name} seems to have updated its Terms Of Service. Please check that the service is up to date. It this error still occurs, please contact us at [contact@cozycloud.cc](mailto:contact@cozycloud.cc)."
+        "description": "%{name} seems to have updated its Terms Of Service. Please check that the service is up to date. It this error still occurs, please contact us at [%{supportMail}](mailto:%{supportMail})."
       },
       "UNKNOWN_ERROR": {
         "title": "Connection error",

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -151,7 +151,7 @@
       },
       "TERMS_VERSION_MISMATCH": {
         "title": "Nouvelles CGUs à accepter",
-        "description": "Il semblerait que %{name} ait mis à jour ses Conditions Générales d'Utilisation. Merci de vérifier que le service est à jour. Si l'erreur persiste, contacter nous via [contact@cozycloud.cc](mailto:contact@cozycloud.cc)."
+        "description": "Il semblerait que %{name} ait mis à jour ses Conditions Générales d'Utilisation. Merci de vérifier que le service est à jour. Si l'erreur persiste, contacter nous via [%{supportMail}](mailto:%{supportMail})."
       },
       "UNKNOWN_ERROR": {
         "title": "Erreur de Connexion",

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -155,7 +155,7 @@
       },
       "UNKNOWN_ERROR": {
         "title": "Erreur de Connexion",
-        "description": "Une erreur inconnue est survenue. Vous pouvez essayer de mettre à jour vos données. Si le problème persiste, n'hésitez pas à nous contacter via [claude@cozycloud.cc](mailto:claude@cozycloud.cc)."
+        "description": "Une erreur inconnue est survenue. Vous pouvez essayer de mettre à jour vos données. Si le problème persiste, n'hésitez pas à nous contacter via [%{supportMail}](mailto:%{supportMail})."
       },
       "USER_ACTION_NEEDED": {
         "title": "Action nécessaire chez le fournisseur",


### PR DESCRIPTION
This will display the expected support mail in the message according to
the context.

I had to convert the TriggerErrorInfo to a Component class since it now
needs asynchronous information from io.cozy.settings.

![image](https://user-images.githubusercontent.com/228695/146044811-31db1ed1-fad7-45ec-b061-81736b215490.png)

