### PR TITLE
feat: Add a check for flagship app in device-helper

### DIFF
--- a/packages/cozy-device-helper/src/index.js
+++ b/packages/cozy-device-helper/src/index.js
@@ -6,7 +6,8 @@ export {
   isMobileApp,
   isAndroid,
   isIOS,
-  isMobile
+  isMobile,
+  isFlagshipApp
 } from './platform'
 export { getDeviceName } from './device'
 export { checkApp, startApp } from './apps'

--- a/packages/cozy-device-helper/src/index.spec.js
+++ b/packages/cozy-device-helper/src/index.spec.js
@@ -7,7 +7,8 @@ import {
   hasDevicePlugin,
   hasInAppBrowserPlugin,
   hasSafariPlugin,
-  hasNetworkInformationPlugin
+  hasNetworkInformationPlugin,
+  isFlagshipApp
 } from './index'
 
 describe('platforms', () => {
@@ -35,6 +36,16 @@ describe('platforms', () => {
     expect(getPlatform()).toEqual('ios')
     window.cordova = { platformId: 'android' }
     expect(getPlatform()).toEqual('android')
+  })
+  it('should identify as a Flagship app webview', () => {
+    window.cozy = undefined
+    expect(isFlagshipApp()).toBeFalsy()
+    window.cozy = {}
+    expect(isFlagshipApp()).toBeFalsy()
+    window.cozy = { isFlagshipApp: '' }
+    expect(isFlagshipApp()).toBeFalsy()
+    window.cozy = { isFlagshipApp: true }
+    expect(isFlagshipApp()).toBeTruthy()
   })
 })
 

--- a/packages/cozy-device-helper/src/platform.js
+++ b/packages/cozy-device-helper/src/platform.js
@@ -23,3 +23,5 @@ export const isIOS = () =>
 
 // isMobile checks if the user is on a smartphone : native app or browser
 export const isMobile = () => isAndroid() || isIOS()
+
+export const isFlagshipApp = () => window.cozy?.isFlagshipApp


### PR DESCRIPTION
Naive check based on the belief that the react-native app will correctly inject a flag in the webview window