### PR TITLE
Add driver_license paper for the strangers

### DIFF
--- a/packages/cozy-mespapiers-lib/package.json
+++ b/packages/cozy-mespapiers-lib/package.json
@@ -23,7 +23,7 @@
     "cozy-intent": "^2.5.0",
     "cozy-realtime": "^4.2.5",
     "cozy-sharing": "^4.5.7",
-    "cozy-ui": "^75.1.0",
+    "cozy-ui": "^75.3.0",
     "jest-environment-jsdom-sixteen": "2.0.0",
     "react-router-dom": "6.3.0"
   },
@@ -44,7 +44,7 @@
     "cozy-intent": ">=2.2.0",
     "cozy-realtime": ">=4.2.0",
     "cozy-sharing": ">=4.3.0",
-    "cozy-ui": ">=75.1.0",
+    "cozy-ui": ">=75.3.0",
     "react-router-dom": ">=6.3.0"
   }
 }

--- a/packages/cozy-mespapiers-lib/package.json
+++ b/packages/cozy-mespapiers-lib/package.json
@@ -16,7 +16,7 @@
     "@testing-library/react": "11.2.7",
     "babel-preset-cozy-app": "2.0.1",
     "cozy-bar": "7.16.0",
-    "cozy-client": "^33.0.6",
+    "cozy-client": "^33.1.0",
     "cozy-device-helper": "^2.4.0",
     "cozy-doctypes": "^1.85.3",
     "cozy-harvest-lib": "^9.26.14",
