### PR TITLE
feat: Update methods interface for biometry

### DIFF
--- a/packages/cozy-intent/src/api/models/methods.ts
+++ b/packages/cozy-intent/src/api/models/methods.ts
@@ -1,12 +1,17 @@
 import { AppManifest, FlagshipUI } from '../../api'
 
 export type NativeMethodsRegister = {
-  backToHome: () => void
-  hideSplashScreen: () => void
-  logout: () => void
-  openApp: (href: string, app: AppManifest, iconParams?: DOMRect) => void
-  setFlagshipUI: (flagshipUI: FlagshipUI, caller?: string) => void
-  showSplashScreen: () => void
+  backToHome: () => Promise<null>
+  hideSplashScreen: () => Promise<null>
+  logout: () => Promise<null>
+  openApp: (
+    href: string,
+    app: AppManifest,
+    iconParams?: DOMRect
+  ) => Promise<null>
+  openSettingBiometry: () => Promise<boolean>
+  setFlagshipUI: (flagshipUI: FlagshipUI, caller?: string) => Promise<null>
+  showSplashScreen: () => Promise<null>
 }
 
 export type WebviewMethods = Record<string, () => unknown>

--- a/packages/cozy-intent/src/api/services/NativeService.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.ts
@@ -136,7 +136,7 @@ export class NativeService {
     uri: string,
     methodName: keyof WebviewMethods,
     ...args: Parameters<NativeMethodsRegister[keyof NativeMethodsRegister]>
-  ): Promise<void> | void =>
+  ): ReturnType<NativeMethodsRegister[keyof NativeMethodsRegister]> | void =>
     this.messengerRegister[this.getHostname(uri)]?.connection
       ?.remoteHandle()
       .call(methodName, ...args)

--- a/packages/cozy-intent/src/api/services/WebviewService.ts
+++ b/packages/cozy-intent/src/api/services/WebviewService.ts
@@ -21,7 +21,7 @@ export class WebviewService {
   public call = (
     methodName: keyof NativeMethodsRegister,
     ...args: Parameters<NativeMethodsRegister[keyof NativeMethodsRegister]>
-  ): Promise<void> => this.remoteHandle.call(methodName, ...args)
+  ): Promise<boolean | null> => this.remoteHandle.call(methodName, ...args)
 
   public closeMessenger = (): void => this.close()
 }


### PR DESCRIPTION
Add new method allowing to open the management of the biometry
setting on the react native application.

Please note that this is NOT an implementation,
but merely an API signature.

It has purely no effect except documentation in js files,
and type checking in ts files