### PR TITLE
fix: Expose sendNotification from cozy-client realtime plugin

### DIFF
--- a/packages/cozy-realtime/src/RealtimePlugin.js
+++ b/packages/cozy-realtime/src/RealtimePlugin.js
@@ -69,6 +69,14 @@ class RealtimePlugin {
     this.checkRealtimeInstance()
     this.realtime.unsubscribeAll()
   }
+
+  /**
+   * @see CozyRealtime.sendNotification
+   */
+  sendNotification(...args) {
+    this.checkRealtimeInstance()
+    this.realtime.sendNotification(...args)
+  }
 }
 
 RealtimePlugin.pluginName = 'realtime'

--- a/packages/cozy-realtime/src/RealtimePlugin.spec.js
+++ b/packages/cozy-realtime/src/RealtimePlugin.spec.js
@@ -21,6 +21,7 @@ it('should expose the same API as CozyRealtime', () => {
   expect(client.plugins.realtime.subscribe).toBeInstanceOf(Function)
   expect(client.plugins.realtime.unsubscribe).toBeInstanceOf(Function)
   expect(client.plugins.realtime.unsubscribeAll).toBeInstanceOf(Function)
+  expect(client.plugins.realtime.sendNotification).toBeInstanceOf(Function)
 })
 
 it('should login/logout correctly', async () => {


### PR DESCRIPTION
It is especially needed in harvest to send notification from harvest
to the banks application to know when a job is waited for.

And since the realtime plugin is supposed to expose the same api as
CozyRealtime
