### PR TITLE
feat: Send context to cozy-bar if it exists

### DIFF
--- a/packages/cozy-intent/src/api/models/applications.ts
+++ b/packages/cozy-intent/src/api/models/applications.ts
@@ -1,3 +1,5 @@
+import { WebviewService } from '../../api/services/WebviewService'
+
 /** App's description resulting of its manifest.webapp file */
 export interface AppManifest {
   /** The app's slug */
@@ -17,4 +19,10 @@ export interface AppManifestMobileInfo {
 
   /** The app's id on Apple AppStore */
   id_appstore: string
+}
+
+export interface CozyBar {
+  bar?: {
+    setWebviewContext?: (webviewContext: WebviewService) => void
+  }
 }

--- a/packages/cozy-intent/src/api/models/environments.ts
+++ b/packages/cozy-intent/src/api/models/environments.ts
@@ -1,3 +1,7 @@
+import { Connection, EventsType, MethodsType } from 'post-me'
+
+import { NativeMethodsRegister } from './methods'
+
 export interface WebviewRef {
   injectJavaScript: (data: string) => void
   props: {
@@ -12,3 +16,10 @@ export interface WebviewWindow extends Window {
     postMessage: (message: string) => void
   }
 }
+
+export type WebviewConnection = Connection<
+  MethodsType,
+  EventsType,
+  NativeMethodsRegister,
+  EventsType
+>

--- a/packages/cozy-intent/src/api/models/methods.ts
+++ b/packages/cozy-intent/src/api/models/methods.ts
@@ -3,4 +3,5 @@ import { AppManifest } from './applications'
 export type NativeMethodsRegister = {
   logout: () => Promise<void>
   openApp: (href: string, app: AppManifest) => Promise<void>
+  backToHome: () => void
 }

--- a/packages/cozy-intent/src/api/services/StaticService.ts
+++ b/packages/cozy-intent/src/api/services/StaticService.ts
@@ -1,7 +1,10 @@
-import { Strings } from '../../api/constants'
-import { WebviewRef } from '../../api/models/environments'
+import { Connection, ChildHandshake } from 'post-me'
+
 import { NativeEvent } from '../../api/models/events'
+import { Strings } from '../../api/constants'
 import { TypeguardService } from './TypeguardService'
+import { WebviewMessenger } from './WebviewMessenger'
+import { WebviewRef } from '../../api/models/environments'
 
 export const StaticService = {
   sendSyncMessage(message: string): void {
@@ -29,5 +32,18 @@ export const StaticService = {
 
   isPostMeMessage({ nativeEvent }: NativeEvent): boolean {
     return nativeEvent.data.includes(Strings.postMeSignature)
+  },
+
+  async getConnection(
+    callBack: (connection: Connection) => void
+  ): Promise<void> {
+    if (!TypeguardService.isWebviewWindow(window))
+      throw new Error(Strings.flagshipButNoRNAPI)
+
+    StaticService.sendSyncMessage(Strings.webviewIsRendered)
+
+    const result = await ChildHandshake(new WebviewMessenger(window))
+
+    callBack(result)
   }
 }

--- a/packages/cozy-intent/src/tests/mocks.ts
+++ b/packages/cozy-intent/src/tests/mocks.ts
@@ -1,9 +1,10 @@
-import { isFlagshipApp } from 'cozy-device-helper'
 import { ChildHandshake } from 'post-me'
 
-import { WebviewWindow } from '../api/models/environments'
+import { isFlagshipApp } from 'cozy-device-helper'
+
 import { WebviewMessenger } from '../api/services/WebviewMessenger'
 import { WebviewService } from '../api/services/WebviewService'
+import { WebviewWindow } from '../api/models/environments'
 
 export class MockWebviewMessenger extends WebviewMessenger {}
 
@@ -32,3 +33,11 @@ export const mockWebviewService = new MockWebviewService(mockConnection)
 export const mockIsFlagshipApp = isFlagshipApp as jest.Mock
 
 export const mockChildHandshake = ChildHandshake as jest.Mock
+
+export const mockSetWebviewContext = jest.fn()
+
+export const mockCozyBar = {
+  bar: {
+    setWebviewContext: mockSetWebviewContext
+  }
+}

--- a/packages/cozy-intent/src/view/components/WebviewIntentProvider.spec.tsx
+++ b/packages/cozy-intent/src/view/components/WebviewIntentProvider.spec.tsx
@@ -1,18 +1,29 @@
-import React from 'react'
-import { render, screen } from '@testing-library/react'
 import 'mutationobserver-shim'
+import React from 'react'
+import { render } from '@testing-library/react'
 
+import { CozyBar } from '../../api/models/applications'
 import { WebviewIntentProvider } from './WebviewIntentProvider'
+import { WebviewService } from '../../api/services/WebviewService'
+
 import {
-  mockWebviewWindow,
   mockChildHandshake,
   mockConnection,
+  mockCozyBar,
   mockIsFlagshipApp,
-  mockWebviewService
+  mockSetWebviewContext,
+  mockWebviewService,
+  mockWebviewWindow
 } from '../../tests/mocks'
 
 // eslint-disable-next-line no-global-assign
 window = mockWebviewWindow()
+
+declare const global: {
+  cozy?: CozyBar
+}
+
+global.cozy = mockCozyBar
 
 jest.mock('cozy-device-helper', () => ({
   isFlagshipApp: jest.fn()
@@ -30,33 +41,86 @@ describe('WebviewIntentProvider', () => {
   afterEach(() => {
     mockChildHandshake.mockClear()
     mockIsFlagshipApp.mockClear()
+    mockSetWebviewContext.mockClear()
   })
 
-  it('renders with no AA context', () => {
+  it('renders with no AA context', async () => {
     mockIsFlagshipApp.mockReturnValue(false)
 
-    const { queryByText } = render(
+    const { findByText } = render(
       <WebviewIntentProvider>Hello</WebviewIntentProvider>
     )
 
-    expect(queryByText('Hello')).toBeDefined()
+    expect(await findByText('Hello')).toBeDefined()
   })
 
   it('renders without injection', async () => {
-    render(<WebviewIntentProvider>Hello</WebviewIntentProvider>)
+    const { findByText } = render(
+      <WebviewIntentProvider>Hello</WebviewIntentProvider>
+    )
 
-    expect(await screen.findByText('Hello')).toBeDefined()
+    expect(await findByText('Hello')).toBeDefined()
     expect(mockChildHandshake).toHaveBeenCalled()
   })
 
   it('renders with injection', async () => {
-    render(
+    const { findByText } = render(
       <WebviewIntentProvider webviewService={mockWebviewService}>
         Hello
       </WebviewIntentProvider>
     )
 
-    expect(await screen.findByText('Hello')).toBeDefined()
+    expect(await findByText('Hello')).toBeDefined()
     expect(mockChildHandshake).not.toHaveBeenCalled()
+  })
+
+  it('does not try to set cozy-bar context if cozy-bar does not exist when provided with a context', async () => {
+    global.cozy = undefined
+
+    const { findByText } = render(
+      <WebviewIntentProvider webviewService={mockWebviewService}>
+        Hello
+      </WebviewIntentProvider>
+    )
+
+    expect(await findByText('Hello')).toBeTruthy()
+    expect(mockSetWebviewContext).not.toHaveBeenCalled()
+  })
+
+  it('does not try to set cozy-bar context if cozy-bar does not exist when not provided with a context', async () => {
+    global.cozy = undefined
+
+    const { findByText } = render(
+      <WebviewIntentProvider>Hello</WebviewIntentProvider>
+    )
+
+    expect(await findByText('Hello')).toBeTruthy()
+    expect(mockSetWebviewContext).not.toHaveBeenCalled()
+  })
+
+  it('sets cozy-bar context if cozy-bar does exist when provided with a context', async () => {
+    global.cozy = mockCozyBar
+
+    const { findByText } = render(
+      <WebviewIntentProvider webviewService={mockWebviewService}>
+        Hello
+      </WebviewIntentProvider>
+    )
+
+    expect(await findByText('Hello')).toBeTruthy()
+    expect(mockSetWebviewContext).toHaveBeenCalledWith(mockWebviewService)
+    expect(mockSetWebviewContext).toBeCalledTimes(1)
+  })
+
+  it('sets cozy-bar context if cozy-bar does exist when not provided with a context', async () => {
+    global.cozy = mockCozyBar
+
+    const { findByText } = render(
+      <WebviewIntentProvider>Hello</WebviewIntentProvider>
+    )
+
+    expect(await findByText('Hello')).toBeTruthy()
+    expect(mockSetWebviewContext).toBeCalledWith(expect.any(WebviewService))
+    expect(mockSetWebviewContext).toBeCalledTimes(1)
   })
 })

--- a/packages/cozy-intent/src/view/components/WebviewIntentProvider.tsx
+++ b/packages/cozy-intent/src/view/components/WebviewIntentProvider.tsx
@@ -1,15 +1,14 @@
 import React, { ReactElement, useEffect, useState } from 'react'
-import { ChildHandshake, Connection, EventsType, MethodsType } from 'post-me'
 
 import { isFlagshipApp } from 'cozy-device-helper'
 
-import { NativeMethodsRegister } from '../../api/models/methods'
+import { CozyBar } from '../../api/models/applications'
 import { StaticService } from '../../api/services/StaticService'
-import { Strings } from '../../api/constants'
-import { TypeguardService } from '../../api/services/TypeguardService'
+import { WebviewConnection } from '../../api/models/environments'
 import { WebviewContext } from '../contexts/WebviewContext'
-import { WebviewMessenger } from '../../api/services/WebviewMessenger'
 import { WebviewService } from '../../api/services/WebviewService'
+
+declare let cozy: CozyBar | undefined
 
 interface Props {
   children?: React.ReactChild
@@ -20,32 +19,26 @@ export const WebviewIntentProvider = ({
   children,
   webviewService
 }: Props): ReactElement => {
-  const [connection, setConnection] =
-    useState<
-      Connection<MethodsType, EventsType, NativeMethodsRegister, EventsType>
-    >()
+  const [connection, setConnection] = useState<WebviewConnection>()
+  const [service, setService] = useState<WebviewService | void>(webviewService)
+  const setBarWebviewContext = cozy?.bar?.setWebviewContext
 
   useEffect(() => {
-    if (connection) return
+    !webviewService &&
+      isFlagshipApp() &&
+      StaticService.getConnection(setConnection)
+  }, [webviewService])
 
-    const init = async (): Promise<void> => {
-      if (!TypeguardService.isWebviewWindow(window))
-        throw new Error(Strings.flagshipButNoRNAPI)
+  useEffect(() => {
+    connection && setService(new WebviewService(connection))
+  }, [connection])
 
-      StaticService.sendSyncMessage(Strings.webviewIsRendered)
-      const result = await ChildHandshake(new WebviewMessenger(window))
-      setConnection(result)
-    }
-
-    !webviewService && isFlagshipApp() && init()
-  }, [connection, webviewService])
-
-  if (!isFlagshipApp()) return <>{children}</>
+  useEffect(() => {
+    setBarWebviewContext && service && setBarWebviewContext(service)
+  }, [setBarWebviewContext, service])
 
   return (
-    <WebviewContext.Provider
-      value={webviewService || (connection && new WebviewService(connection))}
-    >
+    <WebviewContext.Provider value={service}>
       {children}
     </WebviewContext.Provider>
   )


### PR DESCRIPTION
That way cozy-bar can use the same IntentService as the parent app

- [x] Implement feature
- [x] Test feature