### PR TITLE
feat: Handle denied biometry access on iOS

### DIFF
--- a/packages/cozy-device-helper/src/flagship.ts
+++ b/packages/cozy-device-helper/src/flagship.ts
@@ -12,6 +12,7 @@ export type BiometryType = 'TouchID' | 'FaceID' | 'Biometrics'
 
 export interface FlagshipMetadata {
   biometry_available?: boolean
+  biometry_authorisation_denied?: boolean
   biometry_type?: BiometryType
   immersive?: boolean
   navbarHeight?: number

--- a/packages/cozy-intent/src/api/models/methods.ts
+++ b/packages/cozy-intent/src/api/models/methods.ts
@@ -18,6 +18,7 @@ interface _NativeMethodsRegister {
     settingName: 'biometryLock' | 'PINLock' | 'autoLock',
     params?: Record<string, unknown>
   ) => Promise<boolean | null>
+  openAppOSSettings: () => Promise<null>
 }
 
 export type NativeMethodsRegister = _NativeMethodsRegister & PostMeDefault

--- a/packages/cozy-intent/src/api/models/methods.ts
+++ b/packages/cozy-intent/src/api/models/methods.ts
@@ -18,6 +18,7 @@ interface _NativeMethodsRegister {
     settingName: 'biometryLock' | 'PINLock' | 'autoLock',
     params?: Record<string, unknown>
   ) => Promise<boolean | null>
+  isBiometryDenied: () => Promise<boolean>
   openAppOSSettings: () => Promise<null>
 }
 


### PR DESCRIPTION
On iOS with FaceID the biometry feature is guarded by OS level authorizations

If the user reject the authorisation process, then the application won't be able to use FaceID anymore until the user re-authorizes it from the OS settings

We want this information to be available from the settings cozy-app and to be able to redirect the user to the OS settings
so they can re-autorize the biometry

___

### Related PRs:

- https://github.com/cozy/cozy-settings/pull/512
- https://github.com/cozy/cozy-flagship-app/pull/457