### PR TITLE
feat: Secure initial handshake

### DIFF
--- a/packages/cozy-intent/package.json
+++ b/packages/cozy-intent/package.json
@@ -10,15 +10,15 @@
     "url": "https://github.com/cozy/cozy-libs/issues"
   },
   "dependencies": {
-    "cozy-device-helper": "^1.16.0",
-    "post-me": "0.4.5",
-    "typescript": "^4.5.2"
+    "cozy-device-helper": "1.16.0",
+    "post-me": "0.4.5"
   },
   "devDependencies": {
-    "@babel/core": "7.12.3",
-    "babel-preset-cozy-app": "2.0.1",
-    "eslint-config-cozy-app": "3.0.1",
-    "react": "17.0.2"
+    "@babel/core": "^7.12.3",
+    "babel-preset-cozy-app": "^2.0.1",
+    "eslint-config-cozy-app": "^4.0.0",
+    "react": "17.0.2",
+    "typescript": "^4.5.2"
   },
   "files": [
     "dist"

--- a/packages/cozy-intent/readme.md
+++ b/packages/cozy-intent/readme.md
@@ -24,7 +24,7 @@ The library needs to be installed both in the parent and the children applicatio
 
 ### Parent
 
-First, we need to provide a React context to our application. This requires no configuration at this moment.
+First, we need to provide a React context to our application. This requires a method object that will be available to all Webview children.
 
 ```tsx
 import React from 'react'
@@ -33,13 +33,15 @@ import { NativeIntentProvider } from 'cozy-webview'
 import { ReactNativeApp } from 'react-native-app'
 
 const MyNativeApp = () => (
-  <NativeIntentProvider>
+  <NativeIntentProvider localMethods={{
+    ping: () => console.log('pong'),
+  }}>
     <ReactNativeApp />
   </NativeIntentProvider>
 )
 ```
 
-Later, in a webview, we need to register a messenger and give it access to some methods. We need a ref object to the webview first.
+Later, in a webview, we need to register a messenger. We need a ref object to the webview first.
 
 ```tsx
 import React, { useEffect, useState } from 'react'
@@ -53,9 +55,7 @@ const MyWebview = () => {
 
   useEffect(() => {
     if (ref) {
-      nativeIntent.registerWebview(ref, {
-        ping: () => console.log('pong'),
-      })
+      nativeIntent.registerWebview(ref)
     }
   }, [ref, nativeIntent])
 

--- a/packages/cozy-intent/src/api/constants/numbers.json
+++ b/packages/cozy-intent/src/api/constants/numbers.json
@@ -1,4 +1,4 @@
 {
-  "maxAttempts": 50,
-  "attemptsInterval": 100
+  "attemptsInterval": 100,
+  "maxAttempts": 50
 }

--- a/packages/cozy-intent/src/api/constants/strings.json
+++ b/packages/cozy-intent/src/api/constants/strings.json
@@ -1,8 +1,10 @@
 {
-  "webviewNoProviderFound": "Your component must be in a <WebviewIntentProvider /> in order to call useWebviewIntent",
-  "nativeNoProviderFound": "Your component must be in a <NativeIntentProvider /> in order to call useNativeIntent",
-  "remoteHandleNotFound": "Remote handle returned undefined, could not call method",
-  "postMeSignature": "post-me",
   "flagshipButNoRNAPI": "<WebviewIntentProvider /> can not instantiate its service. The application was detected as running in a Flagship webview but has no access to `window.ReactNativeWebView`, which is contradictory.",
-  "noListenerFound": "Could not handle event, this `NativeMessenger` instance does not have a listener."
+  "nativeNoProviderFound": "Your component must be in a <NativeIntentProvider /> in order to call useNativeIntent",
+  "noListenerFound": "Could not handle event, this `NativeMessenger` instance does not have a listener.",
+  "noRNAPIFound": "You tried to send a synchronous message to a React Native listener, but no React Native API was found in the DOM. Are you in a webview?",
+  "postMeSignature": "post-me",
+  "remoteHandleNotFound": "Remote handle returned undefined, could not call method",
+  "webviewIsRendered": "webviewIsRendered",
+  "webviewNoProviderFound": "Your component must be in a <WebviewIntentProvider /> in order to call useWebviewIntent"
 }

--- a/packages/cozy-intent/src/api/services/NativeMessenger.ts
+++ b/packages/cozy-intent/src/api/services/NativeMessenger.ts
@@ -2,6 +2,7 @@ import { Messenger } from 'post-me'
 
 import { MessageListener, ListenerRemover } from '../models/messengers'
 import { NativeEvent } from '../models/events'
+import { StaticService } from './StaticService'
 import { Strings } from '../constants'
 import { WebviewRef } from '../models/environments'
 
@@ -27,7 +28,7 @@ export class NativeMessenger implements Messenger {
   }
 
   public onMessage = (event: NativeEvent): void => {
-    const data = <Record<string, unknown>>JSON.parse(event.nativeEvent.data)
+    const data = StaticService.parseNativeEvent(event)
 
     if (!this.listener) throw new Error(Strings.noListenerFound)
 

--- a/packages/cozy-intent/src/api/services/StaticService.ts
+++ b/packages/cozy-intent/src/api/services/StaticService.ts
@@ -1,0 +1,33 @@
+import { Strings } from '../../api/constants'
+import { WebviewRef } from '../../api/models/environments'
+import { NativeEvent } from '../../api/models/events'
+import { TypeguardService } from './TypeguardService'
+
+export const StaticService = {
+  sendSyncMessage(message: string): void {
+    if (!TypeguardService.hasReactNativeAPI(window))
+      throw new Error(Strings.noRNAPIFound)
+
+    return window.ReactNativeWebView.postMessage(
+      JSON.stringify({
+        signature: Strings.postMeSignature,
+        uri: window.location.hostname,
+        message
+      })
+    )
+  },
+
+  getUri(source: WebviewRef | NativeEvent): string {
+    return TypeguardService.isWebviewRef(source)
+      ? new URL(source.props.source.uri).hostname
+      : new URL(source.nativeEvent.url).hostname
+  },
+
+  parseNativeEvent({ nativeEvent }: NativeEvent): Record<string, string> {
+    return <Record<string, string>>JSON.parse(nativeEvent.data)
+  },
+
+  isPostMeMessage({ nativeEvent }: NativeEvent): boolean {
+    return nativeEvent.data.includes(Strings.postMeSignature)
+  }
+}

--- a/packages/cozy-intent/src/api/services/TypeguardService.ts
+++ b/packages/cozy-intent/src/api/services/TypeguardService.ts
@@ -1,0 +1,17 @@
+import { NativeEvent } from '../../api/models/events'
+import { WebviewRef, WebviewWindow } from '../../api/models/environments'
+
+export const TypeguardService = {
+  hasReactNativeAPI(window: Window): window is WebviewWindow {
+    return (window as WebviewWindow).ReactNativeWebView !== undefined
+  },
+  isWebviewRef(object: unknown): object is WebviewRef {
+    return (object as WebviewRef).injectJavaScript !== undefined
+  },
+  isNativeEvent(object: unknown): object is NativeEvent {
+    return (object as NativeEvent).nativeEvent !== undefined
+  },
+  isWebviewWindow(window: Window): window is WebviewWindow {
+    return (window as WebviewWindow).ReactNativeWebView !== undefined
+  }
+}

--- a/packages/cozy-intent/src/view/components/NativeIntentProvider.tsx
+++ b/packages/cozy-intent/src/view/components/NativeIntentProvider.tsx
@@ -1,14 +1,19 @@
 import React, { ReactElement } from 'react'
 
 import { NativeContext } from '../contexts/NativeContext'
+import { NativeMethodsRegister } from '../../api/models/methods'
 import { NativeService } from '../../api/services/NativeService'
 
 interface Props {
   children: React.ReactChild
+  localMethods: NativeMethodsRegister
 }
 
-export const NativeIntentProvider = ({ children }: Props): ReactElement => (
-  <NativeContext.Provider value={new NativeService()}>
+export const NativeIntentProvider = ({
+  children,
+  localMethods
+}: Props): ReactElement => (
+  <NativeContext.Provider value={new NativeService(localMethods)}>
     {children}
   </NativeContext.Provider>
 )

--- a/packages/cozy-intent/src/view/components/WebviewIntentProvider.tsx
+++ b/packages/cozy-intent/src/view/components/WebviewIntentProvider.tsx
@@ -4,18 +4,15 @@ import { ChildHandshake, Connection, EventsType, MethodsType } from 'post-me'
 import { isFlagshipApp } from 'cozy-device-helper'
 
 import { NativeMethodsRegister } from '../../api/models/methods'
+import { StaticService } from '../../api/services/StaticService'
 import { Strings } from '../../api/constants'
+import { TypeguardService } from '../../api/services/TypeguardService'
 import { WebviewContext } from '../contexts/WebviewContext'
 import { WebviewMessenger } from '../../api/services/WebviewMessenger'
 import { WebviewService } from '../../api/services/WebviewService'
-import { WebviewWindow } from '../../api/models/environments'
 
 interface Props {
   children: React.ReactChild
-}
-
-function isWebviewWindow(window: Window): window is WebviewWindow {
-  return (window as WebviewWindow).ReactNativeWebView !== undefined
 }
 
 export const WebviewIntentProvider = ({ children }: Props): ReactElement => {
@@ -25,8 +22,13 @@ export const WebviewIntentProvider = ({ children }: Props): ReactElement => {
     >()
 
   useEffect(() => {
+    if (connection) return
+
     const init = async (): Promise<void> => {
-      if (!isWebviewWindow(window)) throw new Error(Strings.flagshipButNoRNAPI)
+      if (!TypeguardService.isWebviewWindow(window))
+        throw new Error(Strings.flagshipButNoRNAPI)
+
+      StaticService.sendSyncMessage(Strings.webviewIsRendered)
 
       const result = await ChildHandshake(new WebviewMessenger(window))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7410,13 +7410,6 @@ cozy-client@23.19.1:
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
-cozy-device-helper@1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.15.0.tgz#1e2436b6459544cc68b0a87a66ed9eb65277a345"
-  integrity sha512-nDWXofI/dHoqVkiWFqib4W4hyRPOyTi5BfSyaiIhK1qt6niY6m0PVYDu/oI27goR+poCzlByApqShXbxXvOVyA==
-  dependencies:
-    lodash "^4.17.19"
-
 cozy-doctypes@1.67.0:
   version "1.67.0"
   resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.67.0.tgz#2e26cf43556cff298d0eec2f06091d15dc1758da"


### PR DESCRIPTION
Implement secured sync-like handshake initiated by the children when it is ready (this will resolve failed handshake when the Webview takes too long to render)

Implement single localMethods object in ReactNative IntentProvider. All children will use the same method object. This allows all Webviews to call all exposed methods.