### PR TITLE
feat: Use devDeps & peerDeps only for cozy packages

### DIFF
--- a/packages/cozy-mespapiers-lib/package.json
+++ b/packages/cozy-mespapiers-lib/package.json
@@ -12,40 +12,49 @@
     "check-locales": "./scripts/check-locales.sh",
     "prepublishOnly": "yarn check-locales && yarn build"
   },
+  "dependencies": {
+    "@date-io/date-fns": "1",
+    "date-fns": "2.23.0",
+    "pdf-lib": "1.17.1",
+    "mui-bottom-sheet": "https://github.com/cozy/mui-bottom-sheet.git#v1.0.6",
+    "node-polyglot": "^2.4.0",
+    "react-router-dom": "5.2.0"
+  },
   "devDependencies": {
+    "@material-ui/core": "4.12.3",
+    "@material-ui/pickers": "3.3.10",
     "@testing-library/react": "11.2.7",
     "babel-preset-cozy-app": "2.0.1",
     "cozy-bar": "7.16.0",
     "cozy-client": "^27.22.0",
+    "cozy-device-helper": "^1.17.0",
+    "cozy-doctypes": "^1.83.3",
+    "cozy-harvest-lib": "^8.0.0",
     "cozy-intent": "^1.13.5",
     "cozy-realtime": "^4.0.2",
+    "cozy-sharing": "^4.0.2",
     "cozy-ui": "^62.5.2",
     "eslint-config-cozy-app": "^4.0.0",
     "git-directory-deploy": "1.5.1",
     "jest-environment-jsdom-sixteen": "2.0.0",
     "jest-resolve-cached": "1.1.1",
-    "react-router-dom": "5.2.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "react-test-renderer": "16.14.0",
     "redux-mock-store": "1.5.4"
   },
-  "dependencies": {
-    "@date-io/date-fns": "1",
+  "peerDependencies": {
     "@material-ui/core": "4.12.3",
     "@material-ui/pickers": "3.3.10",
-    "cozy-device-helper": "^1.17.0",
-    "cozy-doctypes": "^1.83.3",
-    "cozy-harvest-lib": "^8.0.0",
-    "cozy-sharing": "^4.0.2",
-    "date-fns": "2.23.0",
-    "mui-bottom-sheet": "https://github.com/cozy/mui-bottom-sheet.git#v1.0.6",
-    "node-polyglot": "^2.4.0",
-    "pdf-lib": "1.17.1"
-  },
-  "peerDependencies": {
     "cozy-client": ">=27.22.0",
     "cozy-intent": ">=1.13.5",
     "cozy-realtime": ">=4.0.2",
     "cozy-ui": ">=62.5.2",
-    "react-router-dom": ">=5.2.0"
+    "cozy-device-helper": ">=1.17.0",
+    "cozy-doctypes": ">=1.83.3",
+    "cozy-harvest-lib": ">=8.0.0",
+    "cozy-sharing": ">=4.0.2",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15770,17 +15770,6 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
-  version "1.0.6"
-  uid "494c40416ecde95732c864f9b921e7e545075aa5"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
-  dependencies:
-    "@juggle/resize-observer" "^3.1.3"
-    jest-environment-jsdom-sixteen "^1.0.3"
-    react-spring "9.0.0-rc.3"
-    react-use-gesture "^7.0.8"
-    react-use-measure "^2.0.0"
-
 "mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
   version "1.0.6"
   resolved "https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
@@ -18340,6 +18329,15 @@ react-dom@16.12.0, react-dom@^16.12.0:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
+react-dom@17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    scheduler "^0.20.2"
+
 react-error-boundary@^3.1.0:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
@@ -18839,6 +18837,14 @@ react@16.12.0, react@^16.12.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
+
+react@17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -20003,6 +20009,14 @@ scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
   integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
fix #1509

Quelques doutes, ne faudrait-il pas mettre :
- les packages `@...` & `react-router-dom` juste en `dependencies` ?
- ajouter les packages `react` & `react-dom` en `dependencies` ? (vue que les apps sont en React, leurs absences ici ne pose pas de problème, mais ce n'est pas logique)

Au final, ne laisser que les packages `cozy` en peer/dev