### PR TITLE
fix: Decouple cozy-intent from cozy-device-helper

### DIFF
--- a/packages/cozy-intent/package.json
+++ b/packages/cozy-intent/package.json
@@ -10,7 +10,6 @@
     "url": "https://github.com/cozy/cozy-libs/issues"
   },
   "dependencies": {
-    "cozy-device-helper": "^2.1.0",
     "post-me": "0.4.5"
   },
   "devDependencies": {
@@ -34,7 +33,7 @@
     "cozy-react-native"
   ],
   "license": "MIT",
-  "main": "./dist/index.js",
+  "main": "dist/index.js",
   "peerDependencies": {
     "react": ">=16"
   },
@@ -53,5 +52,5 @@
     "test:watch": "yarn test --watchAll",
     "start": "yarn build:watch"
   },
-  "types": "./dist/index.d.ts"
+  "types": "dist/index.d.ts"
 }

--- a/packages/cozy-intent/src/api/models/environments.ts
+++ b/packages/cozy-intent/src/api/models/environments.ts
@@ -32,6 +32,9 @@ export interface WebviewRef {
 }
 
 export interface WebviewWindow extends Window {
+  cozy?: {
+    flagship?: boolean
+  }
   ReactNativeWebView: {
     postMessage: (message: string) => void
   }

--- a/packages/cozy-intent/src/view/components/WebviewIntentProvider.tsx
+++ b/packages/cozy-intent/src/view/components/WebviewIntentProvider.tsx
@@ -1,8 +1,6 @@
 import React, { ReactElement, useEffect, useState } from 'react'
 import { Connection, ChildHandshake, debug } from 'post-me'
 
-import { isFlagshipApp } from 'cozy-device-helper'
-
 import {
   CozyBar,
   WebviewConnection,
@@ -71,7 +69,7 @@ const getConnection = async (
 }
 
 const isValidEnv = (): boolean => {
-  const flagshipApp = isFlagshipApp()
+  const flagshipApp = assumeWebviewWindow.cozy?.flagship
 
   if (!flagshipApp) return false
 

--- a/packages/cozy-intent/src/view/hooks/useWebviewIntent.spec.tsx
+++ b/packages/cozy-intent/src/view/hooks/useWebviewIntent.spec.tsx
@@ -5,10 +5,6 @@ import { WebviewContext, useWebviewIntent } from '../../view'
 import { WebviewService } from '../../api'
 import { mockConnection } from '../../../tests'
 
-jest.mock('cozy-device-helper', () => ({
-  isFlagshipApp: jest.fn(() => true)
-}))
-
 describe('useNativeIntent', () => {
   it('Should not throw if the context does not exist in a Flagship app', () => {
     const { result } = renderHook(() => useWebviewIntent())

--- a/packages/cozy-intent/tests/mocks.ts
+++ b/packages/cozy-intent/tests/mocks.ts
@@ -1,7 +1,5 @@
 import { ChildHandshake, RemoteHandle } from 'post-me'
 
-import { isFlagshipApp } from 'cozy-device-helper'
-
 import {
   NativeMethodsRegister,
   WebviewMessenger,
@@ -42,16 +40,12 @@ export const mockConnection = {
 
 export const mockWebviewService = new MockWebviewService(mockConnection)
 
-export const mockIsFlagshipApp = isFlagshipApp as jest.Mock
-
 export const mockChildHandshake = ChildHandshake as jest.Mock
 
 export const mockSetWebviewContext = jest.fn()
 
 export const mockCozyBar = {
-  bar: {
-    setWebviewContext: mockSetWebviewContext
-  }
+  setWebviewContext: mockSetWebviewContext
 }
 
 export const mockWebviewRef = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3526,9 +3526,9 @@
   integrity sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==
 
 "@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.10"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.10.tgz#db436f0917d655393851bc258918c00226c9b183"
-  integrity sha512-Q0YbBd6OTsXm8Y21+YUSDXupHnodNC2M4O18jtd3iwJ3+vMZNdKGols0a9G6JOK0dcJ3IdUUHoh908ZI6qhk8Q==
+  version "0.3.13"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz#dcfe3e95f224c8fe97a87a5235defec999aa92ea"
+  integrity sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
@@ -7000,9 +7000,9 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000980, caniuse-lite@^1.0.30000984, can
   integrity sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw==
 
 caniuse-lite@^1.0.30001332:
-  version "1.0.30001338"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz#b5dd7a7941a51a16480bdf6ff82bded1628eec0d"
-  integrity sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==
+  version "1.0.30001340"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001340.tgz#029a2f8bfc025d4820fafbfaa6259fd7778340c7"
+  integrity sha512-jUNz+a9blQTQVu4uFcn17uAD8IDizPzQkIKh3LCJfg9BkyIqExYYdyc/ZSlWUSKb8iYiXxKsxbv4zYSvkqjrxw==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -7852,9 +7852,9 @@ core-js-compat@^3.21.0:
     semver "7.0.0"
 
 core-js-compat@^3.22.1:
-  version "3.22.4"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.22.4.tgz#d700f451e50f1d7672dcad0ac85d910e6691e579"
-  integrity sha512-dIWcsszDezkFZrfm1cnB4f/J85gyhiCpxbgBdohWCDtSVuAaChTSpPV7ldOQf/Xds2U5xCIJZOK82G4ZPAIswA==
+  version "3.22.5"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.22.5.tgz#7fffa1d20cb18405bd22756ca1353c6f1a0e8614"
+  integrity sha512-rEF75n3QtInrYICvJjrAgV03HwKiYvtKHdPtaba1KucG+cNZ4NJnH9isqt979e67KZlhpbCOTwnsvnIr+CVeOg==
   dependencies:
     browserslist "^4.20.3"
     semver "7.0.0"


### PR DESCRIPTION
As it's used only once and blocking the CI when publishing,
it is simpler for the time being to decouple the two libs.
We are investigating why is the lerna publishing failing.