### PR TITLE
Support React Router DOM V6 in cozy authentication

### DIFF
--- a/packages/cozy-authentication/package.json
+++ b/packages/cozy-authentication/package.json
@@ -70,6 +70,7 @@
     "cozy-client": ">=13.15.1",
     "cozy-ui": ">=40.9.1",
     "react": ">=15",
-    "react-router": "3"
+    "react-router": "3",
+    "react-router-dom": "^6.4.1"
   }
 }

--- a/packages/cozy-authentication/src/MobileRouter.jsx
+++ b/packages/cozy-authentication/src/MobileRouter.jsx
@@ -124,7 +124,7 @@ export class MobileRouter extends Component {
   }
 
   handleUniversalLink(eventData) {
-    /* 
+    /*
     @TODO: openUniversalLink seems to be called only on iOS.
     android uses handleOpenURL by default ?!
    */
@@ -213,7 +213,6 @@ export class MobileRouter extends Component {
 
   render() {
     const {
-      history,
       appIcon,
       appTitle,
       appRoutes,
@@ -267,7 +266,7 @@ export class MobileRouter extends Component {
         />
       )
     } else {
-      return <Router history={history}>{appRoutes || children}</Router>
+      return <>{appRoutes || children}</>
     }
   }
 
@@ -361,6 +360,24 @@ MobileRouter.propTypes = {
   initialTriedToReconnect: PropTypes.bool
 }
 
+const MobileRouterV3 = ({ children, history, ...props }) => {
+  return (
+    <MobileRouter history={history} {...props}>
+      {children}
+    </MobileRouter>
+  )
+}
+
+const MobileRouterWrapper = ({ children, history, ...props }) => {
+    return (
+      <Router history={history}>
+        <MobileRouterV3 history={history} {...props}>
+          {children}
+        </MobileRouterV3>
+      </Router>
+    )
+}
+
 export const DumbMobileRouter = MobileRouter
 
-export default withClient(MobileRouter)
+export default withClient(MobileRouterWrapper)

--- a/packages/cozy-authentication/src/MobileRouter.jsx
+++ b/packages/cozy-authentication/src/MobileRouter.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import { Router } from 'react-router'
+import { HashRouter, useLocation, useNavigate } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import { withClient } from 'cozy-client'
 
@@ -328,7 +329,7 @@ MobileRouter.defaultProps = {
 }
 
 MobileRouter.propTypes = {
-  history: PropTypes.object.isRequired,
+  history: PropTypes.object,
 
   appRoutes: PropTypes.node,
   children: PropTypes.node,
@@ -368,7 +369,27 @@ const MobileRouterV3 = ({ children, history, ...props }) => {
   )
 }
 
+const MobileRouterDomV6 = ({ children, ...props }) => {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const history = {
+    replace: path => {
+      navigate(path, { replace: true })
+    },
+    getCurrentLocation: () => {
+      return location
+    }
+  }
+  return (
+    <MobileRouter history={history} {...props}>
+      {children}
+    </MobileRouter>
+  )
+}
+
 const MobileRouterWrapper = ({ children, history, ...props }) => {
+  if (history) {
+    // react-router@3
     return (
       <Router history={history}>
         <MobileRouterV3 history={history} {...props}>
@@ -376,6 +397,14 @@ const MobileRouterWrapper = ({ children, history, ...props }) => {
         </MobileRouterV3>
       </Router>
     )
+  } else {
+    // react-router-dom@6
+    return (
+      <HashRouter>
+        <MobileRouterDomV6 {...props}>{children}</MobileRouterDomV6>
+      </HashRouter>
+    )
+  }
 }
 
 export const DumbMobileRouter = MobileRouter


### PR DESCRIPTION
This adds an alternate implementation for `MobileRouter` to help to upgrade React Router in apps consuming `cozy-authentication`.

This new one is written with `react-router-dom@6`, while the previous one, written with `react-router@3` is kept for retro-compatibility.

Apps can opt for the new implementation by omitting the `history` prop which is then mocked with modern hooks internally.

(untested for now, so kept as a draft)