### PR TITLE
fix: Avoid React error message when not in BI webview mode

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/BiContractActivationWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/BiContractActivationWindow.jsx
@@ -47,7 +47,7 @@ const BIContractActivationWindow = ({ konnector, account, t }) => {
   }, [konnector, account, client, konnectorPolicy])
 
   return (
-    konnectorPolicy.fetchContractSynchronizationUrl && (
+    konnectorPolicy.fetchContractSynchronizationUrl ? (
       <ListItem>
         <Button disabled={!initialUrl} onClick={() => setWindowVisible(true)}>
           {t('contracts.handle-synchronization')}
@@ -64,7 +64,7 @@ const BIContractActivationWindow = ({ konnector, account, t }) => {
             />
           ))}
       </ListItem>
-    )
+    ) : null
   )
 }
 


### PR DESCRIPTION
Error message : Nothing was returned from render. This usually means a
return statement is missing. Or, to render nothing, return null
