### PR TITLE
fix(eslint-config-cozy-app): Settings for react

### DIFF
--- a/packages/eslint-config-cozy-app/react.js
+++ b/packages/eslint-config-cozy-app/react.js
@@ -8,7 +8,7 @@ module.exports = {
   parser: basics.parser,
   parserOptions: { ecmaFeatures: { jsx: true } },
   env: basics.env,
-  settings: { react: { version: 'latest' } },
+  settings: { react: { version: 'detect' } },
   rules: Object.assign({}, basics.rules, {
     'react/prop-types': 'off',
     'react/jsx-curly-brace-presence': [


### PR DESCRIPTION
Warning: React version specified in eslint-plugin-react-settings must
be a valid semver version, or "detect"; got “latest”