### PR TITLE
Feat/improve paper fab

### DIFF
--- a/packages/cozy-mespapiers-lib/README.md
+++ b/packages/cozy-mespapiers-lib/README.md
@@ -101,52 +101,52 @@ const AppRouter = () => {
 }
 ```
 
-Then inside your route component, you have to import exposed components from `cozy-mespapiers-lib`.
-:warning: You have to pass the `lang` prop of the application so that it uses the right locales files.
+Then inside your route component, you have to import exposed component from `cozy-mespapiers-lib`.
+:warning: You must pass it the `lang` prop of the application so that it uses the right locales files.
 
-Here an example with overrided style of `PapersFab`:
+You can also overload some components (currently only the `PapersFab` component) or not use them.
+
+Here some examples:
+
+***
+
+- Default usage
 
 ```jsx
-/* global cozy */
+<MesPapiers {...props} lang={lang} />
+```
 
-import React from 'react'
+***
 
-import MesPapiers, { PapersFab } from 'cozy-mespapiers-lib'
-import makeStyles from 'cozy-ui/transpiled/react/helpers/makeStyles'
-import { useI18n } from 'cozy-ui/transpiled/react/I18n'
-import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
-import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
-import BarTitle from 'cozy-ui/transpiled/react/BarTitle'
+- PapersFab overloaded
 
-const useStyles = makeStyles({
-  root: {
-    bottom: ({ isDesktop }) =>
-      isDesktop ? '1rem' : 'calc(var(--sidebarHeight) + 1rem)'
-  }
-})
-
-const MesPapiersView = props => {
-  const { lang } = useI18n()
-  const { isDesktop, isMobile } = useBreakpoints()
-  const styles = useStyles({ isDesktop })
-  const { BarCenter } = cozy.bar
-
+```jsx
+const CustomFab = ({ onClick }) => {
   return (
-    <>
-      {isMobile && (
-        <BarCenter>
-          <MuiCozyTheme>
-            <BarTitle>My Title</BarTitle>
-          </MuiCozyTheme>
-        </BarCenter>
-      )}
-      <MesPapiers {...props} lang={lang} />
-      <PapersFab classes={{ root: styles.root }} />
-    </>
+    <Button
+      label="Custom btn"
+      onClick={onClick}
+    />
   )
 }
 
-export default MesPapiersView
+<MesPapiers
+  {...props}
+  lang={lang}
+  components={{ PapersFab: CustomFab }}
+/>
+```
+
+***
+
+- PapersFab unused
+
+```jsx
+<MesPapiers
+  {...props}
+  lang={lang}
+  components={{ PapersFab: null }}
+/>
 ```
 
 # Call modal with URL
@@ -164,6 +164,8 @@ const handleClick = () => {
   })
 }
 ```
+
+***
 
 ## Development
 

--- a/packages/cozy-mespapiers-lib/src/components/MesPapiersLib.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/MesPapiersLib.jsx
@@ -15,6 +15,8 @@ import { MultiSelectionProvider } from './Contexts/MultiSelectionProvider'
 import { AppRouter } from './AppRouter'
 import { usePapersDefinitions } from './Hooks/usePapersDefinitions'
 import MoreOptions from './MoreOptions/MoreOptions'
+import { getComponents } from '../helpers/defaultComponent'
+import PapersFabWrapper from './PapersFab/PapersFabWrapper'
 
 const App = () => {
   const { t } = useI18n()
@@ -50,8 +52,9 @@ const App = () => {
   )
 }
 
