### PR TITLE
fix(cozy-intent): Allow undefined hook return

### DIFF
--- a/packages/cozy-intent/src/api/constants/strings.json
+++ b/packages/cozy-intent/src/api/constants/strings.json
@@ -11,6 +11,6 @@
   "errorUnregisterWebview": "Cannot unregister webview. No webview is registered into cozy-intent with the uri: ${uri}",
   "errorInitWebview": "Cannot init handshake for Webview with uri: '${uri}'. The handshake was already made and succeeded. You probably remounted WebviewIntentProvider and lost its state, or you forgot to call unregisterWebview on parent-side.",
   "errorEmitMessage": "Cannot emit message. No webview is registered with uri: ${webviewUri}",
-  "errorGetCozyBarAPI": "The above error occured while trying to get the setWebviewContext() API from cozy-bar. Cozy-bar webview intents will not work. Your cozy-bar might be outdated or unreachable.",
+  "errorGetCozyBarAPI": "An error occured while trying to get the setWebviewContext() API from cozy-bar. Cozy-bar webview intents will not work. Your cozy-bar is most likely unreachable.",
   "errorCozyBarAPIMissing": "Cozy-bar was detected by WebviewIntentProvider but the required setWebviewContext() API was not found. Cozy-bar webview intents will not work. Your cozy-bar version is most likely outdated."
 }

--- a/packages/cozy-intent/src/view/components/WebviewIntentProvider.tsx
+++ b/packages/cozy-intent/src/view/components/WebviewIntentProvider.tsx
@@ -27,14 +27,12 @@ function isWebviewWindow(window: Window): window is WebviewWindow {
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 const getBarInitAPI = (): ((webviewContext: WebviewService) => void) | void => {
   try {
-    if (cozy!.bar!.setWebviewContext === undefined) {
+    if (cozy!.bar && cozy!.bar.setWebviewContext === undefined) {
       return console.warn(strings.errorCozyBarAPIMissing)
     }
 
     return cozy!.bar!.setWebviewContext
   } catch (err) {
-    console.warn((err as Error).stack)
-
     return console.warn(strings.errorGetCozyBarAPI)
   }
 }

--- a/packages/cozy-intent/src/view/hooks/useWebviewIntent.spec.tsx
+++ b/packages/cozy-intent/src/view/hooks/useWebviewIntent.spec.tsx
@@ -4,7 +4,6 @@ import { renderHook } from '@testing-library/react-hooks'
 import { WebviewContext } from '../contexts/WebviewContext'
 import { WebviewService } from '../../api/services/WebviewService'
 import { mockConnection } from '../../tests/mocks'
-import { strings } from '../../api/constants'
 import { useWebviewIntent } from './useWebviewIntent'
 
 jest.mock('cozy-device-helper', () => ({
@@ -12,9 +11,10 @@ jest.mock('cozy-device-helper', () => ({
 }))
 
 describe('useNativeIntent', () => {
-  it('Should throw if the context does not exist in a Flagship app', () => {
+  it('Should not throw if the context does not exist in a Flagship app', () => {
     const { result } = renderHook(() => useWebviewIntent())
-    expect(result?.error?.message).toBe(strings.webviewNoProviderFound)
+
+    expect(result.current).toBeUndefined()
   })
 
   it('Should return the context if it exists', () => {

--- a/packages/cozy-intent/src/view/hooks/useWebviewIntent.ts
+++ b/packages/cozy-intent/src/view/hooks/useWebviewIntent.ts
@@ -1,16 +1,7 @@
 import { useContext } from 'react'
 
-import { isFlagshipApp } from 'cozy-device-helper'
-
-import { strings } from '../../api/constants'
 import { WebviewContext } from '../contexts/WebviewContext'
 import { WebviewService } from '../../api/services/WebviewService'
 
-export const useWebviewIntent = (): WebviewService | void => {
-  const context = useContext(WebviewContext)
-
-  if (isFlagshipApp() && !context)
-    throw new Error(strings.webviewNoProviderFound)
-
-  return context
-}
+export const useWebviewIntent = (): WebviewService | void =>
+  useContext(WebviewContext)


### PR DESCRIPTION
When throwing an error, some race conditions could make an app crash which is very unwanted. Allowing the context to be undefined (which is idiomatic React) is much safer. 

Also reduced the amount of warning output and improved an error message. Updated test file to reflect changes made.