### PR TITLE
fix(renovate): Limit to 1 PR by hour

### DIFF
--- a/packages/renovate-config-cozy/package.json
+++ b/packages/renovate-config-cozy/package.json
@@ -23,6 +23,7 @@
       "addLabels": [
         "dependencies"
       ],
+      "prHourlyLimit": 1,
       "updateNotScheduled": false
     }
   },


### PR DESCRIPTION
To limit the load of renovate to 5 PRs by repository.