### PR TITLE
Feat/viewer route

### DIFF
--- a/packages/cozy-harvest-lib/src/components/Routes.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes.jsx
@@ -7,6 +7,11 @@ import {
   DialogCloseButton,
   useCozyDialog
 } from 'cozy-ui/transpiled/react/CozyDialogs'
+import {
+  useVaultUnlockContext,
+  VaultUnlockProvider,
+  VaultUnlockPlaceholder
+} from 'cozy-keys-lib'
 
 import KonnectorAccounts from './KonnectorAccounts'
 import AccountModal from './AccountModal'
@@ -18,11 +23,8 @@ import HarvestVaultProvider from './HarvestVaultProvider'
 import { MountPointProvider } from './MountPointContext'
 import DialogContext from './DialogContext'
 import { DatacardOptions } from './Datacards/DatacardOptionsContext'
-import {
-  useVaultUnlockContext,
-  VaultUnlockProvider,
-  VaultUnlockPlaceholder
-} from 'cozy-keys-lib'
+
+import { ViewerModal } from '../datacards/ViewerModal'
 
 /**
  * Dialog will not be centered vertically since we need the modal to "stay in place"
@@ -99,6 +101,13 @@ const Routes = ({ konnectorRoot, konnector, onDismiss, datacardOptions }) => {
                             accountId={match.params.accountId}
                             accounts={accountsAndTriggers}
                           />
+                        )}
+                      />
+                      <Route
+                        path={`${konnectorRoot}/viewer/:accountId/:folderToSaveId/:fileIndex`}
+                        exact
+                        render={routeComponentProps => (
+                          <ViewerModal {...routeComponentProps} />
                         )}
                       />
                       <Route

--- a/packages/cozy-harvest-lib/src/datacards/ViewerModal.jsx
+++ b/packages/cozy-harvest-lib/src/datacards/ViewerModal.jsx
@@ -1,0 +1,43 @@
+import React, { useContext } from 'react'
+
+import Overlay from 'cozy-ui/transpiled/react/Overlay'
+import Viewer from 'cozy-ui/transpiled/react/Viewer'
+
+import { MountPointContext } from '../components/MountPointContext'
+import { useDataCardFiles } from './useDataCardFiles'
+
+export const ViewerModal = ({
+  match: {
+    params: { accountId, folderToSaveId, fileIndex }
+  }
+}) => {
+  const { pushHistory, replaceHistory } = useContext(MountPointContext)
+  const { data, fetchStatus } = useDataCardFiles(accountId, folderToSaveId)
+
+  const handleCloseViewer = () => replaceHistory(`/accounts`)
+  const handleFileChange = (_file, newIndex) =>
+    pushHistory(`/viewer/${accountId}/${folderToSaveId}/${newIndex}`)
+
+  if (
+    fetchStatus === 'empty' ||
+    fetchStatus === 'failed' ||
+    (fetchStatus === 'loaded' && fileIndex > data.length)
+  ) {
+    handleCloseViewer()
+
+    return null
+  }
+
+  if (fetchStatus === 'loading') return <Overlay />
+
+  return (
+    <Overlay>
+      <Viewer
+        files={data}
+        currentIndex={Number(fileIndex)}
+        onCloseRequest={handleCloseViewer}
+        onChangeRequest={handleFileChange}
+      />
+    </Overlay>
+  )
+}

--- a/packages/cozy-harvest-lib/src/datacards/useDataCardFiles.js
+++ b/packages/cozy-harvest-lib/src/datacards/useDataCardFiles.js
@@ -1,0 +1,84 @@
+import { useMemo } from 'react'
+import get from 'lodash/get'
+import sortBy from 'lodash/sortBy'
+import uniq from 'lodash/uniq'
+
+import CozyClient, { Q, useQuery, hasQueryBeenLoaded } from 'cozy-client'
+
+const useFolderToSaveFiles = folderToSaveId =>
+  useQuery(
+    Q('io.cozy.files')
+      .where({
+        dir_id: folderToSaveId,
+        trashed: false
+      })
+      .indexFields(['dir_id', 'cozyMetadata.createdAt'])
+      .sortBy([{ dir_id: 'desc' }, { 'cozyMetadata.createdAt': 'desc' }])
+      .limitBy(5),
+    {
+      as: `fileDataCard_io.cozy.files/${folderToSaveId}/io.cozy.files`,
+      fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000)
+    }
+  )
+
+const useSourceAccountFiles = accountId =>
+  useQuery(
+    Q('io.cozy.files')
+      .where({ 'cozyMetadata.sourceAccount': accountId, trashed: false })
+      .indexFields(['cozyMetadata.sourceAccount', 'cozyMetadata.createdAt'])
+      .sortBy([
+        { 'cozyMetadata.sourceAccount': 'desc' },
+        { 'cozyMetadata.createdAt': 'desc' }
+      ])
+      .limitBy(5),
+    {
+      as: `fileDataCard_io.cozy.accounts/${accountId}/io.cozy.files`,
+      fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000)
+    }
+  )
+
+const getResponse = (folderToSaveFiles, sourceAccountFiles) => {
+  const loaded = Boolean(
+    hasQueryBeenLoaded(folderToSaveFiles) &&
+      hasQueryBeenLoaded(sourceAccountFiles)
+  )
+
+  if (
+    folderToSaveFiles.fetchStatus === 'failed' &&
+    sourceAccountFiles === 'failed'
+  )
+    return { fetchStatus: 'failed' }
+
+  if (
+    loaded &&
+    folderToSaveFiles.data.length === 0 &&
+    sourceAccountFiles.data.length === 0
+  )
+    return { fetchStatus: 'empty' }
+
+  if (loaded)
+    return {
+      data: sortBy(
+        uniq(
+          [...folderToSaveFiles.data, ...sourceAccountFiles.data],
+          x => x._id
+        ),
+        x => get(x, 'cozyMetadata.createdAt')
+      )
+        .reverse()
+        .slice(0, 5),
+      fetchStatus: 'loaded'
+    }
+
+  return { fetchStatus: 'loading' }
+}
+
+export const useDataCardFiles = (accountId, folderToSaveId) => {
+  const folderToSaveFiles = useFolderToSaveFiles(folderToSaveId)
+  const sourceAccountFiles = useSourceAccountFiles(accountId)
+
+  return useMemo(
+    () => getResponse(folderToSaveFiles, sourceAccountFiles),
+    [folderToSaveFiles, sourceAccountFiles]
+  )
+}

--- a/packages/cozy-harvest-lib/src/datacards/useDataCardFiles.spec.js
+++ b/packages/cozy-harvest-lib/src/datacards/useDataCardFiles.spec.js
@@ -1,0 +1,135 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import { useDataCardFiles } from './useDataCardFiles'
+
+const mockUseQuery = jest.fn()
+const mockFile1 = { cozyMetadata: { createdAt: '1970-01-01T00:00:11Z' } }
+const mockFile2 = { cozyMetadata: { createdAt: '1970-01-01T00:00:10Z' } }
+const mockFile3 = { cozyMetadata: { createdAt: '1970-01-01T00:00:09Z' } }
+const mockFile4 = { cozyMetadata: { createdAt: '1970-01-01T00:00:08Z' } }
+const mockFile5 = { cozyMetadata: { createdAt: '1970-01-01T00:00:07Z' } }
+const mockFile6 = { cozyMetadata: { createdAt: '1970-01-01T00:00:06Z' } }
+const mockFile7 = { cozyMetadata: { createdAt: '1970-01-01T00:00:05Z' } }
+const mockFile8 = { cozyMetadata: { createdAt: '1970-01-01T00:00:04Z' } }
+const mockFile9 = { cozyMetadata: { createdAt: '1970-01-01T00:00:03Z' } }
+const mockFile10 = { cozyMetadata: { createdAt: '1970-01-01T00:00:02Z' } }
+const mockFile11 = { cozyMetadata: { createdAt: '1970-01-01T00:00:01Z' } }
+const mockFile12 = { cozyMetadata: { createdAt: '1970-01-01T00:00:00Z' } }
+
+jest.mock('cozy-client', () => ({
+  ...jest.requireActual('cozy-client'),
+  useQuery: () => mockUseQuery()
+}))
+
+afterEach(() => {
+  mockUseQuery.mockClear()
+})
+
+it('handles files pending', () => {
+  mockUseQuery.mockReturnValueOnce({ fetchStatus: 'pending', data: null })
+  mockUseQuery.mockReturnValueOnce({ fetchStatus: 'pending', data: null })
+  const { result } = renderHook(() => useDataCardFiles('1', '2'))
+  expect(result.current).toStrictEqual({ fetchStatus: 'loading' })
+})
+
+it('handles files loading', () => {
+  mockUseQuery.mockReturnValueOnce({ fetchStatus: 'loading', data: null })
+  mockUseQuery.mockReturnValueOnce({ fetchStatus: 'loading', data: null })
+  const { result } = renderHook(() => useDataCardFiles('1', '2'))
+  expect(result.current).toStrictEqual({ fetchStatus: 'loading' })
+})
+
+it('handles files loading with partial data', () => {
+  mockUseQuery.mockReturnValueOnce({
+    fetchStatus: 'loading',
+    data: [mockFile1]
+  })
+  mockUseQuery.mockReturnValueOnce({
+    fetchStatus: 'loading',
+    data: [mockFile2]
+  })
+  const { result } = renderHook(() => useDataCardFiles('1', '2'))
+  expect(result.current).toStrictEqual({ fetchStatus: 'loading' })
+})
+
+it('handles files loading with more partial data', () => {
+  mockUseQuery.mockReturnValueOnce({
+    fetchStatus: 'loading',
+    data: [mockFile1, mockFile2]
+  })
+  mockUseQuery.mockReturnValueOnce({
+    fetchStatus: 'loading',
+    data: [mockFile3, mockFile4]
+  })
+  const { result } = renderHook(() => useDataCardFiles('1', '2'))
+  expect(result.current).toStrictEqual({ fetchStatus: 'loading' })
+})
+
+it('handles files loading with empty data', () => {
+  mockUseQuery.mockReturnValueOnce({
+    fetchStatus: 'loaded',
+    data: [],
+    lastFetch: 1
+  })
+  mockUseQuery.mockReturnValueOnce({
+    fetchStatus: 'loaded',
+    data: [],
+    lastFetch: 1
+  })
+  const { result } = renderHook(() => useDataCardFiles('1', '2'))
+  expect(result.current).toStrictEqual({ fetchStatus: 'empty' })
+})
+
+it('handles files loaded and return in correct order', () => {
+  mockUseQuery.mockReturnValueOnce({
+    fetchStatus: 'loaded',
+    data: [mockFile2, mockFile1],
+    lastFetch: 1
+  })
+  mockUseQuery.mockReturnValueOnce({
+    fetchStatus: 'loaded',
+    data: [mockFile3, mockFile4],
+    lastFetch: 1
+  })
+  const { result } = renderHook(() => useDataCardFiles('1', '2'))
+  expect(result.current).toStrictEqual({
+    data: [mockFile1, mockFile2, mockFile3, mockFile4],
+    fetchStatus: 'loaded'
+  })
+})
+
+it('handles files loaded with identical double return', () => {
+  mockUseQuery.mockReturnValueOnce({
+    fetchStatus: 'loaded',
+    data: [mockFile1, mockFile2, mockFile3, mockFile4],
+    lastFetch: 1
+  })
+  mockUseQuery.mockReturnValueOnce({
+    fetchStatus: 'loaded',
+    data: [mockFile3, mockFile2, mockFile3, mockFile4],
+    lastFetch: 1
+  })
+  const { result } = renderHook(() => useDataCardFiles('1', '2'))
+  expect(result.current).toStrictEqual({
+    data: [mockFile1, mockFile2, mockFile3, mockFile4],
+    fetchStatus: 'loaded'
+  })
+})
+
+it('handles files loaded with more than 5 result', () => {
+  mockUseQuery.mockReturnValueOnce({
+    fetchStatus: 'loaded',
+    data: [mockFile1, mockFile2, mockFile3, mockFile4, mockFile5, mockFile6],
+    lastFetch: 1
+  })
+  mockUseQuery.mockReturnValueOnce({
+    fetchStatus: 'loaded',
+    data: [mockFile7, mockFile8, mockFile9, mockFile10, mockFile11, mockFile12],
+    lastFetch: 1
+  })
+  const { result } = renderHook(() => useDataCardFiles('1', '2'))
+  expect(result.current).toStrictEqual({
+    data: [mockFile1, mockFile2, mockFile3, mockFile4, mockFile5],
+    fetchStatus: 'loaded'
+  })
+})


### PR DESCRIPTION
https://trello.com/c/Ge6JSeCT/377-harvest-gestion-dune-route-pour-la-visionneuse-de-fichier

### Features

- [x] Adding a new route in cozy-harvest for the file viewer, allowing better navigation
- [x] It is now possible to navigate between files and back/forward with browser history

### Implementation

- [x] Remove Viewer from FileDataCard
- [x] Create Route
- [x] Create a new hook to get files data
- [x] Create a new component to display this data
- [x] Refactor old FileDataCard to use the new hook

### Caveats

When leaving the viewer with the "goback" arrow, we replace history. But that means we're still 2 back aways from returning to the home from there.
