### PR TITLE
fix: Add prepublish script

### DIFF
--- a/packages/cozy-authentication/package.json
+++ b/packages/cozy-authentication/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "prepare": "yarn build; yarn copy-files",
     "build": "env BABEL_ENV=transpilation yarn babel src/ --out-dir dist",
+    "prepublishOnly": "yarn build",
     "watch": "yarn build -w",
     "test": "yarn jest src",
     "copy-files": "cp -r src/locales/ dist/locales/",

--- a/packages/cozy-codemods/package.json
+++ b/packages/cozy-codemods/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "docs": "jsdoc2md -f 'src/**/*.js' -t .README.md.template > README.md",
     "build": "babel src -d dist --verbose",
+    "prepublishOnly": "yarn build",
     "test": "jest",
     "cli": "node src/cli.js"
   },

--- a/packages/cozy-doctypes/package.json
+++ b/packages/cozy-doctypes/package.json
@@ -37,7 +37,8 @@
   },
   "scripts": {
     "lint": "cd ../../; yarn eslint --ext js,jsx packages/cozy-doctypes",
-    "build": "babel src -d dist",
+    "build": "babel src -d dist --verbose",
+    "prepublishOnly": "yarn build",
     "watch": "yarn build --watch",
     "test": "jest src/",
     "encrypt-banking-tests": "cd src/banking/; make encrypted.tar.gz.gpg",

--- a/packages/cozy-interapp/package.json
+++ b/packages/cozy-interapp/package.json
@@ -15,7 +15,8 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "babel src -d dist --ignore *.spec.js"
+    "build": "babel src -d dist --ignore *.spec.js",
+    "prepublishOnly": "yarn build"
   },
   "devDependencies": {
     "@babel/cli": "7.16.8",

--- a/packages/cozy-logger/package.json
+++ b/packages/cozy-logger/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "test": "yarn jest",
-    "build": "babel src/ --out-dir dist"
+    "build": "babel src/ --out-dir dist",
+    "prepublishOnly": "yarn build"
   },
   "prettier": {
     "semi": false,

--- a/packages/cozy-mjml/package.json
+++ b/packages/cozy-mjml/package.json
@@ -21,6 +21,7 @@
   },
   "scripts": {
     "build": "webpack",
+    "prepublishOnly": "yarn build",
     "watch": "webpack --watch",
     "test": "jest"
   },

--- a/packages/cozy-procedures/package.json
+++ b/packages/cozy-procedures/package.json
@@ -14,6 +14,7 @@
     "prepare": "yarn build; yarn copy-files",
     "watch": "env BABEL_ENV=transpilation yarn babel src/ --out-dir dist --watch",
     "build": "env BABEL_ENV=transpilation yarn babel src/ --out-dir dist && yarn run copy-files",
+    "prepublishOnly": "yarn build",
     "copy-files": "cp -rf src/locales dist/",
     "test": "jest",
     "lint": "cd ..; yarn eslint --ext js,jsx packages/cozy-procedures"

--- a/packages/cozy-scanner/package.json
+++ b/packages/cozy-scanner/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "prepare": "yarn build; yarn copy-files",
     "build": "env BABEL_ENV=transpilation yarn babel src/ --out-dir dist --copy-files --verbose",
+    "prepublishOnly": "yarn build",
     "copy-files": "cp -rf src/locales dist/",
     "test": "jest src/",
     "lint": "cd .. && yarn eslint --ext js,jsx packages/cozy-scanner",


### PR DESCRIPTION
We add issue on a few packages since we have
added a new travis' job. Indeed, the
"repo doctor"'s job is the first one to be run.

So it's also the one to handle the lerna
process to publish. But since this job doesn't
build the package, we can have published package
without all the build stuff in it.

So let's add a prepublish script to all the
repo in order to not have issue and dep with
the job's order.