### PR TITLE
Feat: Add forward confirm modal

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Contexts/MultiSelectionProvider.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Contexts/MultiSelectionProvider.jsx
@@ -7,7 +7,13 @@ const MultiSelectionProvider = ({ children }) => {
   const [multiSelectionFiles, setMultiSelectionFiles] = useState([])
 
   const addMultiSelectionFile = fileToAdd => {
-    setMultiSelectionFiles(files => [...files, fileToAdd])
+    const fileAlreadySelected = multiSelectionFiles.some(
+      file => file._id === fileToAdd._id
+    )
+
+    if (!fileAlreadySelected) {
+      setMultiSelectionFiles(files => [...files, fileToAdd])
+    }
   }
 
   const removeMultiSelectionFile = fileToRemove => {

--- a/packages/cozy-mespapiers-lib/src/components/Contexts/MultiSelectionProvider.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Contexts/MultiSelectionProvider.spec.jsx
@@ -1,0 +1,184 @@
+import React, { useContext } from 'react'
+import { fireEvent, render } from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+import MultiSelectionContext, {
+  MultiSelectionProvider
+} from './MultiSelectionProvider'
+
+const setup = ({ firstAdd, secondAdd, removeFile }) => {
+  const TestComponent = () => {
+    const {
+      isMultiSelectionActive,
+      setIsMultiSelectionActive,
+      addMultiSelectionFile,
+      removeMultiSelectionFile,
+      removeAllMultiSelectionFiles,
+      multiSelectionFiles
+    } = useContext(MultiSelectionContext)
+
+    return (
+      <>
+        <div data-testid="result">{JSON.stringify(multiSelectionFiles)}</div>
+        <div data-testid="isActive">
+          {JSON.stringify(isMultiSelectionActive)}
+        </div>
+        <button
+          data-testid="setActiveBtn"
+          onClick={() => setIsMultiSelectionActive(prev => !prev)}
+        />
+        <button
+          data-testid="firstAddBtn"
+          onClick={() => addMultiSelectionFile(firstAdd)}
+        />
+        <button
+          data-testid="secondAddBtn"
+          onClick={() => addMultiSelectionFile(secondAdd)}
+        />
+        <button
+          data-testid="removeFileBtn"
+          onClick={() => removeMultiSelectionFile(removeFile)}
+        />
+        <button
+          data-testid="removeAllBtn"
+          onClick={() => removeAllMultiSelectionFiles()}
+        />
+      </>
+    )
+  }
+
+  return render(
+    <MultiSelectionProvider>
+      <TestComponent />
+    </MultiSelectionProvider>
+  )
+}
+
+describe('MultiSelectionProvider', () => {
+  describe('isMultiSelectionActive', () => {
+    it('should remove all files to its state if isMultiSelectionActive is set to false', () => {
+      const fileMock01 = { _id: '01', name: 'file01' }
+      const fileMock02 = { _id: '02', name: 'file02' }
+      const { getByTestId } = setup({
+        firstAdd: fileMock01,
+        secondAdd: fileMock02
+      })
+
+      const setActiveBtn = getByTestId('setActiveBtn')
+      const firstAddBtn = getByTestId('firstAddBtn')
+      const secondAddBtn = getByTestId('secondAddBtn')
+      const result = getByTestId('result')
+
+      // isMultiSelectionActive => true
+      fireEvent.click(setActiveBtn)
+
+      fireEvent.click(firstAddBtn)
+      expect(result.textContent).toBe('[{"_id":"01","name":"file01"}]')
+
+      fireEvent.click(secondAddBtn)
+      expect(result.textContent).toBe(
+        '[{"_id":"01","name":"file01"},{"_id":"02","name":"file02"}]'
+      )
+
+      // isMultiSelectionActive => false
+      fireEvent.click(setActiveBtn)
+      expect(result.textContent).toBe('[]')
+    })
+  })
+
+  describe('addMultiSelectionFile', () => {
+    it('should add file to its state', () => {
+      const fileMock = { _id: '00', name: 'file00' }
+      const { getByTestId } = setup({ firstAdd: fileMock })
+
+      const firstAddBtn = getByTestId('firstAddBtn')
+      const result = getByTestId('result')
+
+      fireEvent.click(firstAddBtn)
+      expect(result.textContent).toBe('[{"_id":"00","name":"file00"}]')
+    })
+
+    it('should add a second file to its state', () => {
+      const fileMock01 = { _id: '01', name: 'file01' }
+      const fileMock02 = { _id: '02', name: 'file02' }
+      const { getByTestId } = setup({
+        firstAdd: fileMock01,
+        secondAdd: fileMock02
+      })
+
+      const firstAddBtn = getByTestId('firstAddBtn')
+      const secondAddBtn = getByTestId('secondAddBtn')
+      const result = getByTestId('result')
+
+      fireEvent.click(firstAddBtn)
+      expect(result.textContent).toBe('[{"_id":"01","name":"file01"}]')
+
+      fireEvent.click(secondAddBtn)
+      expect(result.textContent).toBe(
+        '[{"_id":"01","name":"file01"},{"_id":"02","name":"file02"}]'
+      )
+    })
+
+    it('should not add a second file to its state if it is the same file', () => {
+      const fileMock01 = { _id: '01', name: 'file01' }
+      const { getByTestId } = setup({
+        firstAdd: fileMock01,
+        secondAdd: fileMock01
+      })
+
+      const firstAddBtn = getByTestId('firstAddBtn')
+      const secondAddBtn = getByTestId('secondAddBtn')
+      const result = getByTestId('result')
+
+      fireEvent.click(firstAddBtn)
+      expect(result.textContent).toBe('[{"_id":"01","name":"file01"}]')
+
+      fireEvent.click(secondAddBtn)
+      expect(result.textContent).toBe('[{"_id":"01","name":"file01"}]')
+    })
+  })
+
+  describe('removeMultiSelectionFile', () => {
+    it('should remove specific file to its state', () => {
+      const fileMock01 = { _id: '01', name: 'file01' }
+      const fileMock02 = { _id: '02', name: 'file02' }
+      const { getByTestId } = setup({
+        firstAdd: fileMock01,
+        secondAdd: fileMock02,
+        removeFile: fileMock01
+      })
+
+      const firstAddBtn = getByTestId('firstAddBtn')
+      const secondAddBtn = getByTestId('secondAddBtn')
+      const removeFileBtn = getByTestId('removeFileBtn')
+      const result = getByTestId('result')
+
+      fireEvent.click(firstAddBtn)
+      fireEvent.click(secondAddBtn)
+      fireEvent.click(removeFileBtn)
+      expect(result.textContent).toBe('[{"_id":"02","name":"file02"}]')
+    })
+  })
+
+  describe('removeAllMultiSelectionFiles', () => {
+    it('should remove all files to its state', () => {
+      const fileMock01 = { _id: '01', name: 'file01' }
+      const fileMock02 = { _id: '02', name: 'file02' }
+      const { getByTestId } = setup({
+        firstAdd: fileMock01,
+        secondAdd: fileMock02,
+        removeFile: fileMock01
+      })
+
+      const firstAddBtn = getByTestId('firstAddBtn')
+      const secondAddBtn = getByTestId('secondAddBtn')
+      const removeAllBtn = getByTestId('removeAllBtn')
+      const result = getByTestId('result')
+
+      fireEvent.click(firstAddBtn)
+      fireEvent.click(secondAddBtn)
+      fireEvent.click(removeAllBtn)
+      expect(result.textContent).toBe('[]')
+    })
+  })
+})

--- a/packages/cozy-mespapiers-lib/src/components/Multiselect/ForwardModal.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Multiselect/ForwardModal.jsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { useClient } from 'cozy-client'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+
+import { forwardFile } from '../Actions/utils'
+
+const ForwardModal = ({ onClose, onForward }) => {
+  const client = useClient()
+  const { t } = useI18n()
+
+  const handleClick = async file => {
+    await forwardFile(client, [file], t)
+    onForward && onForward()
+  }
+
+  return (
+    <ConfirmDialog
+      open
+      onClose={onClose}
+      content={
+        <>
+          <div className="u-ta-center u-mb-1">
+            <Icon icon="file-type-zip" size={64} />
+          </div>
+          <Typography>{t('ForwardModal.content')}</Typography>
+        </>
+      }
+      actions={
+        <Button
+          label={t('ForwardModal.action')}
+          onClick={handleClick}
+        />
+      }
+    />
+  )
+}
+
+ForwardModal.propTypes = {
+  onForward: PropTypes.func,
+  onClose: PropTypes.func
+}
+
+export default ForwardModal

--- a/packages/cozy-mespapiers-lib/src/components/Multiselect/MultiselectViewActions.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Multiselect/MultiselectViewActions.jsx
@@ -2,23 +2,49 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 
 import { useClient, models } from 'cozy-client'
+import useRealtime from 'cozy-realtime/dist/useRealtime'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Button from 'cozy-ui/transpiled/react/Buttons'
-import useRealtime from 'cozy-realtime/dist/useRealtime'
+import Backdrop from 'cozy-ui/transpiled/react/Backdrop'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import { LinearProgress } from 'cozy-ui/transpiled/react/Progress'
+import makeStyles from 'cozy-ui/transpiled/react/helpers/makeStyles'
 
-import { downloadFiles, forwardFile, makeZipFolder } from '../Actions/utils'
+import { downloadFiles, makeZipFolder } from '../Actions/utils'
 import { useMultiSelection } from '../Hooks/useMultiSelection'
 import { FILES_DOCTYPE } from '../../doctypes'
 import { fetchCurrentUser } from '../../helpers/fetchCurrentUser'
 import getOrCreateAppFolderWithReference from '../../helpers/getFolderWithReference'
+import ForwardModal from './ForwardModal'
 
 const { getDisplayName } = models.contact
+
+const useStyles = makeStyles(theme => ({
+  backdropRoot: {
+    zIndex: 'var(--zIndex-modal)'
+  },
+  barText: {
+    color: 'var(--primaryContrastTextColor)'
+  },
+  bar: {
+    borderRadius: theme.shape.borderRadius
+  },
+  barBackgroundColorPrimary: {
+    backgroundColor: 'var(--secondaryTextColor)'
+  },
+  barBackgroundActiveColorPrimary: {
+    backgroundColor: 'var(--primaryContrastTextColor)'
+  }
+}))
 
 const MultiselectViewActions = ({ onClose }) => {
   const { t, f } = useI18n()
   const client = useClient()
+  const classes = useStyles()
   const { multiSelectionFiles } = useMultiSelection()
   const [zipFolder, setZipFolder] = useState({ name: '', dirId: '' })
+  const [isTransferModalOpen, setIsTransferModalOpen] = useState(false)
+  const [isBackdropOpen, setIsBackdropOpen] = useState(false)
 
   const onFileCreate = async file => {
     if (
@@ -26,9 +52,9 @@ const MultiselectViewActions = ({ onClose }) => {
       file.name === zipFolder.name &&
       file.dir_id === zipFolder.dirId
     ) {
-      await forwardFile(client, [file], t)
+      setIsBackdropOpen(false)
+      setIsTransferModalOpen(true)
     }
-    onClose()
   }
 
   useRealtime(client, {
@@ -43,6 +69,8 @@ const MultiselectViewActions = ({ onClose }) => {
   }
 
   const forward = async () => {
+    setIsBackdropOpen(true)
+
     const currentUser = await fetchCurrentUser(client)
     const defaultZipFolderName = t('Multiselect.folderZipName', {
       contactName: getDisplayName(currentUser),
@@ -65,18 +93,41 @@ const MultiselectViewActions = ({ onClose }) => {
 
   return (
     <>
+      <Backdrop classes={{ root: classes.backdropRoot }} open={isBackdropOpen}>
+        <div className="u-w-100 u-mh-2 u-ta-center">
+          <Typography classes={{ root: classes.barText }} className="u-mb-1">
+            {t('Multiselect.backdrop')}
+          </Typography>
+          <LinearProgress
+            classes={{
+              root: classes.bar,
+              colorPrimary: classes.barBackgroundColorPrimary,
+              barColorPrimary: classes.barBackgroundActiveColorPrimary
+            }}
+          />
+        </div>
+      </Backdrop>
+
       <Button
         variant="secondary"
         label={t('action.download')}
         onClick={download}
         disabled={multiSelectionFiles.length === 0}
       />
+
       {navigator.share && (
         <Button
           variant="secondary"
           label={t('action.forward')}
           onClick={forward}
           disabled={multiSelectionFiles.length === 0}
+        />
+      )}
+
+      {isTransferModalOpen && (
+        <ForwardModal
+          onClose={() => setIsTransferModalOpen(false)}
+          onForward={onClose}
         />
       )}
     </>

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -77,6 +77,10 @@
     "title": "Delete this file?",
     "text": "The item is associated with the file \"%{name}\" in your drive."
   },
+  "ForwardModal": {
+    "action": "Select a recipient",
+    "content": "Your papers have been collected. Select a recipient to proceed with the forwarding."
+  },
   "Home": {
     "Empty": {
       "text": "Always keep them with you in a secure space to simplify your administrative procedures. They will never be used without your explicit consent.",
@@ -257,6 +261,7 @@
     }
   },
   "Multiselect": {
+    "backdrop": "Gather your papers...",
     "title": "Select papers",
     "empty": "Select papers to perform a bulk upload or download.",
     "select": "Select a papier",

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -77,6 +77,10 @@
     "title": "Supprimer cet élément ?",
     "text": "L’élément est associé au fichier <strong>\"%{name}\"</strong> dans votre drive."
   },
+  "ForwardModal": {
+    "action": "Sélectionner un destinataire",
+    "content": "Vos papiers on bien été rassemblés. Sélectionner un destinataire pour procéder à l’envoi."
+  },
   "Home": {
     "Empty": {
       "text": "Gardez les toujours sur vous dans un espace sécurisé pour simplifier vos démarches administratives. Ils ne seront jamais utilisés sans votre consentement explicite.",
@@ -257,6 +261,7 @@
     }
   },
   "Multiselect": {
+    "backdrop": "Rassemblement de vos papiers...",
     "title": "Sélectionner des papiers",
     "empty": "Sélectionner des papiers pour effectuer un téléchargement ou un transfert groupé.",
     "select": "Sélectionner un papier",


### PR DESCRIPTION
This modal will be mandatory to have the function to transfer to mobile because we can't trigger the native transfer menu asynchronously.

See point 6 for more details: https://w3c.github.io/web-share/#share-method