### PR TITLE
feat: Allow to pass custom Properties to OAuthForm wrapper

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -325,6 +325,7 @@ export class DumbTriggerManager extends Component {
       flowState,
       client,
       OAuthFormWrapperComp,
+      OAuthFormWrapperCompProps = {},
       reconnect,
       intentsApi
     } = this.props
@@ -346,7 +347,7 @@ export class DumbTriggerManager extends Component {
         ? OAuthFormWrapperComp
         : React.Fragment
       return (
-        <Wrapper>
+        <Wrapper {...OAuthFormWrapperCompProps}>
           <OAuthForm
             client={client}
             flow={flow}
@@ -456,6 +457,8 @@ DumbTriggerManager.propTypes = {
     PropTypes.element,
     PropTypes.func
   ]),
+  /** Used to pass props to OAuthFormWrapperComp without causing a rerender of TriggerManager */
+  OAuthFormWrapperCompProps: PropTypes.object,
   /** Is it a reconnection or not */
   reconnect: PropTypes.bool,
   // custom intents api. Can have fetchSessionCode, showInAppBrowser, closeInAppBrowser at the moment


### PR DESCRIPTION
via OAuthFormWrapperCompProps and without unmounting/remounting
OauthForm on each rerender

This avoids the disparition of the BI webview in banks when a new job is
expected
