### PR TITLE
feat: Add papers filter on Home

### DIFF
--- a/packages/cozy-mespapiers-lib/package.json
+++ b/packages/cozy-mespapiers-lib/package.json
@@ -23,7 +23,7 @@
     "cozy-intent": "^1.17.1",
     "cozy-realtime": "^4.0.8",
     "cozy-sharing": "^4.1.7",
-    "cozy-ui": "^65.0.1",
+    "cozy-ui": "^66.2.0",
     "eslint-config-cozy-app": "^4.0.2",
     "git-directory-deploy": "1.5.1",
     "jest-environment-jsdom-sixteen": "2.0.0",
@@ -43,13 +43,13 @@
   },
   "peerDependencies": {
     "cozy-client": ">=28.2.1",
-    "cozy-device-helper": ">=1.18.0",
+    "cozy-device-helper": ">=2.0.0",
     "cozy-doctypes": ">=1.83.3",
     "cozy-harvest-lib": ">=8.4.2",
     "cozy-intent": ">=1.13.5",
     "cozy-realtime": ">=4.0.2",
     "cozy-sharing": ">=4.1.6",
-    "cozy-ui": ">=65.0.1",
+    "cozy-ui": ">=66.2.0",
     "react-router-dom": ">=5.2.0"
   }
 }

--- a/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 import uniqBy from 'lodash/uniqBy'
 
-import { hasQueryBeenLoaded, isQueryLoading, useQuery } from 'cozy-client'
+import { isQueryLoading, useQuery } from 'cozy-client'
 import Empty from 'cozy-ui/transpiled/react/Empty'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
@@ -26,33 +26,30 @@ const Home = () => {
     ...queryResult
   } = useQuery(filesQueryByLabels.definition, filesQueryByLabels.options)
 
