### PR TITLE
Fix Oauth Flow in non intentsApi apps

### DIFF
--- a/packages/cozy-harvest-lib/src/helpers/oauth.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.js
@@ -130,7 +130,7 @@ export const getOAuthUrl = ({
     oAuthConf.scope !== false
   ) {
     const urlScope = Array.isArray(oAuthConf.scope)
-      ? oAuthConf.scope.join('+')
+      ? oAuthConf.scope.join('%2B')
       : oAuthConf.scope
     oAuthUrl.searchParams.set('scope', urlScope)
   }

--- a/packages/cozy-harvest-lib/src/helpers/oauth.spec.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.spec.js
@@ -50,7 +50,7 @@ describe('Oauth helper', () => {
         oAuthConf: { scope: ['thescope', 'thescope2'] }
       })
       expect(url).toEqual(
-        'https://cozyurl/accounts/testslug/start?state=statekey&nonce=1234&scope=thescope+thescope2'
+        'https://cozyurl/accounts/testslug/start?state=statekey&nonce=1234&scope=thescope%2Bthescope2'
       )
     })
     it('should use redirectSlug if present', () => {


### PR DESCRIPTION
We had a few regressions in our flagship app for our OAuth Konnectors because of the work done for the BI webview: The InAppBrowser was opened but we tried to open it several times resulting an error (because the IAB can be only open once) since fetchSessionCode() was returning an error. 

This PR fix these issues. 