### PR TITLE
fix: Get proper locale in banks using withLocales

### DIFF
--- a/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
@@ -2,10 +2,10 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 
 import Button from 'cozy-ui/transpiled/react/Button'
-import { translate } from 'cozy-ui/transpiled/react/I18n'
 import OAuthWindow from './OAuthWindow'
 import compose from 'lodash/flowRight'
 import withConnectionFlow from '../models/withConnectionFlow'
+import withLocales from './hoc/withLocales'
 import { findKonnectorPolicy } from '../konnector-policies'
 import { intentsApiProptype } from '../helpers/proptypes'
 
@@ -124,4 +124,4 @@ OAuthForm.propTypes = {
   intentsApi: intentsApiProptype
 }
 
-export default compose(translate(), withConnectionFlow())(OAuthForm)
+export default compose(withLocales, withConnectionFlow())(OAuthForm)


### PR DESCRIPTION
This avoids the following behavior in banks

![image](https://user-images.githubusercontent.com/228695/173629274-685bf05f-cf28-4904-8303-4b013b49e6fd.png)
