### PR TITLE
fix: Bind this automatically with arrow function

### DIFF
--- a/packages/cozy-sharing/src/SharingProvider.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.jsx
@@ -98,8 +98,6 @@ export class SharingProvider extends Component {
     const { client } = props
     this.sharingCol = client.collection(SHARING_DOCTYPE)
     this.permissionCol = client.collection(PERMISSION_DOCTYPE)
-
-    this.fetchAllSharings = this.fetchAllSharings.bind(this)
   }
 
   dispatch = action =>
@@ -169,7 +167,7 @@ export class SharingProvider extends Component {
     }
   }
 
-  async fetchAllSharings() {
+  fetchAllSharings = async () => {
     const { doctype, client } = this.props
     const [sharings, permissions, apps] = await Promise.all([
       this.sharingCol.findByDoctype(doctype),


### PR DESCRIPTION
In drive, when moving a file, I got a "this.props" is undefined. It seems that fetchAllsharing was
already binded to this, but by converting it to
an arrow function, I don't have the issue anymore.