### PR TITLE
fix(renovate): Set caret on cozy-libs, pin on other dependencies

### DIFF
--- a/packages/renovate-config-cozy/package.json
+++ b/packages/renovate-config-cozy/package.json
@@ -11,12 +11,19 @@
       "rangeStrategy": "pin",
       "packageRules": [
         {
-          "excludePackageNames": [
-            "^cozy-"
+          "excludePackagePrefixes": [
+            "cozy-"
           ],
           "extends": [
             "schedule:monthly"
-          ]
+          ],
+          "rangeStrategy": "pin"
+        },
+        {
+          "matchPackagePrefixes": [
+            "cozy-"
+          ],
+          "rangeStrategy": "bump"
         }
       ],
       "timezone": "Europe/Paris",


### PR DESCRIPTION
Thanks to this commit, Renovate will try to pin only dependencies
Example:
- "react": "16.12.0"
- "cozy-client": "^32.2.0"