### PR TITLE
feat: Synchronize the versions of cozy packages on devDeps/peerDeps

### DIFF
--- a/packages/cozy-mespapiers-lib/package.json
+++ b/packages/cozy-mespapiers-lib/package.json
@@ -46,10 +46,10 @@
     "cozy-client": ">=28.2.1",
     "cozy-device-helper": ">=2.0.0",
     "cozy-doctypes": ">=1.83.3",
-    "cozy-harvest-lib": ">=8.4.2",
-    "cozy-intent": ">=1.13.5",
-    "cozy-realtime": ">=4.0.2",
-    "cozy-sharing": ">=4.1.6",
+    "cozy-harvest-lib": ">=9.1.1",
+    "cozy-intent": ">=1.17.1",
+    "cozy-realtime": ">=4.0.8",
+    "cozy-sharing": ">=4.1.7",
     "cozy-ui": ">=66.2.0",
     "react-router-dom": ">=5.2.0"
   }


### PR DESCRIPTION
no problem with BC of harvest : cozy-keys-lib isn't used here