### PR TITLE
fix(mespapiers): Modification of the `country` attribute if empty

### DIFF
--- a/packages/cozy-mespapiers-lib/package.json
+++ b/packages/cozy-mespapiers-lib/package.json
@@ -23,7 +23,7 @@
     "cozy-intent": "^2.5.0",
     "cozy-realtime": "^4.2.5",
     "cozy-sharing": "^4.5.7",
-    "cozy-ui": "^75.4.0",
+    "cozy-ui": "^75.6.0",
     "jest-environment-jsdom-sixteen": "2.0.0",
     "react-router-dom": "6.3.0"
   },
@@ -44,7 +44,7 @@
     "cozy-intent": ">=2.2.0",
     "cozy-realtime": ">=4.2.0",
     "cozy-sharing": ">=4.3.0",
-    "cozy-ui": ">=75.4.0",
+    "cozy-ui": ">=75.6.0",
     "react-router-dom": ">=6.3.0"
   }
 }

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/helpers.js
@@ -102,7 +102,7 @@ export const updateReferencedContact = async ({
 export const getPaperDefinitionByFile = (papersDefinitions, file) => {
   return papersDefinitions.find(paper => {
     const countryCondition =
-      file.metadata.country && paper.country
+      Object.keys(file.metadata).includes('country') && paper.country
         ? file.metadata.country === 'fr'
           ? paper.country === 'fr'
           : paper.country === 'stranger'

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/helpers.spec.js
@@ -82,7 +82,7 @@ const makeFakeFile = ({ country, qualificationLabel } = {}) => ({
     datetimeLabel: 'expirationDate',
     expirationDate: '2022-09-29T11:53:00.000Z',
     page: 'front',
-    ...(country && { country }),
+    ...(country !== undefined && { country }),
     qualification: {
       label: qualificationLabel
     }
@@ -403,6 +403,18 @@ describe('getPaperDefinitionByFile', () => {
       const fakeFile = makeFakeFile({
         qualificationLabel: 'driver_license',
         country: 'en'
+      })
+      const res = getPaperDefinitionByFile(mockPapersDefinitions, fakeFile)
+
+      expect(res).toMatchObject({
+        label: 'driver_license',
+        country: 'stranger'
+      })
+    })
+    it('should return the paperDefinition "driver_license", with the country "stranger" if it empty in file', () => {
+      const fakeFile = makeFakeFile({
+        qualificationLabel: 'driver_license',
+        country: ''
       })
       const res = getPaperDefinitionByFile(mockPapersDefinitions, fakeFile)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6791,10 +6791,10 @@ cozy-ui@62.1.2:
     react-select "^4.3.0"
     react-swipeable-views "^0.13.3"
 
-cozy-ui@^75.4.0:
-  version "75.4.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-75.4.0.tgz#7cdab71ae16f046028bbdc7e470a412c0ef15522"
-  integrity sha512-+mz3kOZ+ON/XTXY0Yc8MRDqgvX02bnMLVnTKwxOrrlz+PDQZh6Ot4NNkw+XCv43j2Hetk+GQOuPpXU1DXlW50Q==
+cozy-ui@^75.6.0:
+  version "75.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-75.6.0.tgz#afb55670cc150dadf5cd8132995e137e7036c346"
+  integrity sha512-tLJLM5GfzMEvnJTPkp7V21brKb2jtQhbgoa1IJQb5MfIAUNamuA7g/olrqqswFqVtEBYOmIfwx2isInIhzIxZQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"


### PR DESCRIPTION
Si l'attribut `country` est présent mais vide("") dans les metadata du fichier, lors de la modification, nous devons bien le considérer comme un papier non FR