### PR TITLE
fix: Let OAuthForm component decide when to remove the OAuth window

### DIFF
--- a/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
@@ -9,7 +9,7 @@ import withLocales from './hoc/withLocales'
 import { findKonnectorPolicy } from '../konnector-policies'
 import { intentsApiProptype } from '../helpers/proptypes'
 import TriggerErrorInfo from './infos/TriggerErrorInfo'
-import { ERROR_EVENT } from '../models/flowEvents'
+import { ERROR_EVENT, LOGIN_SUCCESS_EVENT } from '../models/flowEvents'
 import { KonnectorJobError } from '../helpers/konnectors'
 
 /**
@@ -23,6 +23,7 @@ export class OAuthForm extends PureComponent {
     this.handleConnect = this.handleConnect.bind(this)
     this.handleOAuthCancel = this.handleOAuthCancel.bind(this)
     this.handleExtraParams = this.handleExtraParams.bind(this)
+    this.handleLoginSuccess = this.handleLoginSuccess.bind(this)
     this.state = {}
   }
 
@@ -46,6 +47,11 @@ export class OAuthForm extends PureComponent {
         })
         .then(this.handleExtraParams)
     }
+    flow.on(LOGIN_SUCCESS_EVENT, this.handleLoginSuccess)
+  }
+
+  handleLoginSuccess() {
+    this.hideOAuthWindow()
   }
 
   handleExtraParams(extraParams) {
@@ -54,12 +60,16 @@ export class OAuthForm extends PureComponent {
 
   handleAccountId(accountId) {
     const { onSuccess } = this.props
-    this.hideOAuthWindow()
     if (typeof onSuccess === 'function') onSuccess(accountId)
   }
 
   handleConnect() {
     this.showOAuthWindow()
+  }
+
+  componentWillUnmount() {
+    const { flow } = this.props
+    flow.removeListener(LOGIN_SUCCESS_EVENT, this.handleLoginSuccess)
   }
 
   /**

--- a/packages/cozy-harvest-lib/src/components/OAuthForm.spec.js
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.spec.js
@@ -5,9 +5,11 @@ import { shallow } from 'enzyme'
 import { OAuthForm } from 'components/OAuthForm'
 import { findKonnectorPolicy } from '../konnector-policies'
 import { KonnectorJobError } from '../helpers/konnectors'
+import ConnectionFlow from '../models/ConnectionFlow'
 jest.mock('../konnector-policies', () => ({
   findKonnectorPolicy: jest.fn()
 }))
+jest.mock('../models/ConnectionFlow')
 const fetchExtraOAuthUrlParams = jest.fn()
 fetchExtraOAuthUrlParams.mockResolvedValue({})
 findKonnectorPolicy.mockReturnValue({
@@ -22,10 +24,17 @@ const fixtures = {
   }
 }
 
+const flow = new ConnectionFlow()
+
 describe('OAuthForm', () => {
   it('should render', () => {
     const component = shallow(
-      <OAuthForm flowState={{}} konnector={fixtures.konnector} t={t} />
+      <OAuthForm
+        flow={flow}
+        flowState={{}}
+        konnector={fixtures.konnector}
+        t={t}
+      />
     ).getElement()
     expect(component).toMatchSnapshot()
   })
@@ -33,6 +42,7 @@ describe('OAuthForm', () => {
   it('should bypass reconnect button when updating an account', () => {
     const component = shallow(
       <OAuthForm
+        flow={flow}
         flowState={{}}
         account={{ oauth: { access_token: '1234abcd' } }}
         konnector={fixtures.konnector}
@@ -45,6 +55,7 @@ describe('OAuthForm', () => {
   it('should call policy fetchExtraOAuthUrlParams with proper params', () => {
     shallow(
       <OAuthForm
+        flow={flow}
         flowState={{}}
         account={{ oauth: { access_token: '1234abcd' } }}
         konnector={fixtures.konnector}
@@ -56,13 +67,14 @@ describe('OAuthForm', () => {
         oauth: { access_token: '1234abcd' }
       },
       client: undefined,
-      flow: undefined,
+      flow,
       konnector: { slug: 'test-konnector' }
     })
   })
   it('should handle oauth cancelation', () => {
     const component = shallow(
       <OAuthForm
+        flow={flow}
         flowState={{ error: new KonnectorJobError('OAUTH_CANCELED') }}
         konnector={fixtures.konnector}
         t={t}

--- a/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
@@ -104,7 +104,6 @@ export class OAuthWindow extends PureComponent {
     this.setState({ succeed: true })
 
     if (typeof onSuccess !== 'function') return
-    this.setState({ succeed: true })
     onSuccess(data.key)
   }
 
@@ -159,10 +158,9 @@ export class OAuthWindow extends PureComponent {
 
   render() {
     const { t, intentsApi } = this.props
-    const { oAuthUrl, succeed } = this.state
+    const { oAuthUrl } = this.state
     return (
       oAuthUrl &&
-      !succeed &&
       (!isFlagshipApp() && !intentsApi ? (
         <Popup
           url={oAuthUrl}


### PR DESCRIPTION
- fix: Let OAuthForm component decide when to remove the OAuth window
- feat: Close OAuthWindow only on login success

This avoids to have unwanted previous screen displayed while waiting for harvest to complete the OAuth account creation
