### PR TITLE
Fix: Correctly handle `onclick` on cozy-harvest-lib's AppLinkCard

### DIFF
--- a/packages/cozy-harvest-lib/src/components/cards/AppLinkCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/AppLinkCard.jsx
@@ -28,7 +28,7 @@ export const AppLinkButton = ({ slug, path }) => {
     <AppLinker app={{ slug }} nativePath={path} href={url || '#'}>
       {({ onClick, href }) => (
         <ButtonLink
-          onClick={fetchStatus !== 'loaded' ? onClick : null}
+          onClick={fetchStatus === 'loaded' ? onClick : null}
           href={href}
           icon={
             isInstalled ? (

--- a/packages/cozy-harvest-lib/src/components/cards/AppLinkCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/AppLinkCard.jsx
@@ -28,6 +28,7 @@ export const AppLinkButton = ({ slug, path }) => {
     <AppLinker app={{ slug }} nativePath={path} href={url || '#'}>
       {({ onClick, href }) => (
         <ButtonLink
+          disabled={fetchStatus !== 'loaded'}
           onClick={fetchStatus === 'loaded' ? onClick : null}
           href={href}
           icon={


### PR DESCRIPTION
Refactoring from 7d06e05cf9cb3647a92c6ab85f2b2262946971c6 introduced a
bug as the `fetchStatus` condition should have been reversed

We didn't notice this error as most of our apps can rely on the
button's `href`

But in ReactNative context, we rely on the onClick behavior in order to
send the correct `openApp` message to the native side

---

Also this PR disable the AppLinkCard's button until `fetchStatus` is `loaded`
to prevent `href` to be called instead of `onClick` if the user clicks on the button
too early