### PR TITLE
fix(mespapiers-lib): Invalidate partial but non-empty values in optional masked inputs

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
@@ -92,9 +92,9 @@ const InputTextAdapter = ({
 
   const handleOnBlur = () => {
     setIsFocus(false)
-    if (currentValue.length > 0) {
+    if (isRequired || currentValue.length !== 0) {
       setIsTooShort(
-        expectedLength.min > 0 && currentValue.length < expectedLength.min
+        expectedLength.min != null && currentValue.length < expectedLength.min
       )
     } else setIsTooShort(false)
   }

--- a/packages/cozy-mespapiers-lib/src/utils/input.js
+++ b/packages/cozy-mespapiers-lib/src/utils/input.js
@@ -25,7 +25,7 @@ export const makeConstraintsOfInput = attrs => {
   const { type = '', required = false, mask } = attrs || {}
 
   const maskLength = mask?.replaceAll(/\s/g, '')?.length
-  const minLength = (required && maskLength) || (attrs?.minLength ?? null)
+  const minLength = maskLength ?? attrs?.minLength ?? null
   const maxLength = maskLength ?? attrs?.maxLength ?? null
   const acceptedTypes = ['number', 'text']
 

--- a/packages/cozy-mespapiers-lib/src/utils/input.js
+++ b/packages/cozy-mespapiers-lib/src/utils/input.js
@@ -12,12 +12,12 @@ import log from 'cozy-logger'
  * Make type and length properties
  * @param {MakeConstraintsOfInputParam} attrs - Definition of type & length of the input
  * @example
- * // For make input number with contraint length to 12
+ * // For make input number with contraint length to 0 or 12
  * makeConstraintsOfInput({ type: 'number', minLength: 12, maxLength: 12 })
  * // For make input text with no contraint length
  * makeConstraintsOfInput()
- * // For make input number with contraint length to 12 & required & size to 15
- * makeConstraintsOfInput({ type: 'number', required: true, minLength: 12, maxLength: 12, size: 15 })
+ * // For make input number with contraint length to 12
+ * makeConstraintsOfInput({ type: 'number', required: true, minLength: 12, maxLength: 12 })
  *
  * @returns {{ inputType: string, expectedLength: { min: number, max: number }, isRequired: boolean }}
  */

--- a/packages/cozy-mespapiers-lib/src/utils/input.js
+++ b/packages/cozy-mespapiers-lib/src/utils/input.js
@@ -63,8 +63,8 @@ export const checkConstraintsOfIinput = (
   const { min, max } = expectedLength
 
   return [
-    valueLength >= min,
-    max > 0 ? valueLength <= max : true,
-    isRequired ? valueLength > 0 : true
+    valueLength !== 0 || !isRequired,
+    valueLength === 0 || min == null || valueLength >= min,
+    valueLength === 0 || max == null || valueLength <= max
   ].every(Boolean)
 }

--- a/packages/cozy-mespapiers-lib/src/utils/input.spec.js
+++ b/packages/cozy-mespapiers-lib/src/utils/input.spec.js
@@ -5,8 +5,8 @@ describe('Input Utils', () => {
     it.each`
       attrs                                                                | result
       ${{ type: 'number' }}                                                | ${{ inputType: 'number', expectedLength: { min: null, max: null }, isRequired: false }}
-      ${{ type: 'number', mask: '99999' }}                                 | ${{ inputType: 'number', expectedLength: { min: null, max: 5 }, isRequired: false }}
-      ${{ type: 'number', mask: '99999', minLength: 3, maxLength: 7 }}     | ${{ inputType: 'number', expectedLength: { min: 3, max: 5 }, isRequired: false }}
+      ${{ type: 'number', mask: '99999' }}                                 | ${{ inputType: 'number', expectedLength: { min: 5, max: 5 }, isRequired: false }}
+      ${{ type: 'number', mask: '99999', minLength: 3, maxLength: 7 }}     | ${{ inputType: 'number', expectedLength: { min: 5, max: 5 }, isRequired: false }}
       ${{ type: 'number', mask: '99999', required: true }}                 | ${{ inputType: 'number', expectedLength: { min: 5, max: 5 }, isRequired: true }}
       ${{ type: 'number', mask: '99 99 99 99 99', required: true }}        | ${{ inputType: 'number', expectedLength: { min: 10, max: 10 }, isRequired: true }}
       ${{ type: 'number', mask: '99999', required: true, minLength: 3 }}   | ${{ inputType: 'number', expectedLength: { min: 5, max: 5 }, isRequired: true }}
@@ -20,8 +20,8 @@ describe('Input Utils', () => {
       ${{ type: 'number', required: true, minLength: 20, maxLength: 10 }}  | ${{ inputType: 'number', expectedLength: { min: 20, max: 10 }, isRequired: true }}
       ${undefined}                                                         | ${{ inputType: 'text', expectedLength: { min: null, max: null }, isRequired: false }}
       ${{ type: 'text' }}                                                  | ${{ inputType: 'text', expectedLength: { min: null, max: null }, isRequired: false }}
-      ${{ type: 'text', mask: 'aaaaa' }}                                   | ${{ inputType: 'text', expectedLength: { min: null, max: 5 }, isRequired: false }}
-      ${{ type: 'text', mask: 'aaaaa', minLength: 3, maxLength: 7 }}       | ${{ inputType: 'text', expectedLength: { min: 3, max: 5 }, isRequired: false }}
+      ${{ type: 'text', mask: 'aaaaa' }}                                   | ${{ inputType: 'text', expectedLength: { min: 5, max: 5 }, isRequired: false }}
+      ${{ type: 'text', mask: 'aaaaa', minLength: 3, maxLength: 7 }}       | ${{ inputType: 'text', expectedLength: { min: 5, max: 5 }, isRequired: false }}
       ${{ type: 'text', mask: 'aaaaa', required: true }}                   | ${{ inputType: 'text', expectedLength: { min: 5, max: 5 }, isRequired: true }}
       ${{ type: 'text', mask: 'aa aa aa aa aa', required: true }}          | ${{ inputType: 'text', expectedLength: { min: 10, max: 10 }, isRequired: true }}
       ${{ type: 'text', mask: 'aaaaa', required: true, minLength: 3 }}     | ${{ inputType: 'text', expectedLength: { min: 5, max: 5 }, isRequired: true }}

--- a/packages/cozy-mespapiers-lib/src/utils/input.spec.js
+++ b/packages/cozy-mespapiers-lib/src/utils/input.spec.js
@@ -54,10 +54,10 @@ describe('Input Utils', () => {
       ${0}        | ${{ min: 0, max: 0 }}       | ${true}    | ${false}
       ${0}        | ${{ min: null, max: 20 }}   | ${false}   | ${true}
       ${0}        | ${{ min: null, max: 20 }}   | ${true}    | ${false}
-      ${0}        | ${{ min: 20, max: null }}   | ${false}   | ${false}
+      ${0}        | ${{ min: 20, max: null }}   | ${false}   | ${true}
       ${0}        | ${{ min: 20, max: null }}   | ${true}    | ${false}
-      ${0}        | ${{ min: 10, max: 30 }}     | ${false}   | ${false}
-      ${0}        | ${{ min: 30, max: 10 }}     | ${false}   | ${false}
+      ${0}        | ${{ min: 10, max: 30 }}     | ${false}   | ${true}
+      ${0}        | ${{ min: 30, max: 10 }}     | ${false}   | ${true}
       ${0}        | ${{ min: 10, max: 30 }}     | ${true}    | ${false}
       ${0}        | ${{ min: 30, max: 10 }}     | ${true}    | ${false}
       ${10}       | ${{ min: 10, max: 30 }}     | ${true}    | ${true}


### PR DESCRIPTION
#1695 allowed masked inputs to be optional: the value could be either empty, partial or full, as long as it matched the start of the mask.
This PR restricts this set by disallowing partial values: now only the empty string (for optional inputs) and values that match and fill the entire mask are valid.