### PR TITLE
fix: Reapply useVaultClient hook call in LegacyTriggerManager

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -5,6 +5,7 @@ import compose from 'lodash/flowRight'
 
 import { withClient } from 'cozy-client'
 import { Account } from 'cozy-doctypes'
+import { useVaultClient } from 'cozy-keys-lib'
 
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
@@ -482,6 +483,17 @@ const LegacyTriggerManager = props => {
     initialTrigger,
     ...otherProps
   } = props
+
+  // Since the 4.1.0 of cozy-keys-lib, we
+  // render children even if vaultClient is
+  // not defined yet. In that case we we were
+  // displaying TriggerManager without vaultClient.
+  // It was raising an error.
+  // The current fix, is to not display the
+  // TriggerManager when vaultClient is null.
+  const vaultClient = useVaultClient()
+  if (!vaultClient) return null
+
   return (
     <FlowProvider
       onLaunch={onLaunch}


### PR DESCRIPTION
This commit reapplies 8a6f02b9e9c161622afedff88ba4805468ee6f59 that has been removed in 439e603cef915e9fede72ae293ae35ca330347eb due to regression on cozy-bank app

Today this regression cannot be reproduced anymore when we reapply the initial commit

So we want to reapply it so we can upgrade cozy-keys-lib to latest version