### PR TITLE
Fix/reference to paper fab component

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/MesPapiersLib.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/MesPapiersLib.jsx
@@ -82,7 +82,7 @@ const MesPapiersLib = ({ lang, components }) => {
 
 MesPapiersLib.propTypes = {
   lang: PropTypes.string,
-  components: PropTypes.objectOf(PropTypes.node)
+  components: PropTypes.objectOf(PropTypes.func)
 }
 
 export default MesPapiersLib

--- a/packages/cozy-mespapiers-lib/src/components/PapersFab/PapersFabWrapper.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/PapersFab/PapersFabWrapper.jsx
@@ -26,7 +26,8 @@ const PapersFabWrapper = ({ children }) => {
   if (!children) return null
 
   const PapersFabOverrided = cloneElement(children, {
-    onClick: toggleActionsMenu
+    onClick: toggleActionsMenu,
+    innerRef: actionBtnRef
   })
 
   return (


### PR DESCRIPTION
Ajout de la référence utilisée par le composant ActionMenuWrapper dans le clone du bouton papersFab, afin que l'application qui surcharge le bouton puisse "attacher" le menu (dans la version Desktop) où elle veut.

exemple:
```
const CustomFab = ({ onClick, innerRef }) => {
  return (
    <div>
      <Button
        label="Custom btn"
        onClick={onClick}
        ref={innerRef}
      />
    </div>
  )
}
```