### PR TITLE
chore: Remove useless dependabot

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,3 +1,0 @@
-commit-message:
-  # Prefix all commit messages with "fix"
-  prefix: "fix"


### PR DESCRIPTION
it is well configured in .github folder