### PR TITLE
fix(account): Update trigger while status changed

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModal.jsx
@@ -58,7 +58,17 @@ export class AccountModal extends Component {
   }
 
   async componentDidUpdate(prevProps) {
-    if (this.props.accountId !== prevProps.accountId) {
+    const { accountId, accountsAndTriggers } = this.props
+    const matchingTrigger = get(
+      accountsAndTriggers.find(
+        accountAndTrigger => accountAndTrigger.account._id === accountId
+      ),
+      'trigger'
+    )
+
+    const hasTriggerStatusChanged = matchingTrigger && this.state.trigger && matchingTrigger.current_state.status !== this.state.trigger.current_state.status
+
+    if (this.props.accountId !== prevProps.accountId || hasTriggerStatusChanged) {
       return await this.loadSelectedAccountId()
     }
   }

--- a/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
@@ -138,7 +138,7 @@ export class EditAccountModal extends Component {
     this.props.trackPage('editer_identifiants')
   }
   /**
-   * TODO use queryConnect to know if we're fecthing or not
+   * TODO use queryConnect to know if we're fetching or not
    */
   async fetchAccount(trigger) {
     const { client } = this.props

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
@@ -250,6 +250,7 @@ ConfigurationTab.propTypes = {
   konnector: PropTypes.object.isRequired,
   account: PropTypes.object.isRequired,
   error: PropTypes.object,
+  flow: PropTypes.object,
   addAccount: PropTypes.func.isRequired,
   onAccountDeleted: PropTypes.func.isRequired,
   intentsApi: intentsApiProptype,

--- a/packages/cozy-harvest-lib/src/connections/triggers.js
+++ b/packages/cozy-harvest-lib/src/connections/triggers.js
@@ -27,7 +27,7 @@ export const createTrigger = async (client, attributes) => {
  * Fetch the trigger based on its id
  * @param  {Object} client CozyClient
  * @param  {string} id
- * @return {Object} Fetched trigger
+ * @return {Object} Fetched trigger data
  */
 export const fetchTrigger = async (client, id) => {
   const { data } = await client.collection(TRIGGERS_DOCTYPE).get(id)


### PR DESCRIPTION
Two PR are needed to remove the error message staying, after reconnection of a konnector, this one and https://github.com/cozy/cozy-banks/pull/2404 

The [HarvestBankAccountSettings](https://github.com/cozy/cozy-banks/blob/master/src/ducks/settings/HarvestBankAccountSettings.jsx#L253) give data to HarvestAccountModal using the [HarvestLoader](https://github.com/cozy/cozy-banks/blob/dbc8d428fbeac34bafea11213607fd565e8daed7/src/ducks/settings/HarvestBankAccountSettings.jsx#L179) .
I noticed the data "trigger" that contains `trigger.current_state.status` (knowing if errored or done) was given inside the "accountsAndTriggers" . 

I also modified AccountModal.componentDidUpdate to update the data (flowState), used by harvest lib, to remove the error message displayed. (This PR in cozy-harvest-lib)

Then, I noticed the request to refresh trigger was executed sometimes. When fetchPolicy returns previous konnector with "errored" status, then the error message was not removed. When a fresh request happens, updating the triggers, then the status was done and the error message was removed.

That's why the solution is to remove the fetchPolicy, as we are not using realtime here + our date trigger can change in this scenario (The other PR in cozy-banks)