### PR TITLE
feat: On mobile, add download action in paper line option

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Actions/utils.js
+++ b/packages/cozy-mespapiers-lib/src/components/Actions/utils.js
@@ -5,6 +5,11 @@ import { isReferencedBy } from 'cozy-client'
 
 import { FILES_DOCTYPE } from '../../doctypes'
 import { getSharingLink } from '../../utils/getSharingLink'
+import { download, forward } from './Actions'
+
+export const makeActionVariant = () => {
+  return navigator.share ? [download, forward] : [download]
+}
 
 export const isAnyFileReferencedBy = (files, doctype) => {
   for (let i = 0, l = files.length; i < l; ++i) {

--- a/packages/cozy-mespapiers-lib/src/components/Actions/utils.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Actions/utils.spec.js
@@ -1,0 +1,18 @@
+import { makeActionVariant } from './utils'
+import { download, forward } from './Actions'
+
+jest.mock('./Actions')
+
+describe('makeActionVariant', () => {
+  it('should have "download" action on desktop', () => {
+    global.navigator.share = null
+
+    expect(makeActionVariant()).toStrictEqual([download])
+  })
+
+  it('should have "download" & "Forward" action (in this order) on mobile', () => {
+    global.navigator.share = () => {}
+
+    expect(makeActionVariant()).toStrictEqual([download, forward])
+  })
+})

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PapersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PapersList.jsx
@@ -8,14 +8,8 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import PaperLine from '../Papers/PaperLine'
 import makeActions from '../Actions/makeActions'
 import { useModal } from '../Hooks/useModal'
-import {
-  download,
-  forward,
-  hr,
-  trash,
-  open,
-  viewInDrive
-} from '../Actions/Actions'
+import { hr, trash, open, viewInDrive } from '../Actions/Actions'
+import { makeActionVariant } from '../Actions/utils'
 
 const PapersList = ({ papers }) => {
   const client = useClient()
@@ -23,10 +17,10 @@ const PapersList = ({ papers }) => {
   const { pushModal, popModal } = useModal()
   const [maxDisplay, setMaxDisplay] = useState(papers.maxDisplay)
 
-  const actionVariant = navigator.share ? forward : download
+  const actionVariant = makeActionVariant()
   const actions = useMemo(
     () =>
-      makeActions([actionVariant, viewInDrive, open, hr, trash], {
+      makeActions([...actionVariant, viewInDrive, open, hr, trash], {
         client,
         pushModal,
         popModal


### PR DESCRIPTION
In the options (...) of each line of Paper, on mobile, we want to add the Download action