### PR TITLE
feat(renovate): Add labels dependencies on renovate PR

### DIFF
--- a/packages/renovate-config-cozy/package.json
+++ b/packages/renovate-config-cozy/package.json
@@ -19,6 +19,7 @@
         }
       ],
       "timezone": "Europe/Paris",
+      "addLabels": ["dependencies"],
       "updateNotScheduled": false
     }
   },


### PR DESCRIPTION
To be able to filter dependencies PR, I suggest renovate add a label called "dependencies"

I follow this documentation:
https://docs.renovatebot.com/configuration-options/#addlabel

Tested in my personal repository:
https://github.com/trollepierre/recontact_travel_blog/blob/dev/.github/renovate.json

And the created PR:
https://github.com/trollepierre/recontact_travel_blog/pull/903