### PR TITLE
feat: Ensure isFlagshipApp returns a boolean value

### DIFF
--- a/packages/cozy-device-helper/src/index.spec.js
+++ b/packages/cozy-device-helper/src/index.spec.js
@@ -1,53 +1,9 @@
 import {
-  isWebApp,
-  isMobileApp,
-  isIOSApp,
-  isAndroidApp,
-  getPlatform,
   hasDevicePlugin,
   hasInAppBrowserPlugin,
   hasSafariPlugin,
-  hasNetworkInformationPlugin,
-  isFlagshipApp
+  hasNetworkInformationPlugin
 } from './index'
-
-describe('platforms', () => {
-  it('should identify is a web application', () => {
-    expect(isWebApp()).toBeTruthy()
-  })
-  it('should identify is a mobile application', () => {
-    window.cordova = true
-    expect(isMobileApp()).toBeTruthy()
-    window.cordova = undefined
-    expect(isMobileApp()).toBeFalsy()
-  })
-  it('should identify is an iOS or Android application', () => {
-    window.cordova = { platformId: 'ios' }
-    expect(isIOSApp()).toBeTruthy()
-    expect(isAndroidApp()).toBeFalsy()
-    window.cordova = { platformId: 'android' }
-    expect(isIOSApp()).toBeFalsy()
-    expect(isAndroidApp()).toBeTruthy()
-  })
-  it('should return platform', () => {
-    window.cordova = undefined
-    expect(getPlatform()).toEqual('web')
-    window.cordova = { platformId: 'ios' }
-    expect(getPlatform()).toEqual('ios')
-    window.cordova = { platformId: 'android' }
-    expect(getPlatform()).toEqual('android')
-  })
-  it('should identify as a Flagship app webview', () => {
-    window.cozy = undefined
-    expect(isFlagshipApp()).toBeFalsy()
-    window.cozy = {}
-    expect(isFlagshipApp()).toBeFalsy()
-    window.cozy = { isFlagshipApp: '' }
-    expect(isFlagshipApp()).toBeFalsy()
-    window.cozy = { isFlagshipApp: true }
-    expect(isFlagshipApp()).toBeTruthy()
-  })
-})
 
 describe('cordova plugins', () => {
   it('should identify has device plugin', () => {

--- a/packages/cozy-device-helper/src/platform.js
+++ b/packages/cozy-device-helper/src/platform.js
@@ -24,4 +24,4 @@ export const isIOS = () =>
 // isMobile checks if the user is on a smartphone : native app or browser
 export const isMobile = () => isAndroid() || isIOS()
 
-export const isFlagshipApp = () => window.cozy?.isFlagshipApp
+export const isFlagshipApp = () => Boolean(window.cozy?.isFlagshipApp)

--- a/packages/cozy-device-helper/src/platform.spec.js
+++ b/packages/cozy-device-helper/src/platform.spec.js
@@ -1,0 +1,46 @@
+import {
+  isWebApp,
+  isMobileApp,
+  isIOSApp,
+  isAndroidApp,
+  getPlatform,
+  isFlagshipApp
+} from './platform'
+
+describe('platforms', () => {
+  it('should identify is a web application', () => {
+    expect(isWebApp()).toBeTruthy()
+  })
+  it('should identify is a mobile application', () => {
+    window.cordova = true
+    expect(isMobileApp()).toBeTruthy()
+    window.cordova = undefined
+    expect(isMobileApp()).toBeFalsy()
+  })
+  it('should identify is an iOS or Android application', () => {
+    window.cordova = { platformId: 'ios' }
+    expect(isIOSApp()).toBeTruthy()
+    expect(isAndroidApp()).toBeFalsy()
+    window.cordova = { platformId: 'android' }
+    expect(isIOSApp()).toBeFalsy()
+    expect(isAndroidApp()).toBeTruthy()
+  })
+  it('should return platform', () => {
+    window.cordova = undefined
+    expect(getPlatform()).toEqual('web')
+    window.cordova = { platformId: 'ios' }
+    expect(getPlatform()).toEqual('ios')
+    window.cordova = { platformId: 'android' }
+    expect(getPlatform()).toEqual('android')
+  })
+  it('should identify as a Flagship app webview', () => {
+    window.cozy = undefined
+    expect(isFlagshipApp()).toBe(false)
+    window.cozy = {}
+    expect(isFlagshipApp()).toBe(false)
+    window.cozy = { isFlagshipApp: '' }
+    expect(isFlagshipApp()).toBe(false)
+    window.cozy = { isFlagshipApp: true }
+    expect(isFlagshipApp()).toBe(true)
+  })
+})


### PR DESCRIPTION
It's less confusing to rely on strict boolean retrn value instead of true|falsy value