### PR TITLE
feat: Add BI webview reconnection

### DIFF
--- a/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
@@ -95,8 +95,10 @@ const DumbEditAccountModal = withRouter(
               showError={true}
               onVaultDismiss={redirectToAccount}
               fieldOptions={fieldOptions}
+              reconnect={fromReconnect}
             />
           )}
+          <div className="u-mb-2" />
         </DialogContent>
       </Dialog>
     )

--- a/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
@@ -20,14 +20,12 @@ export class OAuthForm extends PureComponent {
     this.handleOAuthCancel = this.handleOAuthCancel.bind(this)
     this.handleExtraParams = this.handleExtraParams.bind(this)
     this.state = {
-      initialValues: null,
       showingOAuthModal: false
     }
   }
 
   componentDidMount() {
     const { account, konnector, flow, client } = this.props
-    this.setState({ initialValues: account ? account.oauth : null })
 
     const konnectorPolicy = findKonnectorPolicy(konnector)
 
@@ -79,6 +77,8 @@ export class OAuthForm extends PureComponent {
       flowState.running ||
       (needExtraParams && !extraParams)
 
+    const buttonLabel = reconnect ? 'oauth.reconnect.label' : 'oauth.connect.label'
+
     return (
       <>
         <Button
@@ -86,7 +86,7 @@ export class OAuthForm extends PureComponent {
           busy={isBusy}
           disabled={isBusy}
           extension="full"
-          label={t(`oauth.${reconnect ? 'reconnect' : 'connect'}.label`)}
+          label={t(buttonLabel)}
           onClick={this.handleConnect}
         />
         {showOAuthWindow && (
@@ -112,7 +112,9 @@ OAuthForm.propTypes = {
   /** Success callback, takes account as parameter */
   onSuccess: PropTypes.func,
   /** Translation function */
-  t: PropTypes.func.isRequired
+  t: PropTypes.func.isRequired,
+  /** Is it a reconnection or not */
+  reconnect: PropTypes.bool
 }
 
 export default compose(translate(), withConnectionFlow())(OAuthForm)

--- a/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
@@ -72,30 +72,31 @@ export class OAuthForm extends PureComponent {
   }
 
   render() {
-    const { konnector, t, flowState } = this.props
-    const { initialValues, showOAuthWindow, needExtraParams, extraParams } =
-      this.state
+    const { konnector, t, flowState, reconnect, account } = this.props
+    const { showOAuthWindow, needExtraParams, extraParams } = this.state
     const isBusy =
       showOAuthWindow === true ||
       flowState.running ||
       (needExtraParams && !extraParams)
 
-    return initialValues ? null : (
+    return (
       <>
         <Button
           className="u-mt-1"
           busy={isBusy}
           disabled={isBusy}
           extension="full"
-          label={t('oauth.connect.label')}
+          label={t(`oauth.${reconnect ? 'reconnect' : 'connect'}.label`)}
           onClick={this.handleConnect}
         />
         {showOAuthWindow && (
           <OAuthWindow
             extraParams={extraParams}
             konnector={konnector}
+            reconnect={reconnect}
             onSuccess={this.handleAccountId}
             onCancel={this.handleOAuthCancel}
+            account={account}
           />
         )}
       </>

--- a/packages/cozy-harvest-lib/src/components/OAuthForm.spec.js
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.spec.js
@@ -29,7 +29,7 @@ describe('OAuthForm', () => {
     expect(component).toMatchSnapshot()
   })
 
-  it('should render reconnect button when update', () => {
+  it('should render reconnect button when updating an account', () => {
     const component = shallow(
       <OAuthForm
         flowState={{}}

--- a/packages/cozy-harvest-lib/src/components/OAuthForm.spec.js
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.spec.js
@@ -29,16 +29,17 @@ describe('OAuthForm', () => {
     expect(component).toMatchSnapshot()
   })
 
-  it('should not render button when update', () => {
+  it('should render reconnect button when update', () => {
     const component = shallow(
       <OAuthForm
         flowState={{}}
         account={{ oauth: { access_token: '1234abcd' } }}
         konnector={fixtures.konnector}
+        reconnect={true}
         t={t}
       />
     ).getElement()
-    expect(component).toBeNull()
+    expect(component).toMatchSnapshot()
   })
   it('should call policy fetchExtraOAuthUrlParams with proper params', () => {
     shallow(

--- a/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
@@ -173,7 +173,11 @@ OAuthWindow.propTypes = {
   an account id */
   onCancel: PropTypes.func,
   /** The app we want to redirect the user on, after the OAuth flow. It used by the stack */
-  redirectSlug: PropTypes.string
+  redirectSlug: PropTypes.string,
+  /** Is it a reconnection or not */
+  reconnect: PropTypes.bool,
+  /** Existing account */
+  account: PropTypes.object
 }
 
 export default translate()(withClient(OAuthWindow))

--- a/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
@@ -45,7 +45,7 @@ export class OAuthWindow extends PureComponent {
   }
 
   componentDidMount() {
-    const { client, konnector, redirectSlug, extraParams } = this.props
+    const { client, konnector, redirectSlug, extraParams, reconnect, account } = this.props
     this.realtime = new CozyRealtime({ client })
     this.realtime.subscribe(
       'notified',
@@ -57,7 +57,9 @@ export class OAuthWindow extends PureComponent {
       client,
       konnector,
       redirectSlug,
-      extraParams
+      extraParams,
+      reconnect,
+      account
     )
     this.setState({ oAuthStateKey, oAuthUrl, succeed: false })
   }

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -320,7 +320,8 @@ export class DumbTriggerManager extends Component {
       flow,
       flowState,
       client,
-      OAuthFormWrapperComp
+      OAuthFormWrapperComp,
+      reconnect
     } = this.props
 
     const submitting = flowState.running
@@ -345,6 +346,7 @@ export class DumbTriggerManager extends Component {
             client={client}
             flow={flow}
             account={account}
+            reconnect={reconnect}
             konnector={konnector}
             onSuccess={this.handleOAuthAccountId}
           />

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -446,7 +446,9 @@ DumbTriggerManager.propTypes = {
   flow: PropTypes.object,
   flowState: PropTypes.object,
   // Used to inject a component around OAuthForm, and so customize the UI from the app
-  OAuthFormWrapperComp: PropTypes.node
+  OAuthFormWrapperComp: PropTypes.node,
+  /** Is it a reconnection or not */
+  reconnect: PropTypes.bool,
 }
 
 const TriggerManager = compose(

--- a/packages/cozy-harvest-lib/src/components/__snapshots__/OAuthForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/src/components/__snapshots__/OAuthForm.spec.js.snap
@@ -12,3 +12,16 @@ exports[`OAuthForm should render 1`] = `
   />
 </React.Fragment>
 `;
+
+exports[`OAuthForm should render reconnect button when update 1`] = `
+<React.Fragment>
+  <DefaultButton
+    busy={true}
+    className="u-mt-1"
+    disabled={true}
+    extension="full"
+    label="oauth.reconnect.label"
+    onClick={[Function]}
+  />
+</React.Fragment>
+`;

--- a/packages/cozy-harvest-lib/src/helpers/oauth.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.js
@@ -108,9 +108,13 @@ export const getOAuthUrl = ({
   oAuthConf = {},
   nonce,
   redirectSlug,
-  extraParams
+  extraParams,
+  reconnect,
+  account
 }) => {
-  let oAuthUrl = `${cozyUrl}/accounts/${accountType}/start?state=${oAuthStateKey}&nonce=${nonce}`
+  const startOrReconnect = reconnect ? 'reconnect' : 'start'
+  const accountIdParam = reconnect ? account._id + '/' : ''
+  let oAuthUrl = `${cozyUrl}/accounts/${accountType}/${accountIdParam}${startOrReconnect}?state=${oAuthStateKey}&nonce=${nonce}`
   if (
     oAuthConf.scope !== undefined &&
     oAuthConf.scope !== null &&
@@ -148,7 +152,14 @@ const getAppSlug = client => {
  * @return {Object}           Object containing: `oAuthUrl` (URL of cozy stack
  * OAuth endpoint) and `oAuthStateKey` (localStorage key)
  */
-export const prepareOAuth = (client, konnector, redirectSlug, extraParams) => {
+export const prepareOAuth = (
+  client,
+  konnector,
+  redirectSlug,
+  extraParams,
+  reconnect = false,
+  account
+) => {
   const { oauth } = konnector
   const accountType = konnectors.getAccountType(konnector)
 
@@ -168,7 +179,9 @@ export const prepareOAuth = (client, konnector, redirectSlug, extraParams) => {
     oAuthConf: oauth,
     nonce: Date.now(),
     redirectSlug: redirectSlug || getAppSlug(client),
-    extraParams
+    extraParams,
+    reconnect,
+    account
   })
 
   return { oAuthStateKey, oAuthUrl }

--- a/packages/cozy-harvest-lib/src/helpers/oauth.spec.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.spec.js
@@ -76,6 +76,21 @@ describe('Oauth helper', () => {
         'https://cozyurl/accounts/testslug/start?state=statekey&nonce=1234&token=thetoken&id_connector=40'
       )
     })
+    it('should return reconnect url with account id if reconnect', () => {
+      const url = getOAuthUrl({
+        ...defaultConf,
+        oAuthConf: {},
+        account: { _id: 'accountid' },
+        reconnect: true,
+        extraParams: {
+          code: 'thecode',
+          connection_id: 12345
+        }
+      })
+      expect(url).toEqual(
+        'https://cozyurl/accounts/testslug/accountid/reconnect?state=statekey&nonce=1234&code=thecode&connection_id=12345'
+      )
+    })
   })
   describe('handleOAuthResponse', () => {
     let originalLocation

--- a/packages/cozy-harvest-lib/src/helpers/oauth.spec.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.spec.js
@@ -50,7 +50,7 @@ describe('Oauth helper', () => {
         oAuthConf: { scope: ['thescope', 'thescope2'] }
       })
       expect(url).toEqual(
-        'https://cozyurl/accounts/testslug/start?state=statekey&nonce=1234&scope=thescope+thescope2'
+        'https://cozyurl/accounts/testslug/start?state=statekey&nonce=1234&scope=thescope%2Bthescope2'
       )
     })
     it('should use redirectSlug if present', () => {

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -386,6 +386,9 @@
     }
   },
   "oauth": {
+    "reconnect": {
+      "label": "Reconnect"
+    },
     "connect": {
       "label": "Connect"
     },

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -386,6 +386,9 @@
     }
   },
   "oauth": {
+    "reconnect": {
+      "label": "Se reconnecter"
+    },
     "connect": {
       "label": "Connecter"
     },

--- a/packages/cozy-harvest-lib/src/services/biWebView.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.js
@@ -190,6 +190,15 @@ export const onBIAccountCreation = async ({
   return updatedAccount
 }
 
+/**
+ * Create OAuth extra parameters specific to reconnect webview
+ *
+ * @param {Number} options.biBankId - Connector bank id (compatible with non webview bi connectors)
+ * @param {Array<Number>} options.biBankIds - connector bank ids (for webview connectors)
+ * @param {String} options.token - BI temporary token
+ * @param {Number} options.connId - BI bi connection id
+ * @return {Object}
+ */
 const getReconnectExtraOAuthUrlParams = async ({
   biBankId,
   biBankIds,
@@ -203,6 +212,14 @@ const getReconnectExtraOAuthUrlParams = async ({
   }
 }
 
+/**
+ * Create OAuth extra parameters
+ *
+ * @param {CozyClient} options.client - CozyClient instance
+ * @param {io.cozy.konnectors} options.konnector connector manifest content
+ * @param {io.cozy.accounts} options.account The account content
+ * @return {Promise<Object>}
+ */
 export const fetchExtraOAuthUrlParams = async ({
   client,
   konnector,

--- a/packages/cozy-harvest-lib/src/services/biWebView.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.js
@@ -13,7 +13,8 @@ import {
   saveBIConfig,
   findAccountWithBiConnection,
   convertBIErrortoKonnectorJobError,
-  isBudgetInsightConnector
+  isBudgetInsightConnector,
+  getBIConnectionIdFromAccount
 } from './budget-insight'
 import { KonnectorJobError } from '../helpers/konnectors'
 import { waitForRealtimeEvent } from './jobUtils'
@@ -189,6 +190,19 @@ export const onBIAccountCreation = async ({
   return updatedAccount
 }
 
+const getReconnectExtraOAuthUrlParams = async ({
+  biBankId,
+  biBankIds,
+  token,
+  connId
+}) => {
+  return {
+    id_connector: biBankId || biBankIds,
+    code: token,
+    connection_id: connId
+  }
+}
+
 export const fetchExtraOAuthUrlParams = async ({
   client,
   konnector,
@@ -204,7 +218,23 @@ export const fetchExtraOAuthUrlParams = async ({
     account
   })
 
-  return { id_connector: biBankId || biBankIds, token }
+  const connId = getBIConnectionIdFromAccount(account)
+
+  const isReconnect = Boolean(connId)
+
+  if (isReconnect) {
+    return getReconnectExtraOAuthUrlParams({
+      biBankId,
+      biBankIds,
+      token,
+      connId
+    })
+  } else {
+    return {
+      id_connector: biBankId || biBankIds,
+      token
+    }
+  }
 }
 
 /**

--- a/packages/cozy-harvest-lib/src/services/biWebView.spec.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.spec.js
@@ -317,7 +317,7 @@ describe('refreshContracts', () => {
 })
 
 describe('fetchExtraOAuthUrlParams', () => {
-  it('should asynchroneously fetch BI token', async () => {
+  it('should asynchronously fetch BI token', async () => {
     const client = new CozyClient({
       uri: 'http://testcozy.mycozy.cloud'
     })

--- a/packages/cozy-harvest-lib/src/services/budget-insight.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.js
@@ -33,8 +33,8 @@ const DECOUPLED_ERROR = 'decoupled'
 const ADDITIONAL_INFORMATION_NEEDED_ERROR = 'additionalInformationNeeded'
 const TEMP_TOKEN_TIMOUT_S = 60
 
-const getBIConnectionIdFromAccount = account =>
-  get(account, 'data.auth.bi.connId')
+export const getBIConnectionIdFromAccount = account =>
+  account?.data?.auth?.bi?.connId
 
 const getBIIdFromContract = bankAccount => bankAccount.vendorId
 


### PR DESCRIPTION
A "reconnect" button is now visible when trying to update credentials of
a bi webview connector or any oauth connector.

An addition in io-cozy-account_types secrets is neededed : the
reconnect_endpoint as documented in
https://docs.cozy.io/en/cozy-stack/konnectors-workflow/#reconnect

Implements https://trello.com/c/3UV7zhvJ/448-webview-bi-int%C3%A9gration-dans-le-workflow-de-reconnexion-dune-banque-1-pt