### PR TITLE
fix: Add cozy-device-helper as real dependency

### DIFF
--- a/packages/cozy-intent/package.json
+++ b/packages/cozy-intent/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/cozy/cozy-libs/issues"
   },
   "dependencies": {
+    "cozy-device-helper": "^2.1.0",
     "post-me": "0.4.5"
   },
   "devDependencies": {
@@ -17,7 +18,6 @@
     "@testing-library/react": "10.4.9",
     "@testing-library/react-hooks": "7.0.2",
     "babel-preset-cozy-app": "^2.0.2",
-    "cozy-device-helper": "^2.1.0",
     "cozy-logger": "^1.9.0",
     "jest": "26.6.3",
     "mutationobserver-shim": "0.3.7",
@@ -36,7 +36,6 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "peerDependencies": {
-    "cozy-device-helper": ">=1.16.1",
     "react": ">=16"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15855,17 +15855,6 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
-  version "1.0.6"
-  uid "494c40416ecde95732c864f9b921e7e545075aa5"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
-  dependencies:
-    "@juggle/resize-observer" "^3.1.3"
-    jest-environment-jsdom-sixteen "^1.0.3"
-    react-spring "9.0.0-rc.3"
-    react-use-gesture "^7.0.8"
-    react-use-measure "^2.0.0"
-
 "mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
   version "1.0.6"
   resolved "https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"


### PR DESCRIPTION
https://app.travis-ci.com/github/cozy/cozy-libs/builds/250570179
When it's a dev-dependency, the publish will fail.
Lerna will not be able to access the typings.
As a real dep, it should be able to.