### PR TITLE
fix(cozy-device-helper): Remove type import

### DIFF
--- a/packages/cozy-device-helper/src/flagship.ts
+++ b/packages/cozy-device-helper/src/flagship.ts
@@ -1,5 +1,3 @@
-import { Platform } from 'react-native'
-
 export enum FlagshipRoutes {
   Home = 'home',
   Cozyapp = 'cozyapp',
@@ -11,7 +9,7 @@ export enum FlagshipRoutes {
 export interface FlagshipMetadata {
   immersive?: boolean
   navbarHeight?: number
-  platform?: typeof Platform
+  platform?: Record<string, unknown>
   route?: FlagshipRoutes
   statusBarHeight?: number
   version?: string


### PR DESCRIPTION
Interface Platform from react-native is imported but not in dependencies
This can create a breaking import bug when the types do not exist.
To handle that in a simple manner we just remove the import.