### PR TITLE
fix: Handle old react-routers in ShareModal

### DIFF
--- a/packages/cozy-sharing/src/ShareModal.jsx
+++ b/packages/cozy-sharing/src/ShareModal.jsx
@@ -30,8 +30,8 @@ const SharingModal = ({ document, ...rest }) => (
 )
 
 export const ShareModal = withLocales(props => {
-  const location = useLocation()
-  const locationProps = location.state?.modalProps
+  const location = useLocation?.()
+  const locationProps = location?.state?.modalProps
   const document = locationProps?.document || props.document
   const rest = omit(locationProps || props, 'document')
 


### PR DESCRIPTION
They do not export any hook, so we just test if they are undefined
If that's the case, the normal props flow will be used instead