### PR TITLE
feat: Add codemods for Radio

### DIFF
--- a/packages/cozy-codemods/src/transforms/__testfixtures__/transform-radio.input.js
+++ b/packages/cozy-codemods/src/transforms/__testfixtures__/transform-radio.input.js
@@ -1,0 +1,8 @@
+import Radio from "cozy-ui/transpiled/react/Radio";
+;<Radio
+  value="radioValue1"
+  label="This is a radio button"
+  error={true}
+  disabled={false}
+  gutter={true}
+/>

--- a/packages/cozy-codemods/src/transforms/__testfixtures__/transform-radio.output.js
+++ b/packages/cozy-codemods/src/transforms/__testfixtures__/transform-radio.output.js
@@ -1,0 +1,6 @@
+import Radio from "cozy-ui/transpiled/react/Radios";
+import FormControlLabel from "cozy-ui/transpiled/react/FormControlLabel";
+<FormControlLabel
+  label="This is a radio button"
+  value="radioValue1"
+  control={<Radio disabled={false} color="secondary" edge="start" />} />

--- a/packages/cozy-codemods/src/transforms/__tests__/transform-radio.spec.js
+++ b/packages/cozy-codemods/src/transforms/__tests__/transform-radio.spec.js
@@ -1,0 +1,2 @@
+const defineTest = require('jscodeshift/dist/testUtils').defineTest
+defineTest(__dirname, 'transform-radio')

--- a/packages/cozy-codemods/src/transforms/transform-radio.js
+++ b/packages/cozy-codemods/src/transforms/transform-radio.js
@@ -1,0 +1,132 @@
+/**
+ * Original:
+ *  <Radio
+ *    value="radioValue1"
+ *    label="This is a radio button"
+ *    error={true}
+ *    disabled={false}
+ *    gutter={true}
+ *  />
+ * New :
+ *  <FormControlLabel
+ *    value="radioValue1"
+ *    label="This is a radio button"
+ *    control={<Radio disabled={false} color="secondary" edge="start" />}
+ *  />
+ */
+
+import remove from 'lodash/remove'
+import { imports } from '..'
+
+const getAttributeName = attribute => attribute?.name?.name
+const getAttributeValue = attribute => attribute?.value?.expression?.value
+const getAttribute = (attributes, name) =>
+  attributes.find(attribute => getAttributeName(attribute) === name)
+
+export default function transformRadio(file, api) {
+  var j = api.jscodeshift
+  const root = j(file.source)
+
+  imports.ensure(
+    root,
+    { default: 'FormControlLabel' },
+    'cozy-ui/transpiled/react/FormControlLabel'
+  )
+
+  root.find(j.ImportDeclaration).forEach(nodePath => {
+    if (nodePath.value.source.value === 'cozy-ui/transpiled/react/Radio') {
+      nodePath.value.source.value = 'cozy-ui/transpiled/react/Radios'
+      nodePath.value.source.raw = 'cozy-ui/transpiled/react/Radios'
+    }
+  })
+
+  const wrapRadioInFormControlLabel = () => {
+    root.findJSXElements('Radio').replaceWith(nodePath => {
+      const parentAttributeName =
+        nodePath?.parentPath?.parentPath?.value?.name?.name
+      const isInCompWithControlAttribute = parentAttributeName === 'control'
+
+      if (isInCompWithControlAttribute) {
+        return nodePath.value
+      }
+
+      const { attributes } = nodePath.node.openingElement
+      const valueAtttribute = getAttribute(attributes, 'value')
+      const labelAttribute = getAttribute(attributes, 'label')
+
+      const formControlLabelAttributes = [
+        j.jsxAttribute(
+          j.jsxIdentifier('control'),
+          j.jsxExpressionContainer(nodePath.value)
+        )
+      ]
+      if (valueAtttribute) {
+        formControlLabelAttributes.push(
+          j.jsxAttribute(j.jsxIdentifier('value'), valueAtttribute.value)
+        )
+      }
+      if (labelAttribute) {
+        formControlLabelAttributes.push(
+          j.jsxAttribute(j.jsxIdentifier('label'), labelAttribute.value)
+        )
+      }
+
+      const jsxFormControlLabel = j.jsxElement(
+        j.jsxOpeningElement(
+          j.jsxIdentifier('FormControlLabel'),
+          formControlLabelAttributes.reverse()
+        )
+      )
+      jsxFormControlLabel.selfClosing = true
+      jsxFormControlLabel.openingElement.selfClosing = true
+
+      remove(attributes, attribute => getAttributeName(attribute) === 'value')
+      remove(attributes, attribute => getAttributeName(attribute) === 'label')
+
+      return jsxFormControlLabel
+    })
+  }
+
+  const transformRadio = nodePath => {
+    const { attributes } = nodePath.node.openingElement
+
+    // add edge prop if previous Radio had no gutter prop
+    if (!getAttribute(attributes, 'gutter')) {
+      attributes.push(
+        j.jsxAttribute(j.jsxIdentifier('edge'), j.literal('start'))
+      )
+    }
+
+    attributes.forEach(attribute => {
+      // replace error={true} by color='secondary'
+      if (
+        getAttributeName(attribute) === 'error' &&
+        getAttributeValue(attribute) === true
+      ) {
+        attributes.push(
+          j.jsxAttribute(j.jsxIdentifier('color'), j.literal('secondary'))
+        )
+        remove(attributes, attribute => getAttributeName(attribute) === 'error')
+      }
+
+      // replace gutter={true} by edge='start'
+      // remove gutter={false}
+      if (getAttributeName(attribute) === 'gutter') {
+        if (getAttributeValue(attribute) === true) {
+          attributes.push(
+            j.jsxAttribute(j.jsxIdentifier('edge'), j.literal('start'))
+          )
+        }
+        remove(
+          attributes,
+          attribute => getAttributeName(attribute) === 'gutter'
+        )
+      }
+    })
+  }
+
+  root.findJSXElements('Radio').forEach(transformRadio)
+  wrapRadioInFormControlLabel()
+
+  return root.toSource()
+}


### PR DESCRIPTION
To be able to transform Radio button from old to new API
related to https://github.com/cozy/cozy-ui/pull/1976

Effect: 
```diff
- import Radio from 'cozy-ui/transpiled/react/Radio'
- <Radio
-   value="radioValue1"
-   label="This is a radio button"
-   error={true}
-   disabled={false}
-   gutter={true}
- />
+ import Radio from 'cozy-ui/transpiled/react/Radios'
+ <FormControlLabel
+   value="radioValue1"
+   label="This is a radio button"
+   control={<Radio disabled={false} color="secondary" edge="start" />}
+ />
```