### PR TITLE
fix(mespapiers-lib): Allow masked inputs to be optional

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
@@ -31,14 +31,7 @@ const InputTextAdapter = ({
   setIsFocus,
   idx
 }) => {
-  const {
-    name,
-    inputLabel,
-    mask,
-    maskPlaceholder = 'ˍ',
-    maxLength,
-    minLength
-  } = attrs
+  const { name, inputLabel, mask, maskPlaceholder = 'ˍ' } = attrs
   const { t } = useI18n()
   const [currentValue, setCurrentValue] = useState(defaultValue || '')
   const [isTooShort, setIsTooShort] = useState(false)
@@ -160,8 +153,8 @@ const InputTextAdapter = ({
       helperText={helperText}
       value={currentValue}
       inputProps={{
-        maxLength: maxLength,
-        minLength: minLength,
+        maxLength: expectedLength.max,
+        minLength: expectedLength.min,
         inputMode: getInputMode(inputType),
         'data-testid': 'TextField-input'
       }}

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.spec.jsx
@@ -12,11 +12,11 @@ jest.mock('cozy-client/dist/models/document/locales', () => ({
 
 const mockAttrs = ({
   type = '',
-  maxLength = 0,
-  minLength = 0,
+  maxLength,
+  minLength,
   required = false,
   mask = null,
-  maskPlaceholder = '_'
+  maskPlaceholder = 'ˍ'
 } = {}) => {
   return {
     name: 'name01',

--- a/packages/cozy-mespapiers-lib/src/utils/input.js
+++ b/packages/cozy-mespapiers-lib/src/utils/input.js
@@ -4,8 +4,8 @@ import log from 'cozy-logger'
  * @typedef {object} MakeConstraintsOfInputParam
  * @property {'text'|'number'} [type] - A string specifying the type of input
  * @property {boolean} [required] - Indicates that the user must specify a value for the input
- * @property {object} [minLength] - Defines the minimum number of characters can enter into the input
- * @property {string} [maxLength] - Defines the maximum number of characters can enter into the input
+ * @property {number} [minLength] - Defines the minimum number of characters can enter into the input
+ * @property {number} [maxLength] - Defines the maximum number of characters can enter into the input
  */
 
 /**

--- a/packages/cozy-mespapiers-lib/src/utils/input.js
+++ b/packages/cozy-mespapiers-lib/src/utils/input.js
@@ -24,17 +24,16 @@ import log from 'cozy-logger'
 export const makeConstraintsOfInput = attrs => {
   const { type = '', required = false, mask } = attrs || {}
 
-  const maskLength = mask ? mask.replaceAll(' ', '').length : null
-  const minLength = maskLength || attrs?.minLength || 0
-  const maxLength = maskLength || attrs?.maxLength || 0
-
+  const maskLength = mask?.replaceAll(/\s/g, '')?.length
+  const minLength = (required && maskLength) || (attrs?.minLength ?? null)
+  const maxLength = maskLength ?? attrs?.maxLength ?? null
   const acceptedTypes = ['number', 'text']
 
   const result = {
     inputType: '',
     expectedLength: {
-      min: maxLength > 0 ? Math.min(minLength, maxLength) : minLength,
-      max: maxLength > 0 ? Math.max(minLength, maxLength) : maxLength
+      min: minLength,
+      max: maxLength
     },
     isRequired: required
   }

--- a/packages/cozy-mespapiers-lib/src/utils/input.spec.js
+++ b/packages/cozy-mespapiers-lib/src/utils/input.spec.js
@@ -4,23 +4,35 @@ describe('Input Utils', () => {
   describe('makeInputTypeAndLength', () => {
     it.each`
       attrs                                                                | result
-      ${{ type: 'number' }}                                                | ${{ inputType: 'number', expectedLength: { min: 0, max: 0 }, isRequired: false }}
+      ${{ type: 'number' }}                                                | ${{ inputType: 'number', expectedLength: { min: null, max: null }, isRequired: false }}
+      ${{ type: 'number', mask: '99999' }}                                 | ${{ inputType: 'number', expectedLength: { min: null, max: 5 }, isRequired: false }}
+      ${{ type: 'number', mask: '99999', minLength: 3, maxLength: 7 }}     | ${{ inputType: 'number', expectedLength: { min: 3, max: 5 }, isRequired: false }}
+      ${{ type: 'number', mask: '99999', required: true }}                 | ${{ inputType: 'number', expectedLength: { min: 5, max: 5 }, isRequired: true }}
+      ${{ type: 'number', mask: '99 99 99 99 99', required: true }}        | ${{ inputType: 'number', expectedLength: { min: 10, max: 10 }, isRequired: true }}
+      ${{ type: 'number', mask: '99999', required: true, minLength: 3 }}   | ${{ inputType: 'number', expectedLength: { min: 5, max: 5 }, isRequired: true }}
+      ${{ type: 'number', mask: '99999', required: true, maxLength: 7 }}   | ${{ inputType: 'number', expectedLength: { min: 5, max: 5 }, isRequired: true }}
       ${{ type: 'number', required: false, minLength: 0, maxLength: 0 }}   | ${{ inputType: 'number', expectedLength: { min: 0, max: 0 }, isRequired: false }}
       ${{ type: 'number', required: false, minLength: 10, maxLength: 0 }}  | ${{ inputType: 'number', expectedLength: { min: 10, max: 0 }, isRequired: false }}
       ${{ type: 'number', required: false, minLength: 0, maxLength: 10 }}  | ${{ inputType: 'number', expectedLength: { min: 0, max: 10 }, isRequired: false }}
       ${{ type: 'number', required: false, minLength: 5, maxLength: 10 }}  | ${{ inputType: 'number', expectedLength: { min: 5, max: 10 }, isRequired: false }}
       ${{ type: 'number', required: false, minLength: 10, maxLength: 10 }} | ${{ inputType: 'number', expectedLength: { min: 10, max: 10 }, isRequired: false }}
       ${{ type: 'number', required: true, minLength: 0, maxLength: 0 }}    | ${{ inputType: 'number', expectedLength: { min: 0, max: 0 }, isRequired: true }}
-      ${{ type: 'number', required: true, minLength: 20, maxLength: 10 }}  | ${{ inputType: 'number', expectedLength: { min: 10, max: 20 }, isRequired: true }}
-      ${undefined}                                                         | ${{ inputType: 'text', expectedLength: { min: 0, max: 0 }, isRequired: false }}
-      ${{ type: 'text' }}                                                  | ${{ inputType: 'text', expectedLength: { min: 0, max: 0 }, isRequired: false }}
+      ${{ type: 'number', required: true, minLength: 20, maxLength: 10 }}  | ${{ inputType: 'number', expectedLength: { min: 20, max: 10 }, isRequired: true }}
+      ${undefined}                                                         | ${{ inputType: 'text', expectedLength: { min: null, max: null }, isRequired: false }}
+      ${{ type: 'text' }}                                                  | ${{ inputType: 'text', expectedLength: { min: null, max: null }, isRequired: false }}
+      ${{ type: 'text', mask: 'aaaaa' }}                                   | ${{ inputType: 'text', expectedLength: { min: null, max: 5 }, isRequired: false }}
+      ${{ type: 'text', mask: 'aaaaa', minLength: 3, maxLength: 7 }}       | ${{ inputType: 'text', expectedLength: { min: 3, max: 5 }, isRequired: false }}
+      ${{ type: 'text', mask: 'aaaaa', required: true }}                   | ${{ inputType: 'text', expectedLength: { min: 5, max: 5 }, isRequired: true }}
+      ${{ type: 'text', mask: 'aa aa aa aa aa', required: true }}          | ${{ inputType: 'text', expectedLength: { min: 10, max: 10 }, isRequired: true }}
+      ${{ type: 'text', mask: 'aaaaa', required: true, minLength: 3 }}     | ${{ inputType: 'text', expectedLength: { min: 5, max: 5 }, isRequired: true }}
+      ${{ type: 'text', mask: 'aaaaa', required: true, maxLength: 7 }}     | ${{ inputType: 'text', expectedLength: { min: 5, max: 5 }, isRequired: true }}
       ${{ type: 'text', required: false, minLength: 0, maxLength: 0 }}     | ${{ inputType: 'text', expectedLength: { min: 0, max: 0 }, isRequired: false }}
       ${{ type: 'text', required: false, minLength: 10, maxLength: 0 }}    | ${{ inputType: 'text', expectedLength: { min: 10, max: 0 }, isRequired: false }}
       ${{ type: 'text', required: false, minLength: 0, maxLength: 10 }}    | ${{ inputType: 'text', expectedLength: { min: 0, max: 10 }, isRequired: false }}
       ${{ type: 'text', required: false, minLength: 5, maxLength: 10 }}    | ${{ inputType: 'text', expectedLength: { min: 5, max: 10 }, isRequired: false }}
       ${{ type: 'text', required: false, minLength: 10, maxLength: 10 }}   | ${{ inputType: 'text', expectedLength: { min: 10, max: 10 }, isRequired: false }}
       ${{ type: 'text', required: true, minLength: 0, maxLength: 0 }}      | ${{ inputType: 'text', expectedLength: { min: 0, max: 0 }, isRequired: true }}
-      ${{ type: 'text', required: true, minLength: 20, maxLength: 10 }}    | ${{ inputType: 'text', expectedLength: { min: 10, max: 20 }, isRequired: true }}
+      ${{ type: 'text', required: true, minLength: 20, maxLength: 10 }}    | ${{ inputType: 'text', expectedLength: { min: 20, max: 10 }, isRequired: true }}
     `(
       `should return $result when passed argument: $attrs`,
       ({ attrs, result }) => {
@@ -31,18 +43,37 @@ describe('Input Utils', () => {
 
   describe('checkInputConstraints', () => {
     it.each`
-      valueLength | expectedLength          | isRequired | result
-      ${0}        | ${{ min: 0, max: 0 }}   | ${false}   | ${true}
-      ${0}        | ${{ min: 0, max: 20 }}  | ${false}   | ${true}
-      ${0}        | ${{ min: 10, max: 0 }}  | ${true}    | ${false}
-      ${0}        | ${{ min: 10, max: 20 }} | ${true}    | ${false}
-      ${10}       | ${{ min: 0, max: 0 }}   | ${false}   | ${true}
-      ${10}       | ${{ min: 0, max: 20 }}  | ${false}   | ${true}
-      ${21}       | ${{ min: 0, max: 20 }}  | ${false}   | ${false}
-      ${0}        | ${{ min: 10, max: 0 }}  | ${true}    | ${false}
-      ${10}       | ${{ min: 10, max: 0 }}  | ${true}    | ${true}
-      ${0}        | ${{ min: 10, max: 20 }} | ${true}    | ${false}
-      ${15}       | ${{ min: 10, max: 20 }} | ${true}    | ${true}
+      valueLength | expectedLength              | isRequired | result
+      ${0}        | ${{ min: null, max: null }} | ${false}   | ${true}
+      ${0}        | ${{ min: null, max: null }} | ${true}    | ${false}
+      ${0}        | ${{ min: null, max: 0 }}    | ${false}   | ${true}
+      ${0}        | ${{ min: null, max: 0 }}    | ${true}    | ${false}
+      ${0}        | ${{ min: 0, max: null }}    | ${false}   | ${true}
+      ${0}        | ${{ min: 0, max: null }}    | ${true}    | ${false}
+      ${0}        | ${{ min: 0, max: 0 }}       | ${false}   | ${true}
+      ${0}        | ${{ min: 0, max: 0 }}       | ${true}    | ${false}
+      ${0}        | ${{ min: null, max: 20 }}   | ${false}   | ${true}
+      ${0}        | ${{ min: null, max: 20 }}   | ${true}    | ${false}
+      ${0}        | ${{ min: 20, max: null }}   | ${false}   | ${false}
+      ${0}        | ${{ min: 20, max: null }}   | ${true}    | ${false}
+      ${0}        | ${{ min: 10, max: 30 }}     | ${false}   | ${false}
+      ${0}        | ${{ min: 30, max: 10 }}     | ${false}   | ${false}
+      ${0}        | ${{ min: 10, max: 30 }}     | ${true}    | ${false}
+      ${0}        | ${{ min: 30, max: 10 }}     | ${true}    | ${false}
+      ${10}       | ${{ min: 10, max: 30 }}     | ${true}    | ${true}
+      ${10}       | ${{ min: 30, max: 10 }}     | ${true}    | ${false}
+      ${20}       | ${{ min: 10, max: 30 }}     | ${true}    | ${true}
+      ${20}       | ${{ min: 30, max: 10 }}     | ${true}    | ${false}
+      ${30}       | ${{ min: 10, max: 30 }}     | ${true}    | ${true}
+      ${30}       | ${{ min: 30, max: 10 }}     | ${true}    | ${false}
+      ${40}       | ${{ min: 10, max: 30 }}     | ${true}    | ${false}
+      ${40}       | ${{ min: 30, max: 10 }}     | ${true}    | ${false}
+      ${20}       | ${{ min: null, max: 10 }}   | ${false}   | ${false}
+      ${20}       | ${{ min: null, max: 20 }}   | ${false}   | ${true}
+      ${20}       | ${{ min: null, max: 30 }}   | ${false}   | ${true}
+      ${20}       | ${{ min: 10, max: null }}   | ${false}   | ${true}
+      ${20}       | ${{ min: 20, max: null }}   | ${false}   | ${true}
+      ${20}       | ${{ min: 30, max: null }}   | ${false}   | ${false}
     `(
       `should return $result when passed argument: ($valueLength, $expectedLength, $isRequired)`,
       ({ valueLength, expectedLength, isRequired, result }) => {


### PR DESCRIPTION
Masked inputs can now be optional, and then any value that matches the start of the mask can be entered.

Also for any optional input, the empty string is now always valid, even if the length does not match min and max length constraints.

This matches the behavior of HTML `<input type="text" />` elements.

This also removes the behavior that swapped `minLength` and `maxLength` when set in the wrong order.