### PR TITLE
fix(renovate): use fix as commit type of renovate PR

### DIFF
--- a/packages/renovate-config-cozy/package.json
+++ b/packages/renovate-config-cozy/package.json
@@ -5,7 +5,8 @@
   "renovate-config": {
     "default": {
       "extends": [
-        "config:base"
+        "config:base",
+        ":semanticCommitTypeAll(fix)"
       ],
       "rangeStrategy": "pin",
       "packageRules": [


### PR DESCRIPTION
We would like to use "fix" as commit type of renovate PR.
According to https://docs.renovatebot.com/semantic-commits/ ,
changing the Semantic Commit type is possible by extending
":semanticCommitTypeAll(fix)" to your extends array.
PR titles and commit messages start with "fix(deps):"