-const MesPapiersLib = ({ lang }) => {
+const MesPapiersLib = ({ lang, components }) => {
   const polyglot = initTranslation(lang, lang => require(`../locales/${lang}`))
+  const { PapersFab } = getComponents(components)
 
   return (
     <I18n lang={lang} polyglot={polyglot}>
@@ -60,6 +63,11 @@ const MesPapiersLib = ({ lang }) => {
           <PapersDefinitionsProvider>
             <ModalProvider>
               <App />
+              {PapersFab && (
+                <PapersFabWrapper>
+                  <PapersFab />
+                </PapersFabWrapper>
+              )}
             </ModalProvider>
           </PapersDefinitionsProvider>
         </ScannerI18nProvider>

--- a/packages/cozy-mespapiers-lib/src/components/MesPapiersLib.test.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/MesPapiersLib.test.jsx
@@ -20,6 +20,9 @@ jest.mock('cozy-client', () => ({
   ...jest.requireActual('cozy-client'),
   RealTimeQueries: () => <div data-testid="RealTimeQueries" />
 }))
+jest.mock('./PapersFab/PapersFabWrapper', () => () => (
+  <div data-testid="PapersFabWrapper" />
+))
 jest.mock('./AppRouter', () => ({
   AppRouter: () => <div data-testid="AppRouter" />
 }))
@@ -35,7 +38,8 @@ const setup = ({
   isFlag = false,
   papersDefinitions = [],
   customPapersDefinitions = { isLoaded: true, name: '' },
-  isStepperDialogOpen = false
+  isStepperDialogOpen = false,
+  components
 } = {}) => {
   flag.mockReturnValue(isFlag)
   useStepperDialog.mockReturnValue({ isStepperDialogOpen })
@@ -46,7 +50,7 @@ const setup = ({
 
   return render(
     <AppLike>
-      <MesPapiersLib />
+      <MesPapiersLib {...(components && { components: components })} />
     </AppLike>
   )
 }
@@ -88,5 +92,17 @@ describe('MesPapiersLib', () => {
     expect(queryAllByTestId('RealTimeQueries')).toHaveLength(2)
     expect(queryByTestId('Alerter')).toBeTruthy()
     expect(queryByTestId('ModalStack')).toBeTruthy()
+  })
+
+  it('should display PapersFabWrapper & PapersFab by default', () => {
+    const { getByTestId } = setup()
+
+    expect(getByTestId('PapersFabWrapper'))
+  })
+
+  it('should not display PapersFabWrapper & PapersFab', () => {
+    const { queryByTestId } = setup({ components: { PapersFab: null } })
+
+    expect(queryByTestId('PapersFabWrapper')).toBeNull()
   })
 })

--- a/packages/cozy-mespapiers-lib/src/components/PapersFab/PapersFab.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/PapersFab/PapersFab.jsx
@@ -1,18 +1,13 @@
-import React, { useState, useRef } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import cx from 'classnames'
 
-import { useClient } from 'cozy-client'
 import makeStyles from 'cozy-ui/transpiled/react/helpers/makeStyles'
 import Fab from 'cozy-ui/transpiled/react/Fab'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 import withLocales from '../../locales/withLocales'
-import ActionMenuWrapper from '../Actions/ActionMenuWrapper'
-import { makeActions } from '../Actions/utils'
-import { ActionsItems } from '../Actions/ActionsItems'
-import { select } from '../Actions/Items/select'
-import { createPaper } from '../Actions/Items/createPaper'
 
 const useStyles = makeStyles(() => ({
   fab: {
@@ -24,39 +19,24 @@ const useStyles = makeStyles(() => ({
 }))
 
 const PapersFab = ({ t, className, ...props }) => {
-  const [generalOptions, setGeneralOptions] = useState(false)
-  const actionBtnRef = useRef()
   const { isDesktop } = useBreakpoints()
   const classes = useStyles(isDesktop)
-  const client = useClient()
-
-  const hideActionsMenu = () => setGeneralOptions(false)
-  const toggleActionsMenu = () => setGeneralOptions(prev => !prev)
-  const actions = makeActions([createPaper, select], {
-    client,
-    hideActionsMenu
-  })
 
   return (
-    <>
-      <Fab
-        color="primary"
-        aria-label={t('Home.Fab.ariaLabel')}
-        className={cx(classes.fab, className)}
-        onClick={toggleActionsMenu}
-        ref={actionBtnRef}
-        {...props}
-      >
-        <Icon icon="plus" />
-      </Fab>
-
-      {generalOptions && (
-        <ActionMenuWrapper onClose={hideActionsMenu} ref={actionBtnRef}>
-          <ActionsItems actions={actions} />
-        </ActionMenuWrapper>
-      )}
-    </>
+    <Fab
+      color="primary"
+      aria-label={t('Home.Fab.ariaLabel')}
+      className={cx(classes.fab, className)}
+      {...props}
+    >
+      <Icon icon="plus" />
+    </Fab>
   )
+}
+
+PapersFab.propTypes = {
+  className: PropTypes.string,
+  t: PropTypes.func
 }
 
 export default withLocales(PapersFab)

--- a/packages/cozy-mespapiers-lib/src/components/PapersFab/PapersFabWrapper.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/PapersFab/PapersFabWrapper.jsx
@@ -1,0 +1,49 @@
+import React, { cloneElement, useRef, useState } from 'react'
+import PropTypes from 'prop-types'
+
+import { useClient } from 'cozy-client'
+
+import ActionMenuWrapper from '../Actions/ActionMenuWrapper'
+import { ActionsItems } from '../Actions/ActionsItems'
+import { makeActions } from '../Actions/utils'
+import { createPaper } from '../Actions/Items/createPaper'
+import { select } from '../Actions/Items/select'
+
+const PapersFabWrapper = ({ children }) => {
+  const [generalOptions, setGeneralOptions] = useState(false)
+  const actionBtnRef = useRef()
+  const client = useClient()
+
+  const hideActionsMenu = () => setGeneralOptions(false)
+  const toggleActionsMenu = () => {
+    setGeneralOptions(prev => !prev)
+  }
+  const actions = makeActions([createPaper, select], {
+    client,
+    hideActionsMenu
+  })
+
+  if (!children) return null
+
+  const PapersFabOverrided = cloneElement(children, {
+    onClick: toggleActionsMenu
+  })
+
+  return (
+    <>
+      {PapersFabOverrided}
+
+      {generalOptions && (
+        <ActionMenuWrapper onClose={hideActionsMenu} ref={actionBtnRef}>
+          <ActionsItems actions={actions} />
+        </ActionMenuWrapper>
+      )}
+    </>
+  )
+}
+
+PapersFabWrapper.propTypes = {
+  children: PropTypes.node
+}
+
+export default PapersFabWrapper

--- a/packages/cozy-mespapiers-lib/src/components/PapersFab/PapersFabWrapper.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/PapersFab/PapersFabWrapper.spec.jsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { fireEvent, render } from '@testing-library/react'
+
+import PapersFabWrapper from './PapersFabWrapper'
+import AppLike from '../../../test/components/AppLike'
+
+/* eslint-disable react/display-name */
+jest.mock('../Actions/ActionMenuWrapper', () => () => (
+  <div data-testid="ActionMenuWrapper" />
+))
+/* eslint-enable react/display-name */
+const MockChild = ({ onClick }) => (
+  <button onClick={onClick} data-testid="MockChild" />
+)
+
+const setup = ({ withChild } = {}) => {
+  return render(
+    <AppLike>
+      <PapersFabWrapper data-testid="PapersFabWrapper">
+        {withChild && <MockChild />}
+      </PapersFabWrapper>
+    </AppLike>
+  )
+}
+
+describe('PapersFabWrapper', () => {
+  it('should not display if have not child', () => {
+    const { queryByTestId } = setup({ withChild: false })
+
+    expect(queryByTestId('PapersFabWrapper')).toBeNull()
+  })
+
+  it('should display a child', () => {
+    const { getByTestId } = setup({ withChild: true })
+
+    expect(getByTestId('MockChild'))
+  })
+
+  it('should display ActionMenuWrapper if click on child', () => {
+    const { getByTestId } = setup({ withChild: true })
+
+    const btn = getByTestId('MockChild')
+    fireEvent.click(btn)
+
+    expect(getByTestId('ActionMenuWrapper'))
+  })
+})

--- a/packages/cozy-mespapiers-lib/src/helpers/defaultComponent.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/defaultComponent.js
@@ -1,0 +1,14 @@
+import PapersFab from '../components/PapersFab/PapersFab'
+
+const defaultComponents = {
+  PapersFab
+}
+
+export const getComponents = components => {
+  return {
+    PapersFab:
+      components?.PapersFab || components?.PapersFab === null
+        ? components.PapersFab
+        : defaultComponents.PapersFab
+  }
+}

--- a/packages/cozy-mespapiers-lib/src/index.js
+++ b/packages/cozy-mespapiers-lib/src/index.js
@@ -1,2 +1,1 @@
 export { default } from './components/MesPapiersLib'
-export { default as PapersFab } from './components/PapersFab/PapersFab'


### PR DESCRIPTION
Aujourd'hui le composant `PapersFab` est exporté à part du composant `MesPapiersLib`.
Cela est une erreur, mise en avant avec cette PR https://github.com/cozy/cozy-libs/pull/1709.

Outre le fait qu'il est limité dans ces actions, les applications désirants utiliser un autre bouton perdent alors toute la logique implémenté dans le `PapersFab`.

Ce composant doit être implémenté dans la lib et profiter des contextes de cette dernière.
Il doit également pouvoir être "remplacé" (besoin sur certaines app), sans perdre sa logique interne.

Voici une première proposition, ce changement impliquera un BC au niveau des applications qui l'utilisent, pour exemple:
Avant
```js
// Utilisation par défaut
<>
  <MesPapiers {...props} lang={lang} />
  <PapersFab />
</>

// Utilisation d'un composant qui remplace "PapersFab" (perd la logique de ce dernier)
const CustomFab = () => {
  const onClick = () => someAction()

  return (
    <Button
      label="Custom btn"
      onClick={onClick}
    />
  )
}

<>
  <MesPapiers {...props} lang={lang} />
  <CustomFab />
</>
```
Après
```js
// Utilisation par défaut
<MesPapiers {...props} lang={lang} />

// Utilisation d'un composant qui remplace "PapersFab" (sans perdre la logique de ce dernier)
const CustomFab = ({ onClick }) => {
  return (
    <Button
      label="Custom btn"
      onClick={onClick}
    />
  )
}

<MesPapiers
  {...props}
  lang={lang}
  components={{ PapersFab: CustomFab }}
/>

// App ne souhaitant pas utiliser de bouton
<MesPapiers
  {...props}
  lang={lang}
  components={{ PapersFab: null }}
/>
``` 