### PR TITLE
fix: Fix width flickering in ModalHeader

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorModalHeader.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModalHeader.jsx
@@ -17,8 +17,7 @@ const KonnectorModalHeader = ({ konnector, children }) => {
       <Media>
         <Img
           className={cx('u-mr-1', {
-            'u-w-3 u-h-3': children,
-            'u-w-2 u-h-2': !children
+            [children === null ? 'u-w-2 u-h-2' : 'u-w-3 u-h-3']: true
           })}
         >
           <KonnectorIcon konnector={konnector} />


### PR DESCRIPTION
The header has 2 width.
One with children, one without children.
It was checking for undefined to decide if it had children or not.
Undefined is not a correct value for a React children,
therefore we now check for the null value.
This allows us to know in sync if we must display the big or the small
icon container.