### PR TITLE
Add search input on Home to filers papers

### DIFF
--- a/packages/cozy-mespapiers-lib/package.json
+++ b/packages/cozy-mespapiers-lib/package.json
@@ -40,7 +40,8 @@
     "mui-bottom-sheet": "https://github.com/cozy/mui-bottom-sheet.git#v1.0.6",
     "node-polyglot": "^2.4.0",
     "pdf-lib": "1.17.1",
-    "react-input-mask": "3.0.0-alpha.2"
+    "react-input-mask": "3.0.0-alpha.2",
+    "fuse.js": "6.6.0"
   },
   "peerDependencies": {
     "cozy-client": ">=28.2.1",

--- a/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
@@ -4,22 +4,25 @@ import uniqBy from 'lodash/uniqBy'
 import { isQueryLoading, useQueryAll, models } from 'cozy-client'
 import Empty from 'cozy-ui/transpiled/react/Empty'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
+import Box from 'cozy-ui/transpiled/react/Box'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import ThemesFilter from '../ThemesFilter'
+import SearchInput from '../SearchInput'
 import PaperGroup from '../Papers/PaperGroup'
 import FeaturedPlaceholdersList from '../Placeholders/FeaturedPlaceholdersList'
 import { usePapersDefinitions } from '../Hooks/usePapersDefinitions'
 import { buildFilesQueryByLabels } from '../../helpers/queries'
 import { getFeaturedPlaceholders } from '../../helpers/findPlaceholders'
 import HomeCloud from '../../assets/icons/HomeCloud.svg'
-import { filterPapersByTheme } from './helpers'
+import { filterPapersByThemeAndSearchValue } from './helpers'
 
 const {
   themes: { themesList }
 } = models.document
 
 const Home = () => {
+  const [searchValue, setSearchValue] = useState('')
   const [selectedTheme, setSelectedTheme] = useState('')
   const { t } = useI18n()
   const { papersDefinitions } = usePapersDefinitions()
@@ -38,10 +41,11 @@ const Home = () => {
     [filesByLabels]
   )
 
-  const filteredPapersByTheme = filterPapersByTheme(
-    allPapersByCategories,
-    selectedTheme
-  )
+  const filteredPapers = filterPapersByThemeAndSearchValue({
+    files: allPapersByCategories,
+    theme: selectedTheme,
+    search: searchValue
+  })
 
   const featuredPlaceholders = useMemo(
     () =>
@@ -68,11 +72,18 @@ const Home = () => {
 
   return (
     <>
-      <ThemesFilter
-        items={themesList}
-        selectedTheme={selectedTheme}
-        handleThemeSelection={handleThemeSelection}
-      />
+      <div className="u-flex u-flex-column-s u-mv-1 u-ph-1">
+        <Box className="u-flex u-flex-items-center u-mb-half-s" flex="1 1 auto">
+          <SearchInput setSearchValue={setSearchValue} />
+        </Box>
+        <Box className="u-flex u-flex-justify-center" flexWrap="wrap">
+          <ThemesFilter
+            items={themesList}
+            selectedTheme={selectedTheme}
+            handleThemeSelection={handleThemeSelection}
+          />
+        </Box>
+      </div>
       {allPapersByCategories.length === 0 ? (
         <Empty
           icon={HomeCloud}
@@ -82,7 +93,7 @@ const Home = () => {
           className={'u-ph-1'}
         />
       ) : (
-        <PaperGroup allPapersByCategories={filteredPapersByTheme} />
+        <PaperGroup allPapersByCategories={filteredPapers} />
       )}
       <FeaturedPlaceholdersList featuredPlaceholders={featuredPlaceholders} />
     </>

--- a/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
@@ -15,6 +15,7 @@ import { usePapersDefinitions } from '../Hooks/usePapersDefinitions'
 import { buildFilesQueryByLabels } from '../../helpers/queries'
 import { getFeaturedPlaceholders } from '../../helpers/findPlaceholders'
 import HomeCloud from '../../assets/icons/HomeCloud.svg'
+import { useScannerI18n } from '../Hooks/useScannerI18n'
 import { filterPapersByThemeAndSearchValue } from './helpers'
 
 const {
@@ -25,6 +26,7 @@ const Home = () => {
   const [searchValue, setSearchValue] = useState('')
   const [selectedTheme, setSelectedTheme] = useState('')
   const { t } = useI18n()
+  const scannerT = useScannerI18n()
   const { papersDefinitions } = usePapersDefinitions()
   const labels = papersDefinitions.map(paper => paper.label)
   const filesQueryByLabels = buildFilesQueryByLabels(labels)
@@ -44,7 +46,8 @@ const Home = () => {
   const filteredPapers = filterPapersByThemeAndSearchValue({
     files: allPapersByCategories,
     theme: selectedTheme,
-    search: searchValue
+    search: searchValue,
+    scannerT
   })
 
   const featuredPlaceholders = useMemo(

--- a/packages/cozy-mespapiers-lib/src/components/Home/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Home/helpers.js
@@ -1,11 +1,36 @@
-// should be in cozy-client : https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document/documentTypeDataHelpers.js
-export const hasItemByLabel = (theme, label) =>
-  theme.items.some(item => item.label === label)
+import Fuse from 'fuse.js'
 
-export const filterPapersByTheme = (files, theme) => {
-  if (!theme) return files
+const fuse = new Fuse([], {
+  findAllMatches: true,
+  threshold: 0.3,
+  ignoreLocation: true,
+  ignoreFieldNorm: true,
+  keys: [
+    {
+      name: 'name'
+    }
+  ]
+})
 
-  return files.filter(file =>
-    hasItemByLabel(theme, file.metadata.qualification.label)
-  )
+// TODO: hasItemByLabel should be in cozy-client : https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document/documentTypeDataHelpers.js
+export const hasItemByLabel = (theme, label) => {
+  if (!theme) return true
+  return theme.items.some(item => item.label === label)
+}
+
+export const filterPapersByThemeAndSearchValue = ({ files, theme, search }) => {
+  let filteredFiles = files
+
+  if (search) {
+    fuse.setCollection(files)
+    filteredFiles = fuse.search(search).map(result => result.item)
+  }
+
+  if (theme) {
+    filteredFiles = filteredFiles.filter(file =>
+      hasItemByLabel(theme, file.metadata.qualification.label)
+    )
+  }
+
+  return filteredFiles
 }

--- a/packages/cozy-mespapiers-lib/src/components/Home/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Home/helpers.spec.js
@@ -1,29 +1,80 @@
-import { filterPapersByTheme, hasItemByLabel } from './helpers'
+import { filterPapersByThemeAndSearchValue, hasItemByLabel } from './helpers'
 
 const files = [
-  { _id: 'file01', metadata: { qualification: { label: 'isp_invoice' } } },
-  { _id: 'file02', metadata: { qualification: { label: 'driver_license' } } },
-  { _id: 'file03', metadata: { qualification: { label: 'phone_invoice' } } }
+  {
+    _id: 'file01',
+    name: 'Facture internet',
+    metadata: { qualification: { label: 'isp_invoice' } }
+  },
+  {
+    _id: 'file02',
+    name: 'Permis de conduire',
+    metadata: { qualification: { label: 'driver_license' } }
+  },
+  {
+    _id: 'file03',
+    name: 'Facture téléphonique',
+    metadata: { qualification: { label: 'phone_invoice' } }
+  }
 ]
 
-describe('filterPapersByTheme', () => {
-  it('should return only the correct files', () => {
-    const res = filterPapersByTheme(files, {
-      items: [{ label: 'isp_invoice' }]
+describe('filterPapersByThemeAndSearchValue', () => {
+  describe('with only theme selected', () => {
+    it('should return only the correct files with one qualification label', () => {
+      const res = filterPapersByThemeAndSearchValue({
+        files,
+        theme: {
+          items: [{ label: 'isp_invoice' }]
+        },
+        search: ''
+      })
+
+      expect(res).toHaveLength(1)
+      expect(res).toContain(files[0])
     })
 
-    expect(res).toHaveLength(1)
-    expect(res).toContain(files[0])
+    it('should return only the correct files with two qualifiation labels', () => {
+      const res = filterPapersByThemeAndSearchValue({
+        files,
+        theme: {
+          items: [{ label: 'isp_invoice' }, { label: 'phone_invoice' }]
+        },
+        search: ''
+      })
+
+      expect(res).toHaveLength(2)
+      expect(res).toContain(files[0])
+      expect(res).toContain(files[2])
+    })
   })
 
-  it('should return only the correct files', () => {
-    const res = filterPapersByTheme(files, {
-      items: [{ label: 'isp_invoice' }, { label: 'phone_invoice' }]
-    })
+  describe('with only search value', () => {
+    it('should return only the correct files with search value', () => {
+      const res = filterPapersByThemeAndSearchValue({
+        files,
+        theme: '',
+        search: 'facture'
+      })
 
-    expect(res).toHaveLength(2)
-    expect(res).toContain(files[0])
-    expect(res).toContain(files[2])
+      expect(res).toHaveLength(2)
+      expect(res).toContain(files[0])
+      expect(res).toContain(files[2])
+    })
+  })
+
+  describe('with theme selected and search value', () => {
+    it('should return only the correct files', () => {
+      const res = filterPapersByThemeAndSearchValue({
+        files,
+        theme: {
+          items: [{ label: 'isp_invoice' }]
+        },
+        search: 'facture'
+      })
+
+      expect(res).toHaveLength(1)
+      expect(res).toContain(files[0])
+    })
   })
 })
 

--- a/packages/cozy-mespapiers-lib/src/components/Home/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Home/helpers.spec.js
@@ -1,4 +1,16 @@
+import get from 'lodash/get'
+
 import { filterPapersByThemeAndSearchValue, hasItemByLabel } from './helpers'
+
+const locales = {
+  items: {
+    isp_invoice: 'Facture internet',
+    driver_license: 'Permis de conduire',
+    phone_invoice: 'Facture téléphonique'
+  }
+}
+
+const scannerT = x => get(locales, x)
 
 const files = [
   {
@@ -13,33 +25,35 @@ const files = [
   },
   {
     _id: 'file03',
-    name: 'Facture téléphonique',
+    name: 'Facture minitel',
     metadata: { qualification: { label: 'phone_invoice' } }
   }
 ]
 
 describe('filterPapersByThemeAndSearchValue', () => {
   describe('with only theme selected', () => {
-    it('should return only the correct files with one qualification label', () => {
+    test('when one qualification label matches', () => {
       const res = filterPapersByThemeAndSearchValue({
         files,
         theme: {
           items: [{ label: 'isp_invoice' }]
         },
-        search: ''
+        search: '',
+        scannerT
       })
 
       expect(res).toHaveLength(1)
       expect(res).toContain(files[0])
     })
 
-    it('should return only the correct files with two qualifiation labels', () => {
+    test('when two qualifiation labels matches', () => {
       const res = filterPapersByThemeAndSearchValue({
         files,
         theme: {
           items: [{ label: 'isp_invoice' }, { label: 'phone_invoice' }]
         },
-        search: ''
+        search: '',
+        scannerT
       })
 
       expect(res).toHaveLength(2)
@@ -49,15 +63,28 @@ describe('filterPapersByThemeAndSearchValue', () => {
   })
 
   describe('with only search value', () => {
-    it('should return only the correct files with search value', () => {
+    test('when names matches', () => {
       const res = filterPapersByThemeAndSearchValue({
         files,
         theme: '',
-        search: 'facture'
+        search: 'facture',
+        scannerT
       })
 
       expect(res).toHaveLength(2)
       expect(res).toContain(files[0])
+      expect(res).toContain(files[2])
+    })
+
+    test('when qualification labels matches', () => {
+      const res = filterPapersByThemeAndSearchValue({
+        files,
+        theme: '',
+        search: 'téléphonique',
+        scannerT
+      })
+
+      expect(res).toHaveLength(1)
       expect(res).toContain(files[2])
     })
   })
@@ -69,7 +96,8 @@ describe('filterPapersByThemeAndSearchValue', () => {
         theme: {
           items: [{ label: 'isp_invoice' }]
         },
-        search: 'facture'
+        search: 'facture',
+        scannerT
       })
 
       expect(res).toHaveLength(1)

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
@@ -62,11 +62,11 @@ const PaperGroup = ({ allPapersByCategories }) => {
             {t('PapersList.empty')}
           </Typography>
         ) : (
-          allPapersByCategories.map((paper, idx) => {
+          allPapersByCategories.map((paper, index) => {
             const category = get(paper, 'metadata.qualification.label')
 
             return (
-              <Fragment key={idx}>
+              <Fragment key={paper.id}>
                 <ListItem button onClick={() => goPapersList(category)}>
                   <ListItemIcon>
                     <FileImageLoader
@@ -93,7 +93,7 @@ const PaperGroup = ({ allPapersByCategories }) => {
                     color={'var(--secondaryTextColor)'}
                   />
                 </ListItem>
-                {idx !== allPapersByCategories.length - 1 && (
+                {index !== allPapersByCategories.length - 1 && (
                   <Divider variant="inset" component="li" />
                 )}
               </Fragment>

--- a/packages/cozy-mespapiers-lib/src/components/SearchInput/SearchInput.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/SearchInput/SearchInput.jsx
@@ -1,0 +1,49 @@
+import React, { useMemo } from 'react'
+import debounce from 'lodash/debounce'
+
+import InputGroup from 'cozy-ui/transpiled/react/InputGroup'
+import Input from 'cozy-ui/transpiled/react/Input'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import MagnifierIcon from 'cozy-ui/transpiled/react/Icons/Magnifier'
+import makeStyles from 'cozy-ui/transpiled/react/helpers/makeStyles'
+
+const useStyles = makeStyles({
+  input: {
+    borderRadius: '25px',
+    '& input': {
+      borderRadius: '25px'
+    }
+  }
+})
+
+const SearchInput = ({ setSearchValue }) => {
+  const { t } = useI18n()
+  const styles = useStyles()
+
+  const delayedSetSearchValue = useMemo(
+    () => debounce(searchValue => setSearchValue(searchValue), 375),
+    [setSearchValue]
+  )
+
+  const handleOnChange = ev => {
+    delayedSetSearchValue(ev.target.value)
+  }
+
+  return (
+    <InputGroup
+      className={`${styles.input} u-mr-0-s u-mr-1 u-maw-100 `}
+      prepend={
+        <Icon
+          className="u-pl-1"
+          icon={MagnifierIcon}
+          color="var(--iconTextColor)"
+        />
+      }
+    >
+      <Input placeholder={t('search')} onChange={handleOnChange} />
+    </InputGroup>
+  )
+}
+
+export default SearchInput

--- a/packages/cozy-mespapiers-lib/src/components/SearchInput/index.js
+++ b/packages/cozy-mespapiers-lib/src/components/SearchInput/index.js
@@ -1,0 +1,3 @@
+import SearchInput from './SearchInput'
+
+export default SearchInput

--- a/packages/cozy-mespapiers-lib/src/components/ThemesFilter/ThemesFilter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ThemesFilter/ThemesFilter.jsx
@@ -42,9 +42,9 @@ const ThemesFilter = ({ items, selectedTheme, handleThemeSelection }) => {
 
   return (
     <Box className="u-flex u-flex-justify-center u-mv-1" flexWrap="wrap">
-      {items.map((item, index) => (
+      {items.map(item => (
         <CircleButton
-          key={index}
+          key={item.id}
           label={makeLabel({ scannerT, t, label: `themes.${item.label}` })}
           variant={selectedTheme.id === item.id ? 'active' : 'default'}
           onClick={() => handleThemeSelection(item)}

--- a/packages/cozy-mespapiers-lib/src/components/ThemesFilter/ThemesFilter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ThemesFilter/ThemesFilter.jsx
@@ -12,7 +12,6 @@ import CarIcon from 'cozy-ui/transpiled/react/Icons/Car'
 import CompassIcon from 'cozy-ui/transpiled/react/Icons/Compass'
 import BankIcon from 'cozy-ui/transpiled/react/Icons/Bank'
 import BillIcon from 'cozy-ui/transpiled/react/Icons/Bill'
-import Box from 'cozy-ui/transpiled/react/Box'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import { useScannerI18n } from '../Hooks/useScannerI18n'
@@ -41,7 +40,7 @@ const ThemesFilter = ({ items, selectedTheme, handleThemeSelection }) => {
   const { t } = useI18n()
 
   return (
-    <Box className="u-flex u-flex-justify-center u-mv-1" flexWrap="wrap">
+    <>
       {items.map(item => (
         <CircleButton
           key={item.id}
@@ -52,7 +51,7 @@ const ThemesFilter = ({ items, selectedTheme, handleThemeSelection }) => {
           <Icon icon={itemIconToSvg[item.icon]} />
         </CircleButton>
       ))}
-    </Box>
+    </>
   )
 }
 

--- a/packages/cozy-mespapiers-lib/src/helpers/queries.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/queries.js
@@ -18,7 +18,7 @@ export const buildFilesQueryByLabels = labels => {
           trashed: false
         })
         .indexFields(['metadata.qualification.label'])
-        .select(['metadata.qualification.label'])
+        .select(['name', 'metadata.qualification.label'])
         .limitBy(1000),
     options: {
       as: `${FILES_DOCTYPE}/${JSON.stringify(labels)}`,

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -238,5 +238,6 @@
       "text": "Link to my document %{name}: ",
       "title": "Link to my document %{name}"
     }
-  }
+  },
+  "search": "Search"
 }

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -238,5 +238,6 @@
       "text": "Voici un lien vers mon document %{name} : ",
       "title": "Lien vers mon document %{name}"
     }
-  }
+  },
+  "search": "Rechercher"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10989,6 +10989,11 @@ functions-have-names@^1.2.1:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.2.tgz#98d93991c39da9361f8e50b337c4f6e41f120e21"
   integrity sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA==
 
+fuse.js@6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.6.0.tgz#9c0dd9337731ebc6541abf44aa3aa9bb6cb5acb6"
+  integrity sha512-4CvUk6GBo1b00xIcCLEoHQX3xwaYIwUX0lD8hDaYUavvSgE8aaySe9Z+fb4bdvzXXbYUfrllwN34U3wwUsG+oA==
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -15771,17 +15776,6 @@ msgpack5@^4.0.2:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
-
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
-  version "1.0.6"
-  uid "494c40416ecde95732c864f9b921e7e545075aa5"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
-  dependencies:
-    "@juggle/resize-observer" "^3.1.3"
-    jest-environment-jsdom-sixteen "^1.0.3"
-    react-spring "9.0.0-rc.3"
-    react-use-gesture "^7.0.8"
-    react-use-measure "^2.0.0"
 
 "mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
   version "1.0.6"


### PR DESCRIPTION
On ajoute un change input de recherche afin de faire une recherche sur les papiers de la Home.

Le champ de recherche vient en complément du tri par thème.

Selon les mots tapés dans le champ de recherche, on fait un matching sur le nom du papier ainsi que le label de qualification.