### PR TITLE
fix: Do not use biBankId from cache

### DIFF
--- a/packages/cozy-harvest-lib/src/services/biWebView.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.js
@@ -201,20 +201,18 @@ export const onBIAccountCreation = async ({
 /**
  * Create OAuth extra parameters specific to reconnect webview
  *
- * @param {Number} options.biBankId - Connector bank id (compatible with non webview bi connectors)
  * @param {Array<Number>} options.biBankIds - connector bank ids (for webview connectors)
  * @param {String} options.token - BI temporary token
  * @param {Number} options.connId - BI bi connection id
  * @return {Object}
  */
 const getReconnectExtraOAuthUrlParams = async ({
-  biBankId,
   biBankIds,
   token,
   connId
 }) => {
   return {
-    id_connector: biBankId || biBankIds,
+    id_connector: biBankIds,
     code: token,
     connection_id: connId
   }
@@ -233,11 +231,7 @@ export const fetchExtraOAuthUrlParams = async ({
   konnector,
   account
 }) => {
-  const {
-    code: token,
-    biBankId,
-    biBankIds
-  } = await createTemporaryToken({
+  const { code: token, biBankIds } = await createTemporaryToken({
     client,
     konnector,
     account
@@ -249,14 +243,13 @@ export const fetchExtraOAuthUrlParams = async ({
 
   if (isReconnect) {
     return getReconnectExtraOAuthUrlParams({
-      biBankId,
       biBankIds,
       token,
       connId
     })
   } else {
     return {
-      id_connector: biBankId || biBankIds,
+      id_connector: biBankIds,
       token
     }
   }
@@ -420,7 +413,7 @@ export const createTemporaryToken = async ({ client, konnector, account }) => {
   )
   const { biMapping } = tokenCache
 
-  tokenCache.biBankIds = cozyBankIds.map(id => biMapping[id])
+  tokenCache.biBankIds = [...new Set(cozyBankIds.map(id => biMapping[id]))]
 
   return tokenCache
 }

--- a/packages/cozy-harvest-lib/src/services/biWebView.spec.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.spec.js
@@ -350,26 +350,6 @@ describe('fetchExtraOAuthUrlParams', () => {
     expect(result).toMatchObject({ token: 'bi-temporary-access-token-123' })
   })
 
-  it('should add id_connector param for mono bankId', async () => {
-    const client = new CozyClient({
-      uri: 'http://testcozy.mycozy.cloud'
-    })
-    client.query = jest.fn().mockResolvedValue({
-      data: {
-        timestamp: Date.now(),
-        code: 'bi-temporary-access-token-123',
-        biBankId: 12,
-        biMapping: {}
-      }
-    })
-    const result = await fetchExtraOAuthUrlParams({
-      client,
-      konnector,
-      account
-    })
-    expect(result).toMatchObject({ id_connector: 12 })
-  })
-
   it('should add id_connector param for multiple bank ids', async () => {
     const client = new CozyClient({
       uri: 'http://testcozy.mycozy.cloud'
@@ -379,6 +359,26 @@ describe('fetchExtraOAuthUrlParams', () => {
         timestamp: Date.now(),
         code: 'bi-temporary-access-token-123',
         biMapping: { [TEST_BANK_COZY_ID]: 2 }
+      }
+    })
+    const result = await fetchExtraOAuthUrlParams({
+      client,
+      konnector,
+      account
+    })
+    expect(result).toMatchObject({ id_connector: [2] })
+  })
+
+  it('should get biBankIds associated to the konnector, even if other bank ids are in cache', async () => {
+    const client = new CozyClient({
+      uri: 'http://testcozy.mycozy.cloud'
+    })
+    client.query = jest.fn().mockResolvedValue({
+      data: {
+        timestamp: Date.now(),
+        code: 'bi-temporary-access-token-123',
+        biMapping: { [TEST_BANK_COZY_ID]: 2 },
+        biBankIds: [1, 2, 3]
       }
     })
     const result = await fetchExtraOAuthUrlParams({


### PR DESCRIPTION
When creating multiple connections on multiple banks, we could have a
webview for the first bank because we did not use the
createTemporaryToken properly.

Since with BI webviews, biBankId has no use. We now only use biBankIds
value, which is also updated even when using cached token.
