### PR TITLE
fix: Avoid trigger last execution "unknown" while the connector is still running

### DIFF
--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -344,7 +344,8 @@ export class ConnectionFlow {
   }
 
   handleLoginSuccess() {
-    this.jobWatcher.handleSuccess()
+    this.jobWatcher.handleLoginSuccess()
+    this.triggerEvent(LOGIN_SUCCESS_EVENT)
   }
 
   handleLoginSuccessHandled() {

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.spec.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.spec.js
@@ -125,9 +125,6 @@ describe('ConnectionFlow', () => {
       jest.clearAllMocks()
     })
 
-    afterAll(() => {
-      jest.restoreAllMocks()
-    })
 
     it('should render as submitting when there is no account', async () => {
       const { flow } = setup()
@@ -337,10 +334,6 @@ describe('ConnectionFlow', () => {
       jest.clearAllMocks()
     })
 
-    afterAll(() => {
-      jest.restoreAllMocks()
-    })
-
     it('should launch trigger without account', async () => {
       const { flow, client } = setup()
       await flow.ensureTriggerAndLaunch(client, {
@@ -499,7 +492,7 @@ describe('ConnectionFlow', () => {
     delete window.ReactNativeWebView
   })
 
-  describe('contructor', () => {
+  describe('constructor', () => {
     beforeAll(() => {
       watchKonnectorJob.mockReturnValue({on: () => ({})})
     })
@@ -508,9 +501,6 @@ describe('ConnectionFlow', () => {
       jest.clearAllMocks()
     })
 
-    afterAll(() => {
-      jest.restoreAllMocks()
-    })
     it('should watch a running trigger', () => {
       setup({trigger: fixtures.runningTrigger})
       expect(watchKonnectorJob).toHaveBeenCalledWith(expect.any(Object), {_id: 'runningjobid'}, {autoSuccessTimer: false})

--- a/packages/cozy-harvest-lib/src/models/konnector/KonnectorJobWatcher.js
+++ b/packages/cozy-harvest-lib/src/models/konnector/KonnectorJobWatcher.js
@@ -66,6 +66,11 @@ export class KonnectorJobWatcher {
     this.emit('error', new KonnectorJobError(error))
   }
 
+  handleLoginSuccess() {
+    logger.info(`KonnectorJobWatcher: login success`)
+    this.disableSuccessTimer()
+  }
+
   handleSuccess() {
     logger.info(`KonnectorJobWatcher: Job has succeeded`)
     this.disableSuccessTimer()

--- a/packages/cozy-harvest-lib/test/fixtures.js
+++ b/packages/cozy-harvest-lib/test/fixtures.js
@@ -125,6 +125,23 @@ const fixtures = {
       }
     }
   },
+  runningTrigger: {
+    id: 'running-trigger-id',
+    _type: 'io.cozy.triggers',
+    current_state: {
+      status: 'running',
+      last_executed_job_id: 'runningjobid'
+    },
+    attributes: {
+      arguments: '0 0 0 * * 0',
+      type: '@cron',
+      worker: 'konnector',
+      message: {
+        account: 'updated-account-id',
+        konnector: 'konnectest'
+      }
+    }
+  },
   createdTriggerWithFolder: {
     id: 'created-trigger-id',
     _type: 'io.cozy.triggers',


### PR DESCRIPTION
This is a problem especially visible with client side connectors but you can also reproduce it with node connecteur :

When you display the harvest dialog for a trigger which is still running and which runs for the first time, the trigger is marked as not running and the last execution date is "unknown"

For node connecteur, when the LOGIN_SUCCESS event is triggered, we display a popup which explains that authentication is a success and that the user can do someting else, then this bug is not too much pain

But for client side connectors, on LOGIN_SUCCESS, the harvest is displayed and the connector is displayed as not running, which is wrong and suggests an error : 

![image](https://user-images.githubusercontent.com/228695/161715545-338e1c50-dbb2-4d8e-b65a-6f19b2efb17f.png)

Now, when a still running trigger is displayed, harvest will mark it a running and watch the corresponding job to get the result of the job and display it


- feat: Do not mark a job as succeeded on login success
- feat: Watch job changes when the trigger is already running
