### PR TITLE
fix: Rename build job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
   include:
     - name: 'Repo Doctor'
       script: '[ $TRAVIS_EVENT_TYPE = "cron" ] && pushd ./packages/repo-doctor && yarn start:mattermost && popd || true'
-    - name: 'Tests'
+    - name: 'Build'
       script:
         - ./scripts/travis.sh
 


### PR DESCRIPTION
Current "test" job is responsible for running build, lint and tests, so
its name is more about building the project than just testing it

This commit renames it "build" to have a clearer intention


___


### Before:
![image](https://user-images.githubusercontent.com/1884255/185926064-c2e644f4-74bc-4afb-8495-2381fe60dac8.png)


### After:
![image](https://user-images.githubusercontent.com/1884255/185926224-eaacce36-dd8a-462d-8e5d-b6395ee9dd1c.png)
