### PR TITLE
Manage of the display of filters by theme

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/Home.jsx
@@ -7,6 +7,10 @@ import Empty from 'cozy-ui/transpiled/react/Empty'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Box from 'cozy-ui/transpiled/react/Box'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import IconButton from 'cozy-ui/transpiled/react/IconButton'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import Badge from 'cozy-ui/transpiled/react/Badge'
+import makeStyles from 'cozy-ui/transpiled/react/helpers/makeStyles'
 
 import ThemesFilter from '../ThemesFilter'
 import SearchInput from '../SearchInput'
@@ -21,16 +25,29 @@ import HomeCloud from '../../assets/icons/HomeCloud.svg'
 import { filterPapersByThemeAndSearchValue } from './helpers'
 import HomeToolbar from './HomeToolbar'
 
+const useStyles = makeStyles(theme => ({
+  iconButton: {
+    color: theme.palette.text.icon,
+    boxShadow: theme.shadows[2],
+    backgroundColor: theme.palette.background.paper,
+    marginLeft: '1rem'
+  }
+}))
+
 const {
   themes: { themesList }
 } = models.document
 
 const Home = ({ setSelectedThemeLabel }) => {
+  const { isMultiSelectionActive } = useMultiSelection()
   const [searchValue, setSearchValue] = useState('')
+  const [isSearchValueFocus, setIsSearchValueFocus] = useState(
+    isMultiSelectionActive
+  )
   const [selectedTheme, setSelectedTheme] = useState('')
+  const styles = useStyles()
   const { t } = useI18n()
   const scannerT = useScannerI18n()
-  const { isMultiSelectionActive } = useMultiSelection()
   const { papersDefinitions } = usePapersDefinitions()
 
   const labels = papersDefinitions.map(paper => paper.label)
@@ -82,23 +99,41 @@ const Home = ({ setSelectedThemeLabel }) => {
     <>
       {isMultiSelectionActive && <HomeToolbar />}
 
-      {!isMultiSelectionActive && (
-        <div className="u-flex u-flex-column-s u-mv-1 u-ph-1">
-          <Box
-            className="u-flex u-flex-items-center u-mb-half-s"
-            flex="1 1 auto"
-          >
-            <SearchInput setSearchValue={setSearchValue} />
-          </Box>
-          <Box className="u-flex u-flex-justify-center" flexWrap="wrap">
+      <div className="u-flex u-flex-column-s u-mv-1 u-ph-1">
+        <Box className="u-flex u-flex-items-center u-mb-half-s" flex="1 1 auto">
+          <SearchInput
+            setSearchValue={setSearchValue}
+            setIsSearchValueFocus={setIsSearchValueFocus}
+          />
+          {isSearchValueFocus && (
+            <Badge
+              badgeContent={selectedTheme ? 1 : 0}
+              showZero={false}
+              color="primary"
+              variant="standard"
+              size="medium"
+            >
+              <IconButton
+                data-testid="SwitchButton"
+                className={styles.iconButton}
+                size="medium"
+                onClick={() => setIsSearchValueFocus(false)}
+              >
+                <Icon icon="setting" />
+              </IconButton>
+            </Badge>
+          )}
+        </Box>
+        <Box className="u-flex u-flex-justify-center" flexWrap="wrap">
+          {!isSearchValueFocus && (
             <ThemesFilter
               items={themesList}
               selectedTheme={selectedTheme}
               handleThemeSelection={handleThemeSelection}
             />
-          </Box>
-        </div>
-      )}
+          )}
+        </Box>
+      </div>
 
       {allPapersByCategories.length === 0 ? (
         <Empty

--- a/packages/cozy-mespapiers-lib/src/components/Home/Home.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/Home.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 
 import { isQueryLoading, useQueryAll } from 'cozy-client'
 
@@ -10,7 +10,6 @@ import { useMultiSelection } from '../Hooks/useMultiSelection'
 /* eslint-disable react/display-name */
 jest.mock('./HomeToolbar', () => () => <div data-testid="HomeToolbar" />)
 jest.mock('../ThemesFilter', () => () => <div data-testid="ThemesFilter" />)
-jest.mock('../SearchInput', () => () => <div data-testid="SearchInput" />)
 jest.mock('../Papers/PaperGroup', () => () => <div data-testid="PaperGroup" />)
 jest.mock('cozy-ui/transpiled/react/Empty', () => () => (
   <div data-testid="Empty" />
@@ -57,25 +56,6 @@ describe('Home components:', () => {
     jest.clearAllMocks()
   })
 
-  it('should be rendered correctly', () => {
-    const { container } = setup()
-
-    expect(container).toBeDefined()
-  })
-
-  it('should display only paperGroup in multi-selection mode', () => {
-    const { queryByTestId, getByTestId } = setup({
-      isLoading: false,
-      withData: true,
-      isMultiSelectionActive: true
-    })
-
-    expect(queryByTestId('ThemesFilter')).toBeNull()
-    expect(queryByTestId('SearchInput')).toBeNull()
-    expect(queryByTestId('FeaturedPlaceholdersList')).toBeNull()
-    expect(getByTestId('PaperGroup'))
-  })
-
   it('should display Spinner when all data are not loaded', () => {
     const { getByRole } = setup()
 
@@ -103,5 +83,103 @@ describe('Home components:', () => {
 
     expect(getByTestId('PaperGroup'))
     expect(queryByTestId('Empty')).toBeNull()
+  })
+
+  it('should display PaperGroup, SearchInput, ThemesFilter & FeaturedPlaceholdersList', () => {
+    const { getByTestId } = setup({
+      isLoading: false,
+      withData: true
+    })
+
+    expect(getByTestId('PaperGroup'))
+    expect(getByTestId('SearchInput'))
+    expect(getByTestId('ThemesFilter'))
+    expect(getByTestId('FeaturedPlaceholdersList'))
+  })
+
+  it('should display ThemesFilter by default', () => {
+    const { getByTestId } = setup({
+      isLoading: false,
+      withData: true
+    })
+
+    expect(getByTestId('ThemesFilter'))
+  })
+
+  it('should not display SwitchButton by default', () => {
+    const { queryByTestId } = setup({
+      isLoading: false,
+      withData: true
+    })
+
+    expect(queryByTestId('SwitchButton')).toBeNull()
+  })
+
+  it('should hide ThemesFilter when SearchInput is focused', () => {
+    const { queryByTestId, getByTestId } = setup({
+      isLoading: false,
+      withData: true
+    })
+
+    expect(getByTestId('ThemesFilter'))
+    fireEvent.focus(getByTestId('SearchInput'))
+    expect(queryByTestId('ThemesFilter')).toBeNull()
+  })
+
+  it('should display ThemesFilter when click on SwitchButton', () => {
+    const { queryByTestId, getByTestId } = setup({
+      isLoading: false,
+      withData: true
+    })
+    fireEvent.focus(getByTestId('SearchInput'))
+    expect(queryByTestId('ThemesFilter')).toBeNull()
+    fireEvent.click(getByTestId('SwitchButton'))
+    expect(getByTestId('ThemesFilter'))
+  })
+
+  it('should hide SwitchButton when click on it', () => {
+    const { queryByTestId, getByTestId } = setup({
+      isLoading: false,
+      withData: true
+    })
+
+    fireEvent.focus(getByTestId('SearchInput'))
+    expect(getByTestId('SwitchButton'))
+    fireEvent.click(getByTestId('SwitchButton'))
+    expect(queryByTestId('SwitchButton')).toBeNull()
+  })
+
+  describe('multi-selection mode', () => {
+    it('should display PaperGroup, SearchInput & SwitchButton', () => {
+      const { getByTestId } = setup({
+        isLoading: false,
+        withData: true,
+        isMultiSelectionActive: true
+      })
+
+      expect(getByTestId('PaperGroup'))
+      expect(getByTestId('SearchInput'))
+      expect(getByTestId('SwitchButton'))
+    })
+
+    it('should not display ThemesFilter by default', () => {
+      const { queryByTestId } = setup({
+        isLoading: false,
+        withData: true,
+        isMultiSelectionActive: true
+      })
+
+      expect(queryByTestId('ThemesFilter')).toBeNull()
+    })
+
+    it('should not display FeaturedPlaceholdersList', () => {
+      const { queryByTestId } = setup({
+        isLoading: false,
+        withData: true,
+        isMultiSelectionActive: true
+      })
+
+      expect(queryByTestId('FeaturedPlaceholdersList')).toBeNull()
+    })
   })
 })

--- a/packages/cozy-mespapiers-lib/src/components/SearchInput/SearchInput.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/SearchInput/SearchInput.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react'
+import PropTypes from 'prop-types'
 import debounce from 'lodash/debounce'
 
 import InputGroup from 'cozy-ui/transpiled/react/InputGroup'
@@ -24,7 +25,7 @@ const useStyles = makeStyles(theme => ({
   }
 }))
 
-const SearchInput = ({ setSearchValue }) => {
+const SearchInput = ({ setSearchValue, setIsSearchValueFocus }) => {
   const { t } = useI18n()
   const styles = useStyles()
 
@@ -48,9 +49,19 @@ const SearchInput = ({ setSearchValue }) => {
         />
       }
     >
-      <Input placeholder={t('common.search')} onChange={handleOnChange} />
+      <Input
+        data-testid="SearchInput"
+        placeholder={t('common.search')}
+        onChange={handleOnChange}
+        onFocus={() => setIsSearchValueFocus(true)}
+      />
     </InputGroup>
   )
+}
+
+SearchInput.propTypes = {
+  setSearchValue: PropTypes.func,
+  setIsSearchValueFocus: PropTypes.func
 }
 
 export default SearchInput


### PR DESCRIPTION
Au focus du `SearchInput`, `ThemesFilter` doit disparaitre et un `IconButton` apparait à côté du `SearchInput` pour permettre de ré-afficher `ThemesFilter`

En multi-sélection uniquement, `ThemesFilter` ne doit pas apparaitre par défaut, et l'`IconButton` doit être présent.