### PR TITLE
feat: Add new ESLint rule: default-param-last

### DIFF
--- a/packages/cozy-scanner/src/ScannerUpload.js
+++ b/packages/cozy-scanner/src/ScannerUpload.js
@@ -12,7 +12,7 @@ import { CozyFile } from 'cozy-doctypes'
 export const doUpload = async (
   imageURI,
   qualification,
-  name = '',
+  name = '', // eslint-disable-line default-param-last
   dirId,
   onConflict,
   contentType

--- a/packages/cozy-sharing/src/SharingBanner/helpers/QueryParameter.js
+++ b/packages/cozy-sharing/src/SharingBanner/helpers/QueryParameter.js
@@ -1,3 +1,4 @@
+/* eslint-disable default-param-last */
 const arrToObj = (obj = {}, [key, val = true]) => {
   obj[key] = decodeURIComponent(val)
   return obj

--- a/packages/cozy-sharing/src/state.js
+++ b/packages/cozy-sharing/src/state.js
@@ -1,3 +1,4 @@
+/* eslint-disable default-param-last */
 import get from 'lodash/get'
 
 const RECEIVE_SHARINGS = 'RECEIVE_SHARINGS'

--- a/packages/eslint-config-cozy-app/basics.js
+++ b/packages/eslint-config-cozy-app/basics.js
@@ -22,6 +22,7 @@ module.exports = {
       }
     ],
     'no-param-reassign': 'warn',
-    'spaced-comment': ['error', 'always']
+    'spaced-comment': ['error', 'always'],
+    'default-param-last': ['error']
   }
 }


### PR DESCRIPTION
BREAKING CHANGE:
To handle this new rule in your project,
there are three available ways, ranked from best to worst:

- Refactor your code so the rule is respecterd
- Disable the rule on files where refactoring is not possible
- Disable it for the entire project if too many files are concerned