### PR TITLE
fix: Missing data in metadata files

### DIFF
--- a/packages/cozy-mespapiers-lib/src/helpers/queries.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/queries.js
@@ -41,8 +41,7 @@ export const buildFilesQueryByLabel = label => ({
     .indexFields(['created_at', 'metadata.qualification'])
     .sortBy([{ created_at: 'desc' }]),
   options: {
-    as: `${FILES_DOCTYPE}/${label}`,
-    fetchPolicy: defaultFetchPolicy
+    as: `${FILES_DOCTYPE}/${label}`
   }
 })
 


### PR DESCRIPTION
The addition of the `.select` on the first query, which is executed on the Home, has significantly improved performance but has a side effect https://github.com/cozy/cozy-client/issues/1175

While waiting for a resolution, we can simply remove the `fetchPolicy` from this request, which is executed on a component that needs the full file.