### PR TITLE
fix: Dispatch account deletion after BI connection deletion

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/BiContractActivationWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/BiContractActivationWindow.jsx
@@ -1,7 +1,7 @@
 // @ts-check
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import PropTypes from 'prop-types'
-import { useClient } from 'cozy-client'
+import { useClient, Mutations } from 'cozy-client'
 import Button from 'cozy-ui/transpiled/react/MuiCozyTheme/Buttons'
 import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
@@ -30,6 +30,16 @@ const BIContractActivationWindow = ({
 
   const konnectorPolicy = findKonnectorPolicy(konnector)
   const client = useClient()
+
+  const onClose = useCallback(async () => {
+    client.dispatch({
+      type: 'RECEIVE_MUTATION_RESULT',
+      mutationId: client.generateRandomId(),
+      response: { data: { ...account, _deleted: true } },
+      definition: Mutations.deleteDocument({ ...account, _deleted: true })
+    })
+    onAccountDeleted()
+  }, [onAccountDeleted, account, client])
 
   /**
    * Detects if a BI connection has been removed
@@ -107,14 +117,14 @@ const BIContractActivationWindow = ({
         open={isDeleteConnectionDialogVisible}
         title={t('modal.deleteBIConnection.title')}
         content={t('modal.deleteBIConnection.description')}
-        onClose={onAccountDeleted}
+        onClose={onClose}
         actions={
           <>
             <Button
               variant="text"
               color="primary"
               aria-label="Close dialog"
-              onClick={onAccountDeleted}
+              onClick={onClose}
             >
               {t('close')}
             </Button>


### PR DESCRIPTION
This store update will espacially allow banks to update the
connected/disconnected status of it's accounts without adding realtime
on accounts, which causes more troubles for OAuthWindow component which
will unmount.

This is a quick fix. A better approach is in progress to make
OAuthWindow independent of Harvest components tree
