### PR TITLE
Fix/multi selection forwarded file

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Multiselect/ForwardModal.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Multiselect/ForwardModal.jsx
@@ -10,12 +10,12 @@ import Icon from 'cozy-ui/transpiled/react/Icon'
 
 import { forwardFile } from '../Actions/utils'
 
-const ForwardModal = ({ onClose, onForward }) => {
+const ForwardModal = ({ onClose, onForward, fileToForward }) => {
   const client = useClient()
   const { t } = useI18n()
 
-  const handleClick = async file => {
-    await forwardFile(client, [file], t)
+  const handleClick = async () => {
+    await forwardFile(client, [fileToForward], t)
     onForward && onForward()
   }
 
@@ -32,10 +32,7 @@ const ForwardModal = ({ onClose, onForward }) => {
         </>
       }
       actions={
-        <Button
-          label={t('ForwardModal.action')}
-          onClick={handleClick}
-        />
+        <Button label={t('ForwardModal.action')} onClick={handleClick} />
       }
     />
   )
@@ -43,7 +40,8 @@ const ForwardModal = ({ onClose, onForward }) => {
 
 ForwardModal.propTypes = {
   onForward: PropTypes.func,
-  onClose: PropTypes.func
+  onClose: PropTypes.func,
+  fileToForward: PropTypes.object
 }
 
 export default ForwardModal

--- a/packages/cozy-mespapiers-lib/src/components/Multiselect/MultiselectViewActions.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Multiselect/MultiselectViewActions.jsx
@@ -43,7 +43,7 @@ const MultiselectViewActions = ({ onClose }) => {
   const classes = useStyles()
   const { multiSelectionFiles } = useMultiSelection()
   const [zipFolder, setZipFolder] = useState({ name: '', dirId: '' })
-  const [isTransferModalOpen, setIsTransferModalOpen] = useState(false)
+  const [isForwardModalOpen, setIsForwardModalOpen] = useState(false)
   const [isBackdropOpen, setIsBackdropOpen] = useState(false)
 
   const onFileCreate = async file => {
@@ -53,7 +53,7 @@ const MultiselectViewActions = ({ onClose }) => {
       file.dir_id === zipFolder.dirId
     ) {
       setIsBackdropOpen(false)
-      setIsTransferModalOpen(true)
+      setIsForwardModalOpen(true)
     }
   }
 
@@ -124,9 +124,9 @@ const MultiselectViewActions = ({ onClose }) => {
         />
       )}
 
-      {isTransferModalOpen && (
+      {isForwardModalOpen && (
         <ForwardModal
-          onClose={() => setIsTransferModalOpen(false)}
+          onClose={() => setIsForwardModalOpen(false)}
           onForward={onClose}
         />
       )}

--- a/packages/cozy-mespapiers-lib/src/components/Multiselect/MultiselectViewActions.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Multiselect/MultiselectViewActions.jsx
@@ -45,6 +45,7 @@ const MultiselectViewActions = ({ onClose }) => {
   const [zipFolder, setZipFolder] = useState({ name: '', dirId: '' })
   const [isForwardModalOpen, setIsForwardModalOpen] = useState(false)
   const [isBackdropOpen, setIsBackdropOpen] = useState(false)
+  const [fileToForward, setFileToForward] = useState(null)
 
   const onFileCreate = async file => {
     if (
@@ -54,6 +55,7 @@ const MultiselectViewActions = ({ onClose }) => {
     ) {
       setIsBackdropOpen(false)
       setIsForwardModalOpen(true)
+      setFileToForward(file)
     }
   }
 
@@ -128,6 +130,7 @@ const MultiselectViewActions = ({ onClose }) => {
         <ForwardModal
           onClose={() => setIsForwardModalOpen(false)}
           onForward={onClose}
+          fileToForward={fileToForward}
         />
       )}
     </>


### PR DESCRIPTION
The `forwardFile` function is no longer called in the real time callback, but in a function called later (and in another component), so it no longer has the file information (so can't generate a share link)

So we pass the file to the component that will share it