### PR TITLE
fix: Avoid to have not sanitized fields as identifier fields

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -132,7 +132,7 @@ export class AccountForm extends PureComponent {
   handleSubmit(values, form) {
     const { account, konnector } = this.props
 
-    const identifier = manifest.getIdentifier(konnector.fields)
+    const identifier = manifest.getIdentifier(manifest.sanitizeFields(konnector.fields))
     if (
       account &&
       account.auth[identifier] &&
@@ -228,7 +228,7 @@ export class AccountForm extends PureComponent {
       this.props.readOnlyIdentifier
 
     if (isReadOnlyIdentifier) {
-      const identifier = manifest.getIdentifier(fields)
+      const identifier = manifest.getIdentifier(sanitizedFields)
       sanitizedFields[identifier].type = 'hidden'
     }
 
@@ -268,7 +268,7 @@ export class AccountForm extends PureComponent {
                 konnector={konnector}
                 identifier={get(
                   account,
-                  `auth.${manifest.getIdentifier(konnector.fields)}`
+                  `auth.${manifest.getIdentifier(sanitizedFields)}`
                 )}
               />
             )}

--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.spec.jsx
@@ -49,6 +49,19 @@ const fixtures = {
       }
     }
   },
+  konnectorWithAdvancedField: {
+    fields: {
+      advancedFields: {
+        folderPath: {
+          advanced: true,
+          isRequired: false
+        }
+      },
+      username: {
+        type: 'text'
+      }
+    }
+  },
   account: {
     auth: {
       username: 'Toto',
@@ -370,6 +383,42 @@ describe('AccountForm', () => {
             flowState={flowState}
             t={t}
             konnector={fixtures.konnector}
+            onSubmit={onSubmit}
+            account={accountWithCipher}
+            readOnlyIdentifier={true}
+            fieldOptions={{}}
+          />
+        </I18n>,
+        {
+          context: { t },
+          childContextTypes: {
+            t: PropTypes.func
+          }
+        }
+      )
+
+      const hiddenInput = wrapper.find('input[type="hidden"][name="username"]')
+
+      expect(hiddenInput).toHaveLength(1)
+    })
+    it('should render a read-only identifier field even with advancedFields field in the manifest', () => {
+      const accountWithCipher = {
+        ...fixtures.account,
+        relationships: {
+          vaultCipher: {
+            _id: 'fake-cipher-id',
+            _type: 'com.bitwarden.ciphers',
+            _protocol: 'bitwarden'
+          }
+        }
+      }
+      const flowState = {}
+      const wrapper = mount(
+        <I18n lang="en" dictRequire={() => {}}>
+          <AccountForm
+            flowState={flowState}
+            t={t}
+            konnector={fixtures.konnectorWithAdvancedField}
             onSubmit={onSubmit}
             account={accountWithCipher}
             readOnlyIdentifier={true}


### PR DESCRIPTION
When some connectors have unusual fields, like ovh, this can lead to
have "advancedFields" as identifier field

This is just a protection. The best fix beeing the connector choosing
itself the the best identifer field by adding `role: "identifier"` to
the corresponding field
