### PR TITLE
fix: Revert ShareByEmail for Notes

### DIFF
--- a/packages/cozy-sharing/src/components/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal.jsx
@@ -30,14 +30,17 @@ export const ShareModal = ({
   twoStepsConfirmationMethods
 }) => {
   const showShareByEmail =
-    documentType !== 'Albums' && !hasSharedParent && !hasSharedChild
+    documentType !== 'Notes' &&
+    documentType !== 'Albums' &&
+    !hasSharedParent &&
+    !hasSharedChild
   const showShareByLink = documentType !== 'Organizations'
   const showShareOnlyByLink = hasSharedParent || hasSharedChild
   const showWhoHasAccess = documentType !== 'Albums'
 
   return (
     <>
-      {documentType === 'Albums' && (
+      {(documentType === 'Notes' || documentType === 'Albums') && (
         <ShareDialogOnlyByLink
           document={document}
           documentType={documentType}
@@ -49,7 +52,7 @@ export const ShareModal = ({
           permissions={permissions}
         />
       )}
-      {documentType !== 'Albums' && (
+      {documentType !== 'Notes' && documentType !== 'Albums' && (
         <ShareDialogCozyToCozy
           contacts={contacts}
           createContact={createContact}


### PR DESCRIPTION
Reverting to the code used before email implementation
in Notes share modals