### PR TITLE
feat: Ignore disabled bank accounts when needed

### DIFF
--- a/packages/cozy-doctypes/src/banking/matching-accounts.js
+++ b/packages/cozy-doctypes/src/banking/matching-accounts.js
@@ -1,4 +1,5 @@
 const sortBy = require('lodash/sortBy')
+const get = require('lodash/get')
 const { eitherIncludes } = require('./matching-tools')
 const { getSlugFromInstitutionLabel } = require('./slug-account')
 
@@ -266,10 +267,17 @@ const matchAccounts = (fetchedAccountsArg, existingAccounts) => {
     if (matchResult) {
       const i = toMatch.indexOf(matchResult.match)
       toMatch.splice(i, 1)
-      // eslint-disable-next-line node/no-unsupported-features/es-syntax
-      results.push({ account: fetchedAccount, ...matchResult })
+      if (
+        !get(fetchedAccount, 'metadata.disabledAt') ||
+        !get(matchResult, 'metadata.disabledAt')
+      ) {
+        // eslint-disable-next-line node/no-unsupported-features/es-syntax
+        results.push({ account: fetchedAccount, ...matchResult })
+      }
     } else {
-      results.push({ account: fetchedAccount })
+      if (!get(fetchedAccount, 'metadata.disabledAt')) {
+        results.push({ account: fetchedAccount })
+      }
     }
   }
   return results

--- a/packages/cozy-doctypes/src/banking/matching-accounts.spec.js
+++ b/packages/cozy-doctypes/src/banking/matching-accounts.spec.js
@@ -237,3 +237,55 @@ describe('approxNumberMatch', () => {
     ).toBe(true)
   })
 })
+
+describe('matchAccounts', () => {
+  it('should ignore disabled accounts if no matching accounts', () => {
+    const fetchedAccounts = [{ metadata: { disabledAt: '2022-07-26' } }]
+    const existingAccounts = []
+    const result = matchAccounts(fetchedAccounts, existingAccounts)
+    expect(result).toEqual([])
+  })
+  it('should update an enabled account if fetched account is disabled', () => {
+    const fetchedAccounts = [{ metadata: { disabledAt: '2022-07-26' } }]
+    const existingAccounts = [{ metadata: { disabledAt: null } }]
+    const result = matchAccounts(fetchedAccounts, existingAccounts)
+    expect(result).toEqual([
+      {
+        account: {
+          metadata: {
+            disabledAt: '2022-07-26'
+          }
+        },
+        match: {
+          metadata: {
+            disabledAt: null
+          }
+        },
+        method: 'no-number-attr-same-type'
+      }
+    ])
+  })
+  it('should update enabled accounts as usual', () => {
+    const fetchedAccounts = [
+      { newAttr: 'value', metadata: { disabledAt: null } }
+    ]
+    const existingAccounts = [{ metadata: { disabledAt: null } }]
+    const result = matchAccounts(fetchedAccounts, existingAccounts)
+    expect(result).toEqual([
+      {
+        account: {
+          newAttr: 'value',
+          metadata: {
+            disabledAt: null
+          }
+        },
+        match: {
+          metadata: {
+            disabledAt: null
+          }
+        },
+        method: 'no-number-attr-same-type'
+      }
+    ])
+  })
+})


### PR DESCRIPTION
Do not update bank accounts when :

- BI account is disabled and there is no corresponding account in stack
- BI account is disabled and there is a corresponding account in stack
which is also disabled

Still do update bank accounts when :

- BI account is disabled and there is a corresponding account in stack
which is enabled
