### PR TITLE
fix(harvest): Handle not existing applications

### DIFF
--- a/packages/cozy-harvest-lib/src/components/Routes.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes.jsx
@@ -1,12 +1,14 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Switch, Route, Redirect } from 'react-router'
 import { withStyles } from '@material-ui/core/styles'
 
+import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import Dialog from 'cozy-ui/transpiled/react/Dialog'
 import {
   DialogCloseButton,
   useCozyDialog
 } from 'cozy-ui/transpiled/react/CozyDialogs'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import {
   useVaultUnlockContext,
@@ -57,16 +59,22 @@ const Routes = ({
   onDismiss,
   datacardOptions
 }) => {
+  const { t } = useI18n()
   const dialogContext = useCozyDialog({
     size: 'l',
     open: true,
     onClose: onDismiss
   })
 
-  const { konnectorWithTriggers, fetching } = useKonnectorWithTriggers(
-    konnectorSlug,
-    konnector
-  )
+  const { konnectorWithTriggers, fetching, notFoundError } =
+    useKonnectorWithTriggers(konnectorSlug, konnector)
+
+  useEffect(() => {
+    if (notFoundError) {
+      onDismiss()
+      Alerter.error(t('error.application-not-found'))
+    }
+  }, [notFoundError, onDismiss, t])
 
   return (
     <DatacardOptions options={datacardOptions}>

--- a/packages/cozy-harvest-lib/src/helpers/useKonnectorWithTriggers.js
+++ b/packages/cozy-harvest-lib/src/helpers/useKonnectorWithTriggers.js
@@ -50,7 +50,11 @@ export const useKonnectorWithTriggers = (slug, injectedKonnector) => {
     ...konnector,
     triggers
   }
-  return { konnectorWithTriggers, fetching: isFetching }
+  return {
+    konnectorWithTriggers,
+    fetching: isFetching,
+    notFoundError: !isFetching && !konnector
+  }
 }
 
 function isKonnectorTrigger(doc) {

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -124,6 +124,7 @@
     "baseDir": "/Administrative"
   },
   "error": {
+    "application-not-found": "This app doesn't exist",
     "reconnect-via-form": "Reconnect",
     "job": {
       "DISK_QUOTA_EXCEEDED": {

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -124,6 +124,7 @@
     "baseDir": "/Administratif"
   },
   "error": {
+    "application-not-found": "Cette application n'existe pas",
     "reconnect-via-form": "Se reconnecter",
     "job": {
       "DISK_QUOTA_EXCEEDED": {


### PR DESCRIPTION
In current implementation, when opening Harvest with an application
slug that does not exist, the opened dialog shows a javascript error

When this happens, we want to automatically close the dialog and
display an error message instead

New behaviour (video is a bit laggy but this is due to my computer+recorder):

https://user-images.githubusercontent.com/1884255/186463201-68df1f9d-19ec-429d-95f7-8fa743a7d6fc.mp4