-  const isQueryOver = useMemo(
-    () =>
-      !isQueryLoading(queryResult) &&
-      hasQueryBeenLoaded(queryResult) &&
-      !hasMore,
-    [hasMore, queryResult]
+  const isLoading = isQueryLoading(queryResult) || hasMore
+
+  const allPapersByCategories = useMemo(
+    () => uniqBy(filesByLabels, 'metadata.qualification.label'),
+    [filesByLabels]
+  )
+
+  const featuredPlaceholders = useMemo(
+    () => getFeaturedPlaceholders(papersDefinitions, filesByLabels),
+    [papersDefinitions, filesByLabels]
   )
 
   if (hasMore) fetchMore()
 
-  const featuredPlaceholders = useMemo(
-    () =>
-      Array.isArray(filesByLabels) && isQueryOver
-        ? getFeaturedPlaceholders(papersDefinitions, filesByLabels)
-        : [],
-    [filesByLabels, isQueryOver, papersDefinitions]
-  )
+  if (isLoading) {
+    return (
+      <Spinner
+        size="xxlarge"
+        className="u-flex u-flex-justify-center u-mt-2 u-h-5"
+      />
+    )
+  }
 
-  const allPapersByCategories = useMemo(
-    () =>
-      filesByLabels?.length > 0 && isQueryOver
-        ? uniqBy(filesByLabels, 'metadata.qualification.label')
-        : [],
-    [filesByLabels, isQueryOver]
-  )
-
-  return isQueryOver ? (
+  return (
     <>
       {allPapersByCategories.length === 0 ? (
         <Empty
@@ -67,11 +64,6 @@ const Home = () => {
       )}
       <FeaturedPlaceholdersList featuredPlaceholders={featuredPlaceholders} />
     </>
-  ) : (
-    <Spinner
-      size="xxlarge"
-      className="u-flex u-flex-justify-center u-mt-2 u-h-5"
-    />
   )
 }
 

--- a/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
@@ -20,36 +20,36 @@ const Home = () => {
   const filesQueryByLabels = buildFilesQueryByLabels(labels)
 
   const {
-    data: allPapers,
-    hasMore: hasMorePapers,
-    fetchMore: fetchMorePapers,
-    ...restPapers
+    data: filesByLabels,
+    hasMore,
+    fetchMore,
+    ...queryResult
   } = useQuery(filesQueryByLabels.definition, filesQueryByLabels.options)
 
   const isQueryOver = useMemo(
     () =>
-      !isQueryLoading(restPapers) &&
-      hasQueryBeenLoaded(restPapers) &&
-      !hasMorePapers,
-    [hasMorePapers, restPapers]
+      !isQueryLoading(queryResult) &&
+      hasQueryBeenLoaded(queryResult) &&
+      !hasMore,
+    [hasMore, queryResult]
   )
 
-  if (hasMorePapers) fetchMorePapers()
+  if (hasMore) fetchMore()
 
   const featuredPlaceholders = useMemo(
     () =>
-      Array.isArray(allPapers) && isQueryOver
-        ? getFeaturedPlaceholders(papersDefinitions, allPapers)
+      Array.isArray(filesByLabels) && isQueryOver
+        ? getFeaturedPlaceholders(papersDefinitions, filesByLabels)
         : [],
-    [allPapers, isQueryOver, papersDefinitions]
+    [filesByLabels, isQueryOver, papersDefinitions]
   )
 
   const allPapersByCategories = useMemo(
     () =>
-      allPapers?.length > 0 && isQueryOver
-        ? uniqBy(allPapers, 'metadata.qualification.label')
+      filesByLabels?.length > 0 && isQueryOver
+        ? uniqBy(filesByLabels, 'metadata.qualification.label')
         : [],
-    [allPapers, isQueryOver]
+    [filesByLabels, isQueryOver]
   )
 
   return isQueryOver ? (

--- a/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
@@ -47,9 +47,10 @@ const Home = () => {
     () =>
       getFeaturedPlaceholders({
         papersDefinitions,
-        filesByLabels
+        files: filesByLabels,
+        selectedTheme
       }),
-    [papersDefinitions, filesByLabels]
+    [papersDefinitions, filesByLabels, selectedTheme]
   )
 
   const handleThemeSelection = nextValue => {

--- a/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
@@ -8,7 +8,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import PaperGroup from '../Papers/PaperGroup'
 import FeaturedPlaceholdersList from '../Placeholders/FeaturedPlaceholdersList'
-import { getAllQualificationLabel } from '../../helpers/queries'
+import { buildFilesQueryByLabels } from '../../helpers/queries'
 import { usePapersDefinitions } from '../Hooks/usePapersDefinitions'
 import { getFeaturedPlaceholders } from '../../helpers/findPlaceholders'
 import HomeCloud from '../../assets/icons/HomeCloud.svg'
@@ -16,16 +16,15 @@ import HomeCloud from '../../assets/icons/HomeCloud.svg'
 const Home = () => {
   const { t } = useI18n()
   const { papersDefinitions } = usePapersDefinitions()
-  const allQualificationLabel = useMemo(
-    () => getAllQualificationLabel(papersDefinitions),
-    [papersDefinitions]
-  )
+  const labels = papersDefinitions.map(paper => paper.label)
+  const filesQueryByLabels = buildFilesQueryByLabels(labels)
+
   const {
     data: allPapers,
     hasMore: hasMorePapers,
     fetchMore: fetchMorePapers,
     ...restPapers
-  } = useQuery(allQualificationLabel.definition, allQualificationLabel.options)
+  } = useQuery(filesQueryByLabels.definition, filesQueryByLabels.options)
 
   const isQueryOver = useMemo(
     () =>

--- a/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 import uniqBy from 'lodash/uniqBy'
 
-import { isQueryLoading, useQuery } from 'cozy-client'
+import { isQueryLoading, useQueryAll } from 'cozy-client'
 import Empty from 'cozy-ui/transpiled/react/Empty'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
@@ -19,14 +19,12 @@ const Home = () => {
   const labels = papersDefinitions.map(paper => paper.label)
   const filesQueryByLabels = buildFilesQueryByLabels(labels)
 
-  const {
-    data: filesByLabels,
-    hasMore,
-    fetchMore,
-    ...queryResult
-  } = useQuery(filesQueryByLabels.definition, filesQueryByLabels.options)
+  const { data: filesByLabels, ...queryResult } = useQueryAll(
+    filesQueryByLabels.definition,
+    filesQueryByLabels.options
+  )
 
-  const isLoading = isQueryLoading(queryResult) || hasMore
+  const isLoading = isQueryLoading(queryResult) || queryResult.hasMore
 
   const allPapersByCategories = useMemo(
     () => uniqBy(filesByLabels, 'metadata.qualification.label'),
@@ -37,8 +35,6 @@ const Home = () => {
     () => getFeaturedPlaceholders(papersDefinitions, filesByLabels),
     [papersDefinitions, filesByLabels]
   )
-
-  if (hasMore) fetchMore()
 
   if (isLoading) {
     return (

--- a/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
@@ -44,7 +44,11 @@ const Home = () => {
   )
 
   const featuredPlaceholders = useMemo(
-    () => getFeaturedPlaceholders(papersDefinitions, filesByLabels),
+    () =>
+      getFeaturedPlaceholders({
+        papersDefinitions,
+        filesByLabels
+      }),
     [papersDefinitions, filesByLabels]
   )
 

--- a/packages/cozy-mespapiers-lib/src/components/Home/Home.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/Home.spec.jsx
@@ -2,20 +2,20 @@
 import React from 'react'
 import { render, waitFor } from '@testing-library/react'
 
-import { isQueryLoading, hasQueryBeenLoaded, useQuery } from 'cozy-client'
+import { isQueryLoading, hasQueryBeenLoaded, useQueryAll } from 'cozy-client'
 
 import AppLike from '../../../test/components/AppLike'
 import Home from './Home'
 
 jest.mock('cozy-client/dist/hooks', () => ({
   ...jest.requireActual('cozy-client/dist/hooks'),
-  useQuery: jest.fn()
+  useQueryAll: jest.fn()
 }))
 jest.mock('cozy-client/dist/utils', () => ({
   ...jest.requireActual('cozy-client/dist/utils'),
   isQueryLoading: jest.fn(),
   hasQueryBeenLoaded: jest.fn(),
-  useQuery: jest.fn()
+  useQueryAll: jest.fn()
 }))
 
 const setup = ({
@@ -25,7 +25,7 @@ const setup = ({
 } = {}) => {
   isQueryLoading.mockReturnValue(isLoading)
   hasQueryBeenLoaded.mockReturnValue(isLoaded)
-  useQuery.mockReturnValue({
+  useQueryAll.mockReturnValue({
     data: withData
       ? [{ metadata: { qualification: { label: 'LabelQualif' } } }]
       : [],

--- a/packages/cozy-mespapiers-lib/src/components/Home/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Home/helpers.js
@@ -1,7 +1,11 @@
+// should be in cozy-client : https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document/documentTypeDataHelpers.js
+export const hasItemByLabel = (theme, label) =>
+  theme.items.some(item => item.label === label)
+
 export const filterPapersByTheme = (files, theme) => {
   if (!theme) return files
 
   return files.filter(file =>
-    theme.items.some(item => item.label === file.metadata.qualification.label)
+    hasItemByLabel(theme, file.metadata.qualification.label)
   )
 }

--- a/packages/cozy-mespapiers-lib/src/components/Home/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Home/helpers.js
@@ -1,0 +1,7 @@
+export const filterPapersByTheme = (files, theme) => {
+  if (!theme) return files
+
+  return files.filter(file =>
+    theme.items.some(item => item.label === file.metadata.qualification.label)
+  )
+}

--- a/packages/cozy-mespapiers-lib/src/components/Home/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Home/helpers.spec.js
@@ -1,4 +1,4 @@
-import { filterPapersByTheme } from './helpers'
+import { filterPapersByTheme, hasItemByLabel } from './helpers'
 
 const files = [
   { _id: 'file01', metadata: { qualification: { label: 'isp_invoice' } } },
@@ -24,5 +24,25 @@ describe('filterPapersByTheme', () => {
     expect(res).toHaveLength(2)
     expect(res).toContain(files[0])
     expect(res).toContain(files[2])
+  })
+})
+
+describe('hasItemByLabel', () => {
+  it('should return true', () => {
+    const res = hasItemByLabel(
+      { items: [{ label: 'isp_invoice' }] },
+      'isp_invoice'
+    )
+
+    expect(res).toBe(true)
+  })
+
+  it('should return false', () => {
+    const res = hasItemByLabel(
+      { items: [{ label: 'isp_invoice' }] },
+      'phone_invoice'
+    )
+
+    expect(res).toBe(false)
   })
 })

--- a/packages/cozy-mespapiers-lib/src/components/Home/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Home/helpers.spec.js
@@ -1,0 +1,28 @@
+import { filterPapersByTheme } from './helpers'
+
+const files = [
+  { _id: 'file01', metadata: { qualification: { label: 'isp_invoice' } } },
+  { _id: 'file02', metadata: { qualification: { label: 'driver_license' } } },
+  { _id: 'file03', metadata: { qualification: { label: 'phone_invoice' } } }
+]
+
+describe('filterPapersByTheme', () => {
+  it('should return only the correct files', () => {
+    const res = filterPapersByTheme(files, {
+      items: [{ label: 'isp_invoice' }]
+    })
+
+    expect(res).toHaveLength(1)
+    expect(res).toContain(files[0])
+  })
+
+  it('should return only the correct files', () => {
+    const res = filterPapersByTheme(files, {
+      items: [{ label: 'isp_invoice' }, { label: 'phone_invoice' }]
+    })
+
+    expect(res).toHaveLength(2)
+    expect(res).toContain(files[0])
+    expect(res).toContain(files[2])
+  })
+})

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
@@ -48,7 +48,7 @@ const PaperGroup = ({ allPapersByCategories }) => {
 
   return (
     <List>
-      <ListSubheader classes={isMobile && classes}>
+      <ListSubheader classes={isMobile ? classes : undefined}>
         {t('PapersList.subheader')}
       </ListSubheader>
       <div className={'u-pv-half'}>

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
@@ -16,6 +16,7 @@ import Icon from 'cozy-ui/transpiled/react/Icon'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 import MuiCardMedia from 'cozy-ui/transpiled/react/CardMedia'
 import { FileImageLoader } from 'cozy-ui/transpiled/react/FileImageLoader'
+import Typography from 'cozy-ui/transpiled/react/Typography'
 
 import { useScannerI18n } from '../Hooks/useScannerI18n'
 
@@ -52,43 +53,53 @@ const PaperGroup = ({ allPapersByCategories }) => {
         {t('PapersList.subheader')}
       </ListSubheader>
       <div className={'u-pv-half'}>
-        {allPapersByCategories.map((paper, idx) => {
-          const category = get(paper, 'metadata.qualification.label')
+        {allPapersByCategories.length === 0 ? (
+          <Typography
+            className="u-ml-1 u-mv-1"
+            variant="body2"
+            color="textSecondary"
+          >
+            {t('PapersList.empty')}
+          </Typography>
+        ) : (
+          allPapersByCategories.map((paper, idx) => {
+            const category = get(paper, 'metadata.qualification.label')
 
-          return (
-            <Fragment key={idx}>
-              <ListItem button onClick={() => goPapersList(category)}>
-                <ListItemIcon>
-                  <FileImageLoader
-                    client={client}
-                    file={paper}
-                    linkType={getLinkType(paper)}
-                    render={src => (
-                      <MuiCardMedia
-                        component={'img'}
-                        width={32}
-                        height={32}
-                        image={src}
-                      />
-                    )}
-                    renderFallback={() => (
-                      <Icon icon={'file-type-image'} size={32} />
-                    )}
+            return (
+              <Fragment key={idx}>
+                <ListItem button onClick={() => goPapersList(category)}>
+                  <ListItemIcon>
+                    <FileImageLoader
+                      client={client}
+                      file={paper}
+                      linkType={getLinkType(paper)}
+                      render={src => (
+                        <MuiCardMedia
+                          component={'img'}
+                          width={32}
+                          height={32}
+                          image={src}
+                        />
+                      )}
+                      renderFallback={() => (
+                        <Icon icon={'file-type-image'} size={32} />
+                      )}
+                    />
+                  </ListItemIcon>
+                  <ListItemText primary={scannerT(`items.${category}`)} />
+                  <Icon
+                    icon={'right'}
+                    size={16}
+                    color={'var(--secondaryTextColor)'}
                   />
-                </ListItemIcon>
-                <ListItemText primary={scannerT(`items.${category}`)} />
-                <Icon
-                  icon={'right'}
-                  size={16}
-                  color={'var(--secondaryTextColor)'}
-                />
-              </ListItem>
-              {idx !== allPapersByCategories.length - 1 && (
-                <Divider variant="inset" component="li" />
-              )}
-            </Fragment>
-          )
-        })}
+                </ListItem>
+                {idx !== allPapersByCategories.length - 1 && (
+                  <Divider variant="inset" component="li" />
+                )}
+              </Fragment>
+            )
+          })
+        )}
       </div>
     </List>
   )

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PapersListByContact.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PapersListByContact.jsx
@@ -21,7 +21,7 @@ const PapersListByContact = ({ paperslistByContact }) => {
       {paperslistByContact.map(({ withHeader, contact, papers }, idx) => (
         <Fragment key={idx}>
           {withHeader && (
-            <ListSubheader classes={isMobile && classes}>
+            <ListSubheader classes={isMobile ? classes : undefined}>
               {contact}
             </ListSubheader>
           )}

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/ActionMenuImportDropdown.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/ActionMenuImportDropdown.jsx
@@ -48,7 +48,7 @@ ActionMenuImportDropdown.propTypes = {
       name: PropTypes.string,
       category: PropTypes.string
     })
-  }).isRequired,
+  }),
   onClose: PropTypes.func,
   onClick: PropTypes.func
 }

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/FeaturedPlaceholdersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/FeaturedPlaceholdersList.jsx
@@ -52,7 +52,7 @@ const FeaturedPlaceholdersList = ({ featuredPlaceholders }) => {
   return (
     <List>
       {featuredPlaceholders.length > 0 && (
-        <ListSubheader classes={isMobile && classes}>
+        <ListSubheader classes={isMobile ? classes : undefined}>
           {t('FeaturedPlaceholdersList.subheader')}
         </ListSubheader>
       )}

--- a/packages/cozy-mespapiers-lib/src/components/ThemesFilter/ThemesFilter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ThemesFilter/ThemesFilter.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import get from 'lodash/get'
+
+import CircleButton from 'cozy-ui/transpiled/react/CircleButton'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import PeopleIcon from 'cozy-ui/transpiled/react/Icons/People'
+import TeamIcon from 'cozy-ui/transpiled/react/Icons/Team'
+import CompanyIcon from 'cozy-ui/transpiled/react/Icons/Company'
+import HeartIcon from 'cozy-ui/transpiled/react/Icons/Heart'
+import HomeIcon from 'cozy-ui/transpiled/react/Icons/Home'
+import CarIcon from 'cozy-ui/transpiled/react/Icons/Car'
+import CompassIcon from 'cozy-ui/transpiled/react/Icons/Compass'
+import BankIcon from 'cozy-ui/transpiled/react/Icons/Bank'
+import BillIcon from 'cozy-ui/transpiled/react/Icons/Bill'
+import Box from 'cozy-ui/transpiled/react/Box'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+import { useScannerI18n } from '../Hooks/useScannerI18n'
+
+import enLocale from '../../locales/en.json'
+
+const itemIconToSvg = {
+  people: PeopleIcon,
+  team: TeamIcon,
+  company: CompanyIcon,
+  heart: HeartIcon,
+  home: HomeIcon,
+  car: CarIcon,
+  compass: CompassIcon,
+  bank: BankIcon,
+  bill: BillIcon
+}
+
+const makeLabel = ({ scannerT, t, label }) => {
+  const hasLocale = get(enLocale, `Scan.${label}`)
+  return hasLocale ? t(`Scan.${label}`) : scannerT(label)
+}
+
+const ThemesFilter = ({ items, selectedTheme, handleThemeSelection }) => {
+  const scannerT = useScannerI18n()
+  const { t } = useI18n()
+
+  return (
+    <Box className="u-flex u-flex-justify-center u-mv-1" flexWrap="wrap">
+      {items.map((item, index) => (
+        <CircleButton
+          key={index}
+          label={makeLabel({ scannerT, t, label: `themes.${item.label}` })}
+          variant={selectedTheme.id === item.id ? 'active' : 'default'}
+          onClick={() => handleThemeSelection(item)}
+        >
+          <Icon icon={itemIconToSvg[item.icon]} />
+        </CircleButton>
+      ))}
+    </Box>
+  )
+}
+
+export default ThemesFilter

--- a/packages/cozy-mespapiers-lib/src/components/ThemesFilter/index.js
+++ b/packages/cozy-mespapiers-lib/src/components/ThemesFilter/index.js
@@ -1,0 +1,3 @@
+import ThemesFilter from './ThemesFilter'
+
+export default ThemesFilter

--- a/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
@@ -1,4 +1,5 @@
 import get from 'lodash/get'
+import { hasItemByLabel } from '../components/Home/helpers'
 
 /**
  * @typedef {Object} StepAttributes
@@ -37,18 +38,35 @@ export const getPaperDefinitionByLabel = (files, paperDefinition) => {
  * Filters and sorts the list of featured Placeholders.
  * @param {PaperDefinition[]} papersDefinitions Array of PapersDefinition
  * @param {IOCozyFile[]} files Array of IOCozyFile
+ * @param {object} selectedTheme Theme selected
  * @returns {PaperDefinition[]} Array of PapersDefinition filtered with the prop "placeholderIndex"
  */
-export const getFeaturedPlaceholders = ({ papersDefinitions, files = [] }) => {
-  return papersDefinitions
-    .filter(
+export const getFeaturedPlaceholders = ({
+  papersDefinitions,
+  files = [],
+  selectedTheme = ''
+}) => {
+  let featuredPlaceholders
+
+  if (selectedTheme) {
+    featuredPlaceholders = papersDefinitions.filter(
+      paperDefinition =>
+        hasItemByLabel(selectedTheme, paperDefinition.label) &&
+        getPaperDefinitionByLabel(files, paperDefinition)
+    )
+  } else {
+    featuredPlaceholders = papersDefinitions.filter(
       paperDefinition =>
         getPaperDefinitionByLabel(files, paperDefinition) &&
         paperDefinition.placeholderIndex &&
         (paperDefinition.acquisitionSteps.length > 0 ||
           paperDefinition.connectorCriteria)
     )
-    .sort((a, b) => a.placeholderIndex - b.placeholderIndex)
+  }
+
+  return featuredPlaceholders.sort(
+    (a, b) => a.placeholderIndex - b.placeholderIndex
+  )
 }
 
 /**

--- a/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
@@ -39,7 +39,7 @@ export const getPaperDefinitionByLabel = (files, paperDefinition) => {
  * @param {IOCozyFile[]} files Array of IOCozyFile
  * @returns {PaperDefinition[]} Array of PapersDefinition filtered with the prop "placeholderIndex"
  */
-export const getFeaturedPlaceholders = (papersDefinitions, files = []) => {
+export const getFeaturedPlaceholders = ({ papersDefinitions, files = [] }) => {
   return papersDefinitions
     .filter(
       paperDefinition =>

--- a/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
@@ -23,7 +23,7 @@ import get from 'lodash/get'
  * @property {number} maxDisplay - Number of document beyond which a "see more" button is displayed.
  */
 
-export const getPaperDefinitionByLabel = (paperDefinition, files) => {
+export const getPaperDefinitionByLabel = (files, paperDefinition) => {
   return (
     files &&
     !files.some(
@@ -43,7 +43,7 @@ export const getFeaturedPlaceholders = (papersDefinitions, files = []) => {
   return papersDefinitions
     .filter(
       paperDefinition =>
-        getPaperDefinitionByLabel(paperDefinition, files) &&
+        getPaperDefinitionByLabel(files, paperDefinition) &&
         paperDefinition.placeholderIndex &&
         (paperDefinition.acquisitionSteps.length > 0 ||
           paperDefinition.connectorCriteria)

--- a/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
@@ -23,10 +23,13 @@ import get from 'lodash/get'
  * @property {number} maxDisplay - Number of document beyond which a "see more" button is displayed.
  */
 
-const getPaperDefinitionByLabel = (paperDefinition, files) => {
-  return !files.some(
-    paper =>
-      get(paper, 'metadata.qualification.label') === paperDefinition.label
+export const getPaperDefinitionByLabel = (paperDefinition, files) => {
+  return (
+    files &&
+    !files.some(
+      paper =>
+        get(paper, 'metadata.qualification.label') === paperDefinition.label
+    )
   )
 }
 

--- a/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.spec.js
@@ -23,9 +23,9 @@ const fakeQualificationItems = [
 describe('getPlaceholders', () => {
   describe('getFeaturedPlaceholders', () => {
     it('should return list of placeholders', () => {
-      const featuredPlaceholders = getFeaturedPlaceholders(
-        mockPapersDefinitions
-      )
+      const featuredPlaceholders = getFeaturedPlaceholders({
+        papersDefinitions: mockPapersDefinitions
+      })
 
       expect(featuredPlaceholders).toEqual(
         expect.arrayContaining([
@@ -48,10 +48,10 @@ describe('getPlaceholders', () => {
     })
 
     it('should return correct list of placeholders with file constraint', () => {
-      const featuredPlaceholders = getFeaturedPlaceholders(
-        mockPapersDefinitions,
-        fakeIspInvoiceFile
-      )
+      const featuredPlaceholders = getFeaturedPlaceholders({
+        papersDefinitions: mockPapersDefinitions,
+        files: fakeIspInvoiceFile
+      })
 
       expect(featuredPlaceholders).toEqual(
         expect.arrayContaining([

--- a/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.spec.js
@@ -68,6 +68,65 @@ describe('getPlaceholders', () => {
         ])
       )
     })
+
+    describe('with theme selected', () => {
+      it('should return list of placeholders', () => {
+        const featuredPlaceholders = getFeaturedPlaceholders({
+          papersDefinitions: mockPapersDefinitions,
+          selectedTheme: {
+            items: [{ label: 'isp_invoice' }, { label: 'tax_notice' }]
+          }
+        })
+
+        expect(featuredPlaceholders).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              label: 'isp_invoice'
+            })
+          ]),
+          expect.arrayContaining([
+            expect.objectContaining({
+              label: 'tax_notice'
+            })
+          ]),
+          expect.arrayContaining([
+            expect.not.objectContaining({
+              label: 'health_certificate'
+            })
+          ])
+        )
+        expect(featuredPlaceholders.length).toBe(2)
+      })
+
+      it('should return correct list of placeholders with file constraint', () => {
+        const featuredPlaceholders = getFeaturedPlaceholders({
+          papersDefinitions: mockPapersDefinitions,
+          files: fakeIspInvoiceFile,
+          selectedTheme: {
+            items: [{ label: 'isp_invoice' }, { label: 'tax_notice' }]
+          }
+        })
+
+        expect(featuredPlaceholders).toEqual(
+          expect.arrayContaining([
+            expect.not.objectContaining({
+              label: 'isp_invoice'
+            })
+          ]),
+          expect.arrayContaining([
+            expect.objectContaining({
+              label: 'tax_notice'
+            })
+          ]),
+          expect.arrayContaining([
+            expect.not.objectContaining({
+              label: 'health_certificate'
+            })
+          ])
+        )
+        expect(featuredPlaceholders.length).toBe(1)
+      })
+    })
   })
 
   describe('findPlaceholdersByQualification', () => {

--- a/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.spec.js
@@ -98,7 +98,7 @@ describe('getPlaceholders', () => {
 
 describe('getPaperDefinitionByLabel', () => {
   it('should handle empty files', () => {
-    const res = getPaperDefinitionByLabel(mockPapersDefinitions, null)
+    const res = getPaperDefinitionByLabel(null, mockPapersDefinitions)
 
     expect(res).toBe(null)
   })

--- a/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.spec.js
@@ -1,6 +1,7 @@
 import {
   getFeaturedPlaceholders,
-  findPlaceholdersByQualification
+  findPlaceholdersByQualification,
+  getPaperDefinitionByLabel
 } from './findPlaceholders'
 import { mockPapersDefinitions } from '../../test/mockPaperDefinitions'
 
@@ -92,5 +93,13 @@ describe('getPlaceholders', () => {
         ])
       )
     })
+  })
+})
+
+describe('getPaperDefinitionByLabel', () => {
+  it('should handle empty files', () => {
+    const res = getPaperDefinitionByLabel(mockPapersDefinitions, null)
+
+    expect(res).toBe(null)
   })
 })

--- a/packages/cozy-mespapiers-lib/src/helpers/queries.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/queries.js
@@ -4,14 +4,13 @@ import { CONTACTS_DOCTYPE, FILES_DOCTYPE, SETTINGS_DOCTYPE } from '../doctypes'
 
 const defaultFetchPolicy = fetchPolicies.olderThan(30 * 1000)
 
-export const getAllQualificationLabel = papersDefinitions => {
-  const papersLabel = papersDefinitions.map(paper => paper.label)
+export const buildFilesQueryByLabels = labels => {
   return {
     definition: () =>
       Q(FILES_DOCTYPE)
         .where({
           'metadata.qualification.label': {
-            $in: papersLabel
+            $in: labels
           }
         })
         .partialIndex({
@@ -20,7 +19,7 @@ export const getAllQualificationLabel = papersDefinitions => {
         })
         .indexFields(['metadata.qualification.label']),
     options: {
-      as: `getAllQualificationLabel`,
+      as: `${FILES_DOCTYPE}/${JSON.stringify(labels)}`,
       fetchPolicy: defaultFetchPolicy
     }
   }

--- a/packages/cozy-mespapiers-lib/src/helpers/queries.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/queries.js
@@ -17,7 +17,9 @@ export const buildFilesQueryByLabels = labels => {
           type: 'file',
           trashed: false
         })
-        .indexFields(['metadata.qualification.label']),
+        .indexFields(['metadata.qualification.label'])
+        .select(['metadata.qualification.label'])
+        .limitBy(1000),
     options: {
       as: `${FILES_DOCTYPE}/${JSON.stringify(labels)}`,
       fetchPolicy: defaultFetchPolicy

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -212,7 +212,8 @@
     "subheader": "Existing",
     "PapersListByContact": {
       "seeMore": "See more (%{number})"
-    }
+    },
+    "empty": "You do not have any papers yet in this topic."
   },
   "PlaceholdersList": {
     "title": "New paper%{name}"
@@ -225,7 +226,11 @@
       "validFileType": "Accepted formats: image or pdf"
     },
     "selectPicFromCozy": "Select from my Cozy",
-    "takePic": "Take a picture"
+    "takePic": "Take a picture",
+    "themes": {
+      "work_study": "Work",
+      "activity": "Activity"
+    }
   },
   "viewer": {
     "shareData": {

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -212,7 +212,8 @@
     "subheader": "Existants",
     "PapersListByContact": {
       "seeMore": "Voir plus (%{number})"
-    }
+    },
+    "empty": "Vous n'avez aucun papier dans ce thème."
   },
   "PlaceholdersList": {
     "title": "Nouveau papier%{name}"
@@ -225,7 +226,11 @@
       "validFileType": "Format acceptés : image ou pdf"
     },
     "selectPicFromCozy": "Sélectionner dans mon Cozy",
-    "takePic": "Prendre en photo"
+    "takePic": "Prendre en photo",
+    "themes": {
+      "work_study": "Travail",
+      "activity": "Loisirs"
+    }
   },
   "viewer": {
     "shareData": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8397,10 +8397,10 @@ cozy-ui@62.1.2:
     react-select "^4.3.0"
     react-swipeable-views "^0.13.3"
 
-cozy-ui@^65.0.1:
-  version "65.0.1"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-65.0.1.tgz#4cf1e529aec4b57908d1b579fdff279b8c59206b"
-  integrity sha512-RMHFdZ6pmx93my/NRVCmlhje/ZLulQpW2A8KroJytn9dRSydx5QOOC6T3pCTQVVHzOJtOzzqElwNwkiLcEuwOQ==
+cozy-ui@^66.2.0:
+  version "66.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-66.2.0.tgz#23d97e5105c8155099967fbf504fb56bbc09f49a"
+  integrity sha512-J6RLHon9WVsr72Ib6fCfAce3dhdJ7QtWnxcV7i0qW1MFPBv5mOevdJL2iRmtworn/EzWQY1v0JDuin4R5OPEMA==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"
@@ -15770,6 +15770,17 @@ msgpack5@^4.0.2:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
+
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
+  version "1.0.6"
+  uid "494c40416ecde95732c864f9b921e7e545075aa5"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
+  dependencies:
+    "@juggle/resize-observer" "^3.1.3"
+    jest-environment-jsdom-sixteen "^1.0.3"
+    react-spring "9.0.0-rc.3"
+    react-use-gesture "^7.0.8"
+    react-use-measure "^2.0.0"
 
 "mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
   version "1.0.6"


### PR DESCRIPTION
On souhaite pouvoir filtrer les papiers sur la home selon les thèmes. Suite à la sélection d'un thème, on affiche tous les papiers correspondants, et toutes les suggestions possible. S'il n'y a aucun papier à afficher, une petite phrase l'indique.

On utilise les nouveaux CircleButton : https://docs.cozy.io/cozy-ui/react/#!/CircleButton

