### PR TITLE
feat: Add codemods for iconButton

### DIFF
--- a/packages/cozy-codemods/src/imports.js
+++ b/packages/cozy-codemods/src/imports.js
@@ -269,8 +269,22 @@ const simplify = (root, options) => {
   mergeImports(root)
 }
 
+const getAttributeName = attribute => attribute?.name?.name
+
+const getAttributeValue = attribute => attribute?.value?.expression?.value
+
+const getAttributeByName = ({ attributes, name }) =>
+  attributes.find(attribute => getAttributeName(attribute) === name)
+
+const makeAttribute = ({ name, value }) =>
+  j.jsxAttribute(j.jsxIdentifier(name), j.literal(value))
+
 module.exports = {
   simplify,
   ensure,
-  removeUnused
+  removeUnused,
+  getAttributeName,
+  getAttributeValue,
+  getAttributeByName,
+  makeAttribute
 }

--- a/packages/cozy-codemods/src/transforms/__testfixtures__/transform-iconButton.input.js
+++ b/packages/cozy-codemods/src/transforms/__testfixtures__/transform-iconButton.input.js
@@ -1,0 +1,6 @@
+import React from 'react'
+import IconButton from 'cozy-ui/transpiled/react/IconButton'
+
+export const Comp = () => {
+  return <IconButton color="primary" disabled={false} />
+}

--- a/packages/cozy-codemods/src/transforms/__testfixtures__/transform-iconButton.output.js
+++ b/packages/cozy-codemods/src/transforms/__testfixtures__/transform-iconButton.output.js
@@ -1,0 +1,6 @@
+import React from 'react'
+import IconButton from 'cozy-ui/transpiled/react/IconButton'
+
+export const Comp = () => {
+  return <IconButton color="primary" disabled={false} size="medium" />;
+}

--- a/packages/cozy-codemods/src/transforms/__tests__/transform-iconButton.spec.js
+++ b/packages/cozy-codemods/src/transforms/__tests__/transform-iconButton.spec.js
@@ -1,0 +1,2 @@
+const defineTest = require('jscodeshift/dist/testUtils').defineTest
+defineTest(__dirname, 'transform-iconButton')

--- a/packages/cozy-codemods/src/transforms/transform-iconButton.js
+++ b/packages/cozy-codemods/src/transforms/transform-iconButton.js
@@ -1,0 +1,18 @@
+import { getAttributeByName, makeAttribute } from '../imports'
+
+export default function transformIconButton(file, api) {
+  var j = api.jscodeshift
+  const root = j(file.source)
+
+  root.findJSXElements('IconButton').forEach(nodePath => {
+    const { attributes } = nodePath.node.openingElement
+
+    const sizeAttribute = getAttributeByName({ attributes, name: 'size' })
+
+    if (!sizeAttribute) {
+      attributes.push(makeAttribute({ name: 'size', value: 'medium' }))
+    }
+  })
+
+  return root.toSource()
+}


### PR DESCRIPTION
Simply add `size="medium"` prop if no `size` prop already set.

Ceci dans le but de changer la size par défaut en `large` dans une prochaine version de cozy-ui.

relatif à https://github.com/cozy/cozy-ui/issues/2107