### PR TITLE
fix(cozy-intent): Allow overriding existing connection

### DIFF
--- a/packages/cozy-intent/src/api/constants/strings.ts
+++ b/packages/cozy-intent/src/api/constants/strings.ts
@@ -11,8 +11,6 @@ export const strings = {
     'Cannot register webview. A webview is already registered into cozy-intent with the uri: ${uri}',
   errorUnregisterWebview:
     'Cannot unregister webview. No webview is registered into cozy-intent with the uri: ${uri}',
-  errorInitWebview:
-    "Cannot init handshake for Webview with uri: '${uri}'. The handshake was already made and succeeded. You probably remounted WebviewIntentProvider and lost its state, or you forgot to call unregisterWebview on parent-side.",
   errorEmitMessage:
     'Cannot emit message. No webview is registered with uri: ${webviewUri}',
   errorCozyBarAPIMissing:

--- a/packages/cozy-intent/src/api/services/NativeService.spec.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.spec.ts
@@ -216,7 +216,7 @@ describe('NativeService', () => {
       expect(ParentHandshake).toHaveBeenCalledTimes(1)
     })
 
-    it('Should bail out when init an existing webview', async () => {
+    it('Should override existing connection when init existing webview', async () => {
       await expect(
         nativeService.tryEmit({
           nativeEvent: {
@@ -226,8 +226,8 @@ describe('NativeService', () => {
         })
       ).resolves.not.toThrow()
 
-      expect(mockDebug).toHaveBeenCalled()
-      expect(ParentHandshake).toHaveBeenCalledTimes(0)
+      expect(mockDebug).not.toHaveBeenCalled()
+      expect(ParentHandshake).toHaveBeenCalledTimes(1)
     })
 
     it('Should bail out when init an undefined messenger', async () => {

--- a/packages/cozy-intent/src/api/services/NativeService.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.ts
@@ -99,9 +99,6 @@ export class NativeService {
       if (!messengerToInit)
         throw new Error(interpolate(strings.errorNoMessengerToInit, { uri }))
 
-      if (messengerToInit.connection)
-        throw new Error(interpolate(strings.errorInitWebview, { uri }))
-
       messengerToInit.connection = await this.initWebview(
         messengerToInit.messenger
       )


### PR DESCRIPTION
By being too strict when initiating a webview connection,
we made it impossible to handle some edge cases scenarios
who actually need to erase their old session and create a new one
in the same messenger object. Simplest way is to let them
write the new connection over the old one,
indeed the old connection will never be used again