### PR TITLE
feat: Close Harvest when BI connection is removed in webview

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/BIContractActivationWindow.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/BIContractActivationWindow.spec.jsx
@@ -117,4 +117,38 @@ describe('BIContractActivationWindow', () => {
       expect.anything()
     )
   })
+  it('should show account delete dialog after BI connection removed and close harvest', async () => {
+    prepareOAuth.mockImplementation(() => ({ oAuthUrl: 'https://test.url' }))
+    isFlagshipApp.mockImplementation(() => false)
+    fetchExtraOAuthUrlParams.mockResolvedValue({})
+    const { getByRole } = setup()
+    await act(async () => {
+      await waitFor(() => {
+        return expect(getByRole('button').getAttribute('class')).not.toContain(
+          'Mui-disabled'
+        )
+      })
+    })
+
+    await act(async () => {
+      fireEvent.click(getByRole('button'))
+    })
+
+    checkOAuthData.mockImplementation(() => true)
+    await act(async () => {
+      sendMessageFn({
+        data: {
+          oAuthStateKey: 'statekey',
+          finalLocation: 'connection_deleted=true'
+        }
+      })
+      await waitFor(() =>
+        expect(
+          getByRole('button', { name: 'Close dialog' })
+        ).toBeInTheDocument()
+      )
+      fireEvent.click(getByRole('button', { name: 'Close dialog' }))
+    })
+    expect(onAccountDeleted).toHaveBeenCalled()
+  })
 })

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/BiContractActivationWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/BiContractActivationWindow.jsx
@@ -20,7 +20,8 @@ const BIContractActivationWindow = ({
   t,
   intentsApi,
   innerAccountModalOverrides,
-  onAccountDeleted
+  onAccountDeleted,
+  realtime
 }) => {
   const [extraParams, setExtraParams] = useState(null)
   const [isWindowVisible, setWindowVisible] = useState(false)
@@ -130,6 +131,7 @@ const BIContractActivationWindow = ({
           onSuccess={onPopupClosed}
           onCancel={onPopupClosed}
           manage={true}
+          realtime={realtime}
         />
       )}
     </ListItem>

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/BiContractActivationWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/BiContractActivationWindow.jsx
@@ -34,7 +34,7 @@ const BIContractActivationWindow = ({
   /**
    * Detects if a BI connection has been removed
    *
-   * @param {String} finalLocation - url search param string from the final oauth location
+   * @param {String} [finalLocation] - url search param string from the final oauth location
    * @returns {Boolean}
    */
   const isBIConnectionRemoved = finalLocation => {
@@ -52,7 +52,7 @@ const BIContractActivationWindow = ({
   /**
    *
    * @param {String} key - OAuth key
-   * @param {FinalOAuthRealtimeMessage} oauthData
+   * @param {FinalOAuthRealtimeMessage} [oauthData]
    */
   const onPopupClosed = (key, oauthData) => {
     setWindowVisible(false)

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/BiContractActivationWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/BiContractActivationWindow.jsx
@@ -20,8 +20,7 @@ const BIContractActivationWindow = ({
   t,
   intentsApi,
   innerAccountModalOverrides,
-  onAccountDeleted,
-  realtime
+  onAccountDeleted
 }) => {
   const [extraParams, setExtraParams] = useState(null)
   const [isWindowVisible, setWindowVisible] = useState(false)
@@ -131,7 +130,6 @@ const BIContractActivationWindow = ({
           onSuccess={onPopupClosed}
           onCancel={onPopupClosed}
           manage={true}
-          realtime={realtime}
         />
       )}
     </ListItem>

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/Contracts.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/Contracts.jsx
@@ -41,7 +41,8 @@ const DumbContracts = ({
   account,
   konnector,
   intentsApi,
-  innerAccountModalOverrides
+  innerAccountModalOverrides,
+  onAccountDeleted
 }) => {
   const { t } = useI18n()
   const contractData = contracts.data ? contracts.data : contracts
@@ -77,6 +78,7 @@ const DumbContracts = ({
               account={account}
               intentsApi={intentsApi}
               innerAccountModalOverrides={innerAccountModalOverrides}
+              onAccountDeleted={onAccountDeleted}
             />
           )}
         </NavigationListSection>
@@ -97,7 +99,9 @@ DumbContracts.propTypes = {
   /** Can be present if showing contracts still linked to an account/konnector/trigger */
   konnector: PropTypes.object,
   intentsApi: intentsApiProptype,
-  innerAccountModalOverrides: innerAccountModalOverridesProptype
+  innerAccountModalOverrides: innerAccountModalOverridesProptype,
+  /** What to do when the current account is deleted */
+  onAccountDeleted: PropTypes.func
 }
 
 export const ContractsForAccount = compose(

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/Contracts.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/Contracts.jsx
@@ -1,3 +1,4 @@
+// @ts-check
 import React from 'react'
 import PropTypes from 'prop-types'
 import compose from 'lodash/flowRight'
@@ -106,6 +107,7 @@ DumbContracts.propTypes = {
 
 export const ContractsForAccount = compose(
   withLocales,
+  // @ts-ignore Aucune surcharge ne correspond à cet appel
   queryConnect({
     contracts: makeContractsConn
   })

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
@@ -1,10 +1,10 @@
+// @ts-check
 import React, { useContext, useState } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
 import { useClient } from 'cozy-client'
 import { Account } from 'cozy-doctypes'
-import { useVaultClient, CozyUtils } from 'cozy-keys-lib'
 
 import Button from 'cozy-ui/transpiled/react/Button'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
@@ -25,7 +25,8 @@ import UnlinkIcon from 'cozy-ui/transpiled/react/Icons/Unlink'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import ListItemSecondaryAction from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemSecondaryAction'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
-import { useVaultUnlockContext } from 'cozy-keys-lib'
+// @ts-ignore peerDep
+import { useVaultClient, CozyUtils, useVaultUnlockContext } from 'cozy-keys-lib'
 
 import { deleteAccount } from '../../../connections/accounts'
 import { unshareCipher } from '../../../models/cipherUtils'
@@ -111,7 +112,9 @@ const ConfigurationTab = ({
     try {
       onAccountDeleted(account)
       await deleteAccount(client, account)
+      // @ts-ignore La propriété 'success' n'existe pas sur le type '(...args: any[]) => any'.
       Alerter.success(t('modal.updateAccount.delete-account-success'))
+      // @ts-ignore 0 arguments attendus, mais 1 reçus.
       tracker.trackEvent({
         name: 'compte_bancaire_supprime',
         connectorSlug: account.account_type
@@ -119,6 +122,7 @@ const ConfigurationTab = ({
     } catch (error) {
       // eslint-disable-next-line no-console
       console.warn('Error while deleting account', error)
+      // @ts-ignore La propriété 'error' n'existe pas sur le type '(...args: any[]) => any'.
       Alerter.error(t('modal.updateAccount.delete-account-error'))
     } finally {
       setDeleting(false)

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
@@ -208,6 +208,7 @@ const ConfigurationTab = ({
           account={account}
           intentsApi={intentsApi}
           innerAccountModalOverrides={innerAccountModalOverrides}
+          onAccountDeleted={onAccountDeleted}
         />
       </NavigationList>
       {showNewAccountButton ? (

--- a/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
@@ -64,7 +64,7 @@ export class OAuthWindow extends PureComponent {
       OAUTH_REALTIME_CHANNEL,
       this.handleMessage
     )
-    const { oAuthStateKey, oAuthUrl } = prepareOAuth(
+    const { oAuthStateKey, oAuthUrl } = prepareOAuth({
       client,
       konnector,
       redirectSlug,
@@ -72,7 +72,7 @@ export class OAuthWindow extends PureComponent {
       reconnect,
       manage,
       account
-    )
+    })
     this.setState({ oAuthStateKey, oAuthUrl, succeed: false })
   }
 

--- a/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
@@ -1,3 +1,4 @@
+// @ts-check
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 
@@ -112,7 +113,7 @@ export class OAuthWindow extends PureComponent {
     this.setState({ succeed: true })
 
     if (typeof onSuccess !== 'function') return
-    onSuccess(data.key)
+    onSuccess(data.key, data)
   }
 
   /**

--- a/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
@@ -55,9 +55,10 @@ export class OAuthWindow extends PureComponent {
       extraParams,
       reconnect = false,
       manage = false,
-      account
+      account,
+      realtime
     } = this.props
-    this.realtime = new CozyRealtime({ client })
+    this.realtime = realtime || new CozyRealtime({ client })
     this.realtime.subscribe(
       'notified',
       'io.cozy.accounts',

--- a/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
@@ -55,10 +55,9 @@ export class OAuthWindow extends PureComponent {
       extraParams,
       reconnect = false,
       manage = false,
-      account,
-      realtime
+      account
     } = this.props
-    this.realtime = realtime || new CozyRealtime({ client })
+    this.realtime = new CozyRealtime({ client })
     this.realtime.subscribe(
       'notified',
       'io.cozy.accounts',

--- a/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthWindow.jsx
@@ -78,7 +78,9 @@ export class OAuthWindow extends PureComponent {
 
   componentWillUnmount() {
     const { oAuthStateKey } = this.state
-    terminateOAuth(oAuthStateKey)
+    if (oAuthStateKey) {
+      terminateOAuth(oAuthStateKey)
+    }
     this.realtime.unsubscribeAll()
   }
 
@@ -95,9 +97,10 @@ export class OAuthWindow extends PureComponent {
    * * realtime message from web apps (see handleMessage)
    * * url changes from mobile apps
    *
-   * @param  {String} data.key - `io.cozy.accounts` id The created OAuth account
-   * @param  {String} data.error - error message
-   * @param  {String} data.oAuthStateKey - key for localStorage
+   * @param  {Object} data
+   * @param  {String|null} data.key - `io.cozy.accounts` id The created OAuth account
+   * @param  {String|null} data.error - error message
+   * @param  {String|null} data.oAuthStateKey - key for localStorage
    */
   handleOAuthData(data) {
     const { konnector, onSuccess, onCancel } = this.props
@@ -212,4 +215,5 @@ OAuthWindow.propTypes = {
   intentsApi: intentsApiProptype
 }
 
+// @ts-ignore L'argument de type 'typeof OAuthWindow' n'est pas attribuable au paramètre de type 'Component<{}, {}, any>' ?
 export default translate()(withClient(OAuthWindow))

--- a/packages/cozy-harvest-lib/src/helpers/oauth.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.js
@@ -71,9 +71,8 @@ export const handleOAuthResponse = (options = {}) => {
   // eslint-disable-next-line no-redeclare
   /* global URLSearchParams */
   const queryParams = new URLSearchParams(window.location.search)
-
-  const accountId = queryParams.get('account')
-  const errorMsg = queryParams.get('error')
+  const key = queryParams.get('account')
+  const error = queryParams.get('error')
 
   /**
    * Key for localStorage, used at the beginning of the OAuth process to store
@@ -84,8 +83,9 @@ export const handleOAuthResponse = (options = {}) => {
   if (!oAuthStateKey) return false
 
   realtime.sendNotification('io.cozy.accounts', OAUTH_REALTIME_CHANNEL, {
-    key: accountId,
-    error: errorMsg,
+    finalLocation: queryParams.toString(),
+    key,
+    error,
     oAuthStateKey
   })
 

--- a/packages/cozy-harvest-lib/src/helpers/oauth.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.js
@@ -163,16 +163,17 @@ const getAppSlug = client => {
  * Initializes client OAuth workflow by storing the current information about
  * account type in localStorage. Generates the OAuth URL to stack endpoint,
  * passing the localStorage key as state in query string.
- * @param  {CozyClient} client
- * @param  {Object} konnector
- * @param  {string} redirectSlug The app we want to redirect the user on after the end of the flow
- * @param  {Object} extraParams some extra parameters to add to the query string
- * @param  {Boolean} reconnect Are we trying to reconnect an existing account ?
- * @param  {Boolean} manage Are we trying to manage an existing account ?
- * @param  {IoCozyAccount} account targetted account if any
+ * @param  {Object} options
+ * @param  {CozyClient} options.client
+ * @param  {Object} options.konnector
+ * @param  {string} options.redirectSlug The app we want to redirect the user on after the end of the flow
+ * @param  {Object} options.extraParams some extra parameters to add to the query string
+ * @param  {Boolean} options.reconnect Are we trying to reconnect an existing account ?
+ * @param  {Boolean} options.manage Are we trying to manage an existing account ?
+ * @param  {IoCozyAccount} options.account targetted account if any
  * @return {Object}           Object containing: `oAuthUrl` (URL of cozy stack OAuth endpoint) and `oAuthStateKey` (localStorage key)
  */
-export const prepareOAuth = (
+export const prepareOAuth = ({
   client,
   konnector,
   redirectSlug,
@@ -180,7 +181,7 @@ export const prepareOAuth = (
   reconnect = false,
   manage = false,
   account
-) => {
+}) => {
   const { oauth } = konnector
   const accountType = konnectors.getAccountType(konnector)
 

--- a/packages/cozy-harvest-lib/src/helpers/oauth.spec.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.spec.js
@@ -132,6 +132,8 @@ describe('Oauth helper', () => {
     it('should send message with query string data', () => {
       const expectedOAuthData = {
         error: null,
+        finalLocation:
+          'account=bc2aca6566cf4a72afe6c615aa1e3d31&state=70720eb0-6204-484d',
         key: 'bc2aca6566cf4a72afe6c615aa1e3d31',
         oAuthStateKey: '70720eb0-6204-484d'
       }
@@ -151,7 +153,8 @@ describe('Oauth helper', () => {
       const expectedOAuthData = {
         error: 'dismissed',
         key: null,
-        oAuthStateKey: '70720eb0-6204-484d'
+        oAuthStateKey: '70720eb0-6204-484d',
+        finalLocation: 'error=dismissed&state=70720eb0-6204-484d'
       }
 
       handleOAuthResponse({ realtime })

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -381,6 +381,10 @@
       "title": "Connect to %{name}",
       "button": "Add an account"
     },
+    "deleteBIConnection": {
+      "title": "Bank disconnect",
+      "description": "Your request has been recorded. It will be effective in a short moment. Previously imported data will not be deleted."
+    },
     "deleteAccount": {
       "title": "Disconnection",
       "description": "Your account will be disconnected, but already imported data will be kept.",

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -381,6 +381,10 @@
       "title": "Connexion à %{name}",
       "button": "Ajouter un compte"
     },
+    "deleteBIConnection": {
+      "title": "Déconnexion de votre banque",
+      "description": "La déconnexion de votre banque a bien été prise en compte et sera effective dans quelques instants. Les données précédemment importées seront conservées."
+    },
     "deleteAccount": {
       "title": "Déconnexion",
       "description": "Vous serez déconnecté de ce compte, mais les données déjà importées seront conservées.",

--- a/packages/cozy-harvest-lib/src/types.js
+++ b/packages/cozy-harvest-lib/src/types.js
@@ -48,6 +48,7 @@
  * @property {String} name
  * @property {Function} refreshContracts
  * @property {Function} fetchExtraOAuthUrlParams
+ * @property {Boolean} isBIWebView
  */
 
 /**


### PR DESCRIPTION
When the user wants to manage his own account and then displays the BI "manage" url, he may remove the BI connection from it.
If the connection is removed, the corresponding account and trigger will also be removed via webhooks.

This is why it is not possible to go back to the display of the current account if the connection has been removed.

How it works :

The BI webview adds a connection_deleted parameters to the redirect uri, this parameter goes to OAuthWindow via realtime, and then BIContractActivationWindows

And in this case, BIContractActivationWindow displays a dialog to explain the situation to the user and then closes the harvest dialog.