### PR TITLE
fix: Wrong proptypes file path

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
@@ -39,7 +39,7 @@ import { useTrackPage, useTracker } from '../../hoc/tracking'
 import RedirectToAccountFormButton from '../../RedirectToAccountFormButton'
 
 import { ContractsForAccount } from './Contracts'
-import { intentsApiProptype } from '../../helpers/proptypes'
+import { intentsApiProptype } from '../../../helpers/proptypes'
 
 const tabMobileNavListStyle = { borderTop: 'none' }
 

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
@@ -12,7 +12,7 @@ import useDOMMutations from '../hooks/useDOMMutations'
 import FlowProvider from '../FlowProvider'
 import DataTab from './DataTab'
 import ConfigurationTab from './ConfigurationTab'
-import { intentsApiProptype } from '../helpers/proptypes'
+import { intentsApiProptype } from '../../helpers/proptypes'
 
 const tabIndexes = {
   data: 0,


### PR DESCRIPTION
I only got an error in cozy-banks unit tests with last version of cozy-harvest-lib.

I don't understand why I did not get any error in harvest unit test since there are unit tests for ConfigurationTab and KonnectorAccountsTab.