### PR TITLE
Feat: Add unregisterWebview method in cozy-intent NativeServices 

### DIFF
--- a/packages/cozy-intent/src/api/services/NativeService.spec.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.spec.ts
@@ -59,7 +59,9 @@ describe('NativeMessenger', () => {
       nativeService.tryEmit({
         nativeEvent: { data: '{"source": "post-me"}', url: 'http://SOME_URI' }
       })
-    ).rejects.toThrow()
+    ).rejects.toThrow(
+      `Cannot emit message. No webview is registered with uri: some_uri`
+    )
   })
 
   describe('registerWebview', () => {

--- a/packages/cozy-intent/src/api/services/NativeService.spec.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.spec.ts
@@ -1,0 +1,140 @@
+import { WebviewRef } from '../models/environments'
+import { NativeEvent } from '../models/events'
+import { NativeMethodsRegister } from '../models/methods'
+import { NativeMessenger } from '../services/NativeMessenger'
+import { NativeService } from './NativeService'
+
+jest.mock('../services/NativeMessenger')
+
+const onMessageMock = jest.fn()
+class MockNativeMessenger extends NativeMessenger {
+  constructor(webviewRef: WebviewRef) {
+    super(webviewRef)
+  }
+
+  public postMessage = jest.fn()
+
+  public addMessageListener = jest.fn()
+
+  public onMessage = (event: NativeEvent): void => {
+    onMessageMock(event)
+  }
+}
+
+describe('NativeMessenger', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('Should allow to register and unregister webviews', async () => {
+    const nativeMethods: NativeMethodsRegister = {
+      logout: jest.fn(),
+      openApp: jest.fn()
+    }
+
+    const webviewRef: WebviewRef = {
+      injectJavaScript: jest.fn(),
+      props: {
+        source: {
+          uri: 'http://SOME_URI'
+        }
+      }
+    }
+
+    const nativeService = new NativeService(nativeMethods, MockNativeMessenger)
+
+    nativeService.registerWebview(webviewRef)
+
+    await nativeService.tryEmit({
+      nativeEvent: { data: '{"source": "post-me"}', url: 'http://SOME_URI' }
+    })
+
+    expect(onMessageMock).toHaveBeenNthCalledWith(1, {
+      nativeEvent: { data: '{"source": "post-me"}', url: 'http://SOME_URI' }
+    })
+
+    nativeService.unregisterWebview(webviewRef)
+
+    await expect(
+      nativeService.tryEmit({
+        nativeEvent: { data: '{"source": "post-me"}', url: 'http://SOME_URI' }
+      })
+    ).rejects.toThrow()
+  })
+
+  describe('registerWebview', () => {
+    it('Should allow to register a webview', () => {
+      const nativeMethods: NativeMethodsRegister = {
+        logout: jest.fn(),
+        openApp: jest.fn()
+      }
+
+      const webviewRef: WebviewRef = {
+        injectJavaScript: jest.fn(),
+        props: {
+          source: {
+            uri: 'http://SOME_URI'
+          }
+        }
+      }
+
+      const nativeService = new NativeService(nativeMethods)
+
+      nativeService.registerWebview(webviewRef)
+
+      expect(NativeMessenger).toHaveBeenNthCalledWith(1, webviewRef)
+    })
+
+    it('Should throw if registering two times the same webview', () => {
+      const nativeMethods: NativeMethodsRegister = {
+        logout: jest.fn(),
+        openApp: jest.fn()
+      }
+
+      const webviewRef: WebviewRef = {
+        injectJavaScript: jest.fn(),
+        props: {
+          source: {
+            uri: 'http://SOME_URI'
+          }
+        }
+      }
+
+      const nativeService = new NativeService(nativeMethods)
+
+      nativeService.registerWebview(webviewRef)
+
+      expect(() => {
+        nativeService.registerWebview(webviewRef)
+      }).toThrow(
+        'Cannot register webview. A webview is already registered into cozy-intent with the uri: some_uri'
+      )
+    })
+  })
+
+  describe('unregisterWebview', () => {
+    it('Should throw if unregistering not registered webview', () => {
+      const nativeMethods: NativeMethodsRegister = {
+        logout: jest.fn(),
+        openApp: jest.fn()
+      }
+
+      const webviewRef: WebviewRef = {
+        injectJavaScript: jest.fn(),
+        props: {
+          source: {
+            uri: 'http://SOME_URI'
+          }
+        }
+      }
+
+      const nativeService = new NativeService(nativeMethods)
+
+      expect(() => {
+        nativeService.unregisterWebview(webviewRef)
+      }).toThrow(
+        'Cannot unregister webview. No webview is registered into cozy-intent with the uri: some_uri'
+      )
+    })
+  })
+})

--- a/packages/cozy-intent/src/api/services/NativeService.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.ts
@@ -58,11 +58,19 @@ export class NativeService {
 
     const { message, uri } = StaticService.parseNativeEvent(event)
 
-    if (message === Strings.webviewIsRendered)
+    if (message === Strings.webviewIsRendered) {
       await this.initWebview(this.messengerRegister[uri].messenger)
-    else
-      this.messengerRegister[StaticService.getUri(event)].messenger.onMessage(
-        event
-      )
+    } else {
+      const webviewUri = StaticService.getUri(event)
+      const registeredWebview = this.messengerRegister[webviewUri]
+
+      if (registeredWebview === undefined) {
+        throw new Error(
+          `Cannot emit message. No webview is registered with uri: ${webviewUri}`
+        )
+      }
+
+      this.messengerRegister[webviewUri].messenger.onMessage(event)
+    }
   }
 }

