### PR TITLE
Fix harvest's AppLinker usage in order to handle onClick event

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -57,7 +57,7 @@
     "cozy-flags": "^2.8.7",
     "cozy-keys-lib": "3.8.0",
     "cozy-realtime": "^4.0.5",
-    "cozy-ui": "57.6.0",
+    "cozy-ui": "60.6.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.6",
     "form-data": "3.0.0",
@@ -80,7 +80,7 @@
     "cozy-flags": ">=2.3.5",
     "cozy-keys-lib": ">=3.7.0",
     "cozy-realtime": ">=3.12.2",
-    "cozy-ui": ">=57.6.0",
+    "cozy-ui": ">=60.6.0",
     "leaflet": "^1.7.1",
     "react-router-dom": "^5.0.1"
   },

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/BanksLink.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/BanksLink.jsx
@@ -15,7 +15,7 @@ const BanksLinkRedirectStore = ({ client, t }) => {
 
   if (fetchStatus === 'loaded') {
     return (
-      <AppLinker slug={slug} href={url}>
+      <AppLinker app={{ slug }} href={url}>
         {({ href, name }) => (
           <ButtonLink
             icon={OpenwithIcon}

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/BanksLink.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/BanksLink.jsx
@@ -16,13 +16,14 @@ const BanksLinkRedirectStore = ({ client, t }) => {
   if (fetchStatus === 'loaded') {
     return (
       <AppLinker app={{ slug }} href={url}>
-        {({ href, name }) => (
+        {({ href, name, onClick }) => (
           <ButtonLink
             icon={OpenwithIcon}
             href={href}
             label={t('account.success.banksLinkText', {
               appName: name
             })}
+            onClick={onClick}
             subtle
           />
         )}

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/DriveLink.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/DriveLink.jsx
@@ -16,13 +16,14 @@ const DriveLink = memo(({ folderId, client, t }) => {
   if (fetchStatus === 'loaded') {
     return (
       <AppLinker app={{ slug }} href={url} nativePath={path}>
-        {({ href, name }) => (
+        {({ href, name, onClick }) => (
           <ButtonLink
             icon={OpenwithIcon}
             href={href}
             label={t('account.success.driveLinkText', {
               appName: name
             })}
+            onClick={onClick}
             subtle
           />
         )}

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/DriveLink.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/Success/DriveLink.jsx
@@ -15,7 +15,7 @@ const DriveLink = memo(({ folderId, client, t }) => {
 
   if (fetchStatus === 'loaded') {
     return (
-      <AppLinker slug={slug} href={url} nativePath={path}>
+      <AppLinker app={{ slug }} href={url} nativePath={path}>
         {({ href, name }) => (
           <ButtonLink
             icon={OpenwithIcon}

--- a/packages/cozy-harvest-lib/src/components/KonnectorSuggestionModal/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorSuggestionModal/index.jsx
@@ -85,7 +85,7 @@ const KonnectorSuggestionModal = ({
               </Typography>
             )}
             <AppLinker
-              slug={storeAppName}
+              app={{ slug: storeAppName }}
               nativePath={nativePath}
               href={generateWebLink({
                 cozyUrl: cozyURL.origin,

--- a/packages/cozy-harvest-lib/src/components/KonnectorUpdateLinker.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorUpdateLinker.jsx
@@ -29,7 +29,7 @@ const KonnectorUpdateLinker = ({ label, isBlocking, konnector }) => {
   const isReady = isLoaded && konnectorUpdateUrl
 
   return isReady ? (
-    <AppLinker slug="store" href={konnectorUpdateUrl}>
+    <AppLinker app={{ slug: 'store' }} href={konnectorUpdateUrl}>
       {({ href }) => {
         return (
           <KonnectorUpdateButton

--- a/packages/cozy-harvest-lib/src/components/KonnectorUpdateLinker.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorUpdateLinker.jsx
@@ -9,11 +9,18 @@ import EyeIcon from 'cozy-ui/transpiled/react/Icons/Eye'
 import { Application } from 'cozy-doctypes'
 import { appsConn } from '../connections/apps'
 
-const KonnectorUpdateButton = ({ disabled, isBlocking, href, label }) => (
+const KonnectorUpdateButton = ({
+  disabled,
+  isBlocking,
+  href,
+  onClick,
+  label
+}) => (
   <ButtonLink
     disabled={disabled}
     className="u-m-0"
     href={href}
+    onClick={onClick}
     icon={EyeIcon}
     label={label}
     theme={isBlocking ? 'danger' : 'secondary'}
@@ -30,12 +37,13 @@ const KonnectorUpdateLinker = ({ label, isBlocking, konnector }) => {
 
   return isReady ? (
     <AppLinker app={{ slug: 'store' }} href={konnectorUpdateUrl}>
-      {({ href }) => {
+      {({ onClick, href }) => {
         return (
           <KonnectorUpdateButton
             href={href}
             isBlocking={isBlocking}
             label={label}
+            onClick={onClick}
           />
         )
       }}

--- a/packages/cozy-harvest-lib/src/components/cards/AppLinkCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/AppLinkCard.jsx
@@ -25,7 +25,7 @@ export const AppLinkButton = ({ slug, path }) => {
     path
   )
   return (
-    <AppLinker slug={slug} nativePath={path} href={url || '#'}>
+    <AppLinker app={{ slug }} nativePath={path} href={url || '#'}>
       {({ onClick, href }) => (
         <ButtonLink
           onClick={fetchStatus !== 'loaded' ? onClick : null}


### PR DESCRIPTION
This PR fixes a bug in Flagship app that prevented to open the Store from Home's connector pane when clicking on `See update`.

This is controlled by `KonnectorUpdateLinker` but I reflected the fix on other similar components. This must be tested tomorrow.

I also propagated changes from cozy/cozy-ui#2015 that deprecated `slug` prop from `AppLinker`

---

TODO

- [ ] Test fix impact on `DriveLink` and `BanksLink`
- [x] Check if a `BREAKING_CHANGE` should be set as the `slug` refactoring implies that `cozy-ui` minimum version is now `60.6.0`