### PR TITLE
feat: Handle banks with mulitple bank ids

### DIFF
--- a/packages/cozy-harvest-lib/src/services/biWebView.spec.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.spec.js
@@ -69,7 +69,7 @@ describe('handleOAuthAccount', () => {
       t,
       account: {
         ...account,
-        ...{ auth: { bankId: TEST_BANK_COZY_ID } },
+        ...{ auth: { bankIds: [TEST_BANK_COZY_ID] } },
         ...{ data: { auth: { bi: { connId: 12 } } } }
       }
     })

--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -27,6 +27,7 @@ import { mkConnAuth, biErrorMap } from 'cozy-bi-auth'
 import { KonnectorJobError } from '../helpers/konnectors'
 import { LOGIN_SUCCESS_EVENT } from '../models/flowEvents'
 import logger from '../logger'
+import '../types'
 
 const DECOUPLED_ERROR = 'decoupled'
 const ADDITIONAL_INFORMATION_NEEDED_ERROR = 'additionalInformationNeeded'
@@ -291,19 +292,6 @@ export const sendAdditionalInformation = (flow, fields) => {
 export const resumeBIConnection = flow => {
   return updateBIConnectionFromFlow(flow, { resume: 'true' })
 }
-
-/**
- * @typedef biConnection
- * @property {number} id
- * @property {number} id_user
- * @property {number} id_connector
- * @property {string|null} state  - ( wrongpass | additionalInformationNeeded | websiteUnavailable | actionNeeded | SCARequired | decoupled | passwordExpired | webauthRequired | rateLimiting | bug). Null indicates a success
- * @property {string|null} last_update - Date string: Last successful update.
- * @property {string|null} created - Date string: Creation date
- * @property {boolean} active - Whether this connection is active and will be automatically synced.
- * @property {string|null} last_push - Date string: Last successfull push
- * @property {string|null} next_try - Date string: Date of next synchronization.
- */
 
 /**
  * Checks for any number 2FA and/or decoupled requests

--- a/packages/cozy-harvest-lib/src/types.js
+++ b/packages/cozy-harvest-lib/src/types.js
@@ -1,0 +1,22 @@
+/**
+ * @typedef createTemporaryTokenResponse
+ * @property {String} code - the temporary token
+ * @property {String} url - BI environment url
+ * @property {String} bankId - Cozy bank id corresponding to the current connector (deprecated once bi webviews are in production)
+ * @property {String} biBankId - BI bank id corresponding to the bankId translated by the connector (deprecated once bi webviews are in production)
+ * @property {Array<String>} bankIds - Cozy bank ids corresponding to the current connector
+ * @property {Array<String>} biBankIds - BI bank ids corresponding to the bankIds translated by the connector
+ */
+
+/**
+ * @typedef biConnection
+ * @property {number} id
+ * @property {number} id_user
+ * @property {number} id_connector
+ * @property {string|null} state  - ( wrongpass | additionalInformationNeeded | websiteUnavailable | actionNeeded | SCARequired | decoupled | passwordExpired | webauthRequired | rateLimiting | bug). Null indicates a success
+ * @property {string|null} last_update - Date string: Last successful update.
+ * @property {string|null} created - Date string: Creation date
+ * @property {boolean} active - Whether this connection is active and will be automatically synced.
+ * @property {string|null} last_push - Date string: Last successfull push
+ * @property {string|null} next_try - Date string: Date of next synchronization.
+ */


### PR DESCRIPTION
With BI webviews, we may have multiple bank ids associated to one
connector (ex: crédit agricole) and we don't know in advance what bankid
the user will chose in the BI webview.

Then we save all the list of the bank ids associated to a connector in
the account to let the connector know which banks may have been chosen.

Also, createTemporaryToken is used to translate bankIds to "BI" bank
ids, and bi webview needs all the ids corresponding to a connector, to
propse them to the user. Then createTemporaryToken can know translate
multiple bank ids to bi bank ids

This PR is associated another MR in bi connectors to be able to receive
these multiple bank ids.