@@ -37,7 +37,7 @@
     "react-input-mask": "3.0.0-alpha.2"
   },
   "peerDependencies": {
-    "cozy-client": ">=33.0.6",
+    "cozy-client": ">=33.1.0",
     "cozy-device-helper": ">=2.2.0",
     "cozy-doctypes": ">=1.83.8",
     "cozy-harvest-lib": ">=9.10.1",

--- a/packages/cozy-mespapiers-lib/src/components/Contexts/ScannerI18nProvider.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Contexts/ScannerI18nProvider.jsx
@@ -13,10 +13,7 @@ const ScannerI18nProvider = ({ children }) => {
   const { lang } = useI18n()
   const scannerI18n = getBoundT(lang || 'fr')
 
-  const scannerT = React.useCallback(
-    key => scannerI18n(`${prefix}.${key}`),
-    [scannerI18n]
-  )
+  const scannerT = (key, country) => scannerI18n(`${prefix}.${key}`, country)
 
   return (
     <ScannerI18nContext.Provider value={scannerT}>

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/helpers.js
@@ -101,3 +101,16 @@ export const updateReferencedContact = async ({
 
   await client.save(currentFile)
 }
+
+export const getPaperDefinitionByFile = (papersDefinitions, file) => {
+  return papersDefinitions.find(paper => {
+    const countryCondition =
+      file.metadata.country && paper.country
+        ? file.metadata.country === 'fr'
+          ? paper.country === 'fr'
+          : paper.country === 'stranger'
+        : true
+
+    return paper.label === file.metadata.qualification.label && countryCondition
+  })
+}

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/useCurrentEditInformations.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/useCurrentEditInformations.jsx
@@ -3,7 +3,7 @@ import { isQueryLoading, useQuery } from 'cozy-client'
 
 import { buildFilesQueryById } from '../../../helpers/queries'
 import { usePapersDefinitions } from '../../Hooks/usePapersDefinitions'
-import { makeCurrentStep } from './helpers'
+import { getPaperDefinitionByFile, makeCurrentStep } from './helpers'
 
 /**
  * @param {string} fileId
@@ -29,9 +29,7 @@ export const useCurrentEditInformations = (fileId, model) => {
 
   const paperDef =
     (!isLoadingFiles &&
-      papersDefinitions.find(
-        paper => paper.label === files?.[0]?.metadata?.qualification?.label
-      )) ||
+      getPaperDefinitionByFile(papersDefinitions, files[0])) ||
     null
 
   const currentStep = makeCurrentStep({ paperDef, model, metadataName })

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/FeaturedPlaceholdersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/FeaturedPlaceholdersList.jsx
@@ -25,9 +25,13 @@ const FeaturedPlaceholdersList = ({ featuredPlaceholders }) => {
   }
 
   const redirectPaperCreation = placeholder => {
+    hideImportDropdown()
+    const countrySearchParam = `${
+      placeholder.country ? `country=${placeholder.country}&` : ''
+    }`
     return navigate({
       pathname: `/paper/create/${placeholder.label}`,
-      search: `backgroundPath=${location.pathname}`
+      search: `${countrySearchParam}backgroundPath=${location.pathname}`
     })
   }
 

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/PlaceholderListModal/PlaceholdersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/PlaceholderListModal/PlaceholdersList.jsx
@@ -64,9 +64,12 @@ const PlaceholdersList = ({ currentQualifItems }) => {
   }
 
   const redirectPaperCreation = placeholder => {
+    const countrySearchParam = `${
+      placeholder.country ? `country=${placeholder.country}&` : ''
+    }`
     return navigate({
       pathname: `/paper/create/${placeholder.label}`,
-      search: `backgroundPath=${backgroundPath}`
+      search: `${countrySearchParam}backgroundPath=${backgroundPath}`
     })
   }
 

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/PlaceholderListModal/PlaceholdersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/PlaceholderListModal/PlaceholdersList.jsx
@@ -98,7 +98,12 @@ const PlaceholdersList = ({ currentQualifItems }) => {
               <ListItemIcon>
                 <FileIcon icon={placeholder.icon} />
               </ListItemIcon>
-              <ListItemText primary={scannerT(`items.${placeholder.label}`)} />
+              <ListItemText
+                primary={scannerT(
+                  `items.${placeholder.label}`,
+                  placeholder.country
+                )}
+              />
             </ListItem>
           )
         })}

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/PlaceholderListModal/PlaceholdersList.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/PlaceholderListModal/PlaceholdersList.spec.jsx
@@ -38,7 +38,7 @@ describe('PlaceholdersList components:', () => {
     const placeholdersLines = getAllByTestId('PlaceholdersList-ListItem')
 
     expect(placeholdersLines).toHaveLength(2)
-    expect(getByText('ID card'))
+    expect(getByText('ID card (🇫🇷)'))
     expect(getByText('ISP invoice'))
   })
 

--- a/packages/cozy-mespapiers-lib/src/components/StepperDialog/CreatePaperModal.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/StepperDialog/CreatePaperModal.jsx
@@ -1,12 +1,12 @@
 import React, { useMemo, useEffect } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 
-import { findPlaceholdersByQualification } from '../../helpers/findPlaceholders'
 import { FormDataProvider } from '../Contexts/FormDataProvider'
 import { StepperDialogProvider } from '../Contexts/StepperDialogProvider'
 import { usePapersDefinitions } from '../Hooks/usePapersDefinitions'
 import { useStepperDialog } from '../Hooks/useStepperDialog'
 import StepperDialogWrapper from './StepperDialogWrapper'
+import { findPlaceholderByLabelAndCountry } from '../../helpers/findPlaceholders'
 
 const CreatePaperModal = () => {
   const { search } = useLocation()
@@ -15,14 +15,15 @@ const CreatePaperModal = () => {
   const { papersDefinitions } = usePapersDefinitions()
   const { setCurrentDefinition, currentDefinition } = useStepperDialog()
   const backgroundPath = new URLSearchParams(search).get('backgroundPath')
+  const country = new URLSearchParams(search).get('country')
   const allPlaceholders = useMemo(
     () =>
-      findPlaceholdersByQualification(papersDefinitions, [
-        {
-          label: qualificationLabel
-        }
-      ]),
-    [qualificationLabel, papersDefinitions]
+      findPlaceholderByLabelAndCountry(
+        papersDefinitions,
+        qualificationLabel,
+        country
+      ),
+    [qualificationLabel, papersDefinitions, country]
   )
 
   const formModel = allPlaceholders[0]

--- a/packages/cozy-mespapiers-lib/src/components/StepperDialog/StepperDialogWrapper.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/StepperDialog/StepperDialogWrapper.jsx
@@ -12,6 +12,7 @@ const StepperDialogWrapper = ({ onClose }) => {
   const scannerT = useScannerI18n()
   const {
     allCurrentSteps,
+    currentDefinition,
     currentStepIndex,
     previousStep,
     stepperDialogTitle
@@ -29,7 +30,10 @@ const StepperDialogWrapper = ({ onClose }) => {
       open
       onClose={onClose}
       onBack={handleBack()}
-      title={stepperDialogTitle && scannerT(`items.${stepperDialogTitle}`)}
+      title={
+        Boolean(stepperDialogTitle) &&
+        scannerT(`items.${stepperDialogTitle}`, currentDefinition.country)
+      }
       content={<StepperDialogContent onClose={onClose} />}
       stepper={`${currentStepIndex}/${allCurrentSteps.length}`}
     />

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -253,6 +253,54 @@
       ]
     },
     {
+      "label": "driver_license",
+      "country": "stranger",
+      "icon": "car",
+      "featureDate": "obtentionDate",
+      "maxDisplay": 2,
+      "acquisitionSteps": [
+        {
+          "stepIndex": 1,
+          "model": "scan",
+          "multipage": true,
+          "illustration": "IlluGenericNewPage.svg",
+          "text": "PaperJSON.generic.multiPages.text"
+        },
+        {
+          "stepIndex": 2,
+          "model": "information",
+          "illustration": "IlluDriverLicenseNumberHelp.png",
+          "text": "PaperJSON.driverLicense.stranger.country.text",
+          "attributes": [
+            {
+              "name": "country",
+              "type": "text",
+              "inputLabel": "PaperJSON.driverLicense.stranger.country.inputLabel"
+            }
+          ]
+        },
+        {
+          "stepIndex": 3,
+          "model": "information",
+          "illustration": "IlluDriverLicenseObtentionDateHelp.png",
+          "text": "PaperJSON.driverLicense.stranger.obtentionDate.text",
+          "attributes": [
+            {
+              "name": "obtentionDate",
+              "type": "date",
+              "inputLabel": "PaperJSON.driverLicense.stranger.obtentionDate.inputLabel"
+            }
+          ]
+        },
+        {
+          "stepIndex": 4,
+          "illustration": "Account.svg",
+          "model": "contact",
+          "text": "PaperJSON.generic.owner.text"
+        }
+      ]
+    },
+    {
       "label": "energy_invoice",
       "icon": "bill",
       "featureDate": "referencedDate",

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -182,6 +182,7 @@
     },
     {
       "label": "driver_license",
+      "country": "fr",
       "placeholderIndex": 2,
       "icon": "car",
       "featureDate": "carObtentionDate",
@@ -490,6 +491,7 @@
     },
     {
       "label": "national_id_card",
+      "country": "fr",
       "placeholderIndex": 1,
       "icon": "people",
       "featureDate": "expirationDate",

--- a/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
@@ -84,3 +84,35 @@ export const findPlaceholdersByQualification = (
     qualificationItems.some(item => item.label === paperDefinition.label)
   )
 }
+
+const filterPlaceholderByLabelAndCountry = ({
+  paperDefinition,
+  label,
+  country
+}) => {
+  const countryCondition = paperDefinition.country
+    ? country == null
+      ? paperDefinition.country === 'fr'
+      : paperDefinition.country === country ||
+        paperDefinition.country === 'stranger'
+    : true
+
+  return label === paperDefinition.label && countryCondition
+}
+
+/**
+ * Find placeholders by Qualification
+ * @param {Object[]} papersDefinitions - Object of qualification
+ * @param {string} label - Label of qualification
+ * @param {string} country - country of document
+ * @returns {PaperDefinition[]} - Array of PapersDefinition
+ */
+export const findPlaceholderByLabelAndCountry = (
+  papersDefinitions,
+  label,
+  country
+) => {
+  return papersDefinitions.filter(paperDefinition =>
+    filterPlaceholderByLabelAndCountry({ paperDefinition, label, country })
+  )
+}

--- a/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.spec.js
@@ -1,7 +1,8 @@
 import {
   getFeaturedPlaceholders,
   findPlaceholdersByQualification,
-  hasNoFileWithSameQualificationLabel
+  hasNoFileWithSameQualificationLabel,
+  findPlaceholderByLabelAndCountry
 } from './findPlaceholders'
 import { mockPapersDefinitions } from '../../test/mockPaperDefinitions'
 
@@ -20,7 +21,7 @@ const fakeQualificationItems = [
   }
 ]
 
-describe('getPlaceholders', () => {
+describe('findPlaceholders', () => {
   describe('getFeaturedPlaceholders', () => {
     it('should return list of placeholders', () => {
       const featuredPlaceholders = getFeaturedPlaceholders({
@@ -172,12 +173,100 @@ describe('getPlaceholders', () => {
       )
     })
   })
-})
+  describe('hasNoFileWithSameQualificationLabel', () => {
+    it('should handle empty files', () => {
+      const res = hasNoFileWithSameQualificationLabel(
+        null,
+        mockPapersDefinitions
+      )
 
-describe('hasNoFileWithSameQualificationLabel', () => {
-  it('should handle empty files', () => {
-    const res = hasNoFileWithSameQualificationLabel(null, mockPapersDefinitions)
+      expect(res).toBe(null)
+    })
+  })
+  describe('findPlaceholderByLabelAndCountry', () => {
+    it('should return an empty list', () => {
+      const placeholders = findPlaceholderByLabelAndCountry(
+        mockPapersDefinitions
+      )
 
-    expect(res).toBe(null)
+      expect(placeholders).toHaveLength(0)
+    })
+    it('should return correct paperDefinition with no country param & paperDefinition has no country', () => {
+      const placeholders = findPlaceholderByLabelAndCountry(
+        mockPapersDefinitions,
+        'isp_invoice'
+      )
+
+      expect(placeholders).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            label: 'isp_invoice'
+          })
+        ])
+      )
+    })
+    it('should return FR paperDefinition by default', () => {
+      const placeholders = findPlaceholderByLabelAndCountry(
+        mockPapersDefinitions,
+        'driver_license'
+      )
+
+      expect(placeholders).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            label: 'driver_license',
+            country: 'fr'
+          })
+        ])
+      )
+    })
+    it('should return FR paperDefinition', () => {
+      const placeholders = findPlaceholderByLabelAndCountry(
+        mockPapersDefinitions,
+        'driver_license',
+        'fr'
+      )
+
+      expect(placeholders).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            label: 'driver_license',
+            country: 'fr'
+          })
+        ])
+      )
+    })
+    it('should return Stranger paperDefinition', () => {
+      const placeholders = findPlaceholderByLabelAndCountry(
+        mockPapersDefinitions,
+        'driver_license',
+        'stranger'
+      )
+
+      expect(placeholders).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            label: 'driver_license',
+            country: 'stranger'
+          })
+        ])
+      )
+    })
+    it("should return Stranger paperDefinition if country is defined but value doesn't exist", () => {
+      const placeholders = findPlaceholderByLabelAndCountry(
+        mockPapersDefinitions,
+        'driver_license',
+        'en'
+      )
+
+      expect(placeholders).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            label: 'driver_license',
+            country: 'stranger'
+          })
+        ])
+      )
+    })
   })
 })

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -209,6 +209,16 @@
       },
       "DObtentionDate": {
         "inputLabel": "Bus"
+      },
+      "stranger": {
+        "country": {
+          "inputLabel": "Country of delivery",
+          "text": "What is the country of delivery?"
+        },
+        "obtentionDate": {
+          "inputLabel": "Date of obtaining",
+          "text": "Fill in the date of obtaining"
+        }
       }
     },
     "card": {

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -209,6 +209,16 @@
       },
       "DObtentionDate": {
         "inputLabel": "Bus (D)"
+      },
+      "stranger": {
+        "country": {
+          "inputLabel": "Pays de délivrance",
+          "text": "Quel est le pays de délivrance ?"
+        },
+        "obtentionDate": {
+          "inputLabel": "Date d'obtention",
+          "text": "Renseignez la date d'obtention"
+        }
       }
     },
     "card": {

--- a/packages/cozy-mespapiers-lib/test/mockPaperDefinitions.js
+++ b/packages/cozy-mespapiers-lib/test/mockPaperDefinitions.js
@@ -90,5 +90,103 @@ export const mockPapersDefinitions = [
     connectorCriteria: {
       name: 'impots'
     }
+  },
+  {
+    label: 'driver_license',
+    country: 'fr',
+    icon: 'car',
+    featureDate: 'obtentionDate',
+    maxDisplay: 2,
+    acquisitionSteps: [
+      {
+        stepIndex: 1,
+        model: 'scan',
+        multipage: true,
+        illustration: 'IlluGenericNewPage.svg',
+        text: 'PaperJSON.generic.multiPages.text'
+      },
+      {
+        stepIndex: 2,
+        model: 'information',
+        illustration: 'IlluDriverLicenseNumberHelp.png',
+        text: 'PaperJSON.driverLicense.stranger.country.text',
+        attributes: [
+          {
+            name: 'country',
+            type: 'text',
+            inputLabel: 'PaperJSON.driverLicense.stranger.country.inputLabel'
+          }
+        ]
+      },
+      {
+        stepIndex: 3,
+        model: 'information',
+        illustration: 'IlluDriverLicenseObtentionDateHelp.png',
+        text: 'PaperJSON.driverLicense.stranger.obtentionDate.text',
+        attributes: [
+          {
+            name: 'obtentionDate',
+            type: 'date',
+            inputLabel:
+              'PaperJSON.driverLicense.stranger.obtentionDate.inputLabel'
+          }
+        ]
+      },
+      {
+        stepIndex: 4,
+        illustration: 'Account.svg',
+        model: 'contact',
+        text: 'PaperJSON.generic.owner.text'
+      }
+    ]
+  },
+  {
+    label: 'driver_license',
+    country: 'stranger',
+    icon: 'car',
+    featureDate: 'obtentionDate',
+    maxDisplay: 2,
+    acquisitionSteps: [
+      {
+        stepIndex: 1,
+        model: 'scan',
+        multipage: true,
+        illustration: 'IlluGenericNewPage.svg',
+        text: 'PaperJSON.generic.multiPages.text'
+      },
+      {
+        stepIndex: 2,
+        model: 'information',
+        illustration: 'IlluDriverLicenseNumberHelp.png',
+        text: 'PaperJSON.driverLicense.stranger.country.text',
+        attributes: [
+          {
+            name: 'country',
+            type: 'text',
+            inputLabel: 'PaperJSON.driverLicense.stranger.country.inputLabel'
+          }
+        ]
+      },
+      {
+        stepIndex: 3,
+        model: 'information',
+        illustration: 'IlluDriverLicenseObtentionDateHelp.png',
+        text: 'PaperJSON.driverLicense.stranger.obtentionDate.text',
+        attributes: [
+          {
+            name: 'obtentionDate',
+            type: 'date',
+            inputLabel:
+              'PaperJSON.driverLicense.stranger.obtentionDate.inputLabel'
+          }
+        ]
+      },
+      {
+        stepIndex: 4,
+        illustration: 'Account.svg',
+        model: 'contact',
+        text: 'PaperJSON.generic.owner.text'
+      }
+    ]
   }
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -6791,10 +6791,10 @@ cozy-ui@62.1.2:
     react-select "^4.3.0"
     react-swipeable-views "^0.13.3"
 
-cozy-ui@^75.1.0:
-  version "75.1.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-75.1.0.tgz#50c85361cba3b398eaeae69fe638cc5f61a4665a"
-  integrity sha512-ouTYbWgRJB8Aaf0SVOZ6o4aCPZ2TAxDNAHS+L9ZNOlDtwImyieeT0IgfIvilGQIt2yI7rGxoZW2IkxvqCtb7og==
+cozy-ui@^75.3.0:
+  version "75.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-75.3.0.tgz#013a3fbd0a879d28722d3d3025b61ad934b50ba3"
+  integrity sha512-6QgjQQjRYqIFx05a1zKOo4gx7vPsZZpz6Jg8S7BBxlTFYbNgi9Dck57CQtGEvtLoGY03UVQ0CAb9j2AIgAp+aQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6528,16 +6528,16 @@ cozy-client@^32.2.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^33.0.6:
-  version "33.0.6"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-33.0.6.tgz#0d7bf21bbb58b3284050d25bb61b5f4b629fd5ba"
-  integrity sha512-HRBbwuAhbH1t3EewAfWCfXrXzuGws/PycY20llNtHG230+ouZL4guTtk3YmIMo3XsV/WzdDynaNE2KbN0aZZFw==
+cozy-client@^33.1.0:
+  version "33.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-33.1.0.tgz#a773191d6b96bcf95602347999078213bc7817f9"
+  integrity sha512-EGZleWdxV50gD+rzDW1Bhg7wRcawMYSjUeN4C89bHR5U4x93/KcO9RjWiIhcepjLE5DWL71tp+NBhyDApCCJkA==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^33.0.6"
+    cozy-stack-client "^33.0.8"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -6676,10 +6676,10 @@ cozy-stack-client@^32.2.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^33.0.6:
-  version "33.0.6"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-33.0.6.tgz#1f83eed0b295b88ae6b51a17a6c0713eba0b7730"
-  integrity sha512-Qfn7dXmIelpefby2GclwjWqr7QiGot18I6+/k92BQtZGZ9qeTlcS9pggnZfKjpntSyzLhguiE4tXs1UmDvVGtQ==
+cozy-stack-client@^33.0.8:
+  version "33.0.8"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-33.0.8.tgz#e08c432687f3b9c5d3c3269634d0316c873e92cb"
+  integrity sha512-Un149jVmuL9e7Y+N1u5pY75VOjo2MUL1nad5R3LRo/EwY4HkvcQ6hQBpYyN1ZnLJxTRI8lwNMXRfZiu9jCKvoQ==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
Maintenant, suite à la version 33.1.0 de [cozy-client](https://github.com/cozy/cozy-client/releases/tag/v33.1.0), nous pouvons spécifier les papiers suivants :
- Carte d'identité (🇫🇷)
- Permis de conduire (🇫🇷)
- Permis de conduire (Étranger)

Les libellés de qualification restes les mêmes, l'ajout de attribut `country` permet de spécifier le pays et ainsi suivre un process de création différent.