### PR TITLE
fix: Mask of vehicle registration

### DIFF
--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -1439,7 +1439,7 @@
             {
               "name": "vinNumber",
               "type": "text",
-              "mask": "aa9 ****** *******",
+              "mask": "*** ****** ********",
               "inputLabel": "PaperJSON.vehicleRegistration.vinNumber.inputLabel"
             }
           ]


### PR DESCRIPTION
The last part was missing a character.
The first part must be alphanumeric.

See https://bit.ly/3PYG9hB for more details