### PR TITLE
feat: Fix back navigation

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModal.jsx
@@ -14,7 +14,7 @@ import * as triggersModel from '../helpers/triggers'
 import KonnectorAccountTabs from './KonnectorConfiguration/KonnectorAccountTabs'
 import AccountSelectBox from './AccountSelectBox/AccountSelectBox'
 import KonnectorModalHeader from './KonnectorModalHeader'
-import { withMountPointPushHistory } from './MountPointContext'
+import { withMountPointHistory } from './MountPointContext'
 import withLocales from './hoc/withLocales'
 import DialogContent from '@material-ui/core/DialogContent'
 
@@ -109,6 +109,7 @@ export class AccountModal extends Component {
       accountsAndTriggers,
       t,
       pushHistory,
+      replaceHistory,
       initialActiveTab,
       breakpoints: { isMobile },
       showAccountSelection,
@@ -164,7 +165,7 @@ export class AccountModal extends Component {
               initialTrigger={trigger}
               account={account}
               onAccountDeleted={onDismiss}
-              addAccount={() => pushHistory('/new')}
+              addAccount={() => replaceHistory('/new')}
               showNewAccountButton={showNewAccountButton}
             />
           </DialogContent>
@@ -197,7 +198,7 @@ AccountModal.propTypes = {
     })
   ).isRequired,
   t: PropTypes.func.isRequired,
-  pushHistory: PropTypes.func.isRequired,
+  replaceHistory: PropTypes.func.isRequired,
   accountId: PropTypes.string.isRequired,
 
   /** @type {string} Can be set to force the initial active tab */
