### PR TITLE
feat: Add the defaultFolderPath attribute to the account

### DIFF
--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -492,7 +492,7 @@ export class ConnectionFlow {
    * Add a default folder path to the account if any folder is needed by the connector
    * and/or the account does not have it yet.
    * The account is saved if any change is done to it.
-   * This defaultFolderPath is needed by the stack te recreate the destination folder this
+   * This defaultFolderPath is needed by the stack to recreate the destination folder.
    * had beed removed by any mean : drive application, desktop application etc
    *
    * @param  {CozyClient} client - A cozy client

--- a/packages/cozy-harvest-lib/test/fixtures.js
+++ b/packages/cozy-harvest-lib/test/fixtures.js
@@ -125,6 +125,20 @@ const fixtures = {
       }
     }
   },
+  createdTriggerWithFolder: {
+    id: 'created-trigger-id',
+    _type: 'io.cozy.triggers',
+    attributes: {
+      arguments: '0 0 0 * * 0',
+      type: '@cron',
+      worker: 'konnector',
+      message: {
+        account: 'updated-account-id',
+        konnector: 'konnectest',
+        folder_to_save: 'folder-id'
+      }
+    }
+  },
   launchedJob: {
     type: 'io.cozy.jobs',
     _id: 'lauched-job-id',


### PR DESCRIPTION
This defaultFolderPath attribute will be used by the stack recreate the
connector's destination folder if it has been removed by the user.
