### PR TITLE
feat: Fetch connector from cozy-stack if undefined

### DIFF
--- a/packages/cozy-harvest-lib/src/components/Routes.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes.jsx
@@ -7,6 +7,7 @@ import {
   DialogCloseButton,
   useCozyDialog
 } from 'cozy-ui/transpiled/react/CozyDialogs'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import {
   useVaultUnlockContext,
   VaultUnlockProvider,
@@ -67,20 +68,22 @@ const Routes = ({
     konnector
   )
 
-  if (fetching) {
-    return <p></p>
-  } else {
-    return (
-      <DatacardOptions options={datacardOptions}>
-        <MountPointProvider baseRoute={konnectorRoot}>
-          <DialogContext.Provider value={dialogContext}>
-            <HarvestVaultProvider>
-              <VaultUnlockProvider>
-                <HarvestDialog
-                  {...dialogContext.dialogProps}
-                  aria-label={konnectorWithTriggers.name}
-                >
-                  <DialogCloseButton onClick={onDismiss} />
+  return (
+    <DatacardOptions options={datacardOptions}>
+      <MountPointProvider baseRoute={konnectorRoot}>
+        <DialogContext.Provider value={dialogContext}>
+          <HarvestVaultProvider>
+            <VaultUnlockProvider>
+              <HarvestDialog
+                {...dialogContext.dialogProps}
+                aria-label={konnectorWithTriggers.name}
+              >
+                <DialogCloseButton onClick={onDismiss} />
+                {fetching ? (
+                  <div className="u-pv-2 u-ta-center">
+                    <Spinner size="xxlarge" />
+                  </div>
+                ) : (
                   <KonnectorAccounts konnector={konnectorWithTriggers}>
                     {accountsAndTriggers => (
                       <Switch>
@@ -161,15 +164,15 @@ const Routes = ({
                       </Switch>
                     )}
                   </KonnectorAccounts>
-                </HarvestDialog>
-                <VaultUnlockPlaceholder />
-              </VaultUnlockProvider>
-            </HarvestVaultProvider>
-          </DialogContext.Provider>
-        </MountPointProvider>
-      </DatacardOptions>
-    )
-  }
+                )}
+              </HarvestDialog>
+              <VaultUnlockPlaceholder />
+            </VaultUnlockProvider>
+          </HarvestVaultProvider>
+        </DialogContext.Provider>
+      </MountPointProvider>
+    </DatacardOptions>
+  )
 }
 
 export default Routes

--- a/packages/cozy-harvest-lib/src/components/Routes.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes.jsx
@@ -25,6 +25,7 @@ import DialogContext from './DialogContext'
 import { DatacardOptions } from './Datacards/DatacardOptionsContext'
 
 import { ViewerModal } from '../datacards/ViewerModal'
+import { useKonnectorWithTriggers } from '../helpers/useKonnectorWithTriggers'
 
 /**
  * Dialog will not be centered vertically since we need the modal to "stay in place"
@@ -60,101 +61,115 @@ const Routes = ({
     open: true,
     onClose: onDismiss
   })
-  return (
-    <DatacardOptions options={datacardOptions}>
-      <MountPointProvider baseRoute={konnectorRoot}>
-        <DialogContext.Provider value={dialogContext}>
-          <HarvestVaultProvider>
-            <VaultUnlockProvider>
-              <HarvestDialog
-                {...dialogContext.dialogProps}
-                aria-label={konnector.name}
-              >
-                <DialogCloseButton onClick={onDismiss} />
-                <KonnectorAccounts konnector={konnector}>
-                  {accountsAndTriggers => (
-                    <Switch>
-                      <Route
-                        path={`${konnectorRoot}/`}
-                        exact
-                        render={() => (
-                          <HarvestModalRoot
-                            accounts={accountsAndTriggers}
-                            konnector={konnector}
-                          />
-                        )}
-                      />
-                      <Route
-                        path={`${konnectorRoot}/accounts/:accountId`}
-                        exact
-                        render={({ match }) => (
-                          <AccountModal
-                            konnector={konnector}
-                            accountId={match.params.accountId}
-                            accountsAndTriggers={accountsAndTriggers}
-                            onDismiss={onDismiss}
-                            showNewAccountButton={!konnector.clientSide}
-                            showAccountSelection={!konnector.clientSide}
-                          />
-                        )}
-                      />
-                      <Route
-                        path={`${konnectorRoot}/accounts/:accountId/edit`}
-                        exact
-                        render={({ match }) => (
-                          <EditAccountModal
-                            konnector={konnector}
-                            accountId={match.params.accountId}
-                            accounts={accountsAndTriggers}
-                          />
-                        )}
-                      />
-                      <Route
-                        path={`${konnectorRoot}/viewer/:accountId/:folderToSaveId/:fileIndex`}
-                        exact
-                        render={routeComponentProps => (
-                          <ViewerModal {...routeComponentProps} />
-                        )}
-                      />
-                      <Route
-                        path={`${konnectorRoot}/new`}
-                        exact
-                        render={() => (
-                          <NewAccountModal
-                            konnector={konnector}
-                            onDismiss={onDismiss}
-                          />
-                        )}
-                      />
-                      <Route
-                        path={`${konnectorRoot}/accounts/:accountId/success`}
-                        exact
-                        render={({ match }) => {
-                          return (
-                            <KonnectorSuccess
-                              konnector={konnector}
+
+  const { konnectorWithTriggers, fetching } = useKonnectorWithTriggers(
+    konnectorSlug,
+    konnector
+  )
+
+  if (fetching) {
+    return <p></p>
+  } else {
+    return (
+      <DatacardOptions options={datacardOptions}>
+        <MountPointProvider baseRoute={konnectorRoot}>
+          <DialogContext.Provider value={dialogContext}>
+            <HarvestVaultProvider>
+              <VaultUnlockProvider>
+                <HarvestDialog
+                  {...dialogContext.dialogProps}
+                  aria-label={konnectorWithTriggers.name}
+                >
+                  <DialogCloseButton onClick={onDismiss} />
+                  <KonnectorAccounts konnector={konnectorWithTriggers}>
+                    {accountsAndTriggers => (
+                      <Switch>
+                        <Route
+                          path={`${konnectorRoot}/`}
+                          exact
+                          render={() => (
+                            <HarvestModalRoot
+                              accounts={accountsAndTriggers}
+                              konnector={konnectorWithTriggers}
+                            />
+                          )}
+                        />
+                        <Route
+                          path={`${konnectorRoot}/accounts/:accountId`}
+                          exact
+                          render={({ match }) => (
+                            <AccountModal
+                              konnector={konnectorWithTriggers}
+                              accountId={match.params.accountId}
+                              accountsAndTriggers={accountsAndTriggers}
+                              onDismiss={onDismiss}
+                              showNewAccountButton={
+                                !konnectorWithTriggers.clientSide
+                              }
+                              showAccountSelection={
+                                !konnectorWithTriggers.clientSide
+                              }
+                            />
+                          )}
+                        />
+                        <Route
+                          path={`${konnectorRoot}/accounts/:accountId/edit`}
+                          exact
+                          render={({ match }) => (
+                            <EditAccountModal
+                              konnector={konnectorWithTriggers}
                               accountId={match.params.accountId}
                               accounts={accountsAndTriggers}
+                            />
+                          )}
+                        />
+                        <Route
+                          path={`${konnectorRoot}/viewer/:accountId/:folderToSaveId/:fileIndex`}
+                          exact
+                          render={routeComponentProps => (
+                            <ViewerModal {...routeComponentProps} />
+                          )}
+                        />
+                        <Route
+                          path={`${konnectorRoot}/new`}
+                          exact
+                          render={() => (
+                            <NewAccountModal
+                              konnector={konnectorWithTriggers}
                               onDismiss={onDismiss}
                             />
-                          )
-                        }}
-                      />
-                      <Redirect
-                        from={`${konnectorRoot}/*`}
-                        to={`${konnectorRoot}/`}
-                      />
-                    </Switch>
-                  )}
-                </KonnectorAccounts>
-              </HarvestDialog>
-              <VaultUnlockPlaceholder />
-            </VaultUnlockProvider>
-          </HarvestVaultProvider>
-        </DialogContext.Provider>
-      </MountPointProvider>
-    </DatacardOptions>
-  )
+                          )}
+                        />
+                        <Route
+                          path={`${konnectorRoot}/accounts/:accountId/success`}
+                          exact
+                          render={({ match }) => {
+                            return (
+                              <KonnectorSuccess
+                                konnector={konnectorWithTriggers}
+                                accountId={match.params.accountId}
+                                accounts={accountsAndTriggers}
+                                onDismiss={onDismiss}
+                              />
+                            )
+                          }}
+                        />
+                        <Redirect
+                          from={`${konnectorRoot}/*`}
+                          to={`${konnectorRoot}/`}
+                        />
+                      </Switch>
+                    )}
+                  </KonnectorAccounts>
+                </HarvestDialog>
+                <VaultUnlockPlaceholder />
+              </VaultUnlockProvider>
+            </HarvestVaultProvider>
+          </DialogContext.Provider>
+        </MountPointProvider>
+      </DatacardOptions>
+    )
+  }
 }
 
 export default Routes

--- a/packages/cozy-harvest-lib/src/components/Routes.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes.jsx
@@ -48,7 +48,13 @@ const HarvestDialog = withStyles({
   return <Dialog disableRestoreFocus {...props} />
 })
 
-const Routes = ({ konnectorRoot, konnector, onDismiss, datacardOptions }) => {
+const Routes = ({
+  konnectorRoot,
+  konnector,
+  konnectorSlug,
+  onDismiss,
+  datacardOptions
+}) => {
   const dialogContext = useCozyDialog({
     size: 'l',
     open: true,

--- a/packages/cozy-harvest-lib/src/helpers/useKonnectorWithTriggers.js
+++ b/packages/cozy-harvest-lib/src/helpers/useKonnectorWithTriggers.js
@@ -1,0 +1,75 @@
+import { useClient, Q } from 'cozy-client'
+import CozyRealtime from 'cozy-realtime'
+import { useEffect, useState } from 'react'
+import get from 'lodash/get'
+
+const TRIGGERS_DOCTYPE = 'io.cozy.triggers'
+const KONNECTORS_DOCTYPE = 'io.cozy.konnectors'
+
+export const useKonnectorWithTriggers = (slug, injectedKonnector) => {
+  const client = useClient()
+  const [isFetching, setIsFetching] = useState(true)
+  const [triggers, setTriggers] = useState([])
+  const [konnector, setKonnector] = useState({})
+
+  useEffect(() => {
+    async function load() {
+      if (injectedKonnector) {
+        setKonnector(injectedKonnector)
+        setTriggers(injectedKonnector.triggers)
+      } else {
+        const [konnector, triggers] = await Promise.all([
+          getKonnector(client, slug),
+          getTriggers(client, slug)
+        ])
+        setKonnector(konnector)
+        setTriggers({ data: triggers })
+      }
+      setIsFetching(false)
+    }
+
+    load()
+  }, [client, injectedKonnector, slug])
+
+  useEffect(() => {
+    const realtime = new CozyRealtime({ client })
+    realtime.subscribe('created', TRIGGERS_DOCTYPE, onTriggerCreated)
+    function onTriggerCreated(trigger) {
+      if (get(trigger, 'message.konnector') === slug) {
+        setTriggers([...triggers, trigger])
+      }
+    }
+    return function cleanUp() {
+      if (realtime) {
+        realtime.unsubscribeAll()
+      }
+    }
+  }, [client, slug, triggers])
+
+  const konnectorWithTriggers = {
+    ...konnector,
+    triggers
+  }
+  return { konnectorWithTriggers, fetching: isFetching }
+}
+
+function isKonnectorTrigger(doc) {
+  return (
+    doc._type === TRIGGERS_DOCTYPE && !!doc.message && !!doc.message.konnector
+  )
+}
+
+async function getKonnector(client, slug) {
+  const result = await client.query(Q(KONNECTORS_DOCTYPE).where({ slug: slug }))
+  return result.data[0]
+}
+
+async function getTriggers(client, slug) {
+  const { data: allTriggers } = await client.query(
+    Q(TRIGGERS_DOCTYPE).where({ worker: ['client', 'konnector'] })
+  )
+  return allTriggers.filter(
+    trigger =>
+      isKonnectorTrigger(trigger) && get(trigger, 'message.konnector') === slug
+  )
+}


### PR DESCRIPTION
If no connector is given by calling app, the Route.jsx wouldn't be able
to display anything and would throw when trying to access connector
props

To allow `cozy-harvest-lib` to display the connector anyway, we can
fetch connector data from cozy-stack based on the new `konnectorSlug`
prop

This scenario may happen in flagship app if RealTime is not active on
`cozy-home` and the app asks `cozy-home` to display a newly installed
connector

However this does not allow to display a not installed connector. If so
`cozy-harvest-lib` would throw as before

___

Implementation is based on https://github.com/cozy/cozy-harvest-app/blob/f4ee79865a9e74bf67f12d1ca9d85f9905e65f4a/src/hooks/useKonnectorWithTriggers.js