@@ -213,6 +214,6 @@ AccountModal.propTypes = {
 export default flow(
   withClient,
   withLocales,
-  withMountPointPushHistory,
+  withMountPointHistory,
   withBreakpoints()
 )(AccountModal)

--- a/packages/cozy-harvest-lib/src/components/AccountModal.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModal.spec.jsx
@@ -37,6 +37,8 @@ const accountIdMock = '123'
 describe('AccountModal', () => {
   const setup = () => {
     const mockHistoryPush = jest.fn()
+    const mockHistoryReplace = jest.fn()
+
     const component = shallow(
       <AccountModal
         konnector={{}}
@@ -44,11 +46,12 @@ describe('AccountModal', () => {
         accountId={accountIdMock}
         accountsAndTriggers={accountsAndTriggersMock}
         pushHistory={mockHistoryPush}
+        replaceHistory={mockHistoryReplace}
         breakpoints={{ isMobile: true }}
         onDismiss={jest.fn()}
       />
     )
-    return { component, mockHistoryPush }
+    return { component, mockHistoryPush, mockHistoryReplace }
   }
 
   it('should display the fetching state by default', () => {
@@ -62,7 +65,9 @@ describe('AccountModal', () => {
       name: 'account 1'
     })
 
-    const { component, mockHistoryPush } = setup({ fetchAccount })
+    const { component, mockHistoryPush } = setup({
+      fetchAccount
+    })
 
     it('should display the AccountSelect & Content if an account is there and we can change the selectedAccount', async () => {
       await component.instance().componentDidMount()

--- a/packages/cozy-harvest-lib/src/components/AccountsListModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountsListModal.jsx
@@ -8,7 +8,7 @@ import { MountPointContext } from './MountPointContext'
 import DialogContent from '@material-ui/core/DialogContent'
 
 const AccountsListModal = ({ konnector, accounts, t }) => {
-  const { pushHistory } = useContext(MountPointContext)
+  const { pushHistory, replaceHistory } = useContext(MountPointContext)
   return (
     <>
       <DialogContent>
@@ -23,7 +23,7 @@ const AccountsListModal = ({ konnector, accounts, t }) => {
         <AccountsList
           accounts={accounts}
           konnector={konnector}
-          onPick={option => pushHistory(`/accounts/${option.account._id}`)}
+          onPick={option => replaceHistory(`/accounts/${option.account._id}`)}
           addAccount={() => pushHistory('/new')}
         />
       </DialogContent>

--- a/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
@@ -19,7 +19,7 @@ import {
 import { fetchAccount } from '../connections/accounts'
 import * as triggersModel from '../helpers/triggers'
 import TriggerManager from './TriggerManager'
-import { withMountPointPushHistory } from './MountPointContext'
+import { withMountPointHistory } from './MountPointContext'
 import logger from '../logger'
 import { withTracker } from './hoc/tracking'
 import useTimeout from './hooks/useTimeout'
@@ -164,7 +164,7 @@ export class EditAccountModal extends Component {
   redirectToAccount() {
     const { account } = this.state
     if (account) {
-      this.props.pushHistory(`/accounts/${account._id}`)
+      this.props.replaceHistory(`/accounts/${account._id}`)
     } else {
       this.props.pushHistory(`/accounts`)
     }
@@ -203,6 +203,6 @@ EditAccountModal.propTypes = {
 
 export default flow(
   withClient,
-  withMountPointPushHistory,
+  withMountPointHistory,
   withTracker
 )(EditAccountModal)

--- a/packages/cozy-harvest-lib/src/components/HarvestModalRoot.jsx
+++ b/packages/cozy-harvest-lib/src/components/HarvestModalRoot.jsx
@@ -4,12 +4,12 @@ import AccountsListModal from './AccountsListModal'
 import { MountPointContext } from './MountPointContext'
 
 const HarvestModalRoot = ({ accounts, konnector }) => {
-  const { pushHistory } = useContext(MountPointContext)
+  const { replaceHistory } = useContext(MountPointContext)
   if (accounts.length === 0) {
-    pushHistory('/new')
+    replaceHistory('/new')
     return null
   } else if (accounts.length === 1) {
-    pushHistory(`/accounts/${accounts[0].account._id}`)
+    replaceHistory(`/accounts/${accounts[0].account._id}`)
     return null
   } else {
     return <AccountsListModal konnector={konnector} accounts={accounts} />

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
@@ -78,7 +78,7 @@ const ConfigurationTab = ({
 }) => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
-  const { pushHistory } = useContext(MountPointContext)
+  const { replaceHistory } = useContext(MountPointContext)
   const client = useClient()
   const vaultClient = useVaultClient()
   const [deleting, setDeleting] = useSafeState(false)
@@ -169,7 +169,7 @@ const ConfigurationTab = ({
             <ListItem
               button
               divider
-              onClick={() => pushHistory(`/accounts/${account._id}/edit`)}
+              onClick={() => replaceHistory(`/accounts/${account._id}/edit`)}
             >
               <ListItemIcon>
                 <Icon icon={KeyIcon} color={palette['slateGrey']} />

--- a/packages/cozy-harvest-lib/src/components/MountPointContext.jsx
+++ b/packages/cozy-harvest-lib/src/components/MountPointContext.jsx
@@ -9,21 +9,31 @@ export class RawMountPointProvider extends React.Component {
     super(props)
 
     this.pushHistory = this.pushHistory.bind(this)
+    this.replaceHistory = this.replaceHistory.bind(this)
 
     this.state = {
       baseRoute: props.baseRoute || '/',
-      pushHistory: this.pushHistory
+      pushHistory: this.pushHistory,
+      replaceHistory: this.replaceHistory
     }
   }
 
-  pushHistory(route) {
+  historyAction(route, method) {
     const { history } = this.props
     const { baseRoute } = this.state
-    const segments = baseRoute
-      .split('/')
-      .concat(route.split('/'))
-      .filter(Boolean)
-    history.push(`/${segments.join('/')}`)
+    const segments = '/'.concat(
+      baseRoute.split('/').concat(route.split('/')).filter(Boolean).join('/')
+    )
+
+    history[method](segments)
+  }
+
+  pushHistory(route) {
+    this.historyAction(route, 'push')
+  }
+
+  replaceHistory(route) {
+    this.historyAction(route, 'replace')
   }
 
   render() {
@@ -40,13 +50,20 @@ RawMountPointProvider.propTypes = {
   history: PropTypes.object
 }
 
-const withMountPointPushHistory = BaseComponent => {
+const withMountPointHistory = BaseComponent => {
   const Component = props => {
-    const { pushHistory } = useContext(MountPointContext)
-    return <BaseComponent pushHistory={pushHistory} {...props} />
+    const { pushHistory, replaceHistory } = useContext(MountPointContext)
+
+    return (
+      <BaseComponent
+        pushHistory={pushHistory}
+        replaceHistory={replaceHistory}
+        {...props}
+      />
+    )
   }
 
-  Component.displayName = `withMountPointPushHistory(${
+  Component.displayName = `withMountPointHistory(${
     BaseComponent.displayName || BaseComponent.name
   })`
 
@@ -54,4 +71,4 @@ const withMountPointPushHistory = BaseComponent => {
 }
 
 const MountPointProvider = withRouter(RawMountPointProvider)
-export { MountPointContext, MountPointProvider, withMountPointPushHistory }
+export { MountPointContext, MountPointProvider, withMountPointHistory }

--- a/packages/cozy-harvest-lib/src/components/MountPointContext.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/MountPointContext.spec.jsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme'
 import { RawMountPointProvider } from 'components/MountPointContext'
 
 describe('MountPointProvider', () => {
-  const historyMock = { push: jest.fn() }
+  const historyMock = { replace: jest.fn() }
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -14,17 +14,17 @@ describe('MountPointProvider', () => {
       <RawMountPointProvider baseRoute="/root" history={historyMock} />
     )
 
-    component.instance().pushHistory('/one')
-    expect(historyMock.push).toHaveBeenCalledWith('/root/one')
+    component.instance().replaceHistory('/one')
+    expect(historyMock.replace).toHaveBeenCalledWith('/root/one')
 
-    component.instance().pushHistory('/one/two')
-    expect(historyMock.push).toHaveBeenCalledWith('/root/one/two')
+    component.instance().replaceHistory('/one/two')
+    expect(historyMock.replace).toHaveBeenCalledWith('/root/one/two')
 
-    component.instance().pushHistory('no/slash')
-    expect(historyMock.push).toHaveBeenCalledWith('/root/no/slash')
+    component.instance().replaceHistory('no/slash')
+    expect(historyMock.replace).toHaveBeenCalledWith('/root/no/slash')
 
-    component.instance().pushHistory('too/many///slashes')
-    expect(historyMock.push).toHaveBeenCalledWith('/root/too/many/slashes')
+    component.instance().replaceHistory('too/many///slashes')
+    expect(historyMock.replace).toHaveBeenCalledWith('/root/too/many/slashes')
   })
 
   it('should handle a trailing slash in the base route', () => {
@@ -32,11 +32,11 @@ describe('MountPointProvider', () => {
       <RawMountPointProvider baseRoute="/root/" history={historyMock} />
     )
 
-    component.instance().pushHistory('/one')
-    expect(historyMock.push).toHaveBeenCalledWith('/root/one')
+    component.instance().replaceHistory('/one')
+    expect(historyMock.replace).toHaveBeenCalledWith('/root/one')
 
-    component.instance().pushHistory('no/slash')
-    expect(historyMock.push).toHaveBeenCalledWith('/root/no/slash')
+    component.instance().replaceHistory('no/slash')
+    expect(historyMock.replace).toHaveBeenCalledWith('/root/no/slash')
   })
 
   it('should handle a base route with multiple segments', () => {
@@ -44,10 +44,10 @@ describe('MountPointProvider', () => {
       <RawMountPointProvider baseRoute="/base/route/" history={historyMock} />
     )
 
-    component.instance().pushHistory('/one')
-    expect(historyMock.push).toHaveBeenCalledWith('/base/route/one')
+    component.instance().replaceHistory('/one')
+    expect(historyMock.replace).toHaveBeenCalledWith('/base/route/one')
 
-    component.instance().pushHistory('/one/two')
-    expect(historyMock.push).toHaveBeenCalledWith('/base/route/one/two')
+    component.instance().replaceHistory('/one/two')
+    expect(historyMock.replace).toHaveBeenCalledWith('/base/route/one/two')
   })
 })

--- a/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
@@ -26,7 +26,7 @@ import { useDialogContext } from './DialogContext'
 const NewAccountModal = ({ konnector, onDismiss }) => {
   const { t } = useI18n()
   const client = useClient()
-  const { pushHistory } = useContext(MountPointContext)
+  const { replaceHistory } = useContext(MountPointContext)
   const {
     fetchStatus,
     data: { isInMaintenance, messages: maintenanceMessages }
@@ -74,7 +74,7 @@ const NewAccountModal = ({ konnector, onDismiss }) => {
               if (trigger.worker !== 'client') {
                 path += '/success'
               }
-              pushHistory(path)
+              replaceHistory(path)
             }}
             onSuccess={trigger => {
               const accountId = triggersModel.getAccountId(trigger)
@@ -82,7 +82,7 @@ const NewAccountModal = ({ konnector, onDismiss }) => {
               if (trigger.worker !== 'client') {
                 path += '/success'
               }
-              pushHistory(path)
+              replaceHistory(path)
             }}
             onVaultDismiss={onDismiss}
             fieldOptions={fieldOptions}

--- a/packages/cozy-harvest-lib/src/components/NewAccountModal.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/NewAccountModal.spec.jsx
@@ -26,9 +26,9 @@ jest.mock('./DialogContext', () => {
 })
 
 describe('NewAccountModal', () => {
-  const pushHistory = jest.fn()
+  const replaceHistory = jest.fn()
   const mountPointContextValue = {
-    pushHistory
+    replaceHistory
   }
   const konnectorTrigger = {
     worker: 'konnector',
@@ -58,7 +58,7 @@ describe('NewAccountModal', () => {
       </AppLike>
     )
     onLoginSuccessFn(konnectorTrigger)
-    expect(pushHistory).toHaveBeenCalledWith('/accounts/accountNumber/success')
+    expect(replaceHistory).toHaveBeenCalledWith('/accounts/accountNumber/success')
   })
   it('should redirect to route without success on login success for client triggers', () => {
     render(
@@ -71,7 +71,7 @@ describe('NewAccountModal', () => {
       </AppLike>
     )
     onLoginSuccessFn(clientTrigger)
-    expect(pushHistory).toHaveBeenCalledWith('/accounts/accountNumberClient')
+    expect(replaceHistory).toHaveBeenCalledWith('/accounts/accountNumberClient')
   })
 
   it('should redirect to success route on success for non client triggers', () => {
@@ -85,7 +85,7 @@ describe('NewAccountModal', () => {
       </AppLike>
     )
     onSuccessFn(konnectorTrigger)
-    expect(pushHistory).toHaveBeenCalledWith('/accounts/accountNumber/success')
+    expect(replaceHistory).toHaveBeenCalledWith('/accounts/accountNumber/success')
   })
   it('should redirect to route without success on success for client triggers', () => {
     render(
@@ -98,6 +98,6 @@ describe('NewAccountModal', () => {
       </AppLike>
     )
     onSuccessFn(clientTrigger)
-    expect(pushHistory).toHaveBeenCalledWith('/accounts/accountNumberClient')
+    expect(replaceHistory).toHaveBeenCalledWith('/accounts/accountNumberClient')
   })
 })

--- a/packages/cozy-harvest-lib/src/components/RedirectToAccountFormButton.jsx
+++ b/packages/cozy-harvest-lib/src/components/RedirectToAccountFormButton.jsx
@@ -7,10 +7,10 @@ import { MountPointContext } from './MountPointContext'
 const RedirectToAccountFormButton = ({ trigger }) => {
   const { t } = useI18n()
   const accountId = getAccountId(trigger)
-  const { pushHistory } = useContext(MountPointContext)
+  const { replaceHistory } = useContext(MountPointContext)
   const handleClick = useCallback(() => {
-    pushHistory(`/accounts/${accountId}/edit?reconnect`)
-  }, [accountId, pushHistory])
+    replaceHistory(`/accounts/${accountId}/edit?reconnect`)
+  }, [accountId, replaceHistory])
   return (
     <Button
       className="u-ml-0"

--- a/packages/cozy-harvest-lib/src/components/RedirectToAccountFormButton.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/RedirectToAccountFormButton.spec.jsx
@@ -5,10 +5,10 @@ import RedirectToAccountFormButton from './RedirectToAccountFormButton'
 import AppLike from '../../test/AppLike'
 
 describe('redirect to account form button', () => {
-  it('should use pushHistory to navigate', () => {
-    const pushHistory = jest.fn()
+  it('should use replaceHistory to navigate', () => {
+    const replaceHistory = jest.fn()
     const mountPointContextValue = {
-      pushHistory
+      replaceHistory
     }
     const trigger = {
       message: {
@@ -23,7 +23,7 @@ describe('redirect to account form button', () => {
       </AppLike>
     )
     fireEvent.click(root.getByText('Reconnect'))
-    expect(pushHistory).toHaveBeenCalledWith(
+    expect(replaceHistory).toHaveBeenCalledWith(
       '/accounts/account-id-1337/edit?reconnect'
     )
   })


### PR DESCRIPTION
Using replace instead of push makes things go easier when going back.
But it also means the connector view is one single route
Going back will always go back to the home