### PR TITLE
Fix/style of input text adapter

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
@@ -133,6 +133,7 @@ const InputTextAdapter = ({
             style: {
               fontFamily: styleFontMono,
               caretColor: 'var(--primaryTextColor)',
+              textAlign: 'center',
               transition: 'color 0.5s',
               color: currentValue
                 ? 'var(--primaryTextColor)'

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -491,8 +491,9 @@
           "attributes": [
             {
               "name": "cardNumber",
-              "type": "number",
-              "mask": "9 9 9 9 9 9 9 9 9 9 9 9",
+              "type": "text",
+              "minLength": 9,
+              "maxLength": 12,
               "inputLabel": "PaperJSON.card.number.inputLabel"
             }
           ]

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -190,7 +190,7 @@
           "attributes": [
             {
               "name": "number",
-              "type": "number",
+              "type": "text",
               "maxLength": 12,
               "inputLabel": "PaperJSON.driverLicense.number.inputLabel"
             }


### PR DESCRIPTION
We want to center only the inputs with a mask.
The "classic" inputs remain aligned to the left.