### PR TITLE
fix(mes-papiers): Fix typos in README.md

### DIFF
--- a/packages/cozy-mespapiers-lib/README.md
+++ b/packages/cozy-mespapiers-lib/README.md
@@ -149,7 +149,7 @@ export default MesPapiersView
 ```
 # Call modal with URL
 In your application, if you want to call a modal to create a Paper, you just have to call the `/paper/create` or `/paper/create/:qualificationLabel` route with the query parameter `backgroundPath=<currentPath>`
-Exemple:
+Example:
 ```jsx
 const { pathname } = useLocation()
 


### PR DESCRIPTION
This commit should be theorically in a docs scoped commit.
Currently upgrading cozy-mespapiers-lib is required to validate
Renovate behaviour in our application.