### PR TITLE
fix: This.input is not defined

### DIFF
--- a/packages/cozy-authentication/src/steps/SelectServer.jsx
+++ b/packages/cozy-authentication/src/steps/SelectServer.jsx
@@ -65,8 +65,6 @@ export class SelectServer extends Component {
         'Cozy-Authentication needs a cozy/cordova-plugin-keyboard plugin to work better.'
       )
     }
-
-    this.input.focus()
   }
   // eslint-disable-next-line
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
Since a few versions, Cozy-UI's input
has been converted to function with a
forwardRef.

It results that the ref callback can
be called after the didMount() method
so calling focus() on it crash the app.

Since cozy-auth is only on "maintenance"
mode, I just remove this focus stuff since
almost all webviews will focus on the input
if there is only one displayed.