### PR TITLE
fix: Each action must have a name attribute

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Actions/Items/download.js
+++ b/packages/cozy-mespapiers-lib/src/components/Actions/Items/download.js
@@ -7,6 +7,7 @@ import ActionMenuItemWrapper from '../ActionMenuItemWrapper'
 
 export const download = ({ client }) => {
   return {
+    name: 'download',
     action: files => downloadFiles(client, files),
     Component: function Download({ onClick, className }) {
       const { t } = useI18n()

--- a/packages/cozy-mespapiers-lib/src/components/Actions/Items/forward.js
+++ b/packages/cozy-mespapiers-lib/src/components/Actions/Items/forward.js
@@ -7,6 +7,7 @@ import ActionMenuItemWrapper from '../ActionMenuItemWrapper'
 
 export const forward = ({ client }) => {
   return {
+    name: 'forward',
     action: (files, t) => forwardFile(client, files, t),
     Component: function Forward({ onClick, className }) {
       const { t } = useI18n()

--- a/packages/cozy-mespapiers-lib/src/components/Actions/Items/open.js
+++ b/packages/cozy-mespapiers-lib/src/components/Actions/Items/open.js
@@ -7,6 +7,7 @@ import ActionMenuItemWrapper from '../ActionMenuItemWrapper'
 
 export const open = () => {
   return {
+    name: 'open',
     Component: function Open({ className, files }) {
       const { t } = useI18n()
       const history = useHistory()

--- a/packages/cozy-mespapiers-lib/src/components/Actions/Items/select.js
+++ b/packages/cozy-mespapiers-lib/src/components/Actions/Items/select.js
@@ -8,6 +8,7 @@ import { useMultiSelection } from '../../Hooks/useMultiSelection'
 
 export const select = ({ hideActionsMenu }) => {
   return {
+    name: 'select',
     Component: function Select({ className, files }) {
       const { t } = useI18n()
       const history = useHistory()

--- a/packages/cozy-mespapiers-lib/src/components/Actions/Items/trash.js
+++ b/packages/cozy-mespapiers-lib/src/components/Actions/Items/trash.js
@@ -9,6 +9,7 @@ import ActionMenuItemWrapper from '../ActionMenuItemWrapper'
 
 export const trash = ({ pushModal, popModal }) => {
   return {
+    name: 'trash',
     action: files =>
       pushModal(
         <DeleteConfirm

--- a/packages/cozy-mespapiers-lib/src/components/Actions/Items/viewInDrive.js
+++ b/packages/cozy-mespapiers-lib/src/components/Actions/Items/viewInDrive.js
@@ -8,6 +8,7 @@ import ActionMenuItemWrapper from '../ActionMenuItemWrapper'
 
 export const viewInDrive = ({ client }) => {
   return {
+    name: 'viewInDrive',
     Component: function ViewInDrive({ onClick, className, files }) {
       const { t } = useI18n()
       const dirId = files[0].dir_id


### PR DESCRIPTION
Otherwise, when the lib is built, we lose this information essential to the proper functioning