### PR TITLE
fix: Expect a state attribute in showInAppBrowser result

### DIFF
--- a/packages/cozy-harvest-lib/src/components/InAppBrowser.jsx
+++ b/packages/cozy-harvest-lib/src/components/InAppBrowser.jsx
@@ -84,7 +84,7 @@ const InAppBrowserWithIntentsApi = ({ url, onClose, intentsApi = {} }) => {
           const urlToOpen = decodeURIComponent(iabUrl.toString())
           logger.debug('url to open: ', urlToOpen)
           const result = await showInAppBrowser(urlToOpen)
-          if (result?.type !== 'dismiss' && result?.type !== 'cancel') {
+          if (result?.state !== 'dismiss' && result?.state !== 'cancel') {
             logger.error('Unexpected InAppBrowser result', result)
           }
         } catch (err) {


### PR DESCRIPTION
for inAppBrowser with custom intentsApi
This will avoid an error log
