### PR TITLE
feat: Use independant OAuth window

### DIFF
--- a/packages/cozy-harvest-lib/src/components/CozyConfirmDialogProvider/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/CozyConfirmDialogProvider/index.jsx
@@ -1,0 +1,77 @@
+import React, { createContext, useContext, useState } from 'react'
+import Buttons from 'cozy-ui/transpiled/react/MuiCozyTheme/Buttons'
+import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+
+export const CozyConfirmDialogContext = createContext()
+
+let currentDialogId = 0
+
+export const useCozyConfirmDialog = () => {
+  const context = useContext(CozyConfirmDialogContext)
+  if (!context) {
+    throw new Error(
+      'Cannot use useCozyConfirmDialog without CozyConfirmDialogProvider. The component must a CozyConfirmDialogProvider above it.'
+    )
+  }
+  return context
+}
+
+export const CozyConfirmDialogProvider = React.memo(props => {
+  const [dialogs, setDialogs] = useState([])
+  const { children } = props
+  const onClose = dialogId => {
+    dialogs.find(dialog => dialog.id === dialogId).callback()
+    setDialogs(prevDialogs =>
+      prevDialogs.filter(dialog => dialog.id !== dialogId)
+    )
+  }
+  const context = {
+    showDialog: ({ title, closeLabel, description }) => {
+      return new Promise(resolve => {
+        setDialogs(prevDialogs => {
+          return [
+            ...prevDialogs,
+            {
+              id: currentDialogId++,
+              title,
+              closeLabel,
+              description,
+              callback: resolve
+            }
+          ]
+        })
+      })
+    }
+  }
+  return (
+    <CozyConfirmDialogContext.Provider value={context}>
+      {dialogs &&
+        dialogs.map(dialog => {
+          return (
+            <ConfirmDialog
+              key={dialog.id}
+              open={true}
+              title={dialog.title}
+              content={dialog.description}
+              onClose={() => onClose(dialog.id)}
+              actions={
+                <>
+                  <Buttons
+                    variant="text"
+                    color="primary"
+                    aria-label="Close dialog"
+                    onClick={() => onClose(dialog.id)}
+                  >
+                    {dialog.closeLabel}
+                  </Buttons>
+                </>
+              }
+            />
+          )
+        })}
+      {children}
+    </CozyConfirmDialogContext.Provider>
+  )
+})
+
+CozyConfirmDialogProvider.displayName = 'CozyConfirmDialogProvider'

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/BiContractActivationWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/BiContractActivationWindow.jsx
@@ -4,32 +4,29 @@ import PropTypes from 'prop-types'
 import { useClient } from 'cozy-client'
 import Button from 'cozy-ui/transpiled/react/MuiCozyTheme/Buttons'
 import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
-import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import { findKonnectorPolicy } from '../../../konnector-policies'
-import OAuthWindow from '../../OAuthWindow'
 import withLocales from '../../hoc/withLocales'
 import {
   intentsApiProptype,
   innerAccountModalOverridesProptype
 } from '../../../helpers/proptypes'
 import isEqual from 'lodash/isEqual'
