### PR TITLE
fix: Import choice via connector

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ImportDropdown/ImportDropdown.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ImportDropdown/ImportDropdown.jsx
@@ -17,7 +17,6 @@ import {
 } from 'cozy-ui/transpiled/react/ActionMenu'
 import { Media, Img, Bd } from 'cozy-ui/transpiled/react/Media'
 
-import { useStepperDialog } from '../Hooks/useStepperDialog'
 import { useScannerI18n } from '../Hooks/useScannerI18n'
 import Konnector from '../../assets/icons/Konnectors.svg'
 
@@ -36,13 +35,17 @@ const useStyles = makeStyles(theme => ({
   }
 }))
 
-const ImportDropdown = ({ label, icon, hasSteps, onClick, onClose }) => {
+const ImportDropdown = ({ placeholder, onClick, onClose }) => {
   const { t } = useI18n()
   const client = useClient()
   const scannerT = useScannerI18n()
-  const { currentDefinition } = useStepperDialog()
-  const konnectorCategory = currentDefinition?.connectorCriteria?.category
-  const konnectorName = currentDefinition?.connectorCriteria?.name
+  const {
+    label,
+    icon,
+    acquisitionSteps: { length: acquisitionStepsLength },
+    connectorCriteria: { category: konnectorCategory, name: konnectorName } = {}
+  } = placeholder
+  const hasSteps = acquisitionStepsLength > 0
   const styles = useStyles()
 
   const goToStore = () => {
@@ -175,11 +178,17 @@ const ImportDropdown = ({ label, icon, hasSteps, onClick, onClose }) => {
 }
 
 ImportDropdown.propTypes = {
-  label: PropTypes.string.isRequired,
-  icon: iconPropType.isRequired,
-  hasSteps: PropTypes.bool,
+  placeholder: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    icon: iconPropType.isRequired,
+    acquisitionSteps: PropTypes.array.isRequired,
+    connectorCriteria: PropTypes.shape({
+      name: PropTypes.string,
+      category: PropTypes.string
+    })
+  }).isRequired,
   onClose: PropTypes.func,
   onClick: PropTypes.func
 }
 
-export default React.memo(ImportDropdown)
+export default ImportDropdown

--- a/packages/cozy-mespapiers-lib/src/components/ImportDropdown/ImportDropdown.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ImportDropdown/ImportDropdown.spec.jsx
@@ -17,9 +17,10 @@ jest.mock('cozy-client/dist/models/document/locales', () => ({
 }))
 
 const setup = (label = 'national_id_card') => {
+  const placeholder = { label, icon: People, acquisitionSteps: [] }
   return render(
     <AppLike>
-      <ImportDropdown label={label} icon={People} />
+      <ImportDropdown placeholder={placeholder} />
     </AppLike>
   )
 }

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/ActionMenuImportDropdown.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/ActionMenuImportDropdown.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import ActionMenu from 'cozy-ui/transpiled/react/ActionMenu'
+import { iconPropType } from 'cozy-ui/transpiled/react/Icon'
 
 import ImportDropdown from '../ImportDropdown/ImportDropdown'
 
@@ -23,14 +25,32 @@ const ActionMenuImportDropdown = ({
       onClose={onClose}
     >
       <ImportDropdown
-        label={placeholder.label}
-        icon={placeholder.icon}
-        hasSteps={placeholder?.acquisitionSteps.length > 0}
+        placeholder={placeholder}
         onClose={onClose}
         onClick={onClick}
       />
     </ActionMenu>
   )
+}
+
+ActionMenuImportDropdown.propTypes = {
+  className: PropTypes.string,
+  anchorElRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) })
+  ]),
+  isOpened: PropTypes.bool.isRequired,
+  placeholder: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    icon: iconPropType.isRequired,
+    acquisitionSteps: PropTypes.array,
+    connectorCriteria: PropTypes.shape({
+      name: PropTypes.string,
+      category: PropTypes.string
+    })
+  }).isRequired,
+  onClose: PropTypes.func,
+  onClick: PropTypes.func
 }
 
 export default ActionMenuImportDropdown


### PR DESCRIPTION
When a suggestion has the `connectorCriteria` property, we should be able to be redirected to the store (pre-filtered)

As a result of this refactor https://github.com/cozy/mespapiers/commit/f1b8c64, the `currentDefinition` property of the `useStepperDialog` hook is no longer defined in the `ImportDropdown` component.
As we have the `placeholder` object (same as `currentDefinition`) we might as well use it directly