### PR TITLE
feat: Add possibility to use params in toggleSetting()

### DIFF
--- a/packages/cozy-intent/src/api/models/methods.ts
+++ b/packages/cozy-intent/src/api/models/methods.ts
@@ -15,7 +15,8 @@ interface _NativeMethodsRegister {
   setFlagshipUI: (flagshipUI: FlagshipUI, caller?: string) => Promise<null>
   showSplashScreen: () => Promise<null>
   toggleSetting: (
-    settingName: 'biometryLock' | 'PINLock' | 'autoLock'
+    settingName: 'biometryLock' | 'PINLock' | 'autoLock',
+    params?: Record<string, unknown>
   ) => Promise<boolean | null>
 }
 


### PR DESCRIPTION
Params can be a hashed PIN value for instance.
The type Record<string, unknown> is lax on purpose, I don't know what will be exactly needed so it sounds better to let the developer some freedom here