### PR TITLE
docs: Update FlagshipUI interface

### DIFF
--- a/packages/cozy-intent/src/api/models/applications.ts
+++ b/packages/cozy-intent/src/api/models/applications.ts
@@ -27,20 +27,15 @@ export interface CozyBar {
   }
 }
 
-export enum NativeThemes {
-  Dark = 'dark',
-  Light = 'light'
-}
-
 export interface FlagshipUI {
   /** Has to be a <color> CSS data type */
   bottomBackground?: string
-  bottomColor?: NativeThemes
   /** Has to be 'rgba(R, G, B[, A])' to enable, 'transparent' to disable */
   bottomOverlay?: string
+  bottomTheme?: 'dark' | 'light'
   /** Has to be a <color> CSS data type */
   topBackground?: string
-  topColor?: NativeThemes
   /** Has to be 'rgba(R, G, B[, A])' to enable, 'transparent' to disable */
   topOverlay?: string
+  topTheme?: 'dark' | 'light'
 }


### PR DESCRIPTION
Makes it clearer and simpler to use.
Mentions Theme instead of color
Drop enum and use union type instead (so you have nothing to import)