### PR TITLE
feat: Trigger success sooner for BI webviews

### DIFF
--- a/packages/cozy-harvest-lib/src/services/biWebView.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.js
@@ -18,6 +18,7 @@ import {
 import { KonnectorJobError } from '../helpers/konnectors'
 import { waitForRealtimeEvent } from './jobUtils'
 import '../types'
+import { LOGIN_SUCCESS_EVENT } from '../models/flowEvents'
 
 const TEMP_TOKEN_TIMOUT_S = 60
 
@@ -166,7 +167,13 @@ export const onBIAccountCreation = async ({
     biConnection
   })
 
-  return await flow.saveAccount(setBIConnectionId(account, biConnection.id))
+  const updatedAccount = await flow.saveAccount(
+    setBIConnectionId(account, biConnection.id)
+  )
+
+  flow.triggerEvent(LOGIN_SUCCESS_EVENT)
+
+  return updatedAccount
 }
 
 export const fetchExtraOAuthUrlParams = async ({


### PR DESCRIPTION
Do not wait the the connector to be run to show the success popup to the
user, since the validity user credentials has already been checked by BI
in the webview.

This is a fix after a feedback on https://trello.com/c/MsGgvX20/397-webview-bi-depuis-une-webview-dans-une-app-native-m%C3%A9canismes-a-rs-avec-browser-inapp-pour-ajouter-un-compte-45-pts
