### PR TITLE
fix: Do not show an error message when the trigger is running

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModal.jsx
@@ -58,24 +58,7 @@ export class AccountModal extends Component {
   }
 
   async componentDidUpdate(prevProps) {
-    const { accountId, accountsAndTriggers } = this.props
-    const matchingTrigger = get(
-      accountsAndTriggers.find(
-        accountAndTrigger => accountAndTrigger.account._id === accountId
-      ),
-      'trigger'
-    )
-
-    const hasTriggerStatusChanged =
-      matchingTrigger &&
-      this.state.trigger &&
-      matchingTrigger?.current_state?.status !==
-        this.state.trigger?.current_state?.status
-
-    if (
-      this.props.accountId !== prevProps.accountId ||
-      hasTriggerStatusChanged
-    ) {
+    if (this.props.accountId !== prevProps.accountId) {
       return await this.loadSelectedAccountId()
     }
   }

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -637,16 +637,17 @@ export class ConnectionFlow {
     const trigger = this.trigger
     const { status, accountError } = this.state
     const triggerError = triggersModel.getKonnectorJobError(trigger)
+    const running =
+      get(trigger, 'current_state.status') === 'running' ||
+      ![ERRORED, IDLE, SUCCESS].includes(status)
     return {
-      running:
-        get(trigger, 'current_state.status') === 'running' ||
-        ![ERRORED, IDLE, SUCCESS].includes(status),
+      running,
       twoFARunning: status === RUNNING_TWOFA,
       twoFARetry: status == TWO_FA_MISMATCH,
       triggerError: triggerError,
       trigger,
       accountError,
-      error: this.getMockError() || accountError || triggerError,
+      error: !running && (this.getMockError() || accountError || triggerError),
       konnectorRunning: triggersModel.isKonnectorRunning(trigger)
     }
   }

--- a/packages/cozy-harvest-lib/test/fixtures.js
+++ b/packages/cozy-harvest-lib/test/fixtures.js
@@ -125,6 +125,23 @@ const fixtures = {
       }
     }
   },
+  erroredTrigger: {
+    id: 'errored-trigger-id',
+    _type: 'io.cozy.triggers',
+    current_state: {
+      status: 'errored',
+      last_error: 'last error message'
+    },
+    attributes: {
+      arguments: '0 0 0 * * 0',
+      type: '@cron',
+      worker: 'konnector',
+      message: {
+        account: 'updated-account-id',
+        konnector: 'konnectest'
+      }
+    }
+  },
   runningTrigger: {
     id: 'running-trigger-id',
     _type: 'io.cozy.triggers',


### PR DESCRIPTION
This caused some regressions in home application. The AccountModal
component would be rerendered infinitely and cause multiple requests
when only updating a trigger