### PR TITLE
fix: Add explicit blocked popup message

### DIFF
--- a/packages/cozy-harvest-lib/src/components/Popup.jsx
+++ b/packages/cozy-harvest-lib/src/components/Popup.jsx
@@ -100,6 +100,12 @@ export class Popup extends PureComponent {
       `scrollbars=yes, width=${w}, height=${h}, top=${top}, left=${left}`
     )
 
+    if (!popup) {
+      throw new Error(
+        'Popup was blocked by browser. Be sure to not call showPopup asynchronously'
+      )
+    }
+
     // Puts focus on the newWindow
     if (popup.focus) {
       popup.focus()


### PR DESCRIPTION
When an OAuth popup was blocked, we got "null is not an object" error in
console.

Now we will get "Popup was blocked by browser. Be sure to not call
showPopup asynchronously" which may be more explicit
