### PR TITLE
Improve Multiselection process

### DIFF
--- a/packages/cozy-mespapiers-lib/package.json
+++ b/packages/cozy-mespapiers-lib/package.json
@@ -23,7 +23,7 @@
     "cozy-intent": "^2.2.0",
     "cozy-realtime": "^4.2.1",
     "cozy-sharing": "^4.3.1",
-    "cozy-ui": "^68.5.0",
+    "cozy-ui": "^68.8.0",
     "jest-environment-jsdom-sixteen": "2.0.0",
     "react-router-dom": "5.2.0"
   },
@@ -44,7 +44,7 @@
     "cozy-intent": ">=2.2.0",
     "cozy-realtime": ">=4.2.0",
     "cozy-sharing": ">=4.3.0",
-    "cozy-ui": ">=68.5.0",
+    "cozy-ui": ">=68.8.0",
     "react-router-dom": ">=5.2.0"
   }
 }

--- a/packages/cozy-mespapiers-lib/src/components/Actions/Items/createPaper.js
+++ b/packages/cozy-mespapiers-lib/src/components/Actions/Items/createPaper.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { useHistory, useLocation } from 'react-router-dom'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+import ActionMenuItemWrapper from '../ActionMenuItemWrapper'
+
+export const createPaper = ({ hideActionsMenu }) => {
+  return {
+    name: 'createPaper',
+    Component: function CreatePaper({ className }) {
+      const { t } = useI18n()
+      const history = useHistory()
+      const { pathname } = useLocation()
+
+      return (
+        <ActionMenuItemWrapper
+          className={className}
+          icon="paper"
+          onClick={() => {
+            history.push({
+              pathname: `/paper/create`,
+              search: `backgroundPath=${pathname}`
+            })
+            hideActionsMenu && hideActionsMenu()
+          }}
+        >
+          {t('action.createPaper')}
+        </ActionMenuItemWrapper>
+      )
+    }
+  }
+}

--- a/packages/cozy-mespapiers-lib/src/components/Actions/Items/select.js
+++ b/packages/cozy-mespapiers-lib/src/components/Actions/Items/select.js
@@ -4,16 +4,14 @@ import { useHistory, useLocation } from 'react-router-dom'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import ActionMenuItemWrapper from '../ActionMenuItemWrapper'
-import { useMultiSelection } from '../../Hooks/useMultiSelection'
 
-export const select = ({ hideActionsMenu }) => {
+export const select = ({ hideActionsMenu, addMultiSelectionFile }) => {
   return {
     name: 'select',
     Component: function Select({ className, files }) {
       const { t } = useI18n()
       const history = useHistory()
       const { pathname } = useLocation()
-      const { addMultiSelectionFile } = useMultiSelection()
 
       return (
         <ActionMenuItemWrapper
@@ -25,7 +23,9 @@ export const select = ({ hideActionsMenu }) => {
               search: `backgroundPath=${pathname}`
             })
             hideActionsMenu && hideActionsMenu()
-            files.length > 0 && addMultiSelectionFile(files[0])
+            files.length > 0 &&
+              addMultiSelectionFile &&
+              addMultiSelectionFile(files[0])
           }}
         >
           {files.length === 0 ? t('action.forwardPapers') : t('action.select')}

--- a/packages/cozy-mespapiers-lib/src/components/Actions/Items/select.js
+++ b/packages/cozy-mespapiers-lib/src/components/Actions/Items/select.js
@@ -28,7 +28,7 @@ export const select = ({ hideActionsMenu }) => {
             files.length > 0 && addMultiSelectionFile(files[0])
           }}
         >
-          {files.length === 0 ? t('action.selectPapers') : t('action.select')}
+          {files.length === 0 ? t('action.forwardPapers') : t('action.select')}
         </ActionMenuItemWrapper>
       )
     }

