### PR TITLE
fix(repo-doctor): Moment and Material-UI should not be dependencies

### DIFF
--- a/packages/repo-doctor/examples/repo-doctor.json
+++ b/packages/repo-doctor/examples/repo-doctor.json
@@ -50,6 +50,10 @@
           "reason": "Used through cozy-scripts"
         },
         {
+          "name": "material-ui",
+          "reason": "Used through cozy-ui"
+        },
+        {
           "name": "moment",
           "reason": "Used Intl/DateTimeFormat or date-fns"
         }


### PR DESCRIPTION
According to our [guidelines](https://github.com/cozy/cozy-guidelines), material-ui and moment should not be set as dependencies.
This decision has been taken during Front meeting of 12th April


<img width="768" alt="Capture d’écran 2022-04-12 à 14 34 48" src="https://user-images.githubusercontent.com/8363334/162963614-866e76eb-9069-40c0-b1d0-7c6f31fa842e.png">
