### PR TITLE
fix: Next button position on contact and information paper creation step

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Contact.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Contact.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, memo } from 'react'
+import cx from 'classnames'
 
 import { useClient, models } from 'cozy-client'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
@@ -16,6 +17,7 @@ import Radio from 'cozy-ui/transpiled/react/Radio'
 import DialogActions from 'cozy-ui/transpiled/react/DialogActions'
 import ContactsListModal from 'cozy-ui/transpiled/react/ContactsListModal'
 import useEventListener from 'cozy-ui/transpiled/react/hooks/useEventListener'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 import { useFormData } from '../Hooks/useFormData'
 import { useSessionstorage } from '../Hooks/useSessionstorage'
@@ -144,6 +146,7 @@ const ContactWrapper = ({ currentStep, onClose }) => {
   const { formSubmit, formData } = useFormData()
   const [onLoad, setOnLoad] = useState(false)
   const [confirmReplaceFileModal, setConfirmReplaceFileModal] = useState(false)
+  const { isMobile } = useBreakpoints()
 
   const cozyFiles = formData.data.filter(d => d.file.constructor === Blob)
 
@@ -196,7 +199,13 @@ const ContactWrapper = ({ currentStep, onClose }) => {
         title={t(text)}
         text={<Contact />}
       />
-      <DialogActions className={'u-w-100 u-mh-0 u-mb-1 cozyDialogActions'}>
+      <DialogActions
+        disableSpacing
+        className={cx('columnLayout u-mb-1-half u-mt-0 cozyDialogActions', {
+          'u-mh-1': !isMobile,
+          'u-mh-0': isMobile
+        })}
+      >
         <Button
           fullWidth
           label={t(!onLoad ? 'ContactStep.save' : 'ContactStep.onLoad')}

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Information.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Information.jsx
@@ -7,6 +7,7 @@ import DialogActions from 'cozy-ui/transpiled/react/DialogActions'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import useEventListener from 'cozy-ui/transpiled/react/hooks/useEventListener'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 import { useFormData } from '../Hooks/useFormData'
 import { useStepperDialog } from '../Hooks/useStepperDialog'
@@ -26,6 +27,7 @@ const Information = ({ currentStep }) => {
   const [value, setValue] = useState({})
   const [validInput, setValidInput] = useState({})
   const [isFocus, setIsFocus] = useState(false)
+  const { isMobile } = useBreakpoints()
 
   const submit = throttle(() => {
     if (value && allInputsValid) {
@@ -119,7 +121,13 @@ const Information = ({ currentStep }) => {
           </div>
         ))}
       />
-      <DialogActions disableSpacing className={'u-mh-0 u-mb-1'}>
+      <DialogActions
+        disableSpacing
+        className={cx('columnLayout u-mb-1-half u-mt-0 cozyDialogActions', {
+          'u-mh-1': !isMobile,
+          'u-mh-0': isMobile
+        })}
+      >
         <Button
           label={t('common.next')}
           onClick={submit}


### PR DESCRIPTION
Lors de la création d'un papier, le bouton "suivant" en bas des étapes d'information et de contact était mal positionné.