### PR TITLE
feat: Handle user dismiss in Oauth window

### DIFF
--- a/packages/cozy-harvest-lib/src/components/OAuthForm.spec.js
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.spec.js
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme'
 
 import { OAuthForm } from 'components/OAuthForm'
 import { findKonnectorPolicy } from '../konnector-policies'
+import { KonnectorJobError } from '../helpers/konnectors'
 jest.mock('../konnector-policies', () => ({
   findKonnectorPolicy: jest.fn()
 }))
@@ -58,5 +59,15 @@ describe('OAuthForm', () => {
       flow: undefined,
       konnector: { slug: 'test-konnector' }
     })
+  })
+  it('should handle oauth cancelation', () => {
+    const component = shallow(
+      <OAuthForm
+        flowState={{ error: new KonnectorJobError('OAUTH_CANCELED') }}
+        konnector={fixtures.konnector}
+        t={t}
+      />
+    ).getElement()
+    expect(component).toMatchSnapshot()
   })
 })

--- a/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
@@ -85,16 +85,20 @@ export class OAuthWindow extends PureComponent {
    * Handles OAuth data. OAuth data may be provided by different way:
    * * realtime message from web apps (see handleMessage)
    * * url changes from mobile apps
-   * @param  {string} data.key `io.cozy.accounts` id The created OAuth account
-   * @param  {string} data.oAuthStateKey key for localStorage
+   *
+   * @param  {String} data.key - `io.cozy.accounts` id The created OAuth account
+   * @param  {String} data.error - error message
+   * @param  {String} data.oAuthStateKey - key for localStorage
    */
   handleOAuthData(data) {
-    const { konnector, onSuccess } = this.props
+    const { konnector, onSuccess, onCancel } = this.props
     if (!checkOAuthData(konnector, data)) return
 
     if (data.error) {
       logger.info('OAuthWindow: oauth error message', data.error)
-      this.handleClose()
+      if (onCancel) {
+        onCancel(data.error)
+      }
       return
     }
     this.setState({ succeed: true })
@@ -131,9 +135,11 @@ export class OAuthWindow extends PureComponent {
   handleUrlChange(url) {
     const account = url.searchParams.get('account')
     const state = url.searchParams.get('state')
+    const error = url.searchParams.get('error')
     if (account && state) {
       return this.handleOAuthData({
         key: account,
+        error,
         oAuthStateKey: state
       })
     }
@@ -142,8 +148,10 @@ export class OAuthWindow extends PureComponent {
       const testedURL = new URL(redirect)
       const accountInRedirect = testedURL.searchParams.get('account')
       const stateInRedirect = testedURL.searchParams.get('state')
+      const errorInRedirect = testedURL.searchParams.get('error')
       return this.handleOAuthData({
         key: accountInRedirect,
+        error: errorInRedirect,
         oAuthStateKey: stateInRedirect
       })
     }

--- a/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
@@ -16,6 +16,7 @@ import {
 import Popup from './Popup'
 import InAppBrowser from './InAppBrowser'
 import { intentsApiProptype } from '../helpers/proptypes'
+import logger from '../logger'
 
 const OAUTH_POPUP_HEIGHT = 800
 const OAUTH_POPUP_WIDTH = 800
@@ -90,6 +91,12 @@ export class OAuthWindow extends PureComponent {
   handleOAuthData(data) {
     const { konnector, onSuccess } = this.props
     if (!checkOAuthData(konnector, data)) return
+
+    if (data.error) {
+      logger.info('OAuthWindow: oauth error message', data.error)
+      this.handleClose()
+      return
+    }
     this.setState({ succeed: true })
 
     if (typeof onSuccess !== 'function') return

--- a/packages/cozy-harvest-lib/src/components/__snapshots__/OAuthForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/src/components/__snapshots__/OAuthForm.spec.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`OAuthForm should handle oauth cancelation 1`] = `
+<React.Fragment>
+  <withI18n(withClient(withKonnectorLocales(TriggerErrorInfo))
+    className="u-mb-1"
+    error={[Error: OAUTH_CANCELED]}
+    konnector={
+      Object {
+        "slug": "test-konnector",
+      }
+    }
+  />
+  <DefaultButton
+    busy={true}
+    className="u-mt-1"
+    disabled={true}
+    extension="full"
+    label="oauth.connect.label"
+    onClick={[Function]}
+  />
+</React.Fragment>
+`;
+
 exports[`OAuthForm should render 1`] = `
 <React.Fragment>
   <DefaultButton

--- a/packages/cozy-harvest-lib/src/helpers/oauth.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.js
@@ -73,6 +73,7 @@ export const handleOAuthResponse = (options = {}) => {
   const queryParams = new URLSearchParams(window.location.search)
 
   const accountId = queryParams.get('account')
+  const errorMsg = queryParams.get('error')
 
   /**
    * Key for localStorage, used at the beginning of the OAuth process to store
@@ -84,6 +85,7 @@ export const handleOAuthResponse = (options = {}) => {
 
   realtime.sendNotification('io.cozy.accounts', OAUTH_REALTIME_CHANNEL, {
     key: accountId,
+    error: errorMsg,
     oAuthStateKey
   })
 

--- a/packages/cozy-harvest-lib/src/helpers/oauth.spec.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.spec.js
@@ -126,11 +126,31 @@ describe('Oauth helper', () => {
 
     afterEach(() => {
       window.location = originalLocation
+      jest.resetAllMocks()
     })
 
     it('should send message with query string data', () => {
       const expectedOAuthData = {
+        error: null,
         key: 'bc2aca6566cf4a72afe6c615aa1e3d31',
+        oAuthStateKey: '70720eb0-6204-484d'
+      }
+
+      handleOAuthResponse({ realtime })
+      expect(realtime.sendNotification).toHaveBeenCalledWith(
+        'io.cozy.accounts',
+        OAUTH_REALTIME_CHANNEL,
+        expectedOAuthData
+      )
+    })
+
+    it('should send message with error if any', () => {
+      window.location = {
+        search: 'error=dismissed&state=70720eb0-6204-484d'
+      }
+      const expectedOAuthData = {
+        error: 'dismissed',
+        key: null,
         oAuthStateKey: '70720eb0-6204-484d'
       }
 

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -134,6 +134,10 @@
         "title": "Challenge required",
         "description": "The website requires a second authentification factor. You may re-run the connector manually to provide the code and continue to retrieve your data."
       },
+      "OAUTH_CANCELED": {
+        "title": "Canceled",
+        "description": "We could not add your bank since you canceled the connection. Click \"Add your bank\" one more time to try again."
+      },
       "LOGIN_FAILED": {
         "title": "Incorrect or expired credentials",
         "description": "Sorry, your login or password are invalid or are expired. You may check your credentials on [%{name}](%{link}) website before updating."

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -134,6 +134,10 @@
         "title": "Second facteur d’authentification demandé",
         "description": "Le site demande une authentification forte à deux facteurs. Vous devez relancer le connecteur manuellement pour vous authentifier et continuer à récupérer vos données."
       },
+      "OAUTH_CANCELED": {
+        "title": "Annulé",
+        "description": "Nous n'avons pas pu ajouter votre banque car vous avez annulé la connexion. Cliquez sur \"Ajouter votre banque\" encore une fois pour faire un nouvel essai."
+      },
       "LOGIN_FAILED": {
         "title": "Identifiants erronés ou expirés",
         "description": "Votre identifiant et/ou mot de passe ne semblent pas corrects. Merci de les vérifier sur le site [%{name}](%{link}) avant de réessayer."

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -219,6 +219,7 @@ export class ConnectionFlow {
       this.setState({ status: eventToStatus[eventName] })
     }
     if (eventName === ERROR_EVENT) {
+      this.setState({ accountError: args[0] })
       this.refetchTrigger()
     }
     this.emit(eventName, ...args)


### PR DESCRIPTION
The dismiss or cancel action of the user in the oauth window generates
an error message which was not handled by Harvest.

Now, a dismiss action of the user causes the closing of the popup or
InAppBrowser.

This supposes that https://github.com/cozy/cozy-stack/pull/3445 is
merged in cozy-stack to not cause a redirect to the store application.
