### PR TITLE
fix: Close the multi-selector returns to the homepage

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Viewer/SelectFileButton.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Viewer/SelectFileButton.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useHistory, useLocation } from 'react-router-dom'
+import { useHistory } from 'react-router-dom'
 
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
@@ -10,7 +10,6 @@ import { useMultiSelection } from '../Hooks/useMultiSelection'
 const SelectFileButton = ({ file }) => {
   const { t } = useI18n()
   const history = useHistory()
-  const { pathname } = useLocation()
   const { addMultiSelectionFile } = useMultiSelection()
 
   return (
@@ -21,7 +20,7 @@ const SelectFileButton = ({ file }) => {
       onClick={() => {
         history.push({
           pathname: `/paper/multiselect`,
-          search: `backgroundPath=${pathname}`
+          search: `backgroundPath=/paper`
         })
         addMultiSelectionFile(file)
       }}


### PR DESCRIPTION
When we select a paper from the Viewer, then we close the multi-selection, we return to the Viewer, but the Viewer does a `goBack` if a history exists (useful to see a selected paper).
But in this present case, we fall into a loop of navigation.
We choose to return to the homepage when closing the multi-selection.