### PR TITLE
Added the possibility to have an InputMask in the information step

### DIFF
--- a/packages/cozy-mespapiers-lib/package.json
+++ b/packages/cozy-mespapiers-lib/package.json
@@ -39,7 +39,8 @@
     "date-fns": "2.23.0",
     "mui-bottom-sheet": "https://github.com/cozy/mui-bottom-sheet.git#v1.0.6",
     "node-polyglot": "^2.4.0",
-    "pdf-lib": "1.17.1"
+    "pdf-lib": "1.17.1",
+    "react-input-mask": "3.0.0-alpha.2"
   },
   "peerDependencies": {
     "cozy-client": ">=28.2.1",

--- a/packages/cozy-mespapiers-lib/src/components/CompositeHeader/CompositeHeader.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/CompositeHeader/CompositeHeader.jsx
@@ -60,7 +60,7 @@ const CompositeHeader = ({
         (isValidElement(Text) || isArray(Text) ? (
           <div
             className={cx({
-              ['u-mv-1']: !isMobile || (isArray(Text) && Text.length <= 1),
+              ['u-mt-1']: !isMobile || (isArray(Text) && Text.length <= 1),
               ['u-mt-1 u-mah-5 u-pv-1 u-ov-scroll']:
                 isMobile && isArray(Text) && Text.length > 1
             })}

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputDateAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputDateAdapter.jsx
@@ -8,10 +8,12 @@ import {
 import { makeStyles } from '@material-ui/styles'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 const useStyles = makeStyles(() => ({
   overrides: {
     width: '100%',
+    height: isDesktop => (isDesktop ? '5rem' : 'inehrit'),
     MuiOutlinedInput: {
       '&:focused': {
         notchedOutline: {
@@ -32,7 +34,8 @@ const InputDateAdapter = ({
 }) => {
   const { name, inputLabel } = attrs
   const { t, lang } = useI18n()
-  const classes = useStyles()
+  const { isDesktop } = useBreakpoints()
+  const classes = useStyles(isDesktop)
   const [locales, setLocales] = useState('')
   const [isValidDate, setIsValidDate] = useState(true)
   const [selectedDate, setSelectedDate] = useState(defaultValue || null)

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
@@ -110,7 +110,7 @@ const InputTextAdapter = ({
     ? t('InputTextAdapter.invalidTextMessage', {
         smart_count: expectedLength.min - currentValue.length
       })
-    : ''
+    : ' '
 
   if (mask) {
     return (

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
@@ -26,7 +26,7 @@ const InputTextAdapter = ({
   const { name, inputLabel, ...otherInputProps } = attrs
   const { t } = useI18n()
   const [currentValue, setCurrentValue] = useState(defaultValue || '')
-  const [isError, setIsError] = useState(false)
+  const [isTooShort, setIsTooShort] = useState(false)
 
   const { inputType, expectedLength, isRequired } = useMemo(
     () => makeConstraintsOfInput(otherInputProps),
@@ -78,26 +78,27 @@ const InputTextAdapter = ({
 
   const handleOnFocus = () => {
     setIsFocus(true)
-    setIsError(false)
+    setIsTooShort(false)
   }
 
   const handleOnBlur = () => {
     setIsFocus(false)
     if (currentValue.length > 0) {
-      setIsError(expectedLength > 0 && currentValue.length !== expectedLength)
-    } else setIsError(false)
+      setIsTooShort(
+        expectedLength.min > 0 && currentValue.length < expectedLength.min
   }
 
-  const helperText = isError
+  const helperText = isTooShort
     ? t('InputTextAdapter.invalidTextMessage', {
-        smart_count: expectedLength - currentValue.length
+        smart_count: expectedLength.min - currentValue.length
       })
     : ''
 
   return (
     <TextField
       value={currentValue}
-      error={isError}
+      inputType={inputType}
+      error={isTooShort}
       onBlur={handleOnBlur}
       onFocus={handleOnFocus}
       helperText={helperText}

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -96,7 +96,7 @@
     "invalidDateMessage": "Invalid Date"
   },
   "InputTextAdapter": {
-    "invalidTextMessage": "%{smart_count} number is missing |||| %{smart_count} numbers are missings"
+    "invalidTextMessage": "%{smart_count} character is missing |||| %{smart_count} characters are missings"
   },
   "Onboarding": {
     "cta": "Let's go!"

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -96,7 +96,7 @@
     "invalidDateMessage": "Date invalide"
   },
   "InputTextAdapter": {
-    "invalidTextMessage": "Il manque %{smart_count} chiffre |||| Il manque %{smart_count} chiffres"
+    "invalidTextMessage": "Il manque %{smart_count} caractère |||| Il manque %{smart_count} caractères"
   },
   "Onboarding": {
     "cta": "C'est parti !"

--- a/packages/cozy-mespapiers-lib/src/utils/input.js
+++ b/packages/cozy-mespapiers-lib/src/utils/input.js
@@ -22,12 +22,11 @@ import log from 'cozy-logger'
  * @returns {{ inputType: string, expectedLength: { min: number, max: number }, isRequired: boolean }}
  */
 export const makeConstraintsOfInput = attrs => {
-  const {
-    type = '',
-    required = false,
-    minLength = 0,
-    maxLength = 0
-  } = attrs || {}
+  const { type = '', required = false, mask } = attrs || {}
+
+  const maskLength = mask ? mask.replaceAll(' ', '').length : null
+  const minLength = maskLength || attrs?.minLength || 0
+  const maxLength = maskLength || attrs?.maxLength || 0
 
   const acceptedTypes = ['number', 'text']
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18396,6 +18396,15 @@ react-input-autosize@^3.0.0:
   dependencies:
     prop-types "^15.5.8"
 
+react-input-mask@3.0.0-alpha.2:
+  version "3.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/react-input-mask/-/react-input-mask-3.0.0-alpha.2.tgz#113102942a557edc7a192e66020b8ce1ba699a5c"
+  integrity sha512-9U7qL+mvDMOJcbOFPdt6Vj+zzmCMNnBjhhjGDrL8BGQmymgvMVKhu/oOVfAkl+5VWOsLr+G3EhZOmae5fBcAkA==
+  dependencies:
+    invariant "^2.2.4"
+    prop-types "^15.7.2"
+    warning "^4.0.3"
+
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
Added the possibility to have an InputMask in the information step when creating a paper, configurable via the configuration file (papersDefinitions.json).

The 2 parameters added are :
- `mask`: To manage the format and the allowed characters.
- maskPlaceholder`: Allows to specify which placeholder to use ("_" by default)

The font used is validated by @joel-costa

PS: je suis preneur de retours mais le dev ayant déjà pris le double du temps estimé...
(Il pourrait, entre autres, avoir plus de tests)