--- a/packages/cozy-mespapiers-lib/src/components/Actions/Items/select.js
+++ b/packages/cozy-mespapiers-lib/src/components/Actions/Items/select.js
@@ -16,7 +16,7 @@ export const select = ({ hideActionsMenu, addMultiSelectionFile }) => {
       return (
         <ActionMenuItemWrapper
           className={className}
-          icon="select-all"
+          icon="paperplane"
           onClick={() => {
             history.push({
               pathname: `/paper/multiselect`,

--- a/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from 'react'
+import PropTypes from 'prop-types'
 import uniqBy from 'lodash/uniqBy'
 
 import { isQueryLoading, useQueryAll, models } from 'cozy-client'
@@ -24,7 +25,7 @@ const {
   themes: { themesList }
 } = models.document
 
-const Home = () => {
+const Home = ({ setSelectedThemeLabel }) => {
   const [searchValue, setSearchValue] = useState('')
   const [selectedTheme, setSelectedTheme] = useState('')
   const { t } = useI18n()
@@ -108,7 +109,10 @@ const Home = () => {
           className="u-ph-1"
         />
       ) : (
-        <PaperGroup allPapersByCategories={filteredPapers} />
+        <PaperGroup
+          allPapersByCategories={filteredPapers}
+          setSelectedThemeLabel={setSelectedThemeLabel}
+        />
       )}
 
       {!isMultiSelectionActive && (
@@ -116,6 +120,10 @@ const Home = () => {
       )}
     </>
   )
+}
+
+Home.propTypes = {
+  setSelectedThemeLabel: PropTypes.func
 }
 
 export default Home

--- a/packages/cozy-mespapiers-lib/src/components/MoreOptions/MoreOptions.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/MoreOptions/MoreOptions.jsx
@@ -8,6 +8,7 @@ import CozyTheme from 'cozy-ui/transpiled/react/CozyTheme'
 
 import { makeActions } from '../Actions/utils'
 import { select } from '../Actions/Items/select'
+import { createPaper } from '../Actions/Items/createPaper'
 import ActionMenuWrapper from '../Actions/ActionMenuWrapper'
 import { ActionsItems } from '../Actions/ActionsItems'
 
@@ -20,7 +21,7 @@ const MoreOptions = () => {
   const hideActionsMenu = () => setGeneralOptions(false)
   const toggleActionsMenu = () => setGeneralOptions(prev => !prev)
 
-  const actions = makeActions([select], {
+  const actions = makeActions([createPaper, select], {
     client,
     hideActionsMenu
   })

--- a/packages/cozy-mespapiers-lib/src/components/Multiselect/MultiselectContent.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Multiselect/MultiselectContent.jsx
@@ -1,5 +1,4 @@
-import React from 'react'
-import { useHistory } from 'react-router-dom'
+import React, { useState } from 'react'
 
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
@@ -8,10 +7,11 @@ import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
 import GhostButton from './GhostButton'
 import PaperCardItem from '../Papers/PaperCardItem'
 import { useMultiSelection } from '../Hooks/useMultiSelection'
+import MultiselectPaperList from './MultiselectPaperList'
 
 const MultiselectContent = () => {
+  const [isActive, setIsActive] = useState(false)
   const { t } = useI18n()
-  const history = useHistory()
   const { multiSelectionFiles } = useMultiSelection()
 
   return (
@@ -34,8 +34,10 @@ const MultiselectContent = () => {
       <GhostButton
         label={t('Multiselect.select')}
         fullWidth
-        onClick={() => history.push(`/paper`)}
+        onClick={() => setIsActive(true)}
       />
+
+      {isActive && <MultiselectPaperList setIsActive={setIsActive} />}
     </div>
   )
 }

--- a/packages/cozy-mespapiers-lib/src/components/Multiselect/MultiselectContent.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Multiselect/MultiselectContent.jsx
@@ -1,11 +1,10 @@
 import React from 'react'
 import { useHistory } from 'react-router-dom'
 
-import Empty from 'cozy-ui/transpiled/react/Empty'
+import Typography from 'cozy-ui/transpiled/react/Typography'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
 
-import MultipapersIcon from '../../assets/icons/Multipapers.svg'
 import GhostButton from './GhostButton'
 import PaperCardItem from '../Papers/PaperCardItem'
 import { useMultiSelection } from '../Hooks/useMultiSelection'
@@ -18,12 +17,9 @@ const MultiselectContent = () => {
   return (
     <div className="u-mb-2 u-w-100">
       {multiSelectionFiles.length === 0 ? (
-        <Empty
-          className="u-ph-1 u-pt-0"
-          icon={MultipapersIcon}
-          iconSize="medium"
-          text={t('Multiselect.empty')}
-        />
+        <Typography variant="h6" className="u-mb-1">
+          {t('Multiselect.empty')}
+        </Typography>
       ) : (
         <List className="u-flex u-flex-column u-flex-justify-center">
           {multiSelectionFiles.map(file => (

--- a/packages/cozy-mespapiers-lib/src/components/Multiselect/MultiselectPaperList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Multiselect/MultiselectPaperList.jsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react'
+import { useHistory } from 'react-router-dom'
+import PropTypes from 'prop-types'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import { FixedDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+
+import Home from '../Home/Home'
+import PapersListWrapper from '../Papers/PapersListWrapper'
+import { useMultiSelection } from '../Hooks/useMultiSelection'
+
+const MultiselectPaperList = ({ setIsActive }) => {
+  const history = useHistory()
+  const [selectedThemeLabel, setSelectedThemeLabel] = useState(null)
+  const { t } = useI18n()
+  const { multiSelectionFiles, removeAllMultiSelectionFiles } =
+    useMultiSelection()
+
+  const title =
+    multiSelectionFiles.length > 0
+      ? t('Multiselect.title.nbSelected', {
+          smart_count: multiSelectionFiles.length
+        })
+      : t('Multiselect.title.default')
+
+  const cancelSelection = () => {
+    removeAllMultiSelectionFiles()
+    setIsActive(false)
+    setSelectedThemeLabel(null)
+  }
+
+  const goToCurrentSelectionList = () => {
+    setIsActive(false)
+    setSelectedThemeLabel(null)
+  }
+
+  const handleBack = () => {
+    selectedThemeLabel ? setSelectedThemeLabel(null) : setIsActive(false)
+  }
+
+  return (
+    <FixedDialog
+      open
+      transitionDuration={0}
+      disableGutters
+      onClose={() => setIsActive(false)}
+      onBack={handleBack}
+      title={title}
+      content={
+        !selectedThemeLabel ? (
+          <Home setSelectedThemeLabel={setSelectedThemeLabel} />
+        ) : (
+          <PapersListWrapper
+            history={history}
+            selectedThemeLabel={selectedThemeLabel}
+          />
+        )
+      }
+      actions={
+        <>
+          <Button
+            label={t('common.add')}
+            onClick={goToCurrentSelectionList}
+            disabled={multiSelectionFiles.length === 0}
+          />
+          <Button
+            label={t('common.cancel')}
+            variant="secondary"
+            onClick={cancelSelection}
+          />
+        </>
+      }
+    />
+  )
+}
+
+MultiselectPaperList.propTypes = {
+  setIsActive: PropTypes.func
+}
+
+export default MultiselectPaperList

--- a/packages/cozy-mespapiers-lib/src/components/Multiselect/MultiselectView.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Multiselect/MultiselectView.jsx
@@ -3,27 +3,13 @@ import { useHistory, useLocation } from 'react-router-dom'
 
 import { FixedDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
-import makeStyles from 'cozy-ui/transpiled/react/helpers/makeStyles'
 
 import MultiselectContent from './MultiselectContent'
 import MultiselectViewActions from './MultiselectViewActions'
 import { useMultiSelection } from '../Hooks/useMultiSelection'
 
-const useStyles = makeStyles({
-  paper: {
-    '& .dialogContentInner': {
-      padding: 0,
-      margin: 0,
-      height: '100%',
-      display: 'flex',
-      alignItems: 'center'
-    }
-  }
-})
-
 const MultiselectView = () => {
   const { t } = useI18n()
-  const classes = useStyles()
   const history = useHistory()
   const location = useLocation()
   const { setIsMultiSelectionActive } = useMultiSelection()
@@ -44,7 +30,6 @@ const MultiselectView = () => {
     <FixedDialog
       open
       transitionDuration={0}
-      classes={classes}
       onClose={handleClose}
       title={t('Multiselect.title')}
       content={<MultiselectContent />}

--- a/packages/cozy-mespapiers-lib/src/components/Multiselect/MultiselectView.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Multiselect/MultiselectView.jsx
@@ -31,7 +31,7 @@ const MultiselectView = () => {
       open
       transitionDuration={0}
       onClose={handleClose}
-      title={t('Multiselect.title')}
+      title={t('Multiselect.title.default')}
       content={<MultiselectContent />}
       actions={<MultiselectViewActions onClose={handleClose} />}
     />

--- a/packages/cozy-mespapiers-lib/src/components/Multiselect/MultiselectViewActions.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Multiselect/MultiselectViewActions.jsx
@@ -9,6 +9,8 @@ import Backdrop from 'cozy-ui/transpiled/react/Backdrop'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import { LinearProgress } from 'cozy-ui/transpiled/react/Progress'
 import makeStyles from 'cozy-ui/transpiled/react/helpers/makeStyles'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import Icon from 'cozy-ui/transpiled/react/Icon'
 
 import { downloadFiles, forwardFile, makeZipFolder } from '../Actions/utils'
 import { useMultiSelection } from '../Hooks/useMultiSelection'
@@ -42,6 +44,7 @@ const MultiselectViewActions = ({ onClose }) => {
   const client = useClient()
   const classes = useStyles()
   const { multiSelectionFiles } = useMultiSelection()
+  const { isMobile } = useBreakpoints()
   const [zipFolder, setZipFolder] = useState({ name: '', dirId: '' })
   const [isForwardModalOpen, setIsForwardModalOpen] = useState(false)
   const [isBackdropOpen, setIsBackdropOpen] = useState(false)
@@ -114,17 +117,22 @@ const MultiselectViewActions = ({ onClose }) => {
         </div>
       </Backdrop>
 
-      <Button
-        variant="secondary"
-        label={t('action.download')}
-        onClick={download}
-        disabled={multiSelectionFiles.length === 0}
-      />
+      {!isMobile ||
+        (isMobile && !navigator.share && (
+          <Button
+            variant="secondary"
+            label={t('action.download')}
+            startIcon={<Icon icon="download" />}
+            onClick={download}
+            disabled={multiSelectionFiles.length === 0}
+          />
+        ))}
 
-      {navigator.share && (
+      {isMobile && navigator.share && (
         <Button
           variant="secondary"
           label={t('action.forward')}
+          startIcon={<Icon icon="paperplane" />}
           onClick={forward}
           disabled={multiSelectionFiles.length === 0}
         />

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperCardItem.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperCardItem.jsx
@@ -26,7 +26,12 @@ const PaperCardItem = ({ paper, divider, className, square = false }) => {
 
   return (
     <Paper className={`u-h-3 ${className}`} square={square}>
-      <PaperItem paper={paper} divider={divider} classes={classes}>
+      <PaperItem
+        paper={paper}
+        divider={divider}
+        classes={classes}
+        withoutCheckbox
+      >
         <IconButton
           color="secondary"
           onClick={() => removeMultiSelectionFile(paper)}

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback } from 'react'
+import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import get from 'lodash/get'
 import { useHistory } from 'react-router-dom'
@@ -19,29 +19,31 @@ import { FileImageLoader } from 'cozy-ui/transpiled/react/FileImageLoader'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
 import { useScannerI18n } from '../Hooks/useScannerI18n'
+import { useMultiSelection } from '../Hooks/useMultiSelection'
 import { getLinksType } from '../../utils/getLinksType'
 
 const useStyles = makeStyles({
   root: { textIndent: '1rem' }
 })
 
-const PaperGroup = ({ allPapersByCategories }) => {
+const PaperGroup = ({ allPapersByCategories, setSelectedThemeLabel }) => {
   const classes = useStyles()
   const client = useClient()
   const { isMobile } = useBreakpoints()
   const history = useHistory()
   const { t } = useI18n()
   const scannerT = useScannerI18n()
+  const { isMultiSelectionActive } = useMultiSelection()
 
-  const goPapersList = useCallback(
-    category => {
+  const goPapersList = category => {
+    if (isMultiSelectionActive) {
+      setSelectedThemeLabel(category)
+    } else {
       history.push({
         pathname: `/paper/files/${category}`
       })
-    },
-    [history]
-  )
-
+    }
+  }
 
   return (
     <List>
@@ -102,7 +104,8 @@ const PaperGroup = ({ allPapersByCategories }) => {
 }
 
 PaperGroup.propTypes = {
-  allPapersByCategories: PropTypes.arrayOf(PropTypes.object)
+  allPapersByCategories: PropTypes.arrayOf(PropTypes.object),
+  setSelectedThemeLabel: PropTypes.func
 }
 
 export default PaperGroup

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
@@ -19,6 +19,7 @@ import { FileImageLoader } from 'cozy-ui/transpiled/react/FileImageLoader'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
 import { useScannerI18n } from '../Hooks/useScannerI18n'
+import { getLinksType } from '../../utils/getLinksType'
 
 const useStyles = makeStyles({
   root: { textIndent: '1rem' }
@@ -41,11 +42,6 @@ const PaperGroup = ({ allPapersByCategories }) => {
     [history]
   )
 
-  const getLinkType = useCallback(paper => {
-    const isImage = paper.class === 'image'
-    const isPdf = paper.class === 'pdf'
-    return isImage ? 'small' : isPdf ? 'icon' : undefined
-  }, [])
 
   return (
     <List>
@@ -72,7 +68,7 @@ const PaperGroup = ({ allPapersByCategories }) => {
                     <FileImageLoader
                       client={client}
                       file={paper}
-                      linkType={getLinkType(paper)}
+                      linkType={getLinksType(paper)}
                       render={src => (
                         <MuiCardMedia
                           component="img"

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperItem.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperItem.jsx
@@ -24,6 +24,7 @@ const PaperItem = ({
   divider,
   className = '',
   classes = {},
+  withoutCheckbox,
   children
 }) => {
   const { f, t } = useI18n()
@@ -63,6 +64,12 @@ const PaperItem = ({
         classes={classes}
         onClick={handleClick}
       >
+        {!withoutCheckbox && isMultiSelectionActive && (
+          <Checkbox
+            checked={multiSelectionFiles.some(file => file._id === paper._id)}
+            value={paper._id}
+          />
+        )}
         <ListItemIcon>
           <FileImageLoader
             client={client}

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperItem.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperItem.jsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from 'react'
+import React from 'react'
+import { useHistory } from 'react-router-dom'
 import PropTypes from 'prop-types'
 
 import { useClient } from 'cozy-client'
@@ -11,6 +12,9 @@ import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import CardMedia from 'cozy-ui/transpiled/react/CardMedia'
 import FileImageLoader from 'cozy-ui/transpiled/react/FileImageLoader'
+import Checkbox from 'cozy-ui/transpiled/react/Checkbox'
+
+import { getLinksType } from '../../utils/getLinksType'
 
 const validPageName = page => page === 'front' || page === 'back'
 
@@ -30,12 +34,6 @@ const PaperItem = ({
     ? f(paper?.metadata?.datetime, 'DD/MM/YYYY')
     : null
 
-  const linkType = useMemo(() => {
-    const isImage = paper.class === 'image'
-    const isPdf = paper.class === 'pdf'
-    return isImage ? 'small' : isPdf ? 'icon' : undefined
-  }, [paper.class])
-
   return (
     <>
       <ListItem
@@ -48,7 +46,7 @@ const PaperItem = ({
           <FileImageLoader
             client={client}
             file={paper}
-            linkType={linkType}
+            linkType={getLinksType(paper)}
             render={src => {
               return (
                 <CardMedia component="img" width={32} height={32} image={src} />

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperItem.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperItem.jsx
@@ -15,6 +15,7 @@ import FileImageLoader from 'cozy-ui/transpiled/react/FileImageLoader'
 import Checkbox from 'cozy-ui/transpiled/react/Checkbox'
 
 import { getLinksType } from '../../utils/getLinksType'
+import { useMultiSelection } from '../Hooks/useMultiSelection'
 
 const validPageName = page => page === 'front' || page === 'back'
 
@@ -23,16 +24,36 @@ const PaperItem = ({
   divider,
   className = '',
   classes = {},
-  onClick,
   children
 }) => {
   const { f, t } = useI18n()
   const client = useClient()
+  const history = useHistory()
+  const {
+    multiSelectionFiles,
+    isMultiSelectionActive,
+    removeMultiSelectionFile,
+    addMultiSelectionFile
+  } = useMultiSelection()
 
   const paperLabel = paper?.metadata?.qualification?.page
   const paperDate = paper?.metadata?.datetime
     ? f(paper?.metadata?.datetime, 'DD/MM/YYYY')
     : null
+
+  const handleClick = () => {
+    if (isMultiSelectionActive) {
+      const paperAlreadySelected = multiSelectionFiles.some(
+        file => file._id === paper._id
+      )
+      if (paperAlreadySelected) removeMultiSelectionFile(paper)
+      else addMultiSelectionFile(paper)
+    } else {
+      history.push({
+        pathname: `/paper/file/${paper.id}`
+      })
+    }
+  }
 
   return (
     <>
@@ -40,7 +61,7 @@ const PaperItem = ({
         button
         className={className}
         classes={classes}
-        onClick={onClick}
+        onClick={handleClick}
       >
         <ListItemIcon>
           <FileImageLoader

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperLine.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperLine.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useRef, memo } from 'react'
-import { useHistory } from 'react-router-dom'
 import PropTypes from 'prop-types'
 
 import { models } from 'cozy-client'
@@ -17,13 +16,12 @@ import { useMultiSelection } from '../Hooks/useMultiSelection'
 const { splitFilename } = models.file
 
 const PaperLine = ({ paper, divider, actions }) => {
-  const history = useHistory()
   const { isMobile } = useBreakpoints()
   const actionBtnRef = useRef()
 
   const [optionFile, setOptionFile] = useState(false)
 
-  const { isMultiSelectionActive, addMultiSelectionFile } = useMultiSelection()
+  const { isMultiSelectionActive } = useMultiSelection()
   const hideActionsMenu = () => setOptionFile(false)
   const toggleActionsMenu = () => setOptionFile(prev => !prev)
 
@@ -32,23 +30,9 @@ const PaperLine = ({ paper, divider, actions }) => {
     type: 'file'
   })
 
-  const handleClick = () => {
-    if (isMultiSelectionActive) {
-      addMultiSelectionFile(paper)
-      history.push({
-        pathname: `/paper/multiselect`,
-        search: `backgroundPath=/paper`
-      })
-    } else {
-      history.push({
-        pathname: `/paper/file/${paper.id}`
-      })
-    }
-  }
-
   return (
     <>
-      <PaperItem paper={paper} divider={divider} onClick={handleClick}>
+      <PaperItem paper={paper} divider={divider}>
         {!isMultiSelectionActive && (
           <IconButton ref={actionBtnRef} onClick={toggleActionsMenu}>
             <Icon icon="dots" />

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperLine.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperLine.jsx
@@ -8,7 +8,6 @@ import { ActionMenuHeader } from 'cozy-ui/transpiled/react/ActionMenu'
 import Filename from 'cozy-ui/transpiled/react/Filename'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import Radio from 'cozy-ui/transpiled/react/Radios'
 
 import { ActionsItems } from '../Actions/ActionsItems'
 import ActionMenuWrapper from '../Actions/ActionMenuWrapper'
@@ -50,9 +49,7 @@ const PaperLine = ({ paper, divider, actions }) => {
   return (
     <>
       <PaperItem paper={paper} divider={divider} onClick={handleClick}>
-        {isMultiSelectionActive ? (
-          <Radio onClick={handleClick} />
-        ) : (
+        {!isMultiSelectionActive && (
           <IconButton ref={actionBtnRef} onClick={toggleActionsMenu}>
             <Icon icon="dots" />
           </IconButton>

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PapersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PapersList.jsx
@@ -13,12 +13,14 @@ import { trash } from '../Actions/Items/trash'
 import { open } from '../Actions/Items/open'
 import { viewInDrive } from '../Actions/Items/viewInDrive'
 import { makeActionVariant, makeActions } from '../Actions/utils'
+import { useMultiSelection } from '../Hooks/useMultiSelection'
 
 const PapersList = ({ papers }) => {
   const client = useClient()
   const { t } = useI18n()
   const { pushModal, popModal } = useModal()
   const [maxDisplay, setMaxDisplay] = useState(papers.maxDisplay)
+  const { addMultiSelectionFile } = useMultiSelection()
 
   const actionVariant = makeActionVariant()
   const actions = useMemo(
@@ -27,11 +29,12 @@ const PapersList = ({ papers }) => {
         [select, hr, ...actionVariant, open, hr, viewInDrive, hr, trash],
         {
           client,
+          addMultiSelectionFile,
           pushModal,
           popModal
         }
       ),
-    [actionVariant, client, popModal, pushModal]
+    [actionVariant, client, addMultiSelectionFile, popModal, pushModal]
   )
 
   const handleClick = () => {

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PapersListWrapper.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PapersListWrapper.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 import { Redirect } from 'react-router-dom'
 import PropTypes from 'prop-types'
+import get from 'lodash/get'
 
 import { getReferencedBy, isQueryLoading, useQueryAll } from 'cozy-client'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
@@ -19,16 +20,14 @@ import { DEFAULT_MAX_FILES_DISPLAYED } from '../../constants/const'
 import { useMultiSelection } from '../Hooks/useMultiSelection'
 import PapersListToolbar from './PapersListToolbar'
 
-const PapersListWrapper = ({ history, match }) => {
+const PapersListWrapper = ({ history, match, selectedThemeLabel = null }) => {
   const scannerT = useScannerI18n()
   const { t } = useI18n()
   const { papersDefinitions } = usePapersDefinitions()
-  const { setIsMultiSelectionActive } = useMultiSelection()
+  const { setIsMultiSelectionActive, isMultiSelectionActive } =
+    useMultiSelection()
 
-  const currentFileTheme = useMemo(
-    () => match?.params?.fileTheme || null,
-    [match]
-  )
+  const currentFileTheme = get(match, 'params.fileTheme', selectedThemeLabel)
   const themeLabel = scannerT(`items.${currentFileTheme}`)
   const filesQueryByLabel = buildFilesQueryByLabel(currentFileTheme)
 
@@ -86,11 +85,13 @@ const PapersListWrapper = ({ history, match }) => {
 
   return (
     <>
-      <PapersListToolbar
-        title={themeLabel}
-        onBack={() => history.push('/paper')}
-        onClose={() => setIsMultiSelectionActive(false)}
-      />
+      {!isMultiSelectionActive && (
+        <PapersListToolbar
+          title={themeLabel}
+          onBack={() => history.push('/paper')}
+          onClose={() => setIsMultiSelectionActive(false)}
+        />
+      )}
 
       {paperslistByContact.length > 0 ? (
         <PapersListByContact paperslistByContact={paperslistByContact} />
@@ -110,7 +111,8 @@ PapersListWrapper.propTypes = {
     params: PropTypes.shape({
       fileTheme: PropTypes.string.isRequired
     })
-  })
+  }),
+  selectedThemeLabel: PropTypes.string
 }
 
 export default PapersListWrapper

--- a/packages/cozy-mespapiers-lib/src/components/PapersFab/PapersFab.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/PapersFab/PapersFab.jsx
@@ -1,14 +1,18 @@
-import React from 'react'
-import { useHistory } from 'react-router-dom'
+import React, { useState, useRef } from 'react'
 import cx from 'classnames'
 
+import { useClient } from 'cozy-client'
 import makeStyles from 'cozy-ui/transpiled/react/helpers/makeStyles'
-import { useLocation } from 'react-router-dom'
 import Fab from 'cozy-ui/transpiled/react/Fab'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 import withLocales from '../../locales/withLocales'
+import ActionMenuWrapper from '../Actions/ActionMenuWrapper'
+import { makeActions } from '../Actions/utils'
+import { ActionsItems } from '../Actions/ActionsItems'
+import { select } from '../Actions/Items/select'
+import { createPaper } from '../Actions/Items/createPaper'
 
 const useStyles = makeStyles(() => ({
   fab: {
@@ -20,28 +24,37 @@ const useStyles = makeStyles(() => ({
 }))
 
 const PapersFab = ({ t, className, ...props }) => {
+  const [generalOptions, setGeneralOptions] = useState(false)
+  const actionBtnRef = useRef()
   const { isDesktop } = useBreakpoints()
   const classes = useStyles(isDesktop)
-  const history = useHistory()
-  const { pathname } = useLocation()
+  const client = useClient()
 
-  const handleClick = () => {
-    history.push({
-      pathname: `/paper/create`,
-      search: `backgroundPath=${pathname}`
-    })
-  }
+  const hideActionsMenu = () => setGeneralOptions(false)
+  const toggleActionsMenu = () => setGeneralOptions(prev => !prev)
+  const actions = makeActions([createPaper, select], {
+    client,
+    hideActionsMenu
+  })
 
   return (
-    <Fab
-      color="primary"
-      aria-label={t('Home.Fab.ariaLabel')}
-      className={cx(classes.fab, className)}
-      onClick={handleClick}
-      {...props}
-    >
-      <Icon icon="plus" />
-    </Fab>
+    <>
+      <Fab
+        color="primary"
+        aria-label={t('Home.Fab.ariaLabel')}
+        className={cx(classes.fab, className)}
+        onClick={toggleActionsMenu}
+        {...props}
+      >
+        <Icon icon="plus" />
+      </Fab>
+
+      {generalOptions && (
+        <ActionMenuWrapper onClose={hideActionsMenu} ref={actionBtnRef}>
+          <ActionsItems actions={actions} />
+        </ActionMenuWrapper>
+      )}
+    </>
   )
 }
 

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -14,7 +14,7 @@
     "phoneDownload": "Make available offline",
     "qualify": "Qualify",
     "rename": "Rename",
-    "selectPapers": "Select papers…",
+    "forwardPapers": "Forward papers…",
     "select": "Select",
     "share": "Share",
     "trash": "Remove",
@@ -262,9 +262,9 @@
   },
   "Multiselect": {
     "backdrop": "Gather your papers...",
-    "title": "Select papers",
-    "empty": "Select papers to perform a bulk upload or download.",
-    "select": "Select or create a paper",
+    "title": "My Selection",
+    "empty": "Select the papers to be forwarded",
+    "select": "Add to my selection",
     "folderZipName": "%{contactName} - papers - %{date}.zip"
   }
 }

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -5,6 +5,7 @@
     "success": "The picture was taken."
   },
   "action": {
+    "createPaper": "Add a paper",
     "download": "Download",
     "forward": "Forward",
     "help": "Help",

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -23,6 +23,7 @@
     "viewInDrive": "View in Drive"
   },
   "common": {
+    "add": "Add",
     "cancel": "Cancel",
     "downloadFile": {
       "error": {
@@ -263,7 +264,10 @@
   },
   "Multiselect": {
     "backdrop": "Gather your papers...",
-    "title": "My Selection",
+    "title": {
+      "default": "My selection",
+      "nbSelected": "%{smart_count} selected item |||| %{smart_count} selected items"
+    },
     "empty": "Select the papers to be forwarded",
     "select": "Add to my selection",
     "folderZipName": "%{contactName} - papers - %{date}.zip"

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -6,7 +6,7 @@
   },
   "action": {
     "download": "Télécharger",
-    "forward": "Transférer",
+    "forward": "Transmettre",
     "help": "Aides",
     "installHomepage": "Installer sur l’accueil de mon mobile",
     "moveTo": "Déplacer vers…",
@@ -14,7 +14,7 @@
     "phoneDownload": "Rendre accessible hors-ligne",
     "qualify": "Qualifier",
     "rename": "Renommer",
-    "selectPapers": "Sélectionner des papiers…",
+    "forwardPapers": "Transmettre des papiers",
     "select": "Sélectionner",
     "share": "Partager",
     "trash": "Supprimer",
@@ -262,9 +262,9 @@
   },
   "Multiselect": {
     "backdrop": "Rassemblement de vos papiers...",
-    "title": "Sélectionner des papiers",
-    "empty": "Sélectionner des papiers pour effectuer un téléchargement ou un transfert groupé.",
-    "select": "Sélectionner ou créer un papier",
+    "title": "Ma Sélection",
+    "empty": "Sélectionner les papiers à transmettre",
+    "select": "Ajouter à ma sélection",
     "folderZipName": "%{contactName} - papiers - %{date}.zip"
   }
 }

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -23,6 +23,7 @@
     "viewInDrive": "Voir dans Drive"
   },
   "common": {
+    "add": "Ajouter",
     "cancel": "Annuler",
     "downloadFile": {
       "error": {
@@ -263,7 +264,10 @@
   },
   "Multiselect": {
     "backdrop": "Rassemblement de vos papiers...",
-    "title": "Ma Sélection",
+    "title": {
+      "default": "Ma sélection",
+      "nbSelected": "%{smart_count} élément sélectionné |||| %{smart_count} éléments sélectionnés"
+    },
     "empty": "Sélectionner les papiers à transmettre",
     "select": "Ajouter à ma sélection",
     "folderZipName": "%{contactName} - papiers - %{date}.zip"

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -5,6 +5,7 @@
     "success": "La photo a bien été prise."
   },
   "action": {
+    "createPaper": "Ajouter un papier",
     "download": "Télécharger",
     "forward": "Transmettre",
     "help": "Aides",

--- a/packages/cozy-mespapiers-lib/src/utils/getLinksType.js
+++ b/packages/cozy-mespapiers-lib/src/utils/getLinksType.js
@@ -1,0 +1,10 @@
+/**
+ * Get type of links to display the thumbnail
+ * @param {IOCozyFile} doc - An io.cozy.files document
+ * @returns {'small'|'icon'}
+ */
+export const getLinksType = doc => {
+  const isImage = doc.class === 'image'
+  const isPdf = doc.class === 'pdf'
+  return isImage ? 'small' : isPdf ? 'icon' : undefined
+}

--- a/packages/cozy-mespapiers-lib/src/utils/getLinksType.spec.js
+++ b/packages/cozy-mespapiers-lib/src/utils/getLinksType.spec.js
@@ -1,0 +1,19 @@
+import { getLinksType } from './getLinksType'
+
+describe('getLinksType', () => {
+  it('should return "small" string', () => {
+    const res = getLinksType({ _id: 0, class: 'image' })
+
+    expect(res).toBe('small')
+  })
+  it('should return "icon" string', () => {
+    const res = getLinksType({ _id: 1, class: 'pdf' })
+
+    expect(res).toBe('icon')
+  })
+  it('should return undefined', () => {
+    const res = getLinksType({ _id: 2, class: 'text' })
+
+    expect(res).toBeUndefined()
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -8424,10 +8424,10 @@ cozy-ui@62.1.2:
     react-select "^4.3.0"
     react-swipeable-views "^0.13.3"
 
-cozy-ui@^68.5.0:
-  version "68.5.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-68.5.0.tgz#f71ea35a39691e10977034a4dc795f12559700f3"
-  integrity sha512-wDGUpNJZiwf6r+h72I+IBsijD29DUlLIzGu16PserTX2hGoOruG3EsmsSiHIqGbTAK1VoPNdg1/gCEVWDEFRQg==
+cozy-ui@^68.8.0:
+  version "68.8.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-68.8.0.tgz#4112bfe2a2fde5cc22ae046683ff7230c0c5038f"
+  integrity sha512-HIsL3z0KZVeNzMSKDOTRxawUqehJDNZLAWM9VtbiS0DEpYJ5zYvWyyLi8CDJP6swv/6RuuH7KRO403iic8WWgQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"
@@ -15782,6 +15782,17 @@ msgpack5@^4.0.2:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
+
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
+  version "1.0.6"
+  uid "494c40416ecde95732c864f9b921e7e545075aa5"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
+  dependencies:
+    "@juggle/resize-observer" "^3.1.3"
+    jest-environment-jsdom-sixteen "^1.0.3"
+    react-spring "9.0.0-rc.3"
+    react-use-gesture "^7.0.8"
+    react-use-measure "^2.0.0"
 
 "mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
   version "1.0.6"


### PR DESCRIPTION
Avant:
Le mode de sélection ne permettait que de sélectionner des papiers un par un pour constituer une liste.
Hormis la liste de des fichiers sélectionnés, la navigation pour sélectionner un papier se faisait sans modale.
Les différents composants qui liste les papiers étaient contextualiser.

Après:
Le mode de sélection permet de sélectionner plusieurs papiers à la fois pour constituer une liste.
Tout le parcours se fait dans des modales, une pour lister la sélection en cours(déjà existante) et une autre pour naviguer.
La modale pour naviguer utilise les composants existants pour éviter un maximum de duplication.
Les différents composants qui liste les papiers reste contextualiser.

NB: Le temps alloué sur ce dev est déjà dépassé, du refactor est prévu sur des prochains dev touchant à ses parties 👍 