### PR TITLE
fix: Use correct type for define input rules

### DIFF
--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -185,7 +185,8 @@
           "attributes": [
             {
               "name": "number",
-              "type": "Number:12",
+              "type": "number",
+              "maxLength": 12,
               "inputLabel": "PaperJSON.driverLicense.number.inputLabel"
             }
           ]
@@ -480,7 +481,8 @@
           "attributes": [
             {
               "name": "cardNumber",
-              "type": "Number:12",
+              "type": "number",
+              "maxLength": 12,
               "inputLabel": "PaperJSON.card.number.inputLabel"
             }
           ]


### PR DESCRIPTION
In the configuration file, we have attribute types on the Information step `Number::12`, which are no longer valid.