### PR TITLE
Select current user by default on contact step

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/ContactList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/ContactList.jsx
@@ -39,15 +39,12 @@ const ContactList = ({
   ])
 
   useEffect(() => {
-    contactIdsSelected.length === 0 &&
-      !multiple &&
-      setContactIdsSelected([currentUser._id])
-  }, [
-    contactIdsSelected.length,
-    multiple,
-    setContactIdsSelected,
-    currentUser._id
-  ])
+    setContactIdsSelected(prev => {
+      if (prev.length === 0) {
+        return [currentUser._id]
+      }
+    })
+  }, [setContactIdsSelected, currentUser._id])
 
   useEffect(() => {
     setFormData(prev => ({

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/ContactWrapper.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/ContactWrapper.jsx
@@ -99,7 +99,7 @@ const ContactWrapper = ({ currentStep, onClose }) => {
           fullWidth
           label={t(!onLoad ? 'ContactStep.save' : 'ContactStep.onLoad')}
           onClick={handleClick}
-          disabled={onLoad}
+          disabled={onLoad || contactIdsSelected.length === 0}
           busy={onLoad}
           data-testid="ButtonSave"
         />


### PR DESCRIPTION
When creating paper, the current user should also be selected by default when multiple selection is enabled at the contact step.