### PR TITLE
fix(cozy-intent): Stricter null-check for cozy-bar

### DIFF
--- a/packages/cozy-intent/src/api/constants/strings.json
+++ b/packages/cozy-intent/src/api/constants/strings.json
@@ -10,5 +10,7 @@
   "errorRegisterWebview": "Cannot register webview. A webview is already registered into cozy-intent with the uri: ${uri}",
   "errorUnregisterWebview": "Cannot unregister webview. No webview is registered into cozy-intent with the uri: ${uri}",
   "errorInitWebview": "Cannot init handshake for Webview with uri: '${uri}'. The handshake was already made and succeeded. You probably remounted WebviewIntentProvider and lost its state, or you forgot to call unregisterWebview on parent-side.",
-  "errorEmitMessage": "Cannot emit message. No webview is registered with uri: ${webviewUri}"
+  "errorEmitMessage": "Cannot emit message. No webview is registered with uri: ${webviewUri}",
+  "errorGetCozyBarAPI": "The above error occured while trying to get the setWebviewContext() API from cozy-bar. Cozy-bar webview intents will not work. Your cozy-bar might be outdated or unreachable.",
+  "errorCozyBarAPIMissing": "Cozy-bar was detected by WebviewIntentProvider but the required setWebviewContext() API was not found. Cozy-bar webview intents will not work. Your cozy-bar version is most likely outdated."
 }

--- a/packages/cozy-intent/src/view/components/WebviewIntentProvider.spec.tsx
+++ b/packages/cozy-intent/src/view/components/WebviewIntentProvider.spec.tsx
@@ -35,6 +35,7 @@ jest.mock('post-me', () => ({
 
 describe('WebviewIntentProvider', () => {
   beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => null)
     mockIsFlagshipApp.mockReturnValue(true)
   })
 

--- a/packages/cozy-intent/src/view/components/WebviewIntentProvider.tsx
+++ b/packages/cozy-intent/src/view/components/WebviewIntentProvider.tsx
@@ -18,19 +18,23 @@ interface Props {
   webviewService?: WebviewService
 }
 
-const getBarInitAPI = ():
-  | ((webviewContext: WebviewService) => void)
-  | undefined => {
+/* eslint-disable no-console */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+const getBarInitAPI = (): ((webviewContext: WebviewService) => void) | void => {
   try {
-    return cozy?.bar?.setWebviewContext
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error((err as Error).stack)
+    if (cozy!.bar!.setWebviewContext === undefined) {
+      return console.warn(strings.errorCozyBarAPIMissing)
+    }
 
-    // If we fail to get the cozy-bar, we want to assume it doesn't exist
-    return undefined
+    return cozy!.bar!.setWebviewContext
+  } catch (err) {
+    console.warn((err as Error).stack)
+
+    return console.warn(strings.errorGetCozyBarAPI)
   }
 }
+/* eslint-enable @typescript-eslint/no-non-null-assertion */
+/* eslint-enable no-console */
 
 const sendSyncMessage = (message: string): void => {
   if (!TypeguardService.hasReactNativeAPI(window))


### PR DESCRIPTION
In some instances runtime was trying to read cozy even if undefined and
with an optional chaining operator.
It is now a lot stricter.