### PR TITLE
feat: Add `app` parameter to `cozy-intent`'s `openApp` method

### DIFF
--- a/packages/cozy-intent/src/api/models/applications.ts
+++ b/packages/cozy-intent/src/api/models/applications.ts
@@ -1,0 +1,20 @@
+/** App's description resulting of its manifest.webapp file */
+export interface AppManifest {
+  /** The app's slug */
+  slug: string
+
+  /** The app's mobile information */
+  mobile: AppManifestMobileInfo
+}
+
+/** App's mobile information. Used to describe the app scheme and its store urls */
+export interface AppManifestMobileInfo {
+  /** The app's URL scheme */
+  schema: string
+
+  /** The app's id on Google PlayStore */
+  id_playstore: string
+
+  /** The app's id on Apple AppStore */
+  id_appstore: string
+}

--- a/packages/cozy-intent/src/api/models/methods.ts
+++ b/packages/cozy-intent/src/api/models/methods.ts
@@ -1,4 +1,6 @@
+import { AppManifest } from './applications'
+
 export type NativeMethodsRegister = {
   logout: () => Promise<void>
-  openApp: (href: string) => Promise<void>
+  openApp: (href: string, app: AppManifest) => Promise<void>
 }


### PR DESCRIPTION
Sender can now send app data to the native host in order to open the
native app when available instead of its webview version

---

Related PRs: 
- https://github.com/cozy/cozy-ui/pull/2015
- https://github.com/cozy/cozy-react-native/pull/65