### PR TITLE
Optimize home query

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Home/Home.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/Home.spec.jsx
@@ -42,7 +42,7 @@ const setup = ({
   isQueryLoading.mockReturnValue(isLoading)
   useQueryAll.mockReturnValue({
     data: withData
-      ? [{ metadata: { qualification: { label: 'LabelQualif' } } }]
+      ? [{ metadata: { qualification: { label: 'driver_license' } } }]
       : [],
     hasMore: false
   })

--- a/packages/cozy-mespapiers-lib/src/helpers/queries.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/queries.js
@@ -2,7 +2,7 @@ import { Q, fetchPolicies } from 'cozy-client'
 
 import { CONTACTS_DOCTYPE, FILES_DOCTYPE, SETTINGS_DOCTYPE } from '../doctypes'
 
-const defaultFetchPolicy = fetchPolicies.olderThan(30 * 1000)
+const defaultFetchPolicy = fetchPolicies.olderThan(86_400_000) // 24 hours
 
 export const buildFilesQueryWithQualificationLabel = () => {
   return {

--- a/packages/cozy-mespapiers-lib/src/helpers/queries.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/queries.js
@@ -4,18 +4,18 @@ import { CONTACTS_DOCTYPE, FILES_DOCTYPE, SETTINGS_DOCTYPE } from '../doctypes'
 
 const defaultFetchPolicy = fetchPolicies.olderThan(30 * 1000)
 
-export const buildFilesQueryByLabels = labels => {
+export const buildFilesQueryWithQualificationLabel = () => {
   return {
     definition: () =>
       Q(FILES_DOCTYPE)
         .where({
-          'metadata.qualification.label': {
-            $in: labels
-          }
-        })
-        .partialIndex({
           type: 'file',
           trashed: false
+        })
+        .partialIndex({
+          'metadata.qualification.label': {
+            $exists: true
+          }
         })
         .indexFields(['metadata.qualification.label'])
         .select([
@@ -28,7 +28,7 @@ export const buildFilesQueryByLabels = labels => {
         ])
         .limitBy(1000),
     options: {
-      as: `${FILES_DOCTYPE}/${JSON.stringify(labels)}`,
+      as: `${FILES_DOCTYPE}/metadata_qualification_label`,
       fetchPolicy: defaultFetchPolicy
     }
   }


### PR DESCRIPTION
La query `buildFilesQueryByLabels` n'était pas optimale avec l'utilisation du sélecteur `$in`
Dernièrement les requêtes pouvaient atteindre 6+ secondes...

Au lieu de lui passer tous les labels de qualification souhaités, il est préférable de retourner tous les fichiers ayant des labels de qualification puis de filtrer dans l'application les qualifications qui correspondent aux labels présents dans le fichier `papersDefinitions.json`

Ainsi le résultat final est inchangé et bien plus performant!