### PR TITLE
fix: Do not double encode url

### DIFF
--- a/packages/cozy-harvest-lib/src/components/InAppBrowser.jsx
+++ b/packages/cozy-harvest-lib/src/components/InAppBrowser.jsx
@@ -31,11 +31,16 @@ const InAppBrowser = ({ url, onClose, intentsApi = {} }) => {
     async function insideEffect() {
       if (isReady) {
         try {
+          logger.debug('url at the beginning: ', url)
           const sessionCode = await fetchSessionCode()
           logger.debug('got session code', sessionCode)
           const iabUrl = new URL(url)
           iabUrl.searchParams.append(tokenParamName, sessionCode)
-          const result = await showInAppBrowser(iabUrl.toString())
+          // we need to decodeURIComponent since toString() encodes URL
+          // but native browser will also encode them.
+          const urlToOpen = decodeURIComponent(iabUrl.toString())
+          logger.debug('url to open: ', urlToOpen)
+          const result = await showInAppBrowser(urlToOpen)
           if (result?.type !== 'dismiss' && result?.type !== 'cancel') {
             logger.error('Unexpected InAppBrowser result', result)
           }


### PR DESCRIPTION
At least on iOS, we have trouble when opening the in app browser. 

It seems that the URL opened by the InAppBrowser contains double encoded character. BI has the good idea to put "/" inside their token. Instead of opening token=t/t or token=t%2Ft we open token=t%252Ft 

We tried a previous fix: https://github.com/cozy/cozy-libs/pull/1685 but it's not working. 

So I add a few logs to have more control over the debug phase. 