### PR TITLE
feat: Add minLength constraint to InputMask

### DIFF
--- a/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
+++ b/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
@@ -67,6 +67,10 @@ Let's see how it is built:
   - `[minLength]`: {number} Requires a minimum number of characters
   - `[maxLength]`: {number} Requires a maximum number of characters
   - `[mask]`: {string} Formats and forces a type (see [here](https://github.com/sanniassin/react-input-mask#properties) for more details)
+    - Varation with the `mask` attribute:
+      - `[required]`: {boolean} Make all Mask mandatory (**high priority**)
+      - `[minLength]`: {number} Requires a minimum number of characters
+      - `[maxLength]`: {number} Ignored, always the length of the Mask
   - `[placeholderMask]`: {string} Choice of placeholder for the mask (default `ˍ`)
 
 <br>

--- a/packages/cozy-mespapiers-lib/src/utils/input.js
+++ b/packages/cozy-mespapiers-lib/src/utils/input.js
@@ -19,14 +19,30 @@ import log from 'cozy-logger'
  * // For make input number with contraint length to 12
  * makeConstraintsOfInput({ type: 'number', required: true, minLength: 12, maxLength: 12 })
  *
+ * // For make an input mask with a length constraint of 0 or full
+ * makeConstraintsOfInput({ type: 'text', mask: '99 aa **' })
+ * // For make an input mask that must be completely filled in
+ * makeConstraintsOfInput({ type: 'text', mask: '99 aa **', required: true })
+ * // For make an input mask with a length constraint of 0 or minimum 4
+ * makeConstraintsOfInput({ type: 'text', mask: '99 aa **', minLength: 4 })
+ * // For make an input mask with a minimum length constraint of 4
+ * makeConstraintsOfInput({ type: 'text', mask: '99 aa **', required: true, minLength: 4 })
+ *
  * @returns {{ inputType: string, expectedLength: { min: number, max: number }, isRequired: boolean }}
  */
 export const makeConstraintsOfInput = attrs => {
   const { type = '', required = false, mask } = attrs || {}
 
-  const maskLength = mask?.replace(/\s/g, '')?.length
-  const minLength = maskLength ?? attrs?.minLength ?? null
-  const maxLength = maskLength ?? attrs?.maxLength ?? null
+  const safeMaxLength = attrs?.maxLength ?? null
+  const safeMinLength = attrs?.minLength ?? null
+
+  const maskLength = mask?.replace(/\s/g, '')?.length ?? null
+  const minLength = maskLength
+    ? Math.min(safeMinLength ?? maskLength, maskLength)
+    : safeMaxLength
+    ? Math.min(safeMinLength, safeMaxLength)
+    : safeMinLength
+  const maxLength = maskLength ?? safeMaxLength
   const acceptedTypes = ['number', 'text']
 
   const result = {

--- a/packages/cozy-mespapiers-lib/src/utils/input.spec.js
+++ b/packages/cozy-mespapiers-lib/src/utils/input.spec.js
@@ -6,10 +6,10 @@ describe('Input Utils', () => {
       attrs                                                                | result
       ${{ type: 'number' }}                                                | ${{ inputType: 'number', expectedLength: { min: null, max: null }, isRequired: false }}
       ${{ type: 'number', mask: '99999' }}                                 | ${{ inputType: 'number', expectedLength: { min: 5, max: 5 }, isRequired: false }}
-      ${{ type: 'number', mask: '99999', minLength: 3, maxLength: 7 }}     | ${{ inputType: 'number', expectedLength: { min: 5, max: 5 }, isRequired: false }}
+      ${{ type: 'number', mask: '99999', minLength: 3, maxLength: 7 }}     | ${{ inputType: 'number', expectedLength: { min: 3, max: 5 }, isRequired: false }}
       ${{ type: 'number', mask: '99999', required: true }}                 | ${{ inputType: 'number', expectedLength: { min: 5, max: 5 }, isRequired: true }}
       ${{ type: 'number', mask: '99 99 99 99 99', required: true }}        | ${{ inputType: 'number', expectedLength: { min: 10, max: 10 }, isRequired: true }}
-      ${{ type: 'number', mask: '99999', required: true, minLength: 3 }}   | ${{ inputType: 'number', expectedLength: { min: 5, max: 5 }, isRequired: true }}
+      ${{ type: 'number', mask: '99999', required: true, minLength: 3 }}   | ${{ inputType: 'number', expectedLength: { min: 3, max: 5 }, isRequired: true }}
       ${{ type: 'number', mask: '99999', required: true, maxLength: 7 }}   | ${{ inputType: 'number', expectedLength: { min: 5, max: 5 }, isRequired: true }}
       ${{ type: 'number', required: false, minLength: 0, maxLength: 0 }}   | ${{ inputType: 'number', expectedLength: { min: 0, max: 0 }, isRequired: false }}
       ${{ type: 'number', required: false, minLength: 10, maxLength: 0 }}  | ${{ inputType: 'number', expectedLength: { min: 10, max: 0 }, isRequired: false }}
@@ -17,14 +17,14 @@ describe('Input Utils', () => {
       ${{ type: 'number', required: false, minLength: 5, maxLength: 10 }}  | ${{ inputType: 'number', expectedLength: { min: 5, max: 10 }, isRequired: false }}
       ${{ type: 'number', required: false, minLength: 10, maxLength: 10 }} | ${{ inputType: 'number', expectedLength: { min: 10, max: 10 }, isRequired: false }}
       ${{ type: 'number', required: true, minLength: 0, maxLength: 0 }}    | ${{ inputType: 'number', expectedLength: { min: 0, max: 0 }, isRequired: true }}
-      ${{ type: 'number', required: true, minLength: 20, maxLength: 10 }}  | ${{ inputType: 'number', expectedLength: { min: 20, max: 10 }, isRequired: true }}
+      ${{ type: 'number', required: true, minLength: 20, maxLength: 10 }}  | ${{ inputType: 'number', expectedLength: { min: 10, max: 10 }, isRequired: true }}
       ${undefined}                                                         | ${{ inputType: 'text', expectedLength: { min: null, max: null }, isRequired: false }}
       ${{ type: 'text' }}                                                  | ${{ inputType: 'text', expectedLength: { min: null, max: null }, isRequired: false }}
       ${{ type: 'text', mask: 'aaaaa' }}                                   | ${{ inputType: 'text', expectedLength: { min: 5, max: 5 }, isRequired: false }}
-      ${{ type: 'text', mask: 'aaaaa', minLength: 3, maxLength: 7 }}       | ${{ inputType: 'text', expectedLength: { min: 5, max: 5 }, isRequired: false }}
+      ${{ type: 'text', mask: 'aaaaa', minLength: 3, maxLength: 7 }}       | ${{ inputType: 'text', expectedLength: { min: 3, max: 5 }, isRequired: false }}
       ${{ type: 'text', mask: 'aaaaa', required: true }}                   | ${{ inputType: 'text', expectedLength: { min: 5, max: 5 }, isRequired: true }}
       ${{ type: 'text', mask: 'aa aa aa aa aa', required: true }}          | ${{ inputType: 'text', expectedLength: { min: 10, max: 10 }, isRequired: true }}
-      ${{ type: 'text', mask: 'aaaaa', required: true, minLength: 3 }}     | ${{ inputType: 'text', expectedLength: { min: 5, max: 5 }, isRequired: true }}
+      ${{ type: 'text', mask: 'aaaaa', required: true, minLength: 3 }}     | ${{ inputType: 'text', expectedLength: { min: 3, max: 5 }, isRequired: true }}
       ${{ type: 'text', mask: 'aaaaa', required: true, maxLength: 7 }}     | ${{ inputType: 'text', expectedLength: { min: 5, max: 5 }, isRequired: true }}
       ${{ type: 'text', required: false, minLength: 0, maxLength: 0 }}     | ${{ inputType: 'text', expectedLength: { min: 0, max: 0 }, isRequired: false }}
       ${{ type: 'text', required: false, minLength: 10, maxLength: 0 }}    | ${{ inputType: 'text', expectedLength: { min: 10, max: 0 }, isRequired: false }}
@@ -32,7 +32,7 @@ describe('Input Utils', () => {
       ${{ type: 'text', required: false, minLength: 5, maxLength: 10 }}    | ${{ inputType: 'text', expectedLength: { min: 5, max: 10 }, isRequired: false }}
       ${{ type: 'text', required: false, minLength: 10, maxLength: 10 }}   | ${{ inputType: 'text', expectedLength: { min: 10, max: 10 }, isRequired: false }}
       ${{ type: 'text', required: true, minLength: 0, maxLength: 0 }}      | ${{ inputType: 'text', expectedLength: { min: 0, max: 0 }, isRequired: true }}
-      ${{ type: 'text', required: true, minLength: 20, maxLength: 10 }}    | ${{ inputType: 'text', expectedLength: { min: 20, max: 10 }, isRequired: true }}
+      ${{ type: 'text', required: true, minLength: 20, maxLength: 10 }}    | ${{ inputType: 'text', expectedLength: { min: 10, max: 10 }, isRequired: true }}
     `(
       `should return $result when passed argument: $attrs`,
       ({ attrs, result }) => {


### PR DESCRIPTION
Après discussions, nous essayons de coller au maximum aux comportements standard de l'`input` de type `text`
A la différence de l'attribut `required` qui, si défini, oblige de renseigner la totalité du `mask`, excepté si il est couplé avec l'attribut `minLength`.

Les contraintes connus aujourd'hui sont les suivantes :
- Ne pas obliger le renseignement
- Obliger le renseignement :
  - Obliger la complétion totale du `mask`
  - Obliger un minimum de caractères. (Raison: Selon le document, certains renseignements peuvent être plus courts d'une personne à l'autre)

Avant :
- `minLength` : Attribut ignoré
- `required` : 
  - `true` : Oblige de renseigner totalement le `mask`
  - `false`(ou non présent) : Permet la validation vide ou totale

Après :
- `minLength` : Permet la validation vide ou avec le minimum de caractère défini (standard)
- `required` : Inchangé
- `minLength` + `required: true` : Oblige le minimum de caractère défini (standard)
