### PR TITLE
fix(renovate): Schedule on Saturday  every month

### DIFF
--- a/packages/renovate-config-cozy/package.json
+++ b/packages/renovate-config-cozy/package.json
@@ -14,8 +14,8 @@
           "excludePackageNames": [
             "^cozy-"
           ],
-          "extends": [
-            "schedule:monthly"
+          "schedule": [
+            "on Saturday every month"
           ]
         }
       ],


### PR DESCRIPTION
according to https://docs.renovatebot.com/presets-schedule/#schedulemonthly , I think it's possible to change how renovate works.

After reading, https://breejs.github.io/later/parsers.html#text I updated the value.