### PR TITLE
fix: Add skip-cleanup to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_deploy:
   - git config --global user.name "Cozy Bot"
 deploy:
   - provider: script
+  - skip-cleanup: true
     script: 'git checkout master && git remote set-url origin https://cozy-bot:$GITHUB_TOKEN@github.com/cozy/cozy-libs.git && echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc && yarn lerna publish --yes -m "[skip ci] Publish"'
     on:
       branch: master


### PR DESCRIPTION
Deleting skip-cleanup in https://github.com/cozy/cozy-libs/commit/51ae10dd3411ef0ff8c8434d8d5d02d31ac44722 would make the CI fail when executing the deploy script (i.e. when merging on master)
The observed error is that lerna command is not recognized anymore
and suggests that the node_modules folder doesn't exist anymore
and so skip-cleanup's default behavior doesn't seem
to be applied as described in the travis documentation