### PR TITLE
mesPapiers : Prohibits putting only spaces in a  document name

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
@@ -36,15 +36,22 @@ const InputTextAdapter = ({
   const [currentValue, setCurrentValue] = useState(defaultValue || '')
   const [isTooShort, setIsTooShort] = useState(false)
   const [hasOnlySpaces, setHasOnlySpaces] = useState(false)
+  const isError = isTooShort || hasOnlySpaces
 
   const { inputType, expectedLength, isRequired } = useMemo(
     () => makeConstraintsOfInput(attrs),
     [attrs]
   )
+
   const isValidInputValue = useMemo(
     () =>
-      checkConstraintsOfIinput(currentValue.length, expectedLength, isRequired),
-    [currentValue.length, expectedLength, isRequired]
+      checkConstraintsOfIinput({
+        valueLength: currentValue.length,
+        expectedLength,
+        isRequired,
+        isError
+      }),
+    [currentValue.length, expectedLength, isRequired, isError]
   )
 
   useEffect(() => {
@@ -131,7 +138,7 @@ const InputTextAdapter = ({
           type="text"
           variant="outlined"
           label={inputLabel ? t(inputLabel) : ''}
-          error={isTooShort || hasOnlySpaces}
+          error={isError}
           helperText={helperText}
           inputProps={{
             style: {
@@ -160,7 +167,7 @@ const InputTextAdapter = ({
       type="text"
       variant="outlined"
       label={inputLabel ? t(inputLabel) : ''}
-      error={isTooShort || hasOnlySpaces}
+      error={isError}
       helperText={helperText}
       value={currentValue}
       inputProps={{

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
@@ -35,6 +35,7 @@ const InputTextAdapter = ({
   const { t } = useI18n()
   const [currentValue, setCurrentValue] = useState(defaultValue || '')
   const [isTooShort, setIsTooShort] = useState(false)
+  const [hasOnlySpaces, setHasOnlySpaces] = useState(false)
 
   const { inputType, expectedLength, isRequired } = useMemo(
     () => makeConstraintsOfInput(attrs),
@@ -81,6 +82,12 @@ const InputTextAdapter = ({
         setCurrentValue(currentValue)
       }
     } else {
+      // regex: contains only spaces
+      if (currentValue.length !== 0 && currentValue.match(/^\s*$/)) {
+        setHasOnlySpaces(true)
+      } else {
+        setHasOnlySpaces(false)
+      }
       setCurrentValue(currentValue)
     }
   }
@@ -96,13 +103,17 @@ const InputTextAdapter = ({
       setIsTooShort(
         expectedLength.min != null && currentValue.length < expectedLength.min
       )
-    } else setIsTooShort(false)
+    } else {
+      setIsTooShort(false)
+    }
   }
 
   const helperText = isTooShort
     ? t('InputTextAdapter.invalidTextMessage', {
         smart_count: expectedLength.min - currentValue.length
       })
+    : hasOnlySpaces
+    ? t('InputTextAdapter.onlySpaces')
     : ' '
 
   if (mask) {
@@ -120,7 +131,7 @@ const InputTextAdapter = ({
           type="text"
           variant="outlined"
           label={inputLabel ? t(inputLabel) : ''}
-          error={isTooShort}
+          error={isTooShort || hasOnlySpaces}
           helperText={helperText}
           inputProps={{
             style: {
@@ -149,7 +160,7 @@ const InputTextAdapter = ({
       type="text"
       variant="outlined"
       label={inputLabel ? t(inputLabel) : ''}
-      error={isTooShort}
+      error={isTooShort || hasOnlySpaces}
       helperText={helperText}
       value={currentValue}
       inputProps={{

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -109,7 +109,8 @@
     "invalidDateMessage": "Invalid Date"
   },
   "InputTextAdapter": {
-    "invalidTextMessage": "%{smart_count} character is missing |||| %{smart_count} characters are missings"
+    "invalidTextMessage": "%{smart_count} character is missing |||| %{smart_count} characters are missings",
+    "onlySpaces": "The name contains only spaces"
   },
   "Onboarding": {
     "cta": "Let's go!"

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -109,7 +109,8 @@
     "invalidDateMessage": "Date invalide"
   },
   "InputTextAdapter": {
-    "invalidTextMessage": "Il manque %{smart_count} caractère |||| Il manque %{smart_count} caractères"
+    "invalidTextMessage": "Il manque %{smart_count} caractère |||| Il manque %{smart_count} caractères",
+    "onlySpaces": "Le nom ne contient que des espaces"
   },
   "Onboarding": {
     "cta": "C'est parti !"

--- a/packages/cozy-mespapiers-lib/src/utils/input.js
+++ b/packages/cozy-mespapiers-lib/src/utils/input.js
@@ -71,14 +71,16 @@ export const makeConstraintsOfInput = attrs => {
  * @param {boolean} isRequired - If value is required
  * @returns {boolean}
  */
-export const checkConstraintsOfIinput = (
+export const checkConstraintsOfIinput = ({
   valueLength,
   expectedLength,
-  isRequired
-) => {
+  isRequired,
+  isError
+}) => {
   const { min, max } = expectedLength
 
   return [
+    !isError,
     valueLength !== 0 || !isRequired,
     valueLength === 0 || min == null || valueLength >= min,
     valueLength === 0 || max == null || valueLength <= max

--- a/packages/cozy-mespapiers-lib/src/utils/input.spec.js
+++ b/packages/cozy-mespapiers-lib/src/utils/input.spec.js
@@ -45,12 +45,15 @@ describe('Input Utils', () => {
     it.each`
       valueLength | expectedLength              | isRequired | isError  | result
       ${0}        | ${{ min: null, max: null }} | ${false}   | ${false} | ${true}
+      ${0}        | ${{ min: null, max: null }} | ${false}   | ${true}  | ${false}
       ${0}        | ${{ min: null, max: null }} | ${true}    | ${false} | ${false}
       ${0}        | ${{ min: null, max: 0 }}    | ${false}   | ${false} | ${true}
+      ${0}        | ${{ min: null, max: 0 }}    | ${false}   | ${true}  | ${false}
       ${0}        | ${{ min: null, max: 0 }}    | ${true}    | ${false} | ${false}
       ${0}        | ${{ min: 0, max: null }}    | ${false}   | ${false} | ${true}
       ${0}        | ${{ min: 0, max: null }}    | ${true}    | ${false} | ${false}
       ${0}        | ${{ min: 0, max: 0 }}       | ${false}   | ${false} | ${true}
+      ${0}        | ${{ min: 0, max: 0 }}       | ${false}   | ${true}  | ${false}
       ${0}        | ${{ min: 0, max: 0 }}       | ${true}    | ${false} | ${false}
       ${0}        | ${{ min: null, max: 20 }}   | ${false}   | ${false} | ${true}
       ${0}        | ${{ min: null, max: 20 }}   | ${true}    | ${false} | ${false}
@@ -61,6 +64,7 @@ describe('Input Utils', () => {
       ${0}        | ${{ min: 10, max: 30 }}     | ${true}    | ${false} | ${false}
       ${0}        | ${{ min: 30, max: 10 }}     | ${true}    | ${false} | ${false}
       ${10}       | ${{ min: 10, max: 30 }}     | ${true}    | ${false} | ${true}
+      ${10}       | ${{ min: 10, max: 30 }}     | ${true}    | ${true}  | ${false}
       ${10}       | ${{ min: 30, max: 10 }}     | ${true}    | ${false} | ${false}
       ${20}       | ${{ min: 10, max: 30 }}     | ${true}    | ${false} | ${true}
       ${20}       | ${{ min: 30, max: 10 }}     | ${true}    | ${false} | ${false}
@@ -71,6 +75,7 @@ describe('Input Utils', () => {
       ${20}       | ${{ min: null, max: 10 }}   | ${false}   | ${false} | ${false}
       ${20}       | ${{ min: null, max: 20 }}   | ${false}   | ${false} | ${true}
       ${20}       | ${{ min: null, max: 30 }}   | ${false}   | ${false} | ${true}
+      ${20}       | ${{ min: null, max: 30 }}   | ${false}   | ${true}  | ${false}
       ${20}       | ${{ min: 10, max: null }}   | ${false}   | ${false} | ${true}
       ${20}       | ${{ min: 20, max: null }}   | ${false}   | ${false} | ${true}
       ${20}       | ${{ min: 30, max: null }}   | ${false}   | ${false} | ${false}

--- a/packages/cozy-mespapiers-lib/src/utils/input.spec.js
+++ b/packages/cozy-mespapiers-lib/src/utils/input.spec.js
@@ -43,42 +43,47 @@ describe('Input Utils', () => {
 
   describe('checkInputConstraints', () => {
     it.each`
-      valueLength | expectedLength              | isRequired | result
-      ${0}        | ${{ min: null, max: null }} | ${false}   | ${true}
-      ${0}        | ${{ min: null, max: null }} | ${true}    | ${false}
-      ${0}        | ${{ min: null, max: 0 }}    | ${false}   | ${true}
-      ${0}        | ${{ min: null, max: 0 }}    | ${true}    | ${false}
-      ${0}        | ${{ min: 0, max: null }}    | ${false}   | ${true}
-      ${0}        | ${{ min: 0, max: null }}    | ${true}    | ${false}
-      ${0}        | ${{ min: 0, max: 0 }}       | ${false}   | ${true}
-      ${0}        | ${{ min: 0, max: 0 }}       | ${true}    | ${false}
-      ${0}        | ${{ min: null, max: 20 }}   | ${false}   | ${true}
-      ${0}        | ${{ min: null, max: 20 }}   | ${true}    | ${false}
-      ${0}        | ${{ min: 20, max: null }}   | ${false}   | ${true}
-      ${0}        | ${{ min: 20, max: null }}   | ${true}    | ${false}
-      ${0}        | ${{ min: 10, max: 30 }}     | ${false}   | ${true}
-      ${0}        | ${{ min: 30, max: 10 }}     | ${false}   | ${true}
-      ${0}        | ${{ min: 10, max: 30 }}     | ${true}    | ${false}
-      ${0}        | ${{ min: 30, max: 10 }}     | ${true}    | ${false}
-      ${10}       | ${{ min: 10, max: 30 }}     | ${true}    | ${true}
-      ${10}       | ${{ min: 30, max: 10 }}     | ${true}    | ${false}
-      ${20}       | ${{ min: 10, max: 30 }}     | ${true}    | ${true}
-      ${20}       | ${{ min: 30, max: 10 }}     | ${true}    | ${false}
-      ${30}       | ${{ min: 10, max: 30 }}     | ${true}    | ${true}
-      ${30}       | ${{ min: 30, max: 10 }}     | ${true}    | ${false}
-      ${40}       | ${{ min: 10, max: 30 }}     | ${true}    | ${false}
-      ${40}       | ${{ min: 30, max: 10 }}     | ${true}    | ${false}
-      ${20}       | ${{ min: null, max: 10 }}   | ${false}   | ${false}
-      ${20}       | ${{ min: null, max: 20 }}   | ${false}   | ${true}
-      ${20}       | ${{ min: null, max: 30 }}   | ${false}   | ${true}
-      ${20}       | ${{ min: 10, max: null }}   | ${false}   | ${true}
-      ${20}       | ${{ min: 20, max: null }}   | ${false}   | ${true}
-      ${20}       | ${{ min: 30, max: null }}   | ${false}   | ${false}
+      valueLength | expectedLength              | isRequired | isError  | result
+      ${0}        | ${{ min: null, max: null }} | ${false}   | ${false} | ${true}
+      ${0}        | ${{ min: null, max: null }} | ${true}    | ${false} | ${false}
+      ${0}        | ${{ min: null, max: 0 }}    | ${false}   | ${false} | ${true}
+      ${0}        | ${{ min: null, max: 0 }}    | ${true}    | ${false} | ${false}
+      ${0}        | ${{ min: 0, max: null }}    | ${false}   | ${false} | ${true}
+      ${0}        | ${{ min: 0, max: null }}    | ${true}    | ${false} | ${false}
+      ${0}        | ${{ min: 0, max: 0 }}       | ${false}   | ${false} | ${true}
+      ${0}        | ${{ min: 0, max: 0 }}       | ${true}    | ${false} | ${false}
+      ${0}        | ${{ min: null, max: 20 }}   | ${false}   | ${false} | ${true}
+      ${0}        | ${{ min: null, max: 20 }}   | ${true}    | ${false} | ${false}
+      ${0}        | ${{ min: 20, max: null }}   | ${false}   | ${false} | ${true}
+      ${0}        | ${{ min: 20, max: null }}   | ${true}    | ${false} | ${false}
+      ${0}        | ${{ min: 10, max: 30 }}     | ${false}   | ${false} | ${true}
+      ${0}        | ${{ min: 30, max: 10 }}     | ${false}   | ${false} | ${true}
+      ${0}        | ${{ min: 10, max: 30 }}     | ${true}    | ${false} | ${false}
+      ${0}        | ${{ min: 30, max: 10 }}     | ${true}    | ${false} | ${false}
+      ${10}       | ${{ min: 10, max: 30 }}     | ${true}    | ${false} | ${true}
+      ${10}       | ${{ min: 30, max: 10 }}     | ${true}    | ${false} | ${false}
+      ${20}       | ${{ min: 10, max: 30 }}     | ${true}    | ${false} | ${true}
+      ${20}       | ${{ min: 30, max: 10 }}     | ${true}    | ${false} | ${false}
+      ${30}       | ${{ min: 10, max: 30 }}     | ${true}    | ${false} | ${true}
+      ${30}       | ${{ min: 30, max: 10 }}     | ${true}    | ${false} | ${false}
+      ${40}       | ${{ min: 10, max: 30 }}     | ${true}    | ${false} | ${false}
+      ${40}       | ${{ min: 30, max: 10 }}     | ${true}    | ${false} | ${false}
+      ${20}       | ${{ min: null, max: 10 }}   | ${false}   | ${false} | ${false}
+      ${20}       | ${{ min: null, max: 20 }}   | ${false}   | ${false} | ${true}
+      ${20}       | ${{ min: null, max: 30 }}   | ${false}   | ${false} | ${true}
+      ${20}       | ${{ min: 10, max: null }}   | ${false}   | ${false} | ${true}
+      ${20}       | ${{ min: 20, max: null }}   | ${false}   | ${false} | ${true}
+      ${20}       | ${{ min: 30, max: null }}   | ${false}   | ${false} | ${false}
     `(
       `should return $result when passed argument: ($valueLength, $expectedLength, $isRequired)`,
-      ({ valueLength, expectedLength, isRequired, result }) => {
+      ({ valueLength, expectedLength, isRequired, isError, result }) => {
         expect(
-          checkConstraintsOfIinput(valueLength, expectedLength, isRequired)
+          checkConstraintsOfIinput({
+            valueLength,
+            expectedLength,
+            isRequired,
+            isError
+          })
         ).toEqual(result)
       }
     )


### PR DESCRIPTION
Lors de la création d'un papier, on souhaite interdire la possibilité de créer un nom avec seulement des espaces. Dans ce cas, on affiche un message d'erreur, et on interdit la possibilité de passer à l'étape suivante.