### PR TITLE
feat: Add BI connection creation via BI webview

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -328,7 +328,7 @@ export class DumbTriggerManager extends Component {
     const showAccountForm = step === 'accountForm'
     const konnectorPolicy = findKonnectorPolicy(konnector)
 
-    if (oauth || konnectorPolicy.isWebView) {
+    if (oauth || konnectorPolicy.isBIWebView) {
       return (
         <OAuthForm
           client={client}

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -326,8 +326,9 @@ export class DumbTriggerManager extends Component {
     const showSpinner = submitting && selectedCipher && step === 'ciphersList'
     const showCiphersList = step === 'ciphersList'
     const showAccountForm = step === 'accountForm'
+    const konnectorPolicy = findKonnectorPolicy(konnector)
 
-    if (oauth) {
+    if (oauth || konnectorPolicy.isWebView) {
       return (
         <OAuthForm
           client={client}

--- a/packages/cozy-harvest-lib/src/helpers/oauth.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.js
@@ -101,7 +101,7 @@ export const getOAuthUrl = ({
   cozyUrl,
   accountType,
   oAuthStateKey,
-  oAuthConf,
+  oAuthConf = {},
   nonce,
   redirectSlug,
   extraParams

--- a/packages/cozy-harvest-lib/src/helpers/oauth.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.js
@@ -92,7 +92,7 @@ export const handleOAuthResponse = (options = {}) => {
  * @param  {string} cozyUrl cozy url
  * @param  {string} accountType connector slug
  * @param  {string} oAuthStateKey localStorage key
- * @param  {Object} oAuthConf connector manifest oauth configuration
+ * @param  {Object} [oAuthConf={}]  connector manifest oauth configuration
  * @param  {string} redirectSlug The app we want to redirect the user on after the end of the flow
  * @param  {string} nonce unique nonce string
  * @param  {Object} extraParams some extra parameters to add to the query string

--- a/packages/cozy-harvest-lib/src/konnector-policies.js
+++ b/packages/cozy-harvest-lib/src/konnector-policies.js
@@ -1,5 +1,6 @@
 import logger from './logger'
 import { konnectorPolicy as biKonnectorPolicy } from './services/budget-insight'
+import { konnectorPolicy as biWebViewPolicy } from './services/biWebView'
 
 const defaultKonnectorPolicy = {
   accountContainsAuth: true,
@@ -9,7 +10,11 @@ const defaultKonnectorPolicy = {
   name: 'default'
 }
 
-const policies = [biKonnectorPolicy, defaultKonnectorPolicy].filter(Boolean)
+const policies = [
+  biWebViewPolicy,
+  biKonnectorPolicy,
+  defaultKonnectorPolicy
+].filter(Boolean)
 
 logger.info('Available konnector policies', policies)
 

--- a/packages/cozy-harvest-lib/src/services/biWebView.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.js
@@ -5,8 +5,8 @@
  */
 
 import get from 'lodash/get'
-import clone from 'lodash/clone'
 import set from 'lodash/set'
+import clone from 'lodash/clone'
 
 import { getBIConnection } from './bi-http'
 import assert from '../assert'
@@ -22,14 +22,20 @@ import {
 } from './budget-insight'
 import { KonnectorJobError } from '../helpers/konnectors'
 
-export const isBiWebViewConnector = konnector => {
-  return (
-    flag('harvest.bi.webview') &&
-    konnector.partnership &&
-    konnector.partnership.domain.includes('budget-insight')
-  )
-}
+export const isBiWebViewConnector = konnector =>
+  flag('harvest.bi.webview') &&
+  get(konnector, 'partnership.domain') === 'budget-insight.com'
 
+/**
+ * Runs multiple checks on the bi connection referenced in the given account
+ *
+ * @param {Object} options.account The account content
+ * @param {Object} options.flow
+ * @param {Object} options.konnector connector manifest content
+ * @param {Object} options.client CozyClient object
+ *
+ * @return {Integer} Connection Id
+ */
 export const checkBIConnection = async ({
   account,
   client,

--- a/packages/cozy-harvest-lib/src/services/biWebView.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.js
@@ -107,7 +107,7 @@ export const handleOAuthAccount = async ({
   const connectionId = getWebviewBIConnectionId(biWebviewAccount)
 
   if (connectionId) {
-    logger.info(`Found a bi webview connection id: ${connectionId}`)
+    logger.info(`Found a BI webview connection id: ${connectionId}`)
     flow.konnector = konnector
     biWebviewAccount = await flow.saveAccount(
       setBIConnectionId(biWebviewAccount, connectionId)

--- a/packages/cozy-harvest-lib/src/services/biWebView.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.js
@@ -1,0 +1,177 @@
+/**
+ * Interface between Budget Insight and Cozy using BI's webview
+ *
+ * - Deals with the konnector to get temporary tokens
+ */
+
+import get from 'lodash/get'
+import clone from 'lodash/clone'
+import set from 'lodash/set'
+
+import { getBIConnection } from './bi-http'
+import assert from '../assert'
+import logger from '../logger'
+import flag from 'cozy-flags'
+import {
+  fetchExtraOAuthUrlParams,
+  createTemporaryToken,
+  setBIConnectionId,
+  saveBIConfig,
+  findAccountWithBiConnection,
+  convertBIErrortoKonnectorJobError
+} from './budget-insight'
+import { KonnectorJobError } from '../helpers/konnectors'
+
+export const isBiWebViewConnector = konnector => {
+  return (
+    flag('harvest.bi.webview') &&
+    konnector.partnership &&
+    konnector.partnership.domain.includes('budget-insight')
+  )
+}
+
+export const checkBIConnection = async ({
+  account,
+  client,
+  konnector,
+  flow
+}) => {
+  try {
+    let connId = getWebviewBIConnectionId(account)
+
+    logger.info('Creating temporary token...')
+
+    const biConfig = await createTemporaryToken({
+      client,
+      konnector,
+      account
+    })
+    saveBIConfig(flow, biConfig)
+
+    const { code: tempToken, ...config } = biConfig
+
+    logger.info('Created temporary token')
+    assert(tempToken, 'No temporary token')
+
+    logger.info(`fetch connection ${connId}...`)
+
+    const connection = await getBIConnection(config, connId, tempToken)
+
+    const sameAccount = await findAccountWithBiConnection({
+      client,
+      konnector,
+      connectionId: connection.id
+    })
+    if (sameAccount) {
+      const err = new KonnectorJobError(
+        'ACCOUNT_WITH_SAME_IDENTIFIER_ALREADY_DEFINED'
+      )
+      err.accountId = sameAccount._id
+      throw err
+    }
+    return connection
+  } catch (err) {
+    return convertBIErrortoKonnectorJobError(err)
+  }
+}
+
+/**
+ * Handles webview connection
+ *
+ * @param {Object} options.account The account content
+ * @param {Object} options.flow
+ * @param {Object} options.konnector connector manifest content
+ * @param {Object} options.client CozyClient object
+ *
+ * @return {Integer} Connection Id
+ */
+export const handleOAuthAccount = async ({
+  account,
+  flow,
+  konnector,
+  client,
+  t
+}) => {
+  let biWebviewAccount = clone(account)
+  const cozyBankId = getCozyBankId({ konnector, account })
+  if (cozyBankId) {
+    set(biWebviewAccount, 'auth.bankId', cozyBankId)
+  }
+
+  const connectionId = getWebviewBIConnectionId(biWebviewAccount)
+
+  if (connectionId) {
+    logger.info(`Found a bi webview connection id: ${connectionId}`)
+    flow.konnector = konnector
+    biWebviewAccount = await flow.saveAccount(
+      setBIConnectionId(biWebviewAccount, connectionId)
+    )
+
+    await flow.handleFormSubmit({
+      client,
+      account: biWebviewAccount,
+      konnector,
+      t
+    })
+  }
+
+  return connectionId
+}
+
+/**
+ * Gets BI webview connection id which is returned in the account by the stack
+ * via oauth callback url
+ *
+ * @param {io.cozy.accounts} The account content created by the stack
+ *
+ * @return {Integer} Connection Id
+ */
+const getWebviewBIConnectionId = account => {
+  return Number(get(account, 'oauth.query.connection_id[0]'))
+}
+
+export const onBIAccountCreation = async ({
+  account: fullAccount,
+  client,
+  flow,
+  konnector
+}) => {
+  let account = clone(fullAccount)
+
+  account = await flow.saveAccount(account)
+
+  const biConnection = await checkBIConnection({
+    account: {
+      ...fullAccount,
+      _id: account._id
+    },
+    client,
+    konnector,
+    flow
+  })
+
+  flow.setData({
+    biConnection
+  })
+
+  return await flow.saveAccount(setBIConnectionId(account, biConnection.id))
+}
+
+export const getCozyBankId = ({ konnector, account }) => {
+  const cozyBankId =
+    get(konnector, 'parameters.bankId') || get(account, 'auth.bankId')
+  if (!cozyBankId) {
+    throw new Error('Could not find any bank id')
+  }
+  return cozyBankId
+}
+
+export const konnectorPolicy = {
+  isWebView: true,
+  name: 'budget-insight-webview',
+  match: isBiWebViewConnector,
+  saveInVault: false,
+  onAccountCreation: onBIAccountCreation,
+  fetchExtraOAuthUrlParams: fetchExtraOAuthUrlParams,
+  handleOAuthAccount
+}

--- a/packages/cozy-harvest-lib/src/services/biWebView.spec.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.spec.js
@@ -1,0 +1,185 @@
+import CozyClient from 'cozy-client'
+import {
+  handleOAuthAccount,
+  checkBIConnection,
+  isBiWebViewConnector
+} from './biWebView'
+import ConnectionFlow from '../models/ConnectionFlow'
+import { waitForRealtimeEvent } from './jobUtils'
+import biPublicKeyProd from './bi-public-key-prod.json'
+import flag from 'cozy-flags'
+
+jest.mock('./bi-http', () => ({
+  createBIConnection: jest
+    .fn()
+    .mockResolvedValue({ text: Promise.resolve('{}') }),
+  updateBIConnection: jest.fn(),
+  getBIConnection: jest.fn()
+}))
+
+import { getBIConnection } from './bi-http'
+
+jest.mock('cozy-logger', () => ({
+  namespace: () => () => {}
+}))
+
+jest.mock('./jobUtils', () => ({
+  waitForRealtimeEvent: jest.fn()
+}))
+
+const sleep = duration => new Promise(resolve => setTimeout(resolve, duration))
+
+const TEST_BANK_COZY_ID = '100000'
+
+const konnector = {
+  slug: 'boursorama83',
+  parameters: {
+    bankId: TEST_BANK_COZY_ID
+  },
+  partnership: {
+    domain: 'https://budget-insight.com'
+  }
+}
+
+const account = {
+  _id: '1337'
+}
+
+describe('handleOAuthAccount', () => {
+  it('should handle bi webview authentication if any connection is found in the account', async () => {
+    const client = new CozyClient({
+      uri: 'http://testcozy.mycozy.cloud'
+    })
+    const flow = new ConnectionFlow(client, null, konnector)
+    flow.account = account
+    flow.handleFormSubmit = jest.fn()
+    flow.saveAccount = async account => account
+    const account = { oauth: { query: { connection_id: ['12'] } } }
+    const t = jest.fn()
+    await handleOAuthAccount({
+      account,
+      flow,
+      client,
+      konnector,
+      t
+    })
+    expect(flow.handleFormSubmit).toHaveBeenCalledWith({
+      client,
+      konnector,
+      t,
+      account: {
+        ...account,
+        ...{ auth: { bankId: TEST_BANK_COZY_ID } },
+        ...{ data: { auth: { bi: { connId: 12 } } } }
+      }
+    })
+  })
+})
+
+describe('checkBIConnection', () => {
+  const setup = () => {
+    const client = new CozyClient({
+      uri: 'http://testcozy.mycozy.cloud'
+    })
+    const flow = new ConnectionFlow(client, { konnector, account })
+    client.stackClient.jobs.create = jest.fn().mockReturnValue({
+      data: {
+        attributes: {
+          _id: 'job-id-1337'
+        }
+      }
+    })
+    waitForRealtimeEvent.mockImplementation(async () => {
+      sleep(2)
+      return {
+        data: {
+          result: {
+            mode: 'prod',
+            url: 'https://cozy.biapi.pro/2.0',
+            publicKey: biPublicKeyProd,
+            code: 'bi-temporary-access-token-145613'
+          }
+        }
+      }
+    })
+    jest.spyOn(client, 'query').mockImplementation(async () => ({ data: [] }))
+
+    return { client, flow }
+  }
+
+  it('should refuse to create an account with a bi connection id which already exists', async () => {
+    const { client, flow } = setup()
+
+    getBIConnection.mockReset().mockResolvedValue({
+      id: 12
+    })
+
+    const account = {}
+
+    const konnector = {
+      slug: 'bankingconnectortest',
+      parameters: {
+        bankId: TEST_BANK_COZY_ID
+      }
+    }
+
+    jest.spyOn(flow, 'saveAccount').mockImplementation(account => ({
+      _id: 'created-account-id',
+      ...account
+    }))
+
+    jest.spyOn(client, 'query').mockImplementation(async ({ doctype }) => {
+      if (doctype === 'io.cozy.accounts') {
+        return {
+          data: [
+            {
+              _id: 'account_id',
+              auth: { bi: { connId: 12 } }
+            }
+          ]
+        }
+      } else if (doctype === 'io.cozy.triggers') {
+        return {
+          data: [
+            {
+              message: { account: 'account_id' }
+            }
+          ]
+        }
+      } else {
+        throw new Error('unexpected doctype ' + doctype)
+      }
+    })
+
+    await expect(
+      checkBIConnection({
+        client,
+        flow,
+        account,
+        konnector
+      })
+    ).rejects.toEqual(new Error('ACCOUNT_WITH_SAME_IDENTIFIER_ALREADY_DEFINED'))
+  })
+})
+
+describe('isBiWebViewConnector', () => {
+  const BIConnector = {
+    slug: 'biconnector',
+    partnership: { domain: 'budget-insight.com' }
+  }
+  const notBIConnector = {
+    slug: 'otherconnector'
+  }
+  it('should return true if the connector is a BI connector and if the and the "harvest.bi.webview" is activated', () => {
+    flag('harvest.bi.webview', true)
+    expect(isBiWebViewConnector(BIConnector)).toEqual(true)
+  })
+  it('should return false if the connector is not a BI connector', () => {
+    flag('harvest.bi.webview', true)
+    expect(isBiWebViewConnector(notBIConnector)).toEqual(false)
+  })
+  it('should return false if the "harvest.bi.webview" flag is not activated', () => {
+    flag('harvest.bi.webview', false)
+    expect(isBiWebViewConnector(BIConnector)).toEqual(false)
+  })
+})

--- a/packages/cozy-harvest-lib/src/services/biWebView.spec.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.spec.js
@@ -170,7 +170,7 @@ describe('isBiWebViewConnector', () => {
   const notBIConnector = {
     slug: 'otherconnector'
   }
-  it('should return true if the connector is a BI connector and if the and the "harvest.bi.webview" is activated', () => {
+  it('should return true if the connector is a BI connector and if the  "harvest.bi.webview" is activated', () => {
     flag('harvest.bi.webview', true)
     expect(isBiWebViewConnector(BIConnector)).toEqual(true)
   })

--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -65,12 +65,8 @@ export const convertBIErrortoKonnectorJobError = error => {
   throw err
 }
 
-export const isBudgetInsightConnector = konnector => {
-  return (
-    konnector.partnership &&
-    konnector.partnership.domain.includes('budget-insight')
-  )
-}
+export const isBudgetInsightConnector = konnector =>
+  konnector?.partnership?.domain === 'budget-insight.com'
 
 export const createTemporaryToken = async ({ client, konnector, account }) => {
   assert(

--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -52,7 +52,7 @@ const extraBIErrorMap = {
 /**
  * Converts and chains error
  */
-const convertBIErrortoKonnectorJobError = error => {
+export const convertBIErrortoKonnectorJobError = error => {
   const errorCode = error ? error.code : null
   const cozyErrorMessage = errorCode
     ? biErrorMap[errorCode] || extraBIErrorMap[errorCode] || null

--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -72,7 +72,7 @@ export const isBudgetInsightConnector = konnector => {
   )
 }
 
-const createTemporaryToken = async ({ client, konnector, account }) => {
+export const createTemporaryToken = async ({ client, konnector, account }) => {
   assert(
     konnector.slug,
     'createTemporaryToken: konnector passed in options has no slug'
@@ -213,10 +213,6 @@ export const setBIConnectionId = (originalAccount, biConnectionId) => {
   const account = clone(originalAccount)
   set(account, 'data.auth.bi.connId', biConnectionId)
   return account
-}
-
-export const getBIConnectionId = account => {
-  return get(account, 'data.auth.bi.connId')
 }
 
 /**

--- a/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
@@ -70,7 +70,7 @@ const konnector = {
     bankId: TEST_BANK_COZY_ID
   },
   partnership: {
-    domain: 'https://budget-insight.com'
+    domain: 'budget-insight.com'
   }
 }
 


### PR DESCRIPTION
This adds the possibility to create a Budget Insight connection using its [webviews](https://docs.budget-insight.com/reference/webview)

But to activate it, you need to add the harvest.bi.webview flag + specific account_type secrets
