### PR TITLE
fix: Remove a reconnection step

### DIFF
--- a/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
@@ -23,18 +23,19 @@ export class OAuthForm extends PureComponent {
     this.handleConnect = this.handleConnect.bind(this)
     this.handleOAuthCancel = this.handleOAuthCancel.bind(this)
     this.handleExtraParams = this.handleExtraParams.bind(this)
-    this.state = {
-      showingOAuthModal: false
-    }
+    this.state = {}
   }
 
   componentDidMount() {
-    const { account, konnector, flow, client } = this.props
+    const { account, konnector, flow, client, reconnect } = this.props
 
     const konnectorPolicy = findKonnectorPolicy(konnector)
 
     if (konnectorPolicy.fetchExtraOAuthUrlParams) {
       this.setState({ needExtraParams: true })
+      if (reconnect) {
+        this.showOAuthWindow()
+      }
       // eslint-disable-next-line promise/catch-or-return
       konnectorPolicy
         .fetchExtraOAuthUrlParams({
@@ -117,15 +118,17 @@ export class OAuthForm extends PureComponent {
             konnector={konnector}
           />
         )}
-        <Button
-          className="u-mt-1"
-          busy={isBusy}
-          disabled={isBusy}
-          extension="full"
-          label={t(buttonLabel)}
-          onClick={this.handleConnect}
-        />
-        {showOAuthWindow && (
+        {!reconnect && (
+          <Button
+            className="u-mt-1"
+            busy={isBusy}
+            disabled={isBusy}
+            extension="full"
+            label={t(buttonLabel)}
+            onClick={this.handleConnect}
+          />
+        )}
+        {showOAuthWindow && extraParams && (
           <OAuthWindow
             extraParams={extraParams}
             konnector={konnector}

--- a/packages/cozy-harvest-lib/src/components/OAuthForm.spec.js
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.spec.js
@@ -30,7 +30,7 @@ describe('OAuthForm', () => {
     expect(component).toMatchSnapshot()
   })
 
-  it('should render reconnect button when updating an account', () => {
+  it('should bypass reconnect button when updating an account', () => {
     const component = shallow(
       <OAuthForm
         flowState={{}}

--- a/packages/cozy-harvest-lib/src/components/__snapshots__/OAuthForm.spec.js.snap
+++ b/packages/cozy-harvest-lib/src/components/__snapshots__/OAuthForm.spec.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`OAuthForm should bypass reconnect button when updating an account 1`] = `<React.Fragment />`;
+
 exports[`OAuthForm should handle oauth cancelation 1`] = `
 <React.Fragment>
   <withI18n(withClient(withKonnectorLocales(TriggerErrorInfo))
@@ -30,19 +32,6 @@ exports[`OAuthForm should render 1`] = `
     disabled={true}
     extension="full"
     label="oauth.connect.label"
-    onClick={[Function]}
-  />
-</React.Fragment>
-`;
-
-exports[`OAuthForm should render reconnect button when updating an account 1`] = `
-<React.Fragment>
-  <DefaultButton
-    busy={true}
-    className="u-mt-1"
-    disabled={true}
-    extension="full"
-    label="oauth.reconnect.label"
     onClick={[Function]}
   />
 </React.Fragment>


### PR DESCRIPTION
When the trigger is in a state which needs reconnection and when the
user clicks on the "Reconnect" button, he still needed to click on a
"reconnect" button one more time to display the BI webview.

Now the BI webview is displayed directly.

There are still some screens we don't want to display after the BI
webview but this will be fixed in another PR
