### PR TITLE
Remove realtime

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/MesPapiersLib.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/MesPapiersLib.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { RealTimeQueries } from 'cozy-client'
 import flag from 'cozy-flags'
 import FlagSwitcher from 'cozy-flags/dist/FlagSwitcher'
 import Typography from 'cozy-ui/transpiled/react/Typography'
@@ -42,8 +41,6 @@ const App = () => {
       ) : (
         <AppRouter />
       )}
-      <RealTimeQueries doctype="io.cozy.files" />
-      <RealTimeQueries doctype="io.cozy.mespapiers.settings" />
       <Alerter t={t} />
       <ModalStack />
     </>


### PR DESCRIPTION
BREAKING CHANGE: Real time must be added in applications Since the update of the router,
the only router present is on the application side, so some navigations in the application
can create new WS, which can create some sync problems.

Add this in your application:
```
import { RealTimeQueries } from 'cozy-client'

<RealTimeQueries doctype="io.cozy.files" />
<RealTimeQueries doctype="io.cozy.mespapiers.settings" />
```