### PR TITLE
fix(cozy-mespapiers-lib): Radio button on multiselect mode

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperLine.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperLine.jsx
@@ -51,7 +51,7 @@ const PaperLine = ({ paper, divider, actions }) => {
     <>
       <PaperItem paper={paper} divider={divider} onClick={handleClick}>
         {isMultiSelectionActive ? (
-          <Radio />
+          <Radio onClick={handleClick} />
         ) : (
           <IconButton ref={actionBtnRef} onClick={toggleActionsMenu}>
             <Icon icon="dots" />


### PR DESCRIPTION
The click on a Radio button must call the same function as the parent