### PR TITLE
Feat: Add share button with recipients

### DIFF
--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -37,12 +37,11 @@
   },
   "devDependencies": {
     "@babel/core": "7.16.12",
-    "@material-ui/core": "4.12.3",
     "babel-jest": "26.6.3",
     "babel-plugin-css-modules-transform": "1.6.2",
     "babel-plugin-inline-react-svg": "1.1.2",
     "cozy-client": "34.1.0",
-    "cozy-ui": "62.1.2",
+    "cozy-ui": "77.6.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.6",
     "enzyme-to-json": "3.6.2",
@@ -52,10 +51,9 @@
     "react-router": "^5.0.1"
   },
   "peerDependencies": {
-    "@material-ui/core": "4",
     "cozy-client": "^34.1.0",
     "cozy-realtime": "^3.11.0",
-    "cozy-ui": "^45.1.0",
+    "cozy-ui": ">=77.6.0",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-router": "^5.0.1"

--- a/packages/cozy-sharing/src/ShareButtonWithRecipients.jsx
+++ b/packages/cozy-sharing/src/ShareButtonWithRecipients.jsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { ShareButton } from './ShareButton'
+import { SharedRecipients } from './SharedRecipients'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import SharingContext from './context'
+import Grid from 'cozy-ui/transpiled/react/MuiCozyTheme/Grid'
+import Skeleton from 'cozy-ui/transpiled/react/Skeleton'
+
+export const ShareButtonWithRecipients = ({ docId, onClick, ...props }) => {
+  const { isMobile } = useBreakpoints()
+
+  return (
+    <SharingContext.Consumer>
+      {({ allLoaded }) => {
+        return allLoaded ? (
+          <Grid container alignItems="center" className="u-w-auto">
+            {!isMobile && (
+              <Grid item>
+                <SharedRecipients docId={docId} onClick={onClick} size={32} />
+              </Grid>
+            )}
+            <Grid item>
+              <ShareButton docId={docId} onClick={onClick} {...props} />
+            </Grid>
+          </Grid>
+        ) : (
+          <Skeleton width={120} animation="wave" />
+        )
+      }}
+    </SharingContext.Consumer>
+  )
+}

--- a/packages/cozy-sharing/src/SharingProvider.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.jsx
@@ -186,22 +186,24 @@ export class SharingProvider extends Component {
     )
     this.setState({ hasLoadedAtLeastOnePage: true })
     // eslint-disable-next-line promise/catch-or-return
-    fetchNextPermissions(permissions, this.dispatch, this.permissionCol).then(
-      this.setState({ allLoaded: true })
-    )
-    if (doctype !== 'io.cozy.files') return
-    const sharedDocIds = getSharedDocIdsBySharings(sharings)
-    const resp = await client.collection(doctype).all({ keys: sharedDocIds })
-    const folderPaths = resp.data
-      .filter(f => f.type === 'directory' && !f.trashed)
-      .map(f => f.path)
-    const filePaths = await fetchFilesPaths(
-      client,
-      doctype,
-      resp.data.filter(f => f.type !== 'directory' && !f.trashed)
-    )
+    await fetchNextPermissions(permissions, this.dispatch, this.permissionCol)
 
-    this.dispatch(receivePaths([...folderPaths, ...filePaths]))
+    if (doctype === 'io.cozy.files') {
+      const sharedDocIds = getSharedDocIdsBySharings(sharings)
+      const resp = await client.collection(doctype).all({ keys: sharedDocIds })
+      const folderPaths = resp.data
+        .filter(f => f.type === 'directory' && !f.trashed)
+        .map(f => f.path)
+      const filePaths = await fetchFilesPaths(
+        client,
+        doctype,
+        resp.data.filter(f => f.type !== 'directory' && !f.trashed)
+      )
+
+      this.dispatch(receivePaths([...folderPaths, ...filePaths]))
+    }
+
+    this.setState({ allLoaded: true })
   }
 
   share = async ({

--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -20,3 +20,4 @@ export { CozyPassFingerprintDialogContent } from './components/CozyPassFingerpri
 export { SharingBannerPlugin } from './SharingBanner'
 export { useSharingInfos } from './SharingBanner/hooks/useSharingInfos'
 export { ConfirmTrustedRecipientsDialog } from './ConfirmTrustedRecipientsDialog'
+export { ShareButtonWithRecipients } from './ShareButtonWithRecipients'

--- a/yarn.lock
+++ b/yarn.lock
@@ -7138,28 +7138,36 @@ cozy-ui@60.6.0:
     react-select "^4.3.0"
     react-swipeable-views "^0.13.3"
 
-cozy-ui@62.1.2:
-  version "62.1.2"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-62.1.2.tgz#608482885cbc699af59b6e99f72bee5b8d93c886"
-  integrity sha512-2Vy9+NrPAKgUu4maU8LPc3ueFUUPPT+iGtP6PoAKVGkcTz+viQpH1KRxm+7F7jJu/mohCZRQlagMX9yPzzkk0Q==
+cozy-ui@77.6.0:
+  version "77.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-77.6.0.tgz#52a0fdd90b96dbeff9e75b54b4b533ea153b9ba5"
+  integrity sha512-efu+Q/wie57NeElWOvP5455N8F7Y/olYWmhbzB/wnbwA61PmxXkWeLXeXRacEx+KMHXPg/IE6EGK+9vR+JZwhw==
   dependencies:
     "@babel/runtime" "^7.3.4"
+    "@material-ui/core" "4.12.3"
+    "@material-ui/lab" "^4.0.0-alpha.61"
     "@popperjs/core" "^2.4.4"
+    bundlemon "^1.3.2"
+    chart.js "3.7.1"
     classnames "^2.2.5"
     cozy-interapp "^0.5.4"
     date-fns "^1.28.5"
     filesize "8.0.7"
     hammerjs "^2.0.8"
     intersection-observer "0.11.0"
-    mui-bottom-sheet "https://github.com/cozy/mui-bottom-sheet.git#v1.0.6"
+    mime-types "2.1.35"
+    mui-bottom-sheet "https://github.com/cozy/mui-bottom-sheet.git#v1.0.9"
     node-polyglot "^2.2.2"
-    normalize.css "^7.0.0"
+    normalize.css "^8.0.0"
+    piwik-react-router "0.12.1"
+    react-chartjs-2 "4.1.0"
     react-markdown "^4.0.8"
     react-pdf "^4.0.5"
     react-popper "^2.2.3"
     react-remove-scroll "^2.4.0"
     react-select "^4.3.0"
     react-swipeable-views "^0.13.3"
+    rooks "^5.11.2"
 
 cozy-ui@^77.2.0:
   version "77.2.0"
@@ -14636,6 +14644,17 @@ msgpack5@^4.0.2:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
+
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+  version "1.0.8"
+  uid "3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  dependencies:
+    "@juggle/resize-observer" "^3.1.3"
+    jest-environment-jsdom-sixteen "^1.0.3"
+    react-spring "9.0.0-rc.3"
+    react-use-gesture "^7.0.8"
+    react-use-measure "^2.0.0"
 
 "mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
   version "1.0.6"


### PR DESCRIPTION
In the cozy-notes with a lot of notes and sharing, there are some late requests. The ShareButton button doesn't wait for everything to be finished to appear. The user may be confused because an already shared note appears unshared first. I take this opportunity to pool two components in order to manage their state together.

**Related PRs:**
- https://github.com/cozy/cozy-ui/pull/2286