### PR TITLE
fix(cozy-intent): Allow cozy-bar V8 to inject callback

### DIFF
--- a/packages/cozy-intent/src/view/components/WebviewIntentProvider.spec.tsx
+++ b/packages/cozy-intent/src/view/components/WebviewIntentProvider.spec.tsx
@@ -137,6 +137,19 @@ describe('WebviewIntentProvider', () => {
     expect(await findByText('Hello')).toBeTruthy()
   })
 
+  it('should allow cozy-bar v8 to inject callback', async () => {
+    const mockSetBarContext = jest.fn()
+    const { findByText } = render(
+      <WebviewIntentProvider setBarContext={mockSetBarContext}>
+        Hello
+      </WebviewIntentProvider>
+    )
+
+    expect(await findByText('Hello')).toBeTruthy()
+    expect(mockSetBarContext).toBeCalledWith(expect.any(WebviewService))
+    expect(mockSetBarContext).toBeCalledTimes(1)
+  })
+
   it('throws in a flagship app context that has no RN API available', () => {
     expect.assertions(1)
     mockIsFlagshipApp.mockReturnValue(true)

--- a/packages/cozy-intent/src/view/components/WebviewIntentProvider.tsx
+++ b/packages/cozy-intent/src/view/components/WebviewIntentProvider.tsx
@@ -14,6 +14,7 @@ declare const cozy: CozyBar | undefined
 
 interface Props {
   children?: React.ReactChild
+  setBarContext?: (webviewContext: WebviewService) => void
   webviewService?: WebviewService
 }
 
@@ -71,11 +72,12 @@ const isValidEnv = (): boolean => {
 
 export const WebviewIntentProvider = ({
   children,
+  setBarContext,
   webviewService
 }: Props): ReactElement => {
   const [connection, setConnection] = useState<WebviewConnection>()
   const [service, setService] = useState<WebviewService | void>(webviewService)
-  const setBarWebviewContext = getBarInitAPI()
+  const setBarWebviewContext = setBarContext || getBarInitAPI()
 
   useEffect(() => {
     !connection &&


### PR DESCRIPTION
Cozy-bar V8 does not have the same API as V7 after further research.
Added an option to inject manually the cozy-bar method to set WebviewContext