### PR TITLE
fix: Make cozy-harvest-lib works with cozy-keys-lib V4

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
@@ -26,7 +26,7 @@ import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import ListItemSecondaryAction from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemSecondaryAction'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 // @ts-ignore peerDep
-import { useVaultClient, CozyUtils, useVaultUnlockContext } from 'cozy-keys-lib'
+import { useVaultClient, useVaultUnlockContext } from 'cozy-keys-lib'
 
 import { deleteAccount } from '../../../connections/accounts'
 import { unshareCipher } from '../../../models/cipherUtils'
@@ -99,8 +99,7 @@ const ConfigurationTab = ({
     if (konnectorPolicy.saveInVault) {
       showUnlockForm({
         closable: true,
-        onUnlock: handleUnlockForDeletion,
-        addCheckShouldUnlock: () => CozyUtils.checkHasInstalledExtension(client)
+        onUnlock: handleUnlockForDeletion
       })
     } else {
       await handleDeleteAccount()

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.spec.jsx
@@ -158,7 +158,7 @@ describe('ConfigurationTab', () => {
       expect(deleteAccount).toHaveBeenCalled()
     })
 
-    xit('should display deletion modal when clicking on disconnect this account (vault needs to be unlocked, connector policy saves in vault)', async () => {
+    it('should display deletion modal when clicking on disconnect this account (vault needs to be unlocked, connector policy saves in vault)', async () => {
       findKonnectorPolicy.mockReturnValue({ saveInVault: true })
       useVaultClient.mockReturnValue({
         isLocked: jest.fn().mockResolvedValue(true)

--- a/packages/cozy-harvest-lib/src/components/Routes.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes.jsx
@@ -10,11 +10,7 @@ import {
 } from 'cozy-ui/transpiled/react/CozyDialogs'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
-import {
-  useVaultUnlockContext,
-  VaultUnlockProvider,
-  VaultUnlockPlaceholder
-} from 'cozy-keys-lib'
+import { useVaultUnlockContext, VaultUnlockPlaceholder } from 'cozy-keys-lib'
 
 import KonnectorAccounts from './KonnectorAccounts'
 import AccountModal from './AccountModal'
@@ -23,6 +19,7 @@ import EditAccountModal from './EditAccountModal'
 import KonnectorSuccess from './KonnectorSuccess'
 import HarvestModalRoot from './HarvestModalRoot'
 import HarvestVaultProvider from './HarvestVaultProvider'
+import VaultUnlockProvider from './VaultUnlockProvider'
 import { MountPointProvider } from './MountPointContext'
 import DialogContext from './DialogContext'
 import { DatacardOptions } from './Datacards/DatacardOptionsContext'

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -15,7 +15,6 @@ import {
   CipherType,
   withVaultUnlockContext,
   VaultUnlockPlaceholder,
-  VaultUnlockProvider,
   CozyUtils
 } from 'cozy-keys-lib'
 
@@ -29,6 +28,7 @@ import logger from '../logger'
 import { findKonnectorPolicy } from '../konnector-policies'
 import withConnectionFlow from '../models/withConnectionFlow'
 import HarvestVaultProvider from './HarvestVaultProvider'
+import VaultUnlockProvider from './VaultUnlockProvider'
 import { intentsApiProptype } from '../helpers/proptypes'
 
 const IDLE = 'IDLE'

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -14,8 +14,7 @@ import { ModalBackButton } from 'cozy-ui/transpiled/react/Modal'
 import {
   CipherType,
   withVaultUnlockContext,
-  VaultUnlockPlaceholder,
-  CozyUtils
+  VaultUnlockPlaceholder
 } from 'cozy-keys-lib'
 
 import AccountForm from './AccountForm'
@@ -216,8 +215,7 @@ export class DumbTriggerManager extends Component {
       showUnlockForm,
       onVaultDismiss,
       vaultClosable,
-      vaultClient,
-      client
+      vaultClient
     } = this.props
     const konnectorPolicy = findKonnectorPolicy(konnector)
     if (konnectorPolicy.saveInVault) {
@@ -231,9 +229,7 @@ export class DumbTriggerManager extends Component {
         showUnlockForm({
           onDismiss: onVaultDismiss,
           closable: vaultClosable,
-          onUnlock: this.handleVaultUnlock,
-          addCheckShouldUnlock: () =>
-            CozyUtils.checkHasInstalledExtension(client)
+          onUnlock: this.handleVaultUnlock
         })
       } else {
         this.handleVaultUnlock()

--- a/packages/cozy-harvest-lib/src/components/VaultUnlockProvider/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/VaultUnlockProvider/index.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { useClient } from 'cozy-client'
+import {
+  VaultUnlockProvider as WrappedVaultUnlockProvider,
+  CozyUtils
+} from 'cozy-keys-lib'
+
+const VaultUnlockProvider = ({ children, ...props }) => {
+  const client = useClient()
+
+  const addCheckShouldUnlock = () => {
+    return CozyUtils.checkHasInstalledExtension(client)
+  }
+
+  return (
+    <WrappedVaultUnlockProvider
+      {...props}
+      addCheckShouldUnlock={addCheckShouldUnlock}
+    >
+      {children}
+    </WrappedVaultUnlockProvider>
+  )
+}
+
+export default React.memo(VaultUnlockProvider)


### PR DESCRIPTION
In cozy/cozy-keys-lib@1e715624654bcd7c66f6fe7d6558d782f336d0fd we
refactored `<VaultUnlockProvider />` so we can inject
`checkShouldUnlock` into it

This method should allow the component to check if the Cozy's vault
need to be unlock before accessing Harvest

We choose to inject it from the parent component as we expect some
scenario to implement their own verification process (i.e: cozy-drive
for folder encryption)

Here we don't need a custom implementation, so we use the one provided
by CozyUtils