### PR TITLE
feat: Now open the BI manage webview to the correct connection id

### DIFF
--- a/packages/cozy-harvest-lib/src/services/biWebView.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.js
@@ -91,7 +91,8 @@ export const fetchContractSynchronizationUrl = async ({
     konnector,
     account
   })
-  return `${url}/auth/webview/manage?client_id=${clientId}&code=${code}`
+  const connId = getBIConnectionIdFromAccount(account)
+  return `${url}/auth/webview/manage?client_id=${clientId}&code=${code}&connection_id=${connId}`
 }
 
 /**

--- a/packages/cozy-harvest-lib/src/services/biWebView.spec.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.spec.js
@@ -216,12 +216,12 @@ describe('fetchContractSynchronizationUrl', () => {
     })
 
     const url = await fetchContractSynchronizationUrl({
-      account,
+      account: { ...account, data: { auth: { bi: { connId: 1337 } } } },
       client,
       konnector
     })
     expect(url).toEqual(
-      'https://cozy.biapi.pro/2.0/auth/webview/manage?client_id=test-client-id&code=bi-temporary-access-token-145613'
+      'https://cozy.biapi.pro/2.0/auth/webview/manage?client_id=test-client-id&code=bi-temporary-access-token-145613&connection_id=1337'
     )
   })
 })


### PR DESCRIPTION
BI now allow use to pass a `connection_id` query parameter to directly
open the webview to the management of the given connection id.
