### PR TITLE
feat: Add warning logs when banking.warn-on-delete flag is activated

### DIFF
--- a/packages/cozy-doctypes/jest.config.js
+++ b/packages/cozy-doctypes/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'jest-environment-jsdom-sixteen'
+}

--- a/packages/cozy-doctypes/package.json
+++ b/packages/cozy-doctypes/package.json
@@ -21,6 +21,7 @@
     "btoa": "1.2.1",
     "cozy-client": "13.21.0",
     "cozy-client-js": "0.19.0",
+    "cozy-flags": "^2.9.0",
     "cozy-stack-client": "13.20.2",
     "eslint-plugin-node": "10.0.0",
     "fs-extra": "8.1.0",
@@ -31,6 +32,7 @@
   "peerDependencies": {
     "@babel/runtime": ">=7.12.5",
     "cozy-client": ">=13.15.1",
+    "cozy-flags": ">=2.3.5",
     "cozy-stack-client": ">=13.15.1"
   },
   "scripts": {

--- a/packages/cozy-doctypes/package.json
+++ b/packages/cozy-doctypes/package.json
@@ -25,6 +25,7 @@
     "eslint-plugin-node": "10.0.0",
     "fs-extra": "8.1.0",
     "jest": "26.6.3",
+    "jest-environment-jsdom-sixteen": "1.0.3",
     "mockdate": "2.0.5"
   },
   "peerDependencies": {

--- a/packages/cozy-doctypes/src/banking/BankTransaction.spec.js
+++ b/packages/cozy-doctypes/src/banking/BankTransaction.spec.js
@@ -1,17 +1,25 @@
 const BankTransaction = require('./BankTransaction')
+const flag = require('cozy-flags').default
+jest.mock('../Document')
+const Document = require('../Document')
+jest.mock('../log')
+const log = require('../log')
 
 const testTransactions = [
   {
+    _id: 'testid37',
     amount: -10,
     originalBankLabel: 'Test 01',
     date: '2018-10-02'
   },
   {
+    _id: 'testid378',
     amount: -20,
     originalBankLabel: 'Test 02',
     date: '2018-10-05'
   },
   {
+    _id: 'testid30',
     amount: -30,
     originalBankLabel: 'Test 03',
     date: '2018-10-06'
@@ -190,6 +198,24 @@ describe('reconciliation', () => {
     expect(trackEvent).not.toHaveBeenCalledWith({
       e_a: 'ReconciliateSplitDate'
     })
+  })
+})
+
+describe('deleteAll', () => {
+  it('should log a warning with id of deleted documents', () => {
+    log.mockReset()
+    flag('banking.warn-on-delete', true)
+    BankTransaction.deleteAll(testTransactions)
+    flag('banking.warn-on-delete', null)
+    expect(Document.deleteAll).toHaveBeenCalledTimes(1)
+    expect(log).toHaveBeenCalledWith(
+      'warn',
+      `OPERATION_DELETE: removing operations with _id : ${JSON.stringify([
+        'testid37',
+        'testid378',
+        'testid30'
+      ])}`
+    )
   })
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5323,6 +5323,11 @@ add-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
   integrity sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=
 
+add@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/add/-/add-2.0.6.tgz#248f0a9f6e5a528ef2295dbeec30532130ae2235"
+  integrity sha512-j5QzrmsokwWWp6kUcJQySpbG+xfOBqqKnup3OIk1pz+kB/80SLorZ9V8zHFLO92Lcd+hbvq8bT+zOGoPkmBV0Q==
+
 address@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/address/-/address-1.1.0.tgz#ef8e047847fcd2c5b6f50c16965f924fd99fe709"
@@ -22866,6 +22871,11 @@ yargs@^8.0.2:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^7.0.0"
+
+yarn@^1.22.19:
+  version "1.22.19"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.19.tgz#4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
+  integrity sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==
 
 yn@3.1.1:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5323,11 +5323,6 @@ add-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
   integrity sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=
 
-add@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/add/-/add-2.0.6.tgz#248f0a9f6e5a528ef2295dbeec30532130ae2235"
-  integrity sha512-j5QzrmsokwWWp6kUcJQySpbG+xfOBqqKnup3OIk1pz+kB/80SLorZ9V8zHFLO92Lcd+hbvq8bT+zOGoPkmBV0Q==
-
 address@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/address/-/address-1.1.0.tgz#ef8e047847fcd2c5b6f50c16965f924fd99fe709"
@@ -22871,11 +22866,6 @@ yargs@^8.0.2:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^7.0.0"
-
-yarn@^1.22.19:
-  version "1.22.19"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.19.tgz#4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
-  integrity sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
We may use this flag with ration to investigate missing transactions
while not generating too many logs