### PR TITLE
fix: Check window existence in cozy-device-helper

### DIFF
--- a/packages/cozy-device-helper/src/flagship.ts
+++ b/packages/cozy-device-helper/src/flagship.ts
@@ -17,6 +17,13 @@ export interface FlagshipMetadata {
   version?: string
 }
 
-export const flagshipMetadata = window.cozy?.flagship || {}
+export const flagshipMetadata = getWindowIfAny()?.cozy?.flagship || {}
 
-export const isFlagshipApp = (): boolean => window.cozy?.flagship !== undefined
+export const isFlagshipApp = (): boolean => getWindowIfAny()?.cozy?.flagship !== undefined
+
+/**
+ * Check window object existence without raising any error
+ */
+function getWindowIfAny() {
+ return typeof window === 'undefined' ? null : window
+}


### PR DESCRIPTION
Do not suppose we are in browser environment.
Since this library is embedded in cozy-client which is embedded in
cozy-konnector-libs, connectors will fail in node environments.
