### PR TITLE
fix: Invalidate temporary token cache when there is a change of BI user

### DIFF
--- a/packages/cozy-harvest-lib/src/services/biWebView.spec.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.spec.js
@@ -5,7 +5,8 @@ import {
   isBiWebViewConnector,
   fetchContractSynchronizationUrl,
   refreshContracts,
-  fetchExtraOAuthUrlParams
+  fetchExtraOAuthUrlParams,
+  isCacheExpired
 } from './biWebView'
 import ConnectionFlow from '../models/ConnectionFlow'
 import { waitForRealtimeEvent } from './jobUtils'
@@ -327,6 +328,34 @@ describe('refreshContracts', () => {
         }
       }
     })
+  })
+})
+
+describe('isCacheExpired', () => {
+  it('should not be marked as expired when userId did not change and cache is not old', () => {
+    const tokenCache = { timestamp: Date.now(), userId: 666 }
+    const biUser = { userId: 666 }
+    expect(isCacheExpired({ tokenCache, biUser })).toBe(false)
+  })
+  it('should be marked as expired when userId did not change and cache is old', () => {
+    const tokenCache = { timestamp: 0, userId: 666 }
+    const biUser = { userId: 666 }
+    expect(isCacheExpired({ tokenCache, biUser })).toBe(true)
+  })
+  it('should be marked as expired when userId did change and cache is old', () => {
+    const tokenCache = { timestamp: 0, userId: 666 }
+    const biUser = { userId: 667 }
+    expect(isCacheExpired({ tokenCache, biUser })).toBe(true)
+  })
+  it('should be marked as expired when userId did change and cache is not old', () => {
+    const tokenCache = { timestamp: Date.now(), userId: 666 }
+    const biUser = { userId: 667 }
+    expect(isCacheExpired({ tokenCache, biUser })).toBe(true)
+  })
+  it('should be marked as expired when cache has no user id', () => {
+    const tokenCache = { timestamp: Date.now() }
+    const biUser = { userId: 666 }
+    expect(isCacheExpired({ tokenCache, biUser })).toBe(true)
   })
 })
 


### PR DESCRIPTION
This avoids fatal error when the token in cache is associated to an old BI user.

BI user can change when the user removes all of his BI connections. In that case, the connector will also remove the current BI user.
The next createTemporaryToken job will create a new BI user