### PR TITLE
docs: Add documentation for calling creation modal

### DIFF
--- a/packages/cozy-mespapiers-lib/README.md
+++ b/packages/cozy-mespapiers-lib/README.md
@@ -126,6 +126,19 @@ const MesPapiersView = props => {
 
 export default MesPapiersView
 ```
+# Call modal with URL
+In your application, if you want to call a modal to create a Paper, you just have to call the `/paper/create` or `/paper/create/:qualificationLabel` route with the query parameter `backgroundPath=<currentPath>`
+Exemple:
+```jsx
+const { pathname } = useLocation()
+
+const handleClick = () => {
+  history.push({
+    pathname: `/paper/create`,
+    search: `backgroundPath=${pathname}`
+  })
+}
+```
 
 ## Development
 


### PR DESCRIPTION
En plus du PaperFab fourni par la lib, il est possible d'appeler les 2 modales pour créer un Papier via :
- `/paper/create?backgroundPath=/<currentPath>`: Utilisé par le PaperFab, elle ouvre la modale pour choisir la qualification du Papier avant de commencer la création.
- `/paper/create/<qualificationLabel>?backgroundPath=/<currentPath>`: Elle ouvre directement la modale de création d'un Papier.