### PR TITLE
feat: Use BI account creation webview to handle accounts synchonization

### DIFF
--- a/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
@@ -40,10 +40,10 @@ export class OAuthForm extends PureComponent {
       // eslint-disable-next-line promise/catch-or-return
       konnectorPolicy
         .fetchExtraOAuthUrlParams({
-          flow,
           account,
           konnector,
-          client
+          client,
+          reconnect
         })
         .then(this.handleExtraParams)
     }

--- a/packages/cozy-harvest-lib/src/components/OAuthForm.spec.js
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.spec.js
@@ -67,7 +67,6 @@ describe('OAuthForm', () => {
         oauth: { access_token: '1234abcd' }
       },
       client: undefined,
-      flow,
       konnector: { slug: 'test-konnector' }
     })
   })

--- a/packages/cozy-harvest-lib/src/services/biWebView.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.js
@@ -89,7 +89,7 @@ export const fetchContractSynchronizationUrl = async ({
  * @param {KonnectorManifest} options.konnector konnector manifest content
  * @param {ConnectionFlow} options.flow The flow
  * @param {CozyClient} options.client CozyClient object
- * @param {Boolean} options.reconnect If this is a reconnexion
+ * @param {Boolean} options.reconnect If this is a reconnection
  * @param {Function} options.t Translation fonction
  * @return {Promise<Number|null>} Connection Id
  */
@@ -232,12 +232,14 @@ const getReconnectExtraOAuthUrlParams = ({ biBankIds, token, connId }) => {
  * @param {CozyClient} options.client - CozyClient instance
  * @param {KonnectorManifest} options.konnector konnector manifest content
  * @param {IoCozyAccount} options.account The account content
+ * @param {Boolean} options.reconnect If this is a reconnection
  * @return {Promise<Object>}
  */
 export const fetchExtraOAuthUrlParams = async ({
   client,
   konnector,
-  account
+  account,
+  reconnect = false
 }) => {
   const { code: token, biBankIds } = await createTemporaryToken({
     client,
@@ -247,9 +249,7 @@ export const fetchExtraOAuthUrlParams = async ({
 
   const connId = getBIConnectionIdFromAccount(account)
 
-  const isReconnect = Boolean(connId)
-
-  if (isReconnect) {
+  if (reconnect) {
     return getReconnectExtraOAuthUrlParams({
       biBankIds,
       token,

--- a/packages/cozy-harvest-lib/src/services/biWebView.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.js
@@ -67,20 +67,6 @@ export const checkBIConnection = async ({ connId, client, konnector }) => {
   }
 }
 
-export const fetchContractSynchronizationUrl = async ({
-  account,
-  client,
-  konnector
-}) => {
-  const { code, url, clientId } = await createTemporaryToken({
-    client,
-    konnector,
-    account
-  })
-  const connId = getBIConnectionIdFromAccount(account)
-  return `${url}/auth/webview/manage?client_id=${clientId}&code=${code}&connection_id=${connId}`
-}
-
 /**
  * Handles webview connection
  *
@@ -452,6 +438,5 @@ export const konnectorPolicy = {
   onAccountCreation: onBIAccountCreation,
   fetchExtraOAuthUrlParams: fetchExtraOAuthUrlParams,
   handleOAuthAccount,
-  fetchContractSynchronizationUrl,
   refreshContracts
 }

--- a/packages/cozy-harvest-lib/src/services/biWebView.spec.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.spec.js
@@ -3,7 +3,6 @@ import {
   handleOAuthAccount,
   checkBIConnection,
   isBiWebViewConnector,
-  fetchContractSynchronizationUrl,
   refreshContracts,
   fetchExtraOAuthUrlParams,
   isCacheExpired
@@ -183,33 +182,6 @@ describe('isBiWebViewConnector', () => {
   it('should return false if the "harvest.bi.webview" flag is not activated', () => {
     flag('harvest.bi.webview', false)
     expect(isBiWebViewConnector(BIConnector)).toEqual(false)
-  })
-})
-
-describe('fetchContractSynchronizationUrl', () => {
-  it('should provide a proper bi manage webview url', async () => {
-    const client = new CozyClient({
-      uri: 'http://testcozy.mycozy.cloud'
-    })
-    client.query = jest.fn().mockResolvedValue({
-      data: {
-        mode: 'prod',
-        timestamp: Date.now(),
-        biMapping: {},
-        url: 'https://cozy.biapi.pro/2.0',
-        clientId: 'test-client-id',
-        code: 'bi-temporary-access-token-145613'
-      }
-    })
-
-    const url = await fetchContractSynchronizationUrl({
-      account: { ...account, data: { auth: { bi: { connId: 1337 } } } },
-      client,
-      konnector
-    })
-    expect(url).toEqual(
-      'https://cozy.biapi.pro/2.0/auth/webview/manage?client_id=test-client-id&code=bi-temporary-access-token-145613&connection_id=1337'
-    )
   })
 })
 

--- a/packages/cozy-harvest-lib/src/services/biWebView.spec.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.spec.js
@@ -393,7 +393,8 @@ describe('fetchExtraOAuthUrlParams', () => {
     const result = await fetchExtraOAuthUrlParams({
       client,
       konnector,
-      account: { ...account, data: { auth: { bi: { connId: 15 } } } }
+      account: { ...account, data: { auth: { bi: { connId: 15 } } } },
+      reconnect: true
     })
     expect(result).toMatchObject({
       connection_id: 15,


### PR DESCRIPTION
The goal is to avoid to display the BI manage webview which allows
modify, delete or create other BI connections of the user, which we
cannot handle on cozy side at the moment.

The user will need to enter it's own bank credentials before modifying
accounts synchronization.

The webview will close on its own.
