### PR TITLE
feat: Update FlagshipMetadata interface

### DIFF
--- a/packages/cozy-device-helper/src/flagship.ts
+++ b/packages/cozy-device-helper/src/flagship.ts
@@ -8,7 +8,19 @@ export enum FlagshipRoutes {
   Stack = 'stack'
 }
 
+export enum BiometryType {
+  Face = 'Face',
+  FaceID = 'FaceID',
+  Fingerprint = 'Fingerprint',
+  Iris = 'Iris',
+  TouchID = 'TouchID'
+}
+
 export interface FlagshipMetadata {
+  capabilities?: {
+    biometryType?: BiometryType
+  }
+  hasBiometry?: boolean
   immersive?: boolean
   navbarHeight?: number
   platform?: Record<string, unknown>


### PR DESCRIPTION
In order to give the webview information about biometry capabilites,
it is necessary that we update the interface so the consuming apps
are aware of the new option and what values it can hold.

The actual injection still has to be done in the native application.