### PR TITLE
Feat/add listener acquisition step

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/AcquisitionResult.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/AcquisitionResult.jsx
@@ -1,5 +1,7 @@
-import React, { useMemo, memo, useCallback } from 'react'
+import React, { memo, useCallback } from 'react'
 import PropTypes from 'prop-types'
+import { makeStyles } from '@material-ui/core/styles'
+import cx from 'classnames'
 
 import Card from 'cozy-ui/transpiled/react/Card'
 import DialogActions from 'cozy-ui/transpiled/react/DialogActions'
@@ -20,7 +22,20 @@ import { PaperDefinitionsStepPropTypes } from '../../constants/PaperDefinitionsP
 
 const isPDF = file => file.type === 'application/pdf'
 
+const useStyles = makeStyles(() => ({
+  img: {
+    maxWidth: '100%',
+    maxHeight: 'inherit'
+  },
+  avatar: {
+    color: 'var(--paperBackgroundColor)',
+    backgroundColor: 'var(--successColor)',
+    marginBottom: '1rem'
+  }
+}))
+
 const AcquisitionResult = ({ file, setFile, currentStep }) => {
+  const styles = useStyles()
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const { nextStep } = useStepperDialog()
@@ -57,32 +72,30 @@ const AcquisitionResult = ({ file, setFile, currentStep }) => {
 
   useEventListener(window, 'keydown', handleKeyDown)
 
-  const style = useMemo(
-    () => ({
-      img: {
-        maxWidth: '100%',
-        maxHeight: 'inherit'
-      },
-      avatar: {
-        color: 'var(--paperBackgroundColor)',
-        backgroundColor: 'var(--successColor)'
-      }
-    }),
-    []
-  )
-
   return (
     <>
-      <div className={'u-h-100 u-flex u-flex-column u-flex-justify-center'}>
-        <div className={!isMobile ? 'u-mh-2' : ''}>
-          <div className={'u-flex u-flex-column u-flex-items-center u-mb-2'}>
-            <Avatar
-              icon={Check}
-              size="xlarge"
-              style={style.avatar}
-              className={'u-mb-1'}
-            />
-            <Typography variant={'h5'}>{t('Acquisition.success')}</Typography>
+      <div
+        className={cx(
+          'u-h-100 u-mb-2 u-flex u-flex-column u-flex-justify-center',
+          {
+            ['u-mt-2 u-mh-1']: !isMobile
+          }
+        )}
+      >
+        <div className={'u-flex u-flex-column u-flex-items-center u-mb-2'}>
+          <Avatar icon={Check} size="xlarge" className={styles.avatar} />
+          <Typography variant={'h5'}>{t('Acquisition.success')}</Typography>
+        </div>
+        <Card className={'u-ta-center u-p-1 u-pb-half'}>
+          <div className={'u-mah-5'}>
+            {!isPDF(file) ? (
+              <img src={URL.createObjectURL(file)} className={styles.img} />
+            ) : (
+              <>
+                <Icon icon={FileTypePdfIcon} size={80} />
+                <Typography variant={'body1'}>{file.name}</Typography>
+              </>
+            )}
           </div>
           <Button
             className={'u-mt-half'}
@@ -95,7 +108,10 @@ const AcquisitionResult = ({ file, setFile, currentStep }) => {
       </div>
       <DialogActions
         disableSpacing
-        className={'columnLayout u-mh-0 u-mb-1 cozyDialogActions'}
+        className={cx('columnLayout u-mb-1-half u-mt-0 cozyDialogActions', {
+          'u-mh-1': !isMobile,
+          'u-mh-0': isMobile
+        })}
       >
         <Button
           className="u-db"

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/AcquisitionResult.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/AcquisitionResult.spec.jsx
@@ -1,0 +1,92 @@
+'use strict'
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+
+import AppLike from '../../../test/components/AppLike'
+import AcquisitionResult from './AcquisitionResult'
+import { FormDataProvider } from '../Contexts/FormDataProvider'
+import { useStepperDialog } from '../Hooks/useStepperDialog'
+
+const mockCurrentStep = { page: '', multipage: false }
+const mockFile = { type: '' }
+
+const setup = ({
+  nextStep = jest.fn(),
+  setFile = jest.fn(),
+  file = mockFile,
+  currentStep = mockCurrentStep
+} = {}) => {
+  useStepperDialog.mockReturnValue({ nextStep })
+
+  return render(
+    <AppLike>
+      <FormDataProvider>
+        <AcquisitionResult
+          setFile={setFile}
+          file={file}
+          currentStep={currentStep}
+        />
+      </FormDataProvider>
+    </AppLike>
+  )
+}
+jest.mock('../Hooks/useStepperDialog')
+
+describe('AcquisitionResult component:', () => {
+  window.URL.createObjectURL = jest.fn()
+
+  it('should be rendered correctly', () => {
+    const { container } = setup()
+
+    expect(container).toBeDefined()
+  })
+
+  it('should setFile must be called once with null when restarting the file selection', () => {
+    const mockSetFile = jest.fn()
+    const { getByTestId } = setup({ setFile: mockSetFile })
+
+    const btn = getByTestId('retry-button')
+
+    fireEvent.click(btn)
+
+    expect(mockSetFile).toHaveBeenCalledWith(null)
+    expect(mockSetFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('should setFile must be called once with null when add more files', () => {
+    const mockSetFile = jest.fn()
+    const { getByTestId } = setup({
+      setFile: mockSetFile,
+      currentStep: { page: '', multipage: true }
+    })
+
+    const btn = getByTestId('repeat-button')
+
+    fireEvent.click(btn)
+
+    expect(mockSetFile).toHaveBeenCalledWith(null)
+    expect(mockSetFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('should nextStep must be called when next button is clicked', () => {
+    const nextStep = jest.fn()
+    const { getByTestId } = setup({
+      nextStep
+    })
+
+    const btn = getByTestId('next-button')
+
+    fireEvent.click(btn)
+
+    expect(nextStep).toHaveBeenCalledTimes(1)
+  })
+
+  it('should nextStep must be called when Enter key is pressed', () => {
+    const nextStep = jest.fn()
+    setup({ nextStep })
+
+    fireEvent.keyDown(window, { key: 'Enter', code: 'Enter', keyCode: 13 })
+
+    expect(nextStep).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
We have added the possibility to validate the acquisition step with the Enter key (to be iso with the following ones)
By the way, fix non-conforming margins