### PR TITLE
fix(sharing): ShareButton should not pass I18n props to Cozy-UI Button

### DIFF
--- a/packages/cozy-sharing/src/ShareButton.jsx
+++ b/packages/cozy-sharing/src/ShareButton.jsx
@@ -12,12 +12,15 @@ import {
 
 export const ShareButton = withLocales(({ docId, useShortLabel, ...rest }) => {
   const { t } = useI18n()
-
+  const restProps = { ...rest, t: null, f: null, lang: null }
   return (
     <SharingContext.Consumer>
       {({ byDocId, documentType, isOwner }) => {
         return !byDocId[docId] ? (
-          <DumbShareButton label={t(`${documentType}.share.cta`)} {...rest} />
+          <DumbShareButton
+            label={t(`${documentType}.share.cta`)}
+            {...restProps}
+          />
         ) : isOwner(docId) ? (
           <SharedByMeButton
             label={
@@ -25,7 +28,7 @@ export const ShareButton = withLocales(({ docId, useShortLabel, ...rest }) => {
                 ? t(`${documentType}.share.shared`)
                 : t(`${documentType}.share.sharedByMe`)
             }
-            {...rest}
+            {...restProps}
           />
         ) : (
           <SharedWithMeButton
@@ -34,7 +37,7 @@ export const ShareButton = withLocales(({ docId, useShortLabel, ...rest }) => {
                 ? t(`${documentType}.share.shared`)
                 : t(`${documentType}.share.sharedWithMe`)
             }
-            {...rest}
+            {...restProps}
           />
         )
       }}

--- a/packages/cozy-sharing/src/ShareButton.spec.jsx
+++ b/packages/cozy-sharing/src/ShareButton.spec.jsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { ShareButton } from './ShareButton'
+
+jest.mock('cozy-ui/transpiled/react', () => ({
+  Button: props => {
+    if (props.t || props.t || props.lang) {
+      throw 'do not pass html button invalid props'
+    }
+    return <></>
+  }
+}))
+
+jest.mock('cozy-ui/transpiled/react/I18n', () => ({
+  useI18n: jest.fn().mockReturnValue({ t: jest.fn() })
+}))
+
+jest.mock('./withLocales', () =>
+  // eslint-disable-next-line react/display-name
+  Component => props => <>{Component(props)}</>
+)
+
+jest.mock('./context', () => ({
+  // eslint-disable-next-line react/display-name
+  Consumer: props => {
+    const Component = () => props.children({ byDocId: { docId: false } })
+    return <Component />
+  }
+}))
+
+describe('ShareButton', () => {
+  it('should not send incorrect props to CozyUI button', () => {
+    // When
+    const { container } = render(
+      <ShareButton
+        f="incorrect prop"
+        t="incorrect prop"
+        lang="incorrect prop"
+      />
+    )
+
+    // Then
+    expect(container).toBeDefined()
+  })
+})


### PR DESCRIPTION
Should remove those warnings in Drive:
<img width="1429" alt="Capture d’écran 2021-12-30 à 10 49 50" src="https://user-images.githubusercontent.com/8363334/147759925-0b4ce137-a088-4967-bfdf-3e8eaf1d9712.png">
