### PR TITLE
fix: Make isFlagshipApp and getFlagshipMetadata work on node environment

### DIFF
--- a/packages/cozy-device-helper/src/flagship.ts
+++ b/packages/cozy-device-helper/src/flagship.ts
@@ -1,3 +1,5 @@
+import log from 'cozy-logger'
+
 export enum FlagshipRoutes {
   Home = 'home',
   Cozyapp = 'cozyapp',
@@ -15,7 +17,19 @@ export interface FlagshipMetadata {
   version?: string
 }
 
-export const getFlagshipMetadata = (): FlagshipMetadata =>
-  window.cozy?.flagship || {}
+const getGlobalWindow = (): Window => {
+  if (typeof window !== 'undefined') return window
+  else {
+    log(
+      'error',
+      `"window" is not defined. This means that getGlobalWindow() shouldn't have been called and investigation should be done to prevent this call`
+    )
+    return undefined
+  }
+}
 
-export const isFlagshipApp = (): boolean => window.cozy?.flagship !== undefined
+export const getFlagshipMetadata = (): FlagshipMetadata =>
+  getGlobalWindow()?.cozy?.flagship || {}
+
+export const isFlagshipApp = (): boolean =>
+  getGlobalWindow()?.cozy?.flagship !== undefined


### PR DESCRIPTION
When using ACH in a node environment, isFlaghsipApp is called and throws because `window` does not exist.

Here is the stack-trace when executing ACH on cozy-contacts.
```
yarn run v1.22.17
$ ACH import fixtures/massiveContacts.json
/Users/XXX/.config/yarn/global/nodemodules/cozy-device-helper/dist/flagship.js:21
var flagshipMetadata = ((window$cozy = window.cozy) === null || _window$cozy === void 0 ? void 0 : _window$cozy.flagship) || {};
^

ReferenceError: window is not defined
at Object. (/Users/XXX/.config/yarn/global/nodemodules/cozy-device-helper/dist/flagship.js:21:24)
at Module.compile (node:internal/modules/cjs/loader:1092:14)
at Object.Module.extensions..js (node:internal/modules/cjs/loader:1121:10)
at Module.load (node:internal/modules/cjs/loader:972:32)
at Function.Module.load (node:internal/modules/cjs/loader:813:14)
at Module.require (node:internal/modules/cjs/loader:996:19)
at require (node:internal/modules/cjs/helpers:92:18)
at Object. (/Users/XXX/.config/yarn/global/nodemodules/cozy-device-helper/dist/index.js:141:17)
at Module.compile (node:internal/modules/cjs/loader:1092:14)
at Object.Module._extensions..js (node:internal/modules/cjs/loader:1121:10)
error Command failed with exit code 1.
```

This fix should prevent cozy-device-helper to throw when executed in a node environment.

---

TODO:

- [x] Check that this resolves ACH execution on cozy-contact
- [x] Check impacts of this modification