### PR TITLE
fix(harvest): ConnectionFlow with CCC

### DIFF
--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -381,7 +381,7 @@ export class ConnectionFlow {
       )
 
       let cipher
-      if (konnectorPolicy.saveInVault) {
+      if (konnectorPolicy.saveInVault && !konnector.clientSide) {
         cipher = await createOrUpdateCipher(vaultClient, cipherId, {
           account,
           konnector,


### PR DESCRIPTION
Using CCC, when submiting the form,first the first
time, we don't have any account.
Also, the Cipher stuff will be handled by the flagship
app.