### PR TITLE
feat: Add one permission exemple in the documentation

### DIFF
--- a/packages/cozy-mespapiers-lib/README.md
+++ b/packages/cozy-mespapiers-lib/README.md
@@ -55,6 +55,13 @@ The following permissions are required in the application `manifest.webapp` file
   "description": "Used to manage your papers settings",
   "type": "io.cozy.mespapiers.settings",
   "verbs": ["GET", "POST", "PUT"]
+},
+"create-a-zip-archive": {
+  "description": "Required to create a zip archive inside the cozy",
+  "type": "io.cozy.jobs",
+  "verbs": ["POST"],
+  "selector": "worker",
+  "values": ["zip"]
 }
 ```
 


### PR DESCRIPTION
BREAKING CHANGE: Adding the Multi-select feature requires adding a permission in the applications
Add this permission in your app:
```
"create-a-zip-archive": {
  "description": "Required to create a zip archive inside the cozy",
  "type": "io.cozy.jobs",
  "verbs": ["POST"],
  "selector": "worker",
  "values": ["zip"]
}
```
(The BC should have been on this commit: c82bebb )