--- a/packages/cozy-intent/src/api/services/NativeService.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.ts
@@ -21,7 +21,11 @@ export class NativeService {
   public registerWebview = (webviewRef: WebviewRef): void => {
     const uri = StaticService.getUri(webviewRef)
 
-    if (this.messengerRegister[uri]) return
+    if (this.messengerRegister[uri]) {
+      throw new Error(
+        `Cannot register webview. A webview is already registered into cozy-intent with the uri: ${uri}`
+      )
+    }
 
     this.messengerRegister = {
       ...this.messengerRegister,

--- a/packages/cozy-intent/src/api/services/NativeService.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.ts
@@ -9,12 +9,16 @@ import { Strings } from '../constants'
 import { WebviewRef } from '../models/environments'
 
 export class NativeService {
-  private messengerService = NativeMessenger
+  private messengerService: typeof NativeMessenger
 
   private localMethods: NativeMethodsRegister
   private messengerRegister = {} as MessengerRegister
 
-  constructor(localMethods: NativeMethodsRegister) {
+  constructor(
+    localMethods: NativeMethodsRegister,
+    messengerService = NativeMessenger
+  ) {
+    this.messengerService = messengerService
     this.localMethods = localMethods
   }
 

--- a/packages/cozy-intent/src/api/services/NativeService.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.ts
@@ -9,9 +9,9 @@ import { Strings } from '../constants'
 import { WebviewRef } from '../models/environments'
 
 export class NativeService {
-  private messengerService: typeof NativeMessenger
+  private readonly messengerService: typeof NativeMessenger
 
-  private localMethods: NativeMethodsRegister
+  private readonly localMethods: NativeMethodsRegister
   private messengerRegister = {} as MessengerRegister
 
   constructor(

--- a/packages/cozy-intent/src/api/services/NativeService.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.ts
@@ -33,6 +33,18 @@ export class NativeService {
     }
   }
 
+  public unregisterWebview = (webviewRef: WebviewRef): void => {
+    const uri = StaticService.getUri(webviewRef)
+
+    if (!this.messengerRegister[uri]) {
+      throw new Error(
+        `Cannot unregister webview. No webview is registered into cozy-intent with the uri: ${uri}`
+      )
+    }
+
+    delete this.messengerRegister[uri]
+  }
+
   private initWebview = async (
     messenger: NativeMessenger
   ): Promise<Connection> => await ParentHandshake(messenger, this.localMethods)


### PR DESCRIPTION
This PR does two things in cozy-intent:
- Edit `registerWebview` behavior to throw an error if duplicate uri is detected
  - This replaces old behavior that only did a silent return
  - We prefer to throw an error on those case in order to highlight lifecycle problems
-  Add a `unregisterWebview` method si webviews can unregister themselves when unmounted
  - Without this method it would not be possible for a webview to register itself again after being re-rendered (if previously unmounted