### PR TITLE
fix: bi webviews reconnection

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
@@ -142,6 +142,8 @@ const ConfigurationTab = ({
     await unshareCipher(vaultClient, account)
   }
 
+  const konnectorPolicy = findKonnectorPolicy(konnector)
+
   return (
     <div className={isMobile ? '' : 'u-pt-1 u-pb-1-half'}>
       {/**
@@ -172,7 +174,7 @@ const ConfigurationTab = ({
           {t('modal.updateAccount.general-subheader')}
         </NavigationListHeader>
         <NavigationListSection>
-          {konnector.oauth ? null : (
+          {konnector.oauth || konnectorPolicy.isBIWebView ? null : (
             <ListItem
               button
               divider

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.spec.jsx
@@ -15,6 +15,7 @@ import {
   useVaultClient
 } from 'cozy-keys-lib'
 import { findKonnectorPolicy } from '../../../konnector-policies'
+import flag from 'cozy-flags'
 
 jest.mock('../../../konnector-policies', () => ({
   findKonnectorPolicy: jest.fn()
@@ -211,11 +212,23 @@ describe('ConfigurationTab', () => {
     })
   })
 
-  it('should not render identifiers for oauth konnectors', () => {
+  it('should not render identifiers for oauthkonnectors', () => {
     useVaultClient.mockReturnValue({
       isLocked: jest.fn().mockResolvedValue(false)
     })
     const { root } = setup({ konnector: { oauth: true } })
     expect(root.queryByText('Identifiers')).toBe(null)
+  })
+
+  it('should not render identifiers for bi webview konnectors', () => {
+    useVaultClient.mockReturnValue({
+      isLocked: jest.fn().mockResolvedValue(false)
+    })
+    flag('harvest.bi.webview', true)
+    const { root } = setup({
+      konnector: { partnership: { domain: 'budget-insight.com' } }
+    })
+    expect(root.queryByText('Identifiers')).toBe(null)
+    flag('harvest.bi.webview', null)
   })
 })

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -87,8 +87,10 @@ export class DumbTriggerManager extends Component {
    * @param  {string}  accountId
    */
   async handleOAuthAccountId(accountId) {
-    const { client, flow, konnector, t } = this.props
-    let oAuthAccount = await fetchAccount(client, accountId)
+    const { client, flow, konnector, t, reconnect } = this.props
+    let oAuthAccount = reconnect
+      ? flow.account
+      : await fetchAccount(client, accountId)
 
     const konnectorPolicy = findKonnectorPolicy(konnector)
 
@@ -99,6 +101,7 @@ export class DumbTriggerManager extends Component {
         flow,
         konnector,
         client,
+        reconnect,
         t
       })
     }

--- a/packages/cozy-harvest-lib/src/helpers/oauth.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.js
@@ -21,8 +21,8 @@ export const OAUTH_REALTIME_CHANNEL = 'oauth-popup'
 export const checkOAuthData = (konnector, data) => {
   if (!data) return false
 
-  const { key, oAuthStateKey } = data
-  if (!key || !oAuthStateKey) return false
+  const { oAuthStateKey } = data
+  if (!oAuthStateKey) return false
 
   const accountType = konnectors.getAccountType(konnector)
 
@@ -41,10 +41,10 @@ export const checkOAuthData = (konnector, data) => {
  * @param  {Object} options.realtime (optional) : cozy-realtime instance used to notify the
  * resulting accountId to the origin harvest window after OAuth redirect
  *
- * We are supposed here to be in the OAuth popup, at the end of the process.
+ * We are supposed here to be in the OAuth popup or OAuth inAppBrowser, at the end of the process.
  *
  * We first check that we are actually getting the response we were expecting
- * for, and then we sent the account Id with postMessage
+ * for, and then we sent the account Id with postMessage if any
  *
  * This handler should be typically used in the OAuth popup the following way:
  * ```js
@@ -73,7 +73,6 @@ export const handleOAuthResponse = (options = {}) => {
   const queryParams = new URLSearchParams(window.location.search)
 
   const accountId = queryParams.get('account')
-  if (!accountId) return false
 
   /**
    * Key for localStorage, used at the beginning of the OAuth process to store

--- a/packages/cozy-harvest-lib/src/helpers/oauth.spec.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.spec.js
@@ -147,15 +147,6 @@ describe('Oauth helper', () => {
       expect(result).toBe(true)
     })
 
-    it('should return false when no account is present in query string', () => {
-      window.location = {
-        search: 'state=70720eb0-6204-484d'
-      }
-
-      const result = handleOAuthResponse({ realtime })
-      expect(result).toBe(false)
-    })
-
     it('should return false when no state is present in query string', () => {
       window.location = {
         search: 'account=bc2aca6566cf4a72afe6c615aa1e3d31'

--- a/packages/cozy-harvest-lib/src/services/biWebView.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.js
@@ -109,8 +109,14 @@ export const handleOAuthAccount = async ({
   flow,
   konnector,
   client,
+  reconnect,
   t
 }) => {
+  if (reconnect) {
+    // No need for specific action here. The trigger will be launched by the trigger manager
+    const connId = getBIConnectionIdFromAccount(account)
+    return connId
+  }
   const cozyBankIds = getCozyBankIds({ konnector, account })
   let biWebviewAccount = {
     ...account,

--- a/packages/cozy-harvest-lib/src/services/biWebView.spec.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.spec.js
@@ -78,6 +78,28 @@ describe('handleOAuthAccount', () => {
       }
     })
   })
+  it('should handle reconnection', async () => {
+    const client = new CozyClient({
+      uri: 'http://testcozy.mycozy.cloud'
+    })
+    const flow = new ConnectionFlow(client, null, konnector)
+    flow.account = account
+    flow.handleFormSubmit = jest.fn()
+    flow.saveAccount = jest.fn()
+    const account = { data: { auth: { bi: { connId: 15 } } } }
+    const t = jest.fn()
+    const result = await handleOAuthAccount({
+      account,
+      flow,
+      client,
+      konnector,
+      reconnect: true,
+      t
+    })
+    expect(flow.handleFormSubmit).not.toHaveBeenCalled()
+    expect(flow.saveAccount).not.toHaveBeenCalled()
+    expect(result).toEqual(15)
+  })
 })
 
 describe('checkBIConnection', () => {


### PR DESCRIPTION
Multiple fixes to the bi webview reconnection :

- Now checkOAuthData and handleOAuthResponse can handle calls without any account id when in reconnection case.
- Do not show identifiers with bi Webviews
- Still run the connector after a full reconnect
