### PR TITLE
fix: Back to Scan step must be displayed file already selected

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan.jsx
@@ -13,6 +13,7 @@ import ScanMobileActions from '../ModelSteps/ScanMobileActions'
 import ScanDesktopActions from '../ModelSteps/ScanDesktopActions'
 import IlluGenericNewPage from '../../assets/icons/IlluGenericNewPage.svg'
 import { makeBlobWithCustomAttrs } from '../../helpers/makeBlobWithCustomAttrs'
+import { useFormData } from '../Hooks/useFormData'
 
 const { fetchBlobFileById } = models.file
 
@@ -26,15 +27,16 @@ const validFileType = file => {
 const Scan = ({ currentStep }) => {
   const { t } = useI18n()
   const client = useClient()
-  const { illustration, text } = currentStep
-  const [file, setFile] = useState(null)
+  const { formData } = useFormData()
+  const { illustration, text, stepIndex } = currentStep
+  const [currentFile, setCurrentFile] = useState(null)
 
   const [isFilePickerModalOpen, setIsFilePickerModalOpen] = useState(false)
   const [cozyFileId, setCozyFileId] = useState('')
 
   const onChangeFile = useCallback(file => {
     if (file) {
-      setFile(file)
+      setCurrentFile(file)
     }
   }, [])
 
@@ -42,6 +44,15 @@ const Scan = ({ currentStep }) => {
   const closeFilePickerModal = () => setIsFilePickerModalOpen(false)
 
   const onChangeFilePicker = fileId => setCozyFileId(fileId)
+
+  useEffect(() => {
+    const data = formData.data.filter(data => data.stepIndex === stepIndex)
+    const { file } = data[data.length - 1] || {}
+
+    if (file) {
+      setCurrentFile(file)
+    }
+  }, [formData.data, stepIndex])
 
   useEffect(() => {
     ;(async () => {
@@ -61,10 +72,10 @@ const Scan = ({ currentStep }) => {
     })()
   }, [client, cozyFileId, onChangeFile])
 
-  return file ? (
+  return currentFile ? (
     <AcquisitionResult
-      file={file}
-      setFile={setFile}
+      currentFile={currentFile}
+      setCurrentFile={setCurrentFile}
       currentStep={currentStep}
     />
   ) : (

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan.spec.jsx
@@ -1,0 +1,113 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import { isMobile } from 'cozy-device-helper'
+
+import AppLike from '../../../test/components/AppLike'
+import Scan from './Scan'
+import { FormDataProvider } from '../Contexts/FormDataProvider'
+import { useFormData } from '../Hooks/useFormData'
+
+const mockCurrentStep = ({
+  page = '',
+  multipage = false,
+  stepIndex = 0
+} = {}) => ({ page, multipage, stepIndex })
+const mockFile = ({ type = '', name = '' } = {}) => ({ type, name })
+const mockFormData = ({ metadata = {}, data = [], contacts = [] } = {}) => ({
+  metadata,
+  data,
+  contacts
+})
+jest.mock('cozy-device-helper', () => ({
+  ...jest.requireActual('cozy-device-helper'),
+  isMobile: jest.fn()
+}))
+jest.mock('../Hooks/useFormData')
+/* eslint-disable react/display-name */
+jest.mock('../CompositeHeader/CompositeHeader', () => () => (
+  <div data-testid="CompositeHeader" />
+))
+jest.mock('./AcquisitionResult', () => () => (
+  <div data-testid="AcquisitionResult" />
+))
+jest.mock('../ModelSteps/ScanMobileActions', () => () => (
+  <div data-testid="ScanMobileActions" />
+))
+jest.mock('../ModelSteps/ScanDesktopActions', () => () => (
+  <div data-testid="ScanDesktopActions" />
+))
+/* eslint-enable react/display-name */
+
+const setup = ({
+  setFormData = jest.fn(),
+  formData = mockFormData(),
+  currentStep = mockCurrentStep()
+} = {}) => {
+  useFormData.mockReturnValue({
+    setFormData,
+    formData
+  })
+
+  return render(
+    <AppLike>
+      <FormDataProvider>
+        <Scan currentStep={currentStep} />
+      </FormDataProvider>
+    </AppLike>
+  )
+}
+
+describe('Scan component:', () => {
+  it('should be rendered correctly', () => {
+    const { container } = setup()
+
+    expect(container).toBeDefined()
+  })
+
+  it('ScanMobileActions component must be displayed if is on Mobile', () => {
+    isMobile.mockReturnValue(true)
+    const { queryByTestId } = setup()
+
+    expect(queryByTestId('ScanMobileActions')).toBeTruthy()
+  })
+
+  it('ScanDesktopActions component must be displayed if is on Desktop', () => {
+    isMobile.mockReturnValue(false)
+    const { queryByTestId } = setup()
+
+    expect(queryByTestId('ScanDesktopActions')).toBeTruthy()
+  })
+
+  it('CompositeHeader component must be displayed if no file exists', () => {
+    const { queryByTestId } = setup({
+      formData: mockFormData({
+        data: []
+      })
+    })
+
+    expect(queryByTestId('CompositeHeader')).toBeTruthy()
+  })
+
+  it('CompositeHeader component must be displayed if no file of the current step exists', () => {
+    const { queryByTestId } = setup({
+      currentStep: mockCurrentStep({ stepIndex: 1 }),
+      formData: mockFormData({
+        data: [{ stepIndex: 2, file: mockFile({ name: 'test.pdf' }) }]
+      })
+    })
+
+    expect(queryByTestId('CompositeHeader')).toBeTruthy()
+  })
+
+  it('AcquisitionResult component must be displayed if a file in the current step exists', () => {
+    const { queryByTestId } = setup({
+      currentStep: mockCurrentStep({ stepIndex: 1 }),
+      formData: mockFormData({
+        data: [{ stepIndex: 1, file: mockFile({ name: 'test.pdf' }) }]
+      })
+    })
+
+    expect(queryByTestId('AcquisitionResult')).toBeTruthy()
+  })
+})

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -1,7 +1,7 @@
 {
   "Acquisition": {
     "repeat": "Scan an additional page",
-    "retry": "Take over",
+    "retry": "Cancel picture",
     "success": "The picture was taken."
   },
   "action": {

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -1,7 +1,7 @@
 {
   "Acquisition": {
     "repeat": "Scanner une page supplémentaire",
-    "retry": "Reprendre la photo",
+    "retry": "Annuler la photo",
     "success": "La photo a bien été prise."
   },
   "action": {


### PR DESCRIPTION
When we have the option "multipage", cancel the last selected image shows directly the previous one.
From there we can continue to undo the images, select a new image or continue the process (if at least one image exists)

Once on the Acquisition page, save the chosen image directly into the FormDataProvider