### PR TITLE
fix: Pin @babel/core version

### DIFF
--- a/packages/cozy-intent/package.json
+++ b/packages/cozy-intent/package.json
@@ -14,7 +14,7 @@
     "post-me": "0.4.5"
   },
   "devDependencies": {
-    "@babel/core": "^7.12.3",
+    "@babel/core": "7.12.3",
     "babel-preset-cozy-app": "^2.0.1",
     "eslint-config-cozy-app": "^4.0.0",
     "react": "17.0.2",


### PR DESCRIPTION
This fixes mismatched versions with other packages
when installing cozy-libs in local env