### PR TITLE
fix: Add missing intentsApi prop in DumbEditAccountModal

### DIFF
--- a/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
@@ -184,11 +184,12 @@ export class EditAccountModal extends Component {
      * When we are on mobile, we display a back button
      * On desktop we display a cross
      */
-    const { konnector, reconnect } = this.props
+    const { konnector, reconnect, intentsApi } = this.props
     const { trigger, account, fetching } = this.state
     return (
       <DumbEditAccountModal
         konnector={konnector}
+        intentsApi={intentsApi}
         account={account}
         trigger={trigger}
         fetching={fetching}


### PR DESCRIPTION
To transmit this param to OAuthWindow ultimately

This fixes an OAuthPopup which would not open in InAppBrowser without it
when the user clicks on the Reconnect Button from a BI error message.
