### PR TITLE
fix(cozy-intent): Allow to register webviews with baseUrl and no uri

### DIFF
--- a/packages/cozy-intent/src/api/models/environments.spec.ts
+++ b/packages/cozy-intent/src/api/models/environments.spec.ts
@@ -1,0 +1,18 @@
+import {isWebviewSourceBaseUrl} from "./environments";
+
+describe('environmments', () => {
+  describe('isWebviewSourceBaseUrl', () => {
+    it('should be true when WebviewSourceBaseUrl providen', () => {
+      // When
+      const result = isWebviewSourceBaseUrl({baseUrl: 'http://', html: '<html></html>'});
+      // Then
+      expect(result).toBe(true)
+    })
+    it('should be false when WebviewSourceUri providen', () => {
+      // When
+      const result = isWebviewSourceBaseUrl({uri: 'http://'});
+      // Then
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/packages/cozy-intent/src/api/models/environments.ts
+++ b/packages/cozy-intent/src/api/models/environments.ts
@@ -9,22 +9,19 @@ export interface WebviewSourceUri {
   html?: never
 }
 
-export interface WebiewSourceBaseUrl {
+export interface WebviewSourceBaseUrl {
   baseUrl: string
   html: string
 
   uri?: never
 }
 
-export type WebviewSource = WebviewSourceUri | WebiewSourceBaseUrl
+export type WebviewSource = WebviewSourceUri | WebviewSourceBaseUrl
 
 export function isWebviewSourceBaseUrl(
   webviewSource: WebviewSource
-): webviewSource is WebiewSourceBaseUrl {
-  if ((webviewSource as WebiewSourceBaseUrl).html) {
-    return true
-  }
-  return false
+): webviewSource is WebviewSourceBaseUrl {
+  return Boolean((webviewSource as WebviewSourceBaseUrl).html)
 }
 
 export interface WebviewRef {

--- a/packages/cozy-intent/src/api/models/environments.ts
+++ b/packages/cozy-intent/src/api/models/environments.ts
@@ -2,12 +2,35 @@ import { Connection, EventsType, MethodsType } from 'post-me'
 
 import { NativeMethodsRegister } from '../../api'
 
+export interface WebviewSourceUri {
+  uri: string
+
+  baseUrl?: never
+  html?: never
+}
+
+export interface WebiewSourceBaseUrl {
+  baseUrl: string
+  html: string
+
+  uri?: never
+}
+
+export type WebviewSource = WebviewSourceUri | WebiewSourceBaseUrl
+
+export function isWebviewSourceBaseUrl(
+  webviewSource: WebviewSource
+): webviewSource is WebiewSourceBaseUrl {
+  if ((webviewSource as WebiewSourceBaseUrl).html) {
+    return true
+  }
+  return false
+}
+
 export interface WebviewRef {
   injectJavaScript: (data: string) => void
   props: {
-    source: {
-      uri: string
-    }
+    source: WebviewSource
   }
 }
 

--- a/packages/cozy-intent/src/api/services/NativeService.spec.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.spec.ts
@@ -141,6 +141,33 @@ describe('NativeService', () => {
 
       expect(mockDebug).toHaveBeenCalled()
     })
+
+    it('Should allow to register a webview with a baseUrl instead of an uri', () => {
+      const nativeMethods: NativeMethodsRegister = {
+        backToHome: jest.fn(),
+        logout: jest.fn(),
+        openApp: jest.fn(),
+        hideSplashScreen: jest.fn(),
+        setFlagshipUI: jest.fn(),
+        showSplashScreen: jest.fn()
+      }
+
+      const webviewRef: WebviewRef = {
+        injectJavaScript: jest.fn(),
+        props: {
+          source: {
+            html: 'SOME HTML',
+            baseUrl: 'http://SOME_BASE_URL'
+          }
+        }
+      }
+
+      const nativeService = new NativeService(nativeMethods)
+
+      nativeService.registerWebview(webviewRef)
+
+      expect(NativeMessenger).toHaveBeenNthCalledWith(1, webviewRef)
+    })
   })
 
   describe('unregisterWebview', () => {

--- a/packages/cozy-intent/src/api/services/NativeService.spec.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.spec.ts
@@ -32,20 +32,18 @@ jest.mock('post-me', () => ({
   ...jest.requireActual('post-me'),
   debug:
     (nameSpace = 'NativeService') =>
-    (): unknown =>
-      mockDebug(nameSpace),
+    (str: string) =>
+      mockDebug(nameSpace, str),
   ParentHandshake: jest.fn(() => Promise.resolve({ foo: 'bar' }))
 }))
 
 jest.mock('../services/NativeMessenger')
 
 describe('NativeService', () => {
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
+  let nativeMethods: NativeMethodsRegister
 
-  it('Should allow to register and unregister webviews, regardless of casing', async () => {
-    const nativeMethods: NativeMethodsRegister = {
+  beforeEach(() => {
+    nativeMethods = {
       backToHome: jest.fn(),
       logout: jest.fn(),
       openApp: jest.fn(),
@@ -53,7 +51,13 @@ describe('NativeService', () => {
       setFlagshipUI: jest.fn(),
       showSplashScreen: jest.fn()
     }
+  })
 
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('Should allow to register and unregister webviews, regardless of casing', async () => {
     const webviewRef: WebviewRef = {
       injectJavaScript: jest.fn(),
       props: {
@@ -87,15 +91,6 @@ describe('NativeService', () => {
 
   describe('registerWebview', () => {
     it('Should allow to register a webview', () => {
-      const nativeMethods: NativeMethodsRegister = {
-        backToHome: jest.fn(),
-        logout: jest.fn(),
-        openApp: jest.fn(),
-        hideSplashScreen: jest.fn(),
-        setFlagshipUI: jest.fn(),
-        showSplashScreen: jest.fn()
-      }
-
       const webviewRef: WebviewRef = {
         injectJavaScript: jest.fn(),
         props: {
@@ -113,15 +108,6 @@ describe('NativeService', () => {
     })
 
     it('Should bail out and log if registering two times the same webview', () => {
-      const nativeMethods: NativeMethodsRegister = {
-        backToHome: jest.fn(),
-        logout: jest.fn(),
-        openApp: jest.fn(),
-        hideSplashScreen: jest.fn(),
-        setFlagshipUI: jest.fn(),
-        showSplashScreen: jest.fn()
-      }
-
       const webviewRef: WebviewRef = {
         injectJavaScript: jest.fn(),
         props: {
@@ -143,15 +129,6 @@ describe('NativeService', () => {
     })
 
     it('Should allow to register a webview with a baseUrl instead of an uri', () => {
-      const nativeMethods: NativeMethodsRegister = {
-        backToHome: jest.fn(),
-        logout: jest.fn(),
-        openApp: jest.fn(),
-        hideSplashScreen: jest.fn(),
-        setFlagshipUI: jest.fn(),
-        showSplashScreen: jest.fn()
-      }
-
       const webviewRef: WebviewRef = {
         injectJavaScript: jest.fn(),
         props: {
@@ -168,19 +145,33 @@ describe('NativeService', () => {
 
       expect(NativeMessenger).toHaveBeenNthCalledWith(1, webviewRef)
     })
+
+    it('Should use correct uri with WebviewSourceBaseUrl', () => {
+      const webviewRef: WebviewRef = {
+        injectJavaScript: jest.fn(),
+        props: {
+          source: {
+            html: 'SOME HTML',
+            baseUrl: 'http://SOME_BASE_URL'
+          }
+        }
+      }
+
+      const nativeService = new NativeService(nativeMethods)
+
+      nativeService.registerWebview(webviewRef)
+      nativeService.registerWebview(webviewRef)
+
+      const baseUrlFromWebview = "some_base_url";
+      expect(mockDebug).toHaveBeenCalledWith(
+        "NativeService",
+        `Cannot register webview. A webview is already registered into cozy-intent with the uri: ${baseUrlFromWebview}`
+      )
+    })
   })
 
   describe('unregisterWebview', () => {
     it('Should bail out and log if unregistering not registered webview', () => {
-      const nativeMethods: NativeMethodsRegister = {
-        backToHome: jest.fn(),
-        logout: jest.fn(),
-        openApp: jest.fn(),
-        hideSplashScreen: jest.fn(),
-        setFlagshipUI: jest.fn(),
-        showSplashScreen: jest.fn()
-      }
-
       const webviewRef: WebviewRef = {
         injectJavaScript: jest.fn(),
         props: {

--- a/packages/cozy-intent/src/api/services/NativeService.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.ts
@@ -2,6 +2,7 @@ import { Connection, debug, ParentHandshake } from 'post-me'
 
 import {
   DebugNativeMessenger,
+  isWebviewSourceBaseUrl,
   MessengerRegister,
   NativeEvent,
   NativeMessenger,
@@ -38,7 +39,11 @@ export class NativeService {
 
   private getUri = (source: WebviewRef | NativeEvent): string => {
     return this.isWebviewRef(source)
-      ? new URL(source.props.source.uri).hostname.toLowerCase()
+      ? new URL(
+          isWebviewSourceBaseUrl(source.props.source)
+            ? source.props.source.baseUrl
+            : source.props.source.uri
+        ).hostname.toLowerCase()
       : new URL(source.nativeEvent.url).hostname.toLowerCase()
   }
 


### PR DESCRIPTION
ReactNative webviews can be registered using two forms of sources:
- `source={{ uri }}`
- `source={{ html, baseUrl }}`

Previous code implementation was able to support only the first form
and would crash when a webview is registered with a baseUrl

Not that react-native-webview priorize check on html+baseUrl over uri,
so we chose to implement only `isWebviewSourceBaseUrl` to prevent a
wrong check

More details:
- https://github.com/react-native-webview/react-native-webview/blob/a36394f598944c1ffe288f739b7441830249dc1e/apple/RNCWebView.m#L679-L686
- https://github.com/react-native-webview/react-native-webview/blob/a36394f598944c1ffe288f739b7441830249dc1e/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java#L513-L518