### PR TITLE
fix: Close Harvest modal with the close button in error dialog

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModal.jsx
@@ -147,7 +147,7 @@ export class AccountModal extends Component {
                 actionButton={
                   <Button
                     theme="danger"
-                    onClick={this.loadSelectedAccountId.bind(this)}
+                    onClick={onDismiss}
                     label={t('modal.konnector.error.button')}
                   />
                 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/228695/199998094-983e3a38-213c-47f1-8e52-8635630c2544.png)

This close button did not do anything on screen. I think the expected action here is to really close the Harvest dialog.