### PR TITLE
Fixes path of the redirections

### DIFF
--- a/packages/cozy-mespapiers-lib/README.md
+++ b/packages/cozy-mespapiers-lib/README.md
@@ -82,21 +82,28 @@ const App = () => {
 }
 ```
 
-You have to create a `/paper` route (the name is important) in your application routeur and add a background location:
+You have to create a `/paper/*` route (the name is important) in your application routeur and add a background location:
 
 ```jsx
-import { Route, Switch, useLocation } from 'react-router-dom'
+import { HashRouter, Route, Routes } from 'react-router-dom'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import MesPapiers from 'cozy-mespapiers-lib'
+
+const PaperView = props => {
+  const { lang } = useI18n()
+
+  return <MesPapiers {...props} lang={lang} />
+}
 
 const AppRouter = () => {
-  const location = useLocation()
-  const background = location?.state?.background
-
   return (
-    <Switch location={background || location}>
-      <Route ... />
-      <Route path="/paper" component={MesPapiersView} />
-      <Route ... />
-    </Switch>
+    <HashRouter>
+      <Routes>
+        <Route ... />
+        <Route path="/paper/*" component={PaperView} />
+        <Route ... />
+      </Routes>
+    </HashRouter>
   )
 }
 ```

--- a/packages/cozy-mespapiers-lib/src/components/AppRouter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/AppRouter.jsx
@@ -24,7 +24,7 @@ export const AppRouter = () => {
     <>
       <Routes location={background || location}>
         <Route element={<OnboardedGuardedRoute />}>
-          <Route index element={<Home />} />
+          <Route path="/" element={<Home />} />
           <Route path="files/:fileTheme" element={<PapersListWrapper />} />
           <Route
             path="file/:fileTheme/:fileId"
@@ -32,7 +32,7 @@ export const AppRouter = () => {
           />
           <Route path="onboarding" element={<OnboardingWrapper />} />
         </Route>
-        <Route path="*" element={<Navigate to="/" />} />
+        <Route path="/paper" element={<Navigate to="/" />} />
       </Routes>
       {background && (
         <Routes>

--- a/packages/cozy-mespapiers-lib/src/components/OnboardedGuardedRoute.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/OnboardedGuardedRoute.jsx
@@ -37,7 +37,7 @@ const OnboardedGuardedRoute = () => {
     !isOnboardingPage && onboarded !== true && OnboardingComponent
 
   if (isAlreadyOnboarded) {
-    return <Navigate to="/" replace />
+    return <Navigate to="/paper" replace />
   }
 
   if (isNotOnboarded) {

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PapersListWrapper.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PapersListWrapper.jsx
@@ -74,7 +74,7 @@ const PapersListWrapper = ({ selectedThemeLabel = null }) => {
   const hasNoFiles = !isLoadingFiles && files.length === 0
 
   if (hasNoFiles) {
-    return <Navigate to="/" replace />
+    return <Navigate to="/paper" replace />
   }
 
   return (
@@ -82,7 +82,7 @@ const PapersListWrapper = ({ selectedThemeLabel = null }) => {
       {!isMultiSelectionActive && (
         <PapersListToolbar
           title={themeLabel}
-          onBack={() => navigate('/')}
+          onBack={() => navigate('/paper')}
           onClose={() => setIsMultiSelectionActive(false)}
         />
       )}


### PR DESCRIPTION
Cette PR traite 2 sujets autour du routeur de la `cozy-mespapiers-lib` :
- Lors de la mise à jour du routeur, nous avons changé les redirections sur la page d'accueil de `/paper` à `/`, sans raison particulière. Mais en conséquence, c'était la route de redirection du côté de l'application qui était trigger, et cela provoquait un démontage/remontage de la lib.

- Depuis la mise à jour du routeur, les applications n'étaient plus forcées d'utiliser la route `/paper` pour consommer la lib. Ce changement n'était pas prévu. Avec cette correction, nous retrouvons l'ancien comportement attendu. A la différence de l'ajout du `/*`comme ceci `/paper/*` requis avec le nouveau routeur.

Exemple :
```
<Route path="/paper/*" element={<PaperView />} />
```