### PR TITLE
Feat/bypass import dropdown

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ImportDropdown/ImportDropdown.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ImportDropdown/ImportDropdown.jsx
@@ -137,36 +137,14 @@ const ImportDropdown = ({ placeholder, onClick, onClose }) => {
         </Typography>
       </ActionMenuItem>
       <ActionMenuItem
-        className={cx('u-flex-items-center', {
-          [styles.disabledItem]: !konnectorCategory && !konnectorName
-        })}
-        left={
-          <Icon
-            className={cx({
-              [styles.disabledIcon]: !konnectorCategory && !konnectorName
-            })}
-            icon={Konnector}
-            size={24}
-          />
-        }
-        onClick={konnectorCategory || konnectorName ? goToStore : null}
+        className={cx('u-flex-items-center')}
+        left={<Icon icon={Konnector} size={24} />}
+        onClick={goToStore}
       >
-        <Typography
-          className={cx({
-            [styles.disabledTypography]: !konnectorCategory && !konnectorName
-          })}
-          variant="body1"
-          gutterBottom
-        >
+        <Typography variant="body1" gutterBottom>
           {t('ImportDropdown.importAuto.title')}
         </Typography>
-        <Typography
-          className={cx({
-            [styles.disabledTypography]: !konnectorCategory && !konnectorName
-          })}
-          variant="caption"
-          color="textSecondary"
-        >
+        <Typography variant="caption" color="textSecondary">
           {t('ImportDropdown.importAuto.text')}
         </Typography>
       </ActionMenuItem>

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/FeaturedPlaceholdersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/FeaturedPlaceholdersList.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useRef } from 'react'
+import React, { useState, useRef } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import PropTypes from 'prop-types'
 import { useHistory, useLocation } from 'react-router-dom'
