### PR TITLE
fix: Better behavior on ACCOUNT_WITH_SAME_IDENTIFIER_ALREADY_DEFINED error

### DIFF
--- a/packages/cozy-harvest-lib/src/components/DisconnectedAccountModal.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/DisconnectedAccountModal.spec.jsx
@@ -8,6 +8,13 @@ import bankAccounts from './KonnectorConfiguration/ConfigurationTab/bank-account
 describe('DisconnectedAccountModal', () => {
   const setup = () => {
     const mockClient = {}
+    mockClient.plugins = {
+      realtime: {
+        subscribe: jest.fn(),
+        unsubscribe: jest.fn()
+      }
+    }
+    mockClient.dispatch = jest.fn()
     const root = render(
       <AppLike client={mockClient}>
         <DisconnectedAccountModal

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/Contracts.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/Contracts.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import compose from 'lodash/flowRight'
 
-import CozyClient, { Q, queryConnect } from 'cozy-client'
+import CozyClient, { Q, queryConnect, RealTimeQueries } from 'cozy-client'
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import NavigationList, {
@@ -52,6 +52,7 @@ const DumbContracts = ({
 
   return (
     <MuiCozyTheme>
+      <RealTimeQueries doctype="io.cozy.bank.accounts" />
       <NavigationList>
         <NavigationListHeader>
           {t(`contracts.headers.${headerKey}`)}

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -217,7 +217,7 @@
       },
       "ACCOUNT_WITH_SAME_IDENTIFIER_ALREADY_DEFINED": {
         "title": "This account already exists",
-        "description": "You already have configured an account with these identifiers."
+        "description": "Your possible modification of the list of synchronized accounts will be taken into account within a few minutes."
       }
     }
   },

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -217,7 +217,7 @@
       },
       "ACCOUNT_WITH_SAME_IDENTIFIER_ALREADY_DEFINED": {
         "title": "Ce compte est déjà configuré",
-        "description": "Vous avez déjà configuré un compte avec ces identifiants."
+        "description": "Votre éventuelle modification de la liste des comptes synchronisés sera prise en compte sous quelques minutes."
       }
     }
   },


### PR DESCRIPTION
These modifications allow a better understanding for the user when the user tried to create an account with identifiers which are already associated to an existing account.

With BI webviews, it is possible to update contract synchronization for the existing account and we need to be synchronized with it.

- fix: Better msg on ACCOUNT_WITH_SAME_IDENTIFIER_ALREADY_DEFINED error
- fix: Add realtime on bank accounts