+import { openOAuthWindow } from '../../OAuthService'
+import { useWebviewIntent } from 'cozy-intent'
+import logger from '../../services/logger'
 
 const BIContractActivationWindow = ({
   konnector,
   account,
   t,
   intentsApi,
-  innerAccountModalOverrides,
-  onAccountDeleted
+  innerAccountModalOverrides
 }) => {
   const [extraParams, setExtraParams] = useState(null)
-  const [isWindowVisible, setWindowVisible] = useState(false)
-  const [isDeleteConnectionDialogVisible, setDeleteConnectionDialogVisible] =
-    useState(false)
-  const [shouldRefreshContracts, setShouldRefreshContracts] = useState(false)
-
   const konnectorPolicy = findKonnectorPolicy(konnector)
   const client = useClient()
+
+  const webviewIntent = useWebviewIntent()
 
   /**
    * Detects if a BI connection has been removed
@@ -42,33 +39,16 @@ const BIContractActivationWindow = ({
     return queryParams.get('connection_deleted') === 'true'
   }
 
+  const afterOAuthWindow = async () => {
+    konnectorPolicy.refreshContracts({ client, account, konnector })
+  }
+
   /**
    * @typedef FinalOAuthRealtimeMessage
    * @property {String} finalLocation - url search param string from the final oauth location
    * @property {String|null} err - OAuth error message
    * @property {String} oAuthStateKey - OAuth key
    */
-
-  /**
-   *
-   * @param {String} key - OAuth key
-   * @param {FinalOAuthRealtimeMessage} [oauthData]
-   */
-  const onPopupClosed = (key, oauthData) => {
-    setWindowVisible(false)
-    if (oauthData && isBIConnectionRemoved(oauthData.finalLocation)) {
-      setDeleteConnectionDialogVisible(true)
-    } else {
-      setShouldRefreshContracts(true)
-    }
-  }
-
-  useEffect(() => {
-    if (shouldRefreshContracts) {
-      setShouldRefreshContracts(false)
-      konnectorPolicy.refreshContracts({ client, account, konnector })
-    }
-  }, [account, client, konnectorPolicy, shouldRefreshContracts, konnector])
 
   useEffect(() => {
     async function handleLinkFetch() {
@@ -98,40 +78,25 @@ const BIContractActivationWindow = ({
           variant="text"
           color="primary"
           disabled={!extraParams}
-          onClick={() => setWindowVisible(true)}
+          onClick={() => {
+            openOAuthWindow({
+              client,
+              konnector,
+              account,
+              extraParams,
+              intentsApi,
+              webviewIntent,
+              manage: true
+            })
+              .then(afterOAuthWindow)
+              .catch(err => {
+                logger.error('openOAuthWindow error', err)
+              })
+          }}
         >
           {t('contracts.handle-synchronization')}
         </Button>
       </ButtonWrapper>
-      <Dialog
-        open={isDeleteConnectionDialogVisible}
-        title={t('modal.deleteBIConnection.title')}
-        content={t('modal.deleteBIConnection.description')}
-        onClose={onAccountDeleted}
-        actions={
-          <>
-            <Button
-              variant="text"
-              color="primary"
-              aria-label="Close dialog"
-              onClick={onAccountDeleted}
-            >
-              {t('close')}
-            </Button>
-          </>
-        }
-      />
-      {isWindowVisible && (
-        <OAuthWindow
-          extraParams={extraParams}
-          konnector={konnector}
-          account={account}
-          intentsApi={intentsApi}
-          onSuccess={onPopupClosed}
-          onCancel={onPopupClosed}
-          manage={true}
-        />
-      )}
     </ListItem>
   )
 }
@@ -140,9 +105,7 @@ BIContractActivationWindow.propTypes = {
   t: PropTypes.func,
   account: PropTypes.object,
   intentsApi: intentsApiProptype,
-  innerAccountModalOverrides: innerAccountModalOverridesProptype,
-  /** What to do when the current account is deleted */
-  onAccountDeleted: PropTypes.func
+  innerAccountModalOverrides: innerAccountModalOverridesProptype
 }
 
 // use isEqual to avoid an infinite rerender since the konnector object is a new one on each render

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/BiContractActivationWindow.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/BiContractActivationWindow.jsx
@@ -1,7 +1,7 @@
 // @ts-check
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
-import { useClient, Mutations } from 'cozy-client'
+import { useClient } from 'cozy-client'
 import Button from 'cozy-ui/transpiled/react/MuiCozyTheme/Buttons'
 import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
@@ -30,16 +30,6 @@ const BIContractActivationWindow = ({
 
   const konnectorPolicy = findKonnectorPolicy(konnector)
   const client = useClient()
-
-  const onClose = useCallback(async () => {
-    client.dispatch({
-      type: 'RECEIVE_MUTATION_RESULT',
-      mutationId: client.generateRandomId(),
-      response: { data: { ...account, _deleted: true } },
-      definition: Mutations.deleteDocument({ ...account, _deleted: true })
-    })
-    onAccountDeleted()
-  }, [onAccountDeleted, account, client])
 
   /**
    * Detects if a BI connection has been removed
@@ -117,14 +107,14 @@ const BIContractActivationWindow = ({
         open={isDeleteConnectionDialogVisible}
         title={t('modal.deleteBIConnection.title')}
         content={t('modal.deleteBIConnection.description')}
-        onClose={onClose}
+        onClose={onAccountDeleted}
         actions={
           <>
             <Button
               variant="text"
               color="primary"
               aria-label="Close dialog"
-              onClick={onClose}
+              onClick={onAccountDeleted}
             >
               {t('close')}
             </Button>

--- a/packages/cozy-harvest-lib/src/components/OAuthService.js
+++ b/packages/cozy-harvest-lib/src/components/OAuthService.js
@@ -1,0 +1,331 @@
+// @ts-check
+import { isFlagshipApp } from 'cozy-device-helper'
+import CozyRealtime from 'cozy-realtime'
+import {
+  prepareOAuth,
+  checkOAuthData,
+  terminateOAuth,
+  OAUTH_REALTIME_CHANNEL
+} from '../helpers/oauth'
+import logger from '../logger'
+import { openWindow } from './PopupService'
+
+const OAUTH_POPUP_HEIGHT = 800
+const OAUTH_POPUP_WIDTH = 800
+
+/**
+ * Monitor URL changes for mobile apps and in app browsers
+ * @param  {import('cozy-client/types/types').KonnectorsDoctype} konnector
+ *
+ * The provider redirect us to something like : oauthcallback.mycozy.cloud/?account=A&state=b
+ * So we listen to the URL change with these informations, and we try to handle it.
+ * It works well on iOS or when we are logged on the same device on the web, but it will
+ * fail on Android if we're ne logged in the browser. Why ?
+ * Our oauthcallback.mycozy.cloud/?account=A&state=b checks if we're logged, if not the server
+ * sends an http redirect.
+ * On Android, the 'loadstart' event is not dispatched by the browser when it get a redirect.
+ * The inAppBrowser follows the URL and arrive on :
+ * https://my.mycozy.cloud/auth?redirect=https://home.cozy.cloud/?account=a&state=b
+ * So if we don't have account & state searchParams we have to check if we've a redirect searchParams
+ * init it and search if we have inside this url an account and state params
+ */
+function handleUrlChange(konnector) {
+  return resolve => {
+    return event => {
+      const { url } = event
+      const oAuthData = extractOAuthDataFromUrl(url)
+      if (oAuthData) {
+        return handleOAuthData(oAuthData, konnector, resolve)
+      }
+      const redirect = url.searchParams.get('redirect')
+      if (redirect) {
+        const redirectOAuthData = extractOAuthDataFromUrl(new URL(redirect))
+        if (redirectOAuthData) {
+          return handleOAuthData(redirectOAuthData, konnector, resolve)
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Handles OAuth data. OAuth data may be provided by different way:
+ * * realtime message from web apps (see handleMessage)
+ * * url changes from mobile apps
+ *
+ * @param {OAuthData} data
+ * @param {import('cozy-client/types/types').KonnectorsDoctype} konnector
+ * @param {Function} resolve - function which will resolve the openOAuthWindow promise
+ * @returns <void>
+ */
+function handleOAuthData(data, konnector, resolve) {
+  if (!checkOAuthData(konnector, data)) return
+
+  if (data.error) {
+    logger.info('OAuthWindow: oauth error message', data.error)
+    resolve({
+      result: 'CANCEL',
+      error: data.error
+    })
+    return
+  }
+
+  resolve({
+    result: 'OK',
+    key: data.key,
+    data
+  })
+}
+
+/**
+ * @typedef OAuthData
+ * @property  {String} key - `io.cozy.accounts` id The created OAuth account
+ * @property  {String} [error] - error message
+ * @property  {String} oAuthStateKey - key for localStorage
+ * @property  {String} [finalLocation] - final query string added to the redirected url
+ */
+
+/**
+ * Extract OAuthData from url search params if any
+ *
+ * @param {URL} url
+ * @returns {OAuthData|null} OAuthData
+ */
+function extractOAuthDataFromUrl(url) {
+  const account = url.searchParams.get('account')
+  const state = url.searchParams.get('state')
+  const error = url.searchParams.get('error')
+  if (account && state) {
+    const oAuthData = { key: account, oAuthStateKey: state }
+    if (error) {
+      oAuthData.error = error
+    }
+    return oAuthData
+  }
+  return null
+}
+
+/**
+ * @typedef OAuthServiceResult
+ * @property {"OK"|"CLOSED"|"DISMISSED"|"ERROR"} result
+ * @property {OAuthData} [data]
+ */
+
+/**
+ * Opens given url in the webview intent inAppBrowser
+ *
+ * @param {Object} options
+ * @param {String} options.oAuthUrl - final url to open in webview intent inAppBrowser
+ * @param {import('cozy-intent').WebviewService} options.webviewIntent - WebviewService object to use
+ * @param {Function} options.registerRealtime
+ * @returns {Promise<OAuthServiceResult>}
+ */
+async function openWebviewIntentInAppBrowser({
+  oAuthUrl,
+  webviewIntent,
+  registerRealtime
+}) {
+  return new Promise((resolve, reject) => {
+    const doExec = async () => {
+      if (!webviewIntent) {
+        return reject('No webviewIntent available')
+      }
+
+      try {
+        registerRealtime(data => {
+          webviewIntent.call('closeInAppBrowser')
+          return resolve(data)
+        })
+        logger.debug('url at the beginning: ', oAuthUrl)
+        const sessionCode = await webviewIntent.call('fetchSessionCode')
+        logger.debug('got session code', sessionCode)
+        const iabUrl = new URL(oAuthUrl)
+        // @ts-ignore wrong return type associated to webviewIntent.call
+        iabUrl.searchParams.append('session_code', sessionCode)
+        // we need to decodeURIComponent since toString() encodes URL
+        // but native browser will also encode them.
+        const urlToOpen = decodeURIComponent(iabUrl.toString())
+        logger.debug('url to open: ', urlToOpen)
+        const result = await webviewIntent.call('showInAppBrowser', {
+          url: urlToOpen
+        })
+        // @ts-ignore wrong return type associated to webviewIntent.call
+        if (result?.type !== 'dismiss' && result?.type !== 'cancel') {
+          // @ts-ignore wrong return type associated to webviewIntent.call
+          resolve({ result: 'ERROR', error: result })
+          return
+        }
+
+        webviewIntent.call('closeInAppBrowser')
+        resolve({ result: 'CLOSED' })
+        return
+      } catch (err) {
+        webviewIntent.call('closeInAppBrowser')
+        resolve({ result: 'ERROR', error: err })
+        return
+      }
+    }
+    doExec()
+  })
+}
+
+/**
+ * @typedef IntentsApi
+ * @property {Function} fetchSessionCode
+ * @property {Function} showInAppBrowser
+ * @property {Function} closeInAppBrowser
+ * @property {String} tokenParamName
+ */
+
+/**
+ * Opens given url in the intentsApi inAppBrowser
+ *
+ * @param {Object} options
+ * @param {String} options.oAuthUrl - final url to open in the intentsApi inAppBrowser
+ * @param {IntentsApi} options.intentsApi - WebviewService object to use
+ * @param {Function} options.registerRealtime
+ * @returns {Promise<OAuthServiceResult>}
+ */
+function openIntentsApiInAppBrowser({
+  oAuthUrl,
+  registerRealtime,
+  intentsApi
+}) {
+  return new Promise((resolve, reject) => {
+    const doExec = async () => {
+      const {
+        fetchSessionCode,
+        showInAppBrowser,
+        closeInAppBrowser,
+        tokenParamName = 'session_code'
+      } = intentsApi
+
+      const isReady = Boolean(
+        intentsApi?.fetchSessionCode &&
+          intentsApi?.showInAppBrowser &&
+          intentsApi?.closeInAppBrowser
+      )
+
+      if (!isReady) {
+        return reject('Missing method in intentsApi')
+      }
+      try {
+        registerRealtime(data => {
+          closeInAppBrowser()
+          return resolve(data)
+        })
+        const sessionCode = await fetchSessionCode()
+        logger.debug('got session code', sessionCode)
+        const iabUrl = new URL(oAuthUrl)
+        iabUrl.searchParams.append(tokenParamName, sessionCode)
+        // we need to decodeURIComponent since toString() encodes URL
+        // but native browser will also encode them.
+        const urlToOpen = decodeURIComponent(iabUrl.toString())
+        logger.debug('url to open: ', urlToOpen)
+        const result = await showInAppBrowser(urlToOpen)
+        if (result?.state !== 'dismiss' && result?.state !== 'cancel') {
+          return resolve({ result: 'ERROR', error: result })
+        }
+        return resolve({ result: 'CLOSED' })
+      } catch (err) {
+        return resolve({ result: 'ERROR', error: err })
+      }
+    }
+    doExec()
+  })
+}
+
+/**
+ * Register to realtime events
+ *
+ * @param {Object} options
+ * @param {Object} options.client
+ * @param {import('cozy-client/types/types').KonnectorsDoctype} options.konnector
+ * @returns  {Function}
+ */
+function registerRealtime({ client, konnector }) {
+  return resolve => {
+    const realtime = new CozyRealtime({ client })
+    realtime.subscribe(
+      'notified',
+      'io.cozy.accounts',
+      OAUTH_REALTIME_CHANNEL,
+      handleRealtime(konnector, resolve)
+    )
+    return () => realtime.unsubscribeAll()
+  }
+}
+
+function handleRealtime(konnector, resolve) {
+  return event => {
+    return handleOAuthData(event.data, konnector, resolve)
+  }
+}
+
+/**
+ * Open an OAuth window in popup or inAppBrowser
+ *
+ * @param {Object} options
+ * @param {Object} options.client - CozyClient instance
+ * @param {import('cozy-client/types/types').KonnectorsDoctype} options.konnector - current manifest of the connector
+ * @param {String}  [options.redirectSlug] - slug of the app to redirect to after OAuth
+ * @param {Object} options.extraParams - any extra parameters to pass in the oauth url
+ * @param {Boolean} [options.reconnect] - if this is a reconnection or not
+ * @param {Boolean} [options.manage] - if we try to manage an existing oauth connection
+ * @param {String} [options.title] - title of the resulting popup
+ * @param {import('cozy-intent').WebviewService} [options.webviewIntent] - WebviewService object to use
+ * @param {import('cozy-client/types/types').AccountsDoctype} options.account - associated account (useful if in reconnection or manage mode)
+ * @param {IntentsApi} options.intentsApi - Intentsapi object to use to communicate with the host native application
+ * @returns {Promise<OAuthServiceResult>}
+ */
+export function openOAuthWindow({
+  client,
+  konnector,
+  redirectSlug,
+  extraParams,
+  reconnect,
+  manage,
+  title,
+  webviewIntent,
+  account,
+  intentsApi
+}) {
+  const { oAuthStateKey, oAuthUrl } = prepareOAuth({
+    client,
+    konnector,
+    redirectSlug,
+    extraParams,
+    reconnect,
+    manage,
+    account
+  })
+
+  let promise
+  if (intentsApi) {
+    promise = openIntentsApiInAppBrowser({
+      oAuthUrl,
+      intentsApi,
+      registerRealtime: registerRealtime({ konnector, client })
+    })
+  } else if (isFlagshipApp() && webviewIntent) {
+    promise = openWebviewIntentInAppBrowser({
+      oAuthUrl,
+      webviewIntent,
+      registerRealtime: registerRealtime({ konnector, client })
+    })
+  } else {
+    promise = openWindow({
+      url: oAuthUrl,
+      title: title || '',
+      width: OAUTH_POPUP_WIDTH,
+      height: OAUTH_POPUP_HEIGHT,
+      handleUrlChange: handleUrlChange(konnector),
+      registerRealtime: registerRealtime({ konnector, client })
+    })
+  }
+
+  return promise.then(result => {
+    terminateOAuth(oAuthStateKey)
+    return result
+  })
+}

--- a/packages/cozy-harvest-lib/src/components/OAuthService.js
+++ b/packages/cozy-harvest-lib/src/components/OAuthService.js
@@ -1,6 +1,5 @@
 // @ts-check
 import { isFlagshipApp } from 'cozy-device-helper'
-import CozyRealtime from 'cozy-realtime'
 import {
   prepareOAuth,
   checkOAuthData,
@@ -245,7 +244,7 @@ function openIntentsApiInAppBrowser({
  */
 function registerRealtime({ client, konnector }) {
   return resolve => {
-    const realtime = new CozyRealtime({ client })
+    const realtime = client.plugins.realtime
     realtime.subscribe(
       'notified',
       'io.cozy.accounts',

--- a/packages/cozy-harvest-lib/src/components/OAuthService.spec.js
+++ b/packages/cozy-harvest-lib/src/components/OAuthService.spec.js
@@ -1,0 +1,258 @@
+import MicroEE from 'microee'
+import util from 'util'
+import { openOAuthWindow } from 'components/OAuthService'
+import { isMobileApp, isFlagshipApp } from 'cozy-device-helper'
+
+import PopupMock from '../helpers/windowWrapperMocks'
+
+import { OAUTH_REALTIME_CHANNEL, terminateOAuth } from '../helpers/oauth'
+
+jest.mock('../helpers/oauth', () => {
+  return {
+    ...jest.requireActual('../helpers/oauth'),
+    terminateOAuth: jest.fn()
+  }
+})
+
+const mockPopup = new PopupMock()
+jest.mock('../helpers/windowWrapper', () => ({
+  windowOpen: jest.fn().mockImplementation(() => {
+    return mockPopup
+  })
+}))
+jest.mock('uuid/v4', () => {
+  return () => 'someuuid'
+})
+
+function CozyRealtimeMock() {
+  this.subscribe = jest
+    .fn()
+    .mockImplementation((eventType, doctype, channel, fn) => {
+      this.on(eventType + doctype + channel, fn)
+    })
+  this.unsubscribeAll = jest.fn().mockImplementation(() => {
+    this.removeAllListeners()
+  })
+
+  this.emitRealtimeEvent = (eventType, doctype, channel, event) => {
+    this.emit(eventType + doctype + channel, event)
+  }
+
+  this.clear = () => {
+    this.removeAllListeners()
+    this.subscribe.mockClear()
+    this.unsubscribeAll.mockClear()
+  }
+}
+MicroEE.mixin(CozyRealtimeMock)
+
+const mockCozyRealtime = new CozyRealtimeMock()
+jest.mock('cozy-realtime', () => {
+  return function CozyRealtime() {
+    return mockCozyRealtime
+  }
+})
+
+const client = {
+  stackClient: {
+    uri: 'https://claud.mycozy.cloud'
+  },
+  appMetadata: { slug: 'home' }
+}
+
+jest.mock('cozy-device-helper', () => ({
+  isMobileApp: jest.fn(),
+  isFlagshipApp: jest.fn()
+}))
+
+describe('OAuthService', () => {
+  describe('openOAuthWindow', () => {
+    beforeEach(() => {
+      mockPopup.clear()
+      mockCozyRealtime.clear()
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    describe('on Flagship app', () => {
+      beforeEach(() => {
+        isFlagshipApp.mockReturnValue(true)
+      })
+
+      it('should render', async () => {
+        const webviewIntent = {
+          call: jest.fn().mockImplementation(fnName => {
+            if (fnName === 'fetchSessionCode') {
+              return Promise.resolve('somesessioncode')
+            } else if (fnName === 'showInAppBrowser') {
+              return Promise.resolve({ result: 'dismiss' })
+            } else if (fnName === 'closeInAppBrowser') {
+              return Promise.resolve()
+            }
+          })
+        }
+        const promise = openOAuthWindow({
+          client,
+          konnector: { slug: 'ameli' },
+          redirectSlug: 'home',
+          extraParams: { extraParam1: 'extraParamValue' },
+          title: 'popup title',
+          account: { _id: 'someaccountid' },
+          webviewIntent
+        })
+
+        expect(isPending(promise)).toBe(true)
+        expect(terminateOAuth).not.toHaveBeenCalled()
+
+        mockCozyRealtime.emitRealtimeEvent(
+          'notified',
+          'io.cozy.accounts',
+          OAUTH_REALTIME_CHANNEL,
+          {
+            _id: 'oauth-popup',
+            data: {
+              error: null,
+              finalLocation: 'connection_id=194&state=someuuid',
+              key: null,
+              oAuthStateKey: 'someuuid'
+            }
+          }
+        )
+        const result = await promise
+        expect(result).toStrictEqual({
+          result: 'OK',
+          key: null,
+          data: {
+            error: null,
+            finalLocation: 'connection_id=194&state=someuuid',
+            key: null,
+            oAuthStateKey: 'someuuid'
+          }
+        })
+
+        expect(terminateOAuth).toHaveBeenCalled()
+      })
+    })
+
+    describe('with intentsApi', () => {
+      beforeEach(() => {
+        isMobileApp.mockReturnValue(true)
+      })
+
+      it('should render', async () => {
+        let closePromise = new Promise(() => {})
+        const intentsApi = {
+          fetchSessionCode: jest.fn().mockResolvedValue('somesessioncode'),
+          showInAppBrowser: jest.fn().mockImplementation(() => {
+            return closePromise
+          }),
+          closeInAppBrowser: jest.fn().mockResolvedValue()
+        }
+        const promise = openOAuthWindow({
+          client,
+          konnector: { slug: 'ameli' },
+          redirectSlug: 'home',
+          extraParams: { extraParam1: 'extraParamValue' },
+          title: 'popup title',
+          account: { _id: 'someaccountid' },
+          intentsApi
+        })
+
+        expect(isPending(promise)).toBe(true)
+        expect(terminateOAuth).not.toHaveBeenCalled()
+
+        await sleep(100) // lets time to show inAppBrowser before realtime event occurs
+
+        mockCozyRealtime.emitRealtimeEvent(
+          'notified',
+          'io.cozy.accounts',
+          OAUTH_REALTIME_CHANNEL,
+          {
+            _id: 'oauth-popup',
+            data: {
+              error: null,
+              finalLocation: 'connection_id=194&state=someuuid',
+              key: null,
+              oAuthStateKey: 'someuuid'
+            }
+          }
+        )
+        const result = await promise
+        expect(result).toStrictEqual({
+          result: 'OK',
+          key: null,
+          data: {
+            error: null,
+            finalLocation: 'connection_id=194&state=someuuid',
+            key: null,
+            oAuthStateKey: 'someuuid'
+          }
+        })
+
+        expect(terminateOAuth).toHaveBeenCalled()
+        expect(intentsApi.fetchSessionCode).toHaveBeenCalledTimes(1)
+        expect(intentsApi.showInAppBrowser).toHaveBeenCalled() // TODO test url mock nonce
+        expect(intentsApi.closeInAppBrowser).toHaveBeenCalled()
+      })
+    })
+
+    describe('on web', () => {
+      beforeEach(() => {
+        isMobileApp.mockReturnValue(false)
+        isFlagshipApp.mockReturnValue(false)
+      })
+
+      it('should render', async () => {
+        const promise = openOAuthWindow({
+          client,
+          konnector: { slug: 'ameli' },
+          redirectSlug: 'home',
+          extraParams: { extraParam1: 'extraParamValue' },
+          title: 'popup title',
+          account: { _id: 'someaccountid' }
+        })
+
+        expect(isPending(promise)).toBe(true)
+        expect(terminateOAuth).not.toHaveBeenCalled()
+
+        mockCozyRealtime.emitRealtimeEvent(
+          'notified',
+          'io.cozy.accounts',
+          OAUTH_REALTIME_CHANNEL,
+          {
+            _id: 'oauth-popup',
+            data: {
+              error: null,
+              finalLocation: 'connection_id=194&state=someuuid',
+              key: null,
+              oAuthStateKey: 'someuuid'
+            }
+          }
+        )
+        const result = await promise
+        expect(result).toStrictEqual({
+          result: 'OK',
+          key: null,
+          data: {
+            error: null,
+            finalLocation: 'connection_id=194&state=someuuid',
+            key: null,
+            oAuthStateKey: 'someuuid'
+          }
+        })
+
+        expect(terminateOAuth).toHaveBeenCalled()
+      })
+    })
+  })
+})
+
+const isPending = promise => {
+  return util.inspect(promise).includes('pending')
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/packages/cozy-harvest-lib/src/components/OAuthService.spec.js
+++ b/packages/cozy-harvest-lib/src/components/OAuthService.spec.js
@@ -47,17 +47,15 @@ function CozyRealtimeMock() {
 MicroEE.mixin(CozyRealtimeMock)
 
 const mockCozyRealtime = new CozyRealtimeMock()
-jest.mock('cozy-realtime', () => {
-  return function CozyRealtime() {
-    return mockCozyRealtime
-  }
-})
 
 const client = {
   stackClient: {
     uri: 'https://claud.mycozy.cloud'
   },
-  appMetadata: { slug: 'home' }
+  appMetadata: { slug: 'home' },
+  plugins: {
+    realtime: mockCozyRealtime
+  }
 }
 
 jest.mock('cozy-device-helper', () => ({

--- a/packages/cozy-harvest-lib/src/components/PopupService.js
+++ b/packages/cozy-harvest-lib/src/components/PopupService.js
@@ -1,0 +1,152 @@
+// @ts-check
+import { popupCenter } from './Popup'
+import { isMobileApp } from 'cozy-device-helper'
+import { windowOpen } from '../helpers/windowWrapper'
+
+/**
+ * @typedef OpenWindowResult
+ * @property {"CLOSED"|"DISMISSED"} result
+ */
+
+/**
+ * Opens a web popup
+ *
+ * @param {Object} options
+ * @param {String} options.url - Url to open the popup on
+ * @param {String} options.title - Title of the popup
+ * @param {Number} options.width - Width of the popup
+ * @param {Number} options.height - Height of the popup
+ * @param {Function} options.handleUrlChange - Function to call when popup url changes
+ * @param {Function} options.registerRealtime - Function to call to register realtime events
+ * @returns {Promise<OpenWindowResult>}
+ */
+export function openWindow({
+  url,
+  title,
+  width,
+  height,
+  handleUrlChange,
+  registerRealtime
+}) {
+  const { w, h, top, left } = popupCenter(width, height)
+  const popup = windowOpen(
+    url,
+    title || '',
+    `scrollbars=yes, width=${w}, height=${h}, top=${top}, left=${left}`
+  )
+
+  return new Promise((resolve, reject) => {
+    if (!popup) {
+      reject(
+        'Popup was blocked by browser. Be sure to not call showPopup asynchronously'
+      )
+    }
+
+    // Puts focus on the new window
+    if (popup.focus) {
+      popup.focus()
+    }
+
+    let checkClosedInterval
+    let unregisterRealtime
+    const cleanAndResolve = data => {
+      if (handleUrlChange) {
+        removeListeners(popup, handleUrlChange)
+      }
+      stopMonitoringClosing(checkClosedInterval)
+      if (registerRealtime) {
+        unregisterRealtime()
+      }
+      if (!popup.closed) popup.close()
+      resolve(data)
+    }
+    if (handleUrlChange) {
+      addListeners(popup, cleanAndResolve, handleUrlChange)
+    }
+    if (registerRealtime) {
+      unregisterRealtime = registerRealtime(cleanAndResolve)
+    }
+    checkClosedInterval = startMonitoringClosing(popup, cleanAndResolve)
+  })
+}
+
+/**
+ * Monitors if the current popup is closed
+ *
+ * @param {Window} popup
+ * @param {Function} resolve - callback to run when popup is closed
+ * @param {Number} checkClosedInterval - setInterval identifier
+ * @returns {void}
+ */
+function monitorClosing(popup, resolve, checkClosedInterval) {
+  if (popup.closed) {
+    stopMonitoringClosing(checkClosedInterval)
+    resolve({ result: 'CLOSED' })
+  }
+}
+
+/**
+ * Check if window is closing every 500ms
+ *
+ * @param  {Window} popup
+ */
+function startMonitoringClosing(popup, resolve) {
+  const checkClosedInterval = setInterval(
+    () => monitorClosing(popup, resolve, checkClosedInterval),
+    500
+  )
+  return checkClosedInterval
+}
+
+/**
+ * Stop monitoriing if the current popup is closed
+ *
+ * @param {Number} checkClosedInterval - setInterval identifier
+ */
+function stopMonitoringClosing(checkClosedInterval) {
+  clearInterval(checkClosedInterval)
+}
+
+/**
+ * Removes all listeners
+ *
+ * @param {Object} popup - Current popup
+ * @param {Function} handleUrlChange - handleUrlChange function not to listen anymore
+ * @returns <void>
+ */
+function removeListeners(popup, handleUrlChange) {
+  // rest of instructions only if popup is still opened
+  if (popup.closed) return
+
+  // rest of instructions only on mobile app
+  if (!isMobileApp()) return
+  popup.removeEventListener('loadstart', handleUrlChange)
+  popup.removeEventListener('exit', handleClose)
+}
+
+/**
+ * Add listeners
+ *
+ * @param {Object} popup
+ * @param {Function} resolve
+ * @param {Function} handleUrlChange
+ * @returns <void>
+ */
+function addListeners(popup, resolve, handleUrlChange) {
+  // rest of instructions only on mobile app
+  if (!isMobileApp()) return
+  popup.addEventListener('loadstart', handleUrlChange(resolve))
+  popup.addEventListener('exit', handleClose(resolve))
+}
+
+/**
+ * Function called when the popup is closed
+ *
+ * @param {Function} resolve
+ * @returns {Function}
+ */
+function handleClose(resolve) {
+  return popup => {
+    resolve(popup)
+  }
+}

--- a/packages/cozy-harvest-lib/src/components/PopupService.spec.js
+++ b/packages/cozy-harvest-lib/src/components/PopupService.spec.js
@@ -1,0 +1,144 @@
+import util from 'util'
+import { openWindow } from 'components/PopupService'
+import { isMobileApp } from 'cozy-device-helper'
+
+import PopupMock from '../helpers/windowWrapperMocks'
+
+const mockPopup = new PopupMock()
+jest.mock('../helpers/windowWrapper', () => ({
+  windowOpen: jest.fn().mockImplementation(() => {
+    return mockPopup
+  })
+}))
+
+jest.mock('cozy-device-helper', () => ({
+  isMobileApp: jest.fn()
+}))
+
+describe('PopupService', () => {
+  describe('openWindow', () => {
+    const handleUrlChange = jest.fn()
+    const handleUrlChangeWrapper = jest.fn().mockReturnValue(handleUrlChange)
+    const unregisterRealtime = jest.fn()
+    const registerRealtime = jest.fn().mockReturnValue(unregisterRealtime)
+
+    beforeEach(() => {
+      mockPopup.clear()
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    describe('on Cordova', () => {
+      beforeEach(() => {
+        isMobileApp.mockReturnValue(true)
+      })
+
+      it('should render', async () => {
+        const promise = openWindow({
+          url: 'http://cozy.tools',
+          title: 'SOME_TITLE',
+          width: '20',
+          height: '30',
+          handleUrlChange: handleUrlChangeWrapper
+        })
+
+        expect(mockPopup.focus).toHaveBeenCalled()
+        expect(mockPopup.addEventListener).toHaveBeenCalledWith(
+          'loadstart',
+          expect.anything()
+        )
+        expect(mockPopup.addEventListener).toHaveBeenCalledWith(
+          'exit',
+          expect.anything()
+        )
+
+        expect(isPending(promise)).toBeTruthy()
+
+        mockPopup.emit('exit', { POPUP: 'data' })
+        const result = await promise
+
+        expect(result).toStrictEqual({ POPUP: 'data' })
+      })
+
+      it('should call handUrlChange', async () => {
+        const promise = openWindow({
+          url: 'http://cozy.tools',
+          title: 'SOME_TITLE',
+          width: '20',
+          height: '30',
+          handleUrlChange: handleUrlChangeWrapper
+        })
+
+        expect(isPending(promise)).toBeTruthy()
+
+        mockPopup.emit('loadstart', 'HELLO')
+        expect(handleUrlChangeWrapper).toHaveBeenCalled()
+        expect(handleUrlChange).toHaveBeenCalledWith('HELLO')
+
+        mockPopup.emit('exit', { POPUP: 'data' })
+        const result = await promise
+        expect(result).toStrictEqual({ POPUP: 'data' })
+      })
+    })
+
+    describe('on web', () => {
+      beforeEach(() => {
+        isMobileApp.mockReturnValue(false)
+      })
+
+      it('should render', async () => {
+        const promise = openWindow(
+          'http://cozy.tools',
+          'SOME_TITLE',
+          'SOME_OPTIONS'
+        )
+
+        expect(mockPopup.focus).toHaveBeenCalled()
+        expect(mockPopup.addEventListener).not.toHaveBeenCalledWith(
+          'loadstart',
+          expect.anything()
+        )
+        expect(mockPopup.addEventListener).not.toHaveBeenCalledWith(
+          'exit',
+          expect.anything()
+        )
+
+        expect(isPending(promise)).toBeTruthy()
+
+        mockPopup.close()
+        const result = await promise
+        expect(result).toStrictEqual({ result: 'CLOSED' })
+      })
+
+      it('should accept registerRealtime parameter', async () => {
+        const promise = openWindow({
+          url: 'http://cozy.tools',
+          title: 'SOME_TITLE',
+          width: '20',
+          height: '30',
+          handleUrlChange: handleUrlChangeWrapper,
+          registerRealtime
+        })
+
+        expect(isPending(promise)).toBeTruthy()
+
+        expect(registerRealtime).toHaveBeenCalledTimes(1)
+        expect(unregisterRealtime).not.toHaveBeenCalled()
+
+        mockPopup.emit('loadstart', 'HELLO')
+        expect(handleUrlChange).not.toHaveBeenCalled()
+
+        mockPopup.close()
+        const result = await promise
+        expect(result).toStrictEqual({ result: 'CLOSED' })
+        expect(unregisterRealtime).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+})
+
+const isPending = promise => {
+  return util.inspect(promise).includes('pending')
+}

--- a/packages/cozy-harvest-lib/src/helpers/oauth.js
+++ b/packages/cozy-harvest-lib/src/helpers/oauth.js
@@ -166,10 +166,10 @@ const getAppSlug = client => {
  * @param  {Object} options
  * @param  {CozyClient} options.client
  * @param  {Object} options.konnector
- * @param  {string} options.redirectSlug The app we want to redirect the user on after the end of the flow
+ * @param  {string} [options.redirectSlug] The app we want to redirect the user on after the end of the flow
  * @param  {Object} options.extraParams some extra parameters to add to the query string
- * @param  {Boolean} options.reconnect Are we trying to reconnect an existing account ?
- * @param  {Boolean} options.manage Are we trying to manage an existing account ?
+ * @param  {Boolean} [options.reconnect] Are we trying to reconnect an existing account ?
+ * @param  {Boolean} [options.manage] Are we trying to manage an existing account ?
  * @param  {IoCozyAccount} options.account targetted account if any
  * @return {Object}           Object containing: `oAuthUrl` (URL of cozy stack OAuth endpoint) and `oAuthStateKey` (localStorage key)
  */

--- a/packages/cozy-harvest-lib/src/helpers/windowWrapper.js
+++ b/packages/cozy-harvest-lib/src/helpers/windowWrapper.js
@@ -1,0 +1,11 @@
+/**
+ * Mockable window.open
+ *
+ * @param {String} url
+ * @param {String} target
+ * @param {String} windowFeatures
+ * @returns {Window} - Popup window instance
+ */
+export const windowOpen = (url, target, windowFeatures) => {
+  return window.open(url, target, windowFeatures)
+}

--- a/packages/cozy-harvest-lib/src/helpers/windowWrapperMocks.js
+++ b/packages/cozy-harvest-lib/src/helpers/windowWrapperMocks.js
@@ -1,0 +1,30 @@
+import MicroEE from 'microee'
+
+function PopupMock() {
+  this.closed = false
+
+  this.focus = jest.fn()
+  this.close = jest.fn().mockImplementation(() => {
+    this.closed = true
+  })
+
+  this.addEventListener = jest.fn().mockImplementation((name, fn) => {
+    this.on(name, fn)
+  })
+  this.removeEventListener = jest.fn().mockImplementation((name, fn) => {
+    this.removeListener(name, fn)
+  })
+
+  this.clear = () => {
+    this.closed = false
+    this.removeAllListeners()
+    this.focus.mockClear()
+    this.close.mockClear()
+    this.addEventListener.mockClear()
+    this.removeEventListener.mockClear()
+  }
+}
+
+MicroEE.mixin(PopupMock)
+
+export default PopupMock

--- a/packages/cozy-harvest-lib/src/index.js
+++ b/packages/cozy-harvest-lib/src/index.js
@@ -45,3 +45,4 @@ export { withLocales }
 export { default as updateAccountsFromCipher } from './services/updateAccountsFromCipher'
 export { default as deleteAccounts } from './services/deleteAccounts'
 export { TrackingContext } from './components/hoc/tracking'
+export { CozyConfirmDialogProvider } from './components/CozyConfirmDialogProvider'


### PR DESCRIPTION
Creation of a new OAuthService class to handle all OAuth communiction
without depending on React component tree

We had to transform Popup.jsx and OAuthWindow.jsx into functions to
avoid to be blocked by browser when opening a popup (Too many useEffect
with render tend to block the popup)- feat: Use independant OAuth window
- feat: Add independent confirm dialog

Still to do :

- migrate OAuthForm to OAuthService
- migrate KonnectorAccountTabs to OAuthService
- remove OAuthWindow.jsx and Popup.jsx