@@ -26,15 +26,27 @@ const FeaturedPlaceholdersList = ({ featuredPlaceholders }) => {
     useState(false)
   const history = useHistory()
   const location = useLocation()
-  const hideImportDropdown = useCallback(
-    () => setIsImportDropdownDisplayed(false),
-    []
-  )
+
+  const hideImportDropdown = () => {
+    setIsImportDropdownDisplayed(false)
+    setPlaceholder(null)
+  }
+
+  const redirectPaperCreation = placeholder => {
+    return history.push({
+      pathname: `/paper/create/${placeholder.label}`,
+      search: `backgroundPath=${location.pathname}`
+    })
+  }
 
   const showImportDropdown = idx => placeholder => {
-    actionBtnRef.current = actionBtnRefs.current[idx]
-    setIsImportDropdownDisplayed(true)
-    setPlaceholder(placeholder)
+    if (placeholder.connectorCriteria) {
+      actionBtnRef.current = actionBtnRefs.current[idx]
+      setIsImportDropdownDisplayed(true)
+      setPlaceholder(placeholder)
+    } else {
+      redirectPaperCreation(placeholder)
+    }
   }
 
   return (
@@ -59,12 +71,7 @@ const FeaturedPlaceholdersList = ({ featuredPlaceholders }) => {
           placeholder={placeholder}
           onClose={hideImportDropdown}
           anchorElRef={actionBtnRef}
-          onClick={() =>
-            history.push({
-              pathname: `/paper/create/${placeholder.label}`,
-              search: `backgroundPath=${location.pathname}`
-            })
-          }
+          onClick={() => redirectPaperCreation(placeholder)}
         />
       </div>
     </List>

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/Placeholder.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/Placeholder.jsx
@@ -17,7 +17,12 @@ const Placeholder = forwardRef(({ placeholder, divider, onClick }, ref) => {
 
   return (
     <>
-      <ListItem button onClick={() => onClick(placeholder)} ref={ref}>
+      <ListItem
+        button
+        onClick={() => onClick(placeholder)}
+        ref={ref}
+        data-testid="Placeholder-ListItem"
+      >
         <ListItemIcon>
           <InfosBadge
             badgeContent={

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/Placeholder.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/Placeholder.spec.jsx
@@ -1,26 +1,52 @@
 'use strict'
 import React from 'react'
-import { render } from '@testing-library/react'
-
-import { models } from 'cozy-client'
+import { fireEvent, render } from '@testing-library/react'
 
 import AppLike from '../../../test/components/AppLike'
-import paperJSON from '../../constants/papersDefinitions.json'
 import Placeholder from './Placeholder'
 
-const {
-  locales: { getBoundT }
-} = models.document
-const papersList = paperJSON.papersDefinitions
+const fakePlaceholders = [
+  {
+    label: 'tax_notice',
+    placeholderIndex: 6,
+    icon: 'bank',
+    featureDate: 'referencedDate',
+    maxDisplay: 3,
+    acquisitionSteps: [],
+    connectorCriteria: {
+      name: 'impots'
+    }
+  },
+  {
+    label: 'driver_license',
+    placeholderIndex: 2,
+    icon: 'car',
+    featureDate: 'carObtentionDate',
+    maxDisplay: 2,
+    acquisitionSteps: [
+      {
+        stepIndex: 1,
+        model: 'scan',
+        page: 'front',
+        illustration: 'IlluDriverLicenseFront.png',
+        text: 'PaperJSON.generic.front.text'
+      }
+    ]
+  }
+]
 
-jest.mock('cozy-client/dist/models/document/locales', () => ({
-  getBoundT: jest.fn(() => jest.fn())
-}))
-
-const setup = (placeholder = papersList[0]) => {
+const setup = ({
+  placeholder = fakePlaceholders[0],
+  divider = false,
+  onClick = jest.fn()
+} = {}) => {
   return render(
     <AppLike>
-      <Placeholder placeholder={placeholder} divider={true} />
+      <Placeholder
+        placeholder={placeholder}
+        divider={divider}
+        onClick={onClick}
+      />
     </AppLike>
   )
 }
@@ -32,17 +58,37 @@ describe('Placeholder components:', () => {
     expect(container).toBeDefined()
   })
 
-  it('should display ID card', () => {
-    getBoundT.mockReturnValueOnce(() => 'ID card')
-    const { getByText } = setup(papersList[0])
+  it('should display label of placeholder', () => {
+    const { getByText } = setup({ placeholder: fakePlaceholders[0] })
 
-    expect(getByText('ID card'))
+    expect(getByText('Tax notice'))
   })
 
-  it('should display Passeport', () => {
-    getBoundT.mockReturnValueOnce(() => 'Passport')
-    const { getByText } = setup(papersList[1])
+  it('should display an divider', () => {
+    const { getByRole } = setup({
+      divider: true
+    })
 
-    expect(getByText('Passport'))
+    expect(getByRole('separator'))
+  })
+
+  it('should not display an divider', () => {
+    const { queryByRole } = setup({
+      divider: false
+    })
+
+    expect(queryByRole('separator')).toBeNull()
+  })
+
+  it('should call onClick when placeholder line is clicked', () => {
+    const mockOnClick = jest.fn()
+    const { getByTestId } = setup({
+      onClick: mockOnClick
+    })
+
+    const placeholderLine = getByTestId('Placeholder-ListItem')
+    fireEvent.click(placeholderLine)
+
+    expect(mockOnClick).toBeCalledTimes(1)
   })
 })

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/PlaceholdersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/PlaceholdersList.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react'
 import PropTypes from 'prop-types'
-import cx from 'classnames'
 import { useHistory, useLocation } from 'react-router-dom'
 import { makeStyles } from '@material-ui/core/styles'
 
@@ -67,9 +66,9 @@ const PlaceholdersList = ({ currentQualifItems }) => {
     return !!isImportDropdownDisplayed && !!placeholderSelected
   }
 
-  const selectPlaceholder = useCallback((placeholder, stepsExists) => {
-    stepsExists ? setPlaceholderSelected(placeholder) : undefined
-  }, [])
+  const selectPlaceholder = (placeholder, validPlaceholder) => {
+    validPlaceholder ? setPlaceholderSelected(placeholder) : undefined
+  }
 
   useEffect(() => {
     if (placeholderSelected) setIsImportDropdownDisplayed(true)
@@ -79,7 +78,7 @@ const PlaceholdersList = ({ currentQualifItems }) => {
     <>
       <List className={styles.placeholderList}>
         {allPlaceholders.map((placeholder, idx) => {
-          const stepsExists =
+          const validPlaceholder =
             placeholder.acquisitionSteps.length > 0 ||
             placeholder.connectorCriteria
 
@@ -87,11 +86,9 @@ const PlaceholdersList = ({ currentQualifItems }) => {
             <ListItem
               button
               disableGutters
+              disabled={!validPlaceholder}
               key={idx}
-              onClick={() => selectPlaceholder(placeholder, stepsExists)}
-              className={cx({
-                ['u-o-50']: !stepsExists
-              })}
+              onClick={() => selectPlaceholder(placeholder, validPlaceholder)}
             >
               <ListItemIcon>
                 <IconStack

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/PlaceholdersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/PlaceholdersList.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback, useEffect } from 'react'
+import React, { useState, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { useHistory, useLocation } from 'react-router-dom'
 import { makeStyles } from '@material-ui/core/styles'
@@ -57,22 +57,30 @@ const PlaceholdersList = ({ currentQualifItems }) => {
       findPlaceholdersByQualification(papersDefinitions, currentQualifItems),
     [currentQualifItems, papersDefinitions]
   )
-  const hideImportDropdown = useCallback(() => {
+  const hideImportDropdown = () => {
     setIsImportDropdownDisplayed(false)
     setPlaceholderSelected(undefined)
-  }, [])
+  }
 
   const shouldDisplayImportDropdown = () => {
     return !!isImportDropdownDisplayed && !!placeholderSelected
   }
 
-  const selectPlaceholder = (placeholder, validPlaceholder) => {
-    validPlaceholder ? setPlaceholderSelected(placeholder) : undefined
+  const redirectPaperCreation = placeholder => {
+    return history.push({
+      pathname: `/paper/create/${placeholder.label}`,
+      search: `deepBack&backgroundPath=${backgroundPath}`
+    })
   }
 
-  useEffect(() => {
-    if (placeholderSelected) setIsImportDropdownDisplayed(true)
-  }, [placeholderSelected])
+  const showImportDropdown = placeholder => {
+    if (placeholder.connectorCriteria) {
+      setIsImportDropdownDisplayed(true)
+      setPlaceholderSelected(placeholder)
+    } else {
+      redirectPaperCreation(placeholder)
+    }
+  }
 
   return (
     <>
@@ -84,11 +92,12 @@ const PlaceholdersList = ({ currentQualifItems }) => {
 
           return (
             <ListItem
+              key={idx}
               button
               disableGutters
               disabled={!validPlaceholder}
-              key={idx}
-              onClick={() => selectPlaceholder(placeholder, validPlaceholder)}
+              onClick={() => showImportDropdown(placeholder)}
+              data-testid="PlaceholdersList-ListItem"
             >
               <ListItemIcon>
                 <IconStack
@@ -118,12 +127,7 @@ const PlaceholdersList = ({ currentQualifItems }) => {
         isOpened={shouldDisplayImportDropdown()}
         placeholder={placeholderSelected}
         onClose={hideImportDropdown}
-        onClick={() =>
-          history.push({
-            pathname: `/paper/create/${placeholderSelected.label}`,
-            search: `deepBack&backgroundPath=${backgroundPath}`
-          })
-        }
+        onClick={() => redirectPaperCreation(placeholderSelected)}
       />
     </>
   )

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/PlaceholdersList.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/PlaceholdersList.spec.jsx
@@ -1,6 +1,5 @@
-'use strict'
 import React from 'react'
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 
 import AppLike from '../../../test/components/AppLike'
 import PlaceholdersList from './PlaceholdersList'
@@ -8,12 +7,11 @@ import PlaceholdersList from './PlaceholdersList'
 const fakeQualificationItems = [
   {
     label: 'national_id_card'
+  },
+  {
+    label: 'isp_invoice'
   }
 ]
-
-jest.mock('cozy-client/dist/models/document/locales', () => ({
-  getBoundT: jest.fn().mockReturnValue(() => 'New paper - Passeport')
-}))
 
 const setup = () => {
   return render(
@@ -30,9 +28,32 @@ describe('PlaceholdersList components:', () => {
     expect(container).toBeDefined()
   })
 
-  it('should display header title with theme', () => {
-    const { getByText } = setup()
+  it('should display the Placeholders corresponding to the qualification', () => {
+    const { getAllByTestId, getByText } = setup()
+    const placeholdersLines = getAllByTestId('PlaceholdersList-ListItem')
 
-    expect(getByText('New paper - Passeport'))
+    expect(placeholdersLines).toHaveLength(2)
+    expect(getByText('ID card'))
+    expect(getByText('ISP invoice'))
+  })
+
+  it('should display ActionMenu modale when clicked', () => {
+    const { getByText, getAllByTestId } = setup()
+
+    const ispInvoiceLine = getAllByTestId('PlaceholdersList-ListItem')[1]
+
+    fireEvent.click(ispInvoiceLine)
+
+    expect(getByText('Add: ISP invoice'))
+  })
+
+  it('should not display ActionMenu modale when clicked', () => {
+    const { queryByText, getAllByTestId } = setup()
+
+    const nationalIdCardLine = getAllByTestId('PlaceholdersList-ListItem')[0]
+
+    fireEvent.click(nationalIdCardLine)
+
+    expect(queryByText('Add: ID card')).toBeNull()
   })
 })

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -1434,10 +1434,7 @@
           "model": "owner",
           "text": "PaperJSON.generic.owner.text"
         }
-      ],
-      "connectorCriteria": {
-        "qualification_labels": "water_invoice"
-      }
+      ]
     },
     {
       "label": "work_disability_recognition",

--- a/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
@@ -23,22 +23,27 @@ import get from 'lodash/get'
  * @property {number} maxDisplay - Number of document beyond which a "see more" button is displayed.
  */
 
+const getPaperDefinitionByLabel = (paperDefinition, files) => {
+  return !files.some(
+    paper =>
+      get(paper, 'metadata.qualification.label') === paperDefinition.label
+  )
+}
+
 /**
- * Filters and sorts the list of featured PlaceHolders
+ * Filters and sorts the list of featured Placeholders.
  * @param {PaperDefinition[]} papersDefinitions Array of PapersDefinition
- * @param {IOCozyFile[]} papers Array of IOCozyFile
- * @returns {PaperDefinition[]} Array of PapersDefinition filtered with the prop "placeholderIndex",
- * which does not already exist in DB and
- * which sorted with the prop "placeholderIndex"
+ * @param {IOCozyFile[]} files Array of IOCozyFile
+ * @returns {PaperDefinition[]} Array of PapersDefinition filtered with the prop "placeholderIndex"
  */
-export const getFeaturedPlaceholders = (papersDefinitions, papers = []) => {
+export const getFeaturedPlaceholders = (papersDefinitions, files = []) => {
   return papersDefinitions
     .filter(
       paperDefinition =>
-        !papers.some(
-          paper =>
-            get(paper, 'metadata.qualification.label') === paperDefinition.label
-        ) && paperDefinition.placeholderIndex
+        getPaperDefinitionByLabel(paperDefinition, files) &&
+        paperDefinition.placeholderIndex &&
+        (paperDefinition.acquisitionSteps.length > 0 ||
+          paperDefinition.connectorCriteria)
     )
     .sort((a, b) => a.placeholderIndex - b.placeholderIndex)
 }

--- a/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.spec.js
@@ -2,49 +2,67 @@ import {
   getFeaturedPlaceholders,
   findPlaceholdersByQualification
 } from './findPlaceholders'
-import * as PaperJSON from '../constants/papersDefinitions.json'
-const { papersDefinitions } = PaperJSON
+import { mockPapersDefinitions } from '../../test/mockPaperDefinitions'
 
-const fakePapers = [
+const fakeIspInvoiceFile = [
   {
     metadata: {
       qualification: {
-        label: 'national_id_card'
+        label: 'isp_invoice'
       }
     }
   }
 ]
 const fakeQualificationItems = [
   {
-    label: 'national_id_card'
+    label: 'isp_invoice'
   }
 ]
 
 describe('getPlaceholders', () => {
   describe('getFeaturedPlaceholders', () => {
-    it('should return list of placeholders whitout param', () => {
-      const featuredPlaceholders = getFeaturedPlaceholders(papersDefinitions)
+    it('should return list of placeholders', () => {
+      const featuredPlaceholders = getFeaturedPlaceholders(
+        mockPapersDefinitions
+      )
 
-      expect(featuredPlaceholders.length).toBeGreaterThan(0)
+      expect(featuredPlaceholders).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            label: 'isp_invoice'
+          })
+        ]),
+        expect.arrayContaining([
+          expect.objectContaining({
+            label: 'tax_notice'
+          })
+        ]),
+        expect.arrayContaining([
+          expect.not.objectContaining({
+            label: 'health_certificate'
+          })
+        ])
+      )
+      expect(featuredPlaceholders.length).toBe(2)
     })
 
-    it('should return correct list of placeholders with param', () => {
+    it('should return correct list of placeholders with file constraint', () => {
       const featuredPlaceholders = getFeaturedPlaceholders(
-        papersDefinitions,
-        fakePapers
+        mockPapersDefinitions,
+        fakeIspInvoiceFile
       )
 
       expect(featuredPlaceholders).toEqual(
         expect.arrayContaining([
           expect.not.objectContaining({
-            label: 'national_id_card'
+            label: 'isp_invoice'
           })
         ])
       )
       expect(featuredPlaceholders).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            label: 'driver_license'
+            label: 'tax_notice'
           })
         ])
       )
@@ -53,21 +71,23 @@ describe('getPlaceholders', () => {
 
   describe('findPlaceholdersByQualification', () => {
     it('should return an empty list', () => {
-      const placeholders = findPlaceholdersByQualification(papersDefinitions)
+      const placeholders = findPlaceholdersByQualification(
+        mockPapersDefinitions
+      )
 
       expect(placeholders).toHaveLength(0)
     })
 
     it('should return correct list of placeholders with param', () => {
       const placeholders = findPlaceholdersByQualification(
-        papersDefinitions,
+        mockPapersDefinitions,
         fakeQualificationItems
       )
 
       expect(placeholders).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            label: 'national_id_card'
+            label: 'isp_invoice'
           })
         ])
       )

--- a/packages/cozy-mespapiers-lib/test/mockPaperDefinitions.js
+++ b/packages/cozy-mespapiers-lib/test/mockPaperDefinitions.js
@@ -1,0 +1,94 @@
+export const mockPapersDefinitions = [
+  {
+    label: 'isp_invoice',
+    placeholderIndex: 2,
+    icon: 'bill',
+    featureDate: 'referencedDate',
+    maxDisplay: 6,
+    acquisitionSteps: [
+      {
+        stepIndex: 1,
+        model: 'scan',
+        multipage: true,
+        illustration: 'IlluInvoice.png',
+        text: 'PaperJSON.generic.multiPages.text'
+      },
+      {
+        stepIndex: 2,
+        model: 'information',
+        illustration: 'IlluGenericDate.svg',
+        text: 'PaperJSON.generic.referencedDate.text',
+        attributes: [
+          {
+            name: 'referencedDate',
+            type: 'date',
+            inputLabel: 'PaperJSON.generic.referencedDate.inputLabel'
+          }
+        ]
+      },
+      {
+        stepIndex: 3,
+        model: 'owner',
+        text: 'PaperJSON.generic.owner.text'
+      }
+    ],
+    connectorCriteria: {
+      category: 'isp'
+    }
+  },
+  {
+    label: 'tax_return',
+    icon: 'bank',
+    featureDate: 'referencedDate',
+    maxDisplay: 3,
+    acquisitionSteps: [
+      {
+        stepIndex: 1,
+        model: 'scan',
+        multipage: true,
+        illustration: 'IlluGenericNewPage.svg',
+        text: 'PaperJSON.generic.multiPages.text'
+      },
+      {
+        stepIndex: 2,
+        model: 'information',
+        illustration: 'IlluGenericDate.svg',
+        text: 'PaperJSON.generic.date.text',
+        attributes: [
+          {
+            name: 'referencedDate',
+            type: 'date',
+            inputLabel: 'PaperJSON.generic.referencedDate.inputLabel'
+          }
+        ]
+      },
+      {
+        stepIndex: 3,
+        model: 'owner',
+        text: 'PaperJSON.generic.owner.text'
+      }
+    ],
+    connectorCriteria: {
+      name: 'impots'
+    }
+  },
+  {
+    label: 'health_certificate',
+    placeholderIndex: 1,
+    icon: 'heart',
+    featureDate: 'issueDate',
+    maxDisplay: 4,
+    acquisitionSteps: []
+  },
+  {
+    label: 'tax_notice',
+    placeholderIndex: 3,
+    icon: 'bank',
+    featureDate: 'referencedDate',
+    maxDisplay: 3,
+    acquisitionSteps: [],
+    connectorCriteria: {
+      name: 'impots'
+    }
+  }
+]


### PR DESCRIPTION
When clicking on a suggestion(placeholder), in case there is no possibility to go through a connector, we want to bypass the ActionMenu and go directly to the creation modal.