### PR TITLE
fix: FlagshipMetadata is now a getter

### DIFF
--- a/packages/cozy-device-helper/src/flagship.ts
+++ b/packages/cozy-device-helper/src/flagship.ts
@@ -17,6 +17,7 @@ export interface FlagshipMetadata {
   version?: string
 }
 
-export const flagshipMetadata = window.cozy?.flagship || {}
+export const getFlagshipMetadata = (): FlagshipMetadata =>
+  window.cozy?.flagship || {}
 
 export const isFlagshipApp = (): boolean => window.cozy?.flagship !== undefined

--- a/packages/cozy-device-helper/src/index.ts
+++ b/packages/cozy-device-helper/src/index.ts
@@ -21,4 +21,4 @@ export { isCordova } from './cordova'
 export { nativeLinkOpen } from './link'
 export { openDeeplinkOrRedirect } from './deeplink'
 
-export { isFlagshipApp, flagshipMetadata } from './flagship'
+export { isFlagshipApp, getFlagshipMetadata } from './flagship'


### PR DESCRIPTION
BREAKING CHANGE: flagshipMetadata reference has been replaced with
getFlagshipMetadata().
It returns the same information but adds safety at file init