### PR TITLE
Show the display name instead of the fullname

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Contact.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Contact.jsx
@@ -10,7 +10,7 @@ import Avatar from 'cozy-ui/transpiled/react/Avatar'
 import Radio from 'cozy-ui/transpiled/react/Radios'
 import Checkbox from 'cozy-ui/transpiled/react/Checkbox'
 
-const { getFullname } = models.contact
+const { getDisplayName } = models.contact
 
 const styleAvatar = {
   color: 'var(--primaryColor)',
@@ -51,7 +51,7 @@ const Contact = ({
         <Avatar size="small" style={styleAvatar} />
       </ListItemIcon>
       <ListItemText
-        primary={`${getFullname(contact)} ${
+        primary={`${getDisplayName(contact)} ${
           contact.me ? `(${t('ContactStep.me')})` : ''
         }`}
       />

--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
@@ -37,13 +37,21 @@ export const getContactsRefIdsByFiles = (files = []) => {
  * @returns {string} Names of the contacts
  */
 export const harmonizeContactsNames = (contacts, t) => {
-  const contactNameList = contacts.map(contact => getDisplayName(contact))
-
-  if (contactNameList.length === 2) {
+  if (contacts.length === 0) {
+    return
+  }
+  if (contacts.length === 2) {
     const firstContactName = contacts[0].name
     const secondContactName = contacts[1].name
 
-    if (firstContactName.familyName === secondContactName.familyName) {
+    if (
+      firstContactName != null &&
+      secondContactName != null &&
+      firstContactName.givenName !== '' &&
+      secondContactName.givenName !== '' &&
+      firstContactName.familyName !== '' &&
+      firstContactName.familyName === secondContactName.familyName
+    ) {
       return t('PapersList.contactMerged', {
         firstGivenName: firstContactName.givenName,
         secondGivenName: secondContactName.givenName,
@@ -52,10 +60,10 @@ export const harmonizeContactsNames = (contacts, t) => {
     }
   }
 
-  let validatedContactName = contactNameList[0]
-  if (contactNameList.length > 1) {
+  let validatedContactName = getDisplayName(contacts[0])
+  if (contacts.length > 1) {
     validatedContactName += `, ${getDisplayName(contacts[1])}`
-    if (contactNameList.length > 2) validatedContactName += ', ... '
+    if (contacts.length > 2) validatedContactName += ', ... '
   }
 
   return validatedContactName


### PR DESCRIPTION
~~The current user and contacts are usually listed together in the app `mespapiers` even if they don't share the same data shape.~~
~~For example, the name parts are missing from the user.~~
The mismatch seems to only happen in dev environnement until the profile for the current user is edited.

~~This PR introduces an helper that either shows the fullname if present, or the display name if not, as a workaround for this mismatch.~~
Using `getDisplayName` directly should be sufficient in production environnement.

This fixes the empty names that could appear by showing an email address if available, and also fixes the save failing for documents not only owned by the current user.