### PR TITLE
Add stylus configuration

### DIFF
--- a/packages/cozy-mespapiers-lib/README.md
+++ b/packages/cozy-mespapiers-lib/README.md
@@ -104,6 +104,16 @@ const AppRouter = () => {
 Then inside your route component, you have to import exposed component from `cozy-mespapiers-lib`.
 :warning: You must pass it the `lang` prop of the application so that it uses the right locales files.
 
+## Styles
+
+You need to add the following import to the base of your application:
+
+```
+import 'cozy-mespapiers-lib/dist/stylesheet.css'
+```
+
+***
+
 # Components Overload
 
 You can also overload some components (currently only the `PapersFab` & `Onboarding` components) or not use them (with `null` value).

--- a/packages/cozy-mespapiers-lib/babel.config.js
+++ b/packages/cozy-mespapiers-lib/babel.config.js
@@ -1,3 +1,17 @@
 module.exports = {
-  presets: ['cozy-app']
+  presets: ['cozy-app'],
+  plugins: [
+    [
+      'css-modules-transform',
+      {
+        extensions: ['.styl'],
+        preprocessCss: './preprocess',
+        extractCss: './dist/stylesheet.css',
+        generateScopedName:
+          process.env['NODE_ENV'] == 'test'
+            ? '[local]'
+            : '[name]__[local]___[hash:base64:5]'
+      }
+    ]
+  ]
 }

--- a/packages/cozy-mespapiers-lib/preprocess.js
+++ b/packages/cozy-mespapiers-lib/preprocess.js
@@ -1,0 +1,15 @@
+const stylus = require('stylus')
+const cozyStylusPlugin = require('cozy-ui/stylus')
+
+const renderStylus = function (css, filename) {
+  try {
+    return stylus(css)
+      .use(cozyStylusPlugin())
+      .set('filename', filename)
+      .render()
+  } catch (e) {
+    console.log(e) // eslint-disable-line no-console
+  }
+}
+
+module.exports = renderStylus


### PR DESCRIPTION
BREAKING CHANGE: In order to have the css styles specific to some components of `cozy-mespapiers-lib`, you need to add the following import to the base of your application: `import 'cozy-mespapiers-lib/dist/stylesheet.css'`