### PR TITLE
fix: Add konnector slug in fake trigger passed to onLoginSuccess

### DIFF
--- a/packages/cozy-harvest-lib/src/components/FlowProvider.jsx
+++ b/packages/cozy-harvest-lib/src/components/FlowProvider.jsx
@@ -141,7 +141,8 @@ export class FlowProvider extends Component {
     // created, this is why a trigger like object is created here
     const triggerLike = {
       message: {
-        account: flow?.account?._id
+        account: flow?.account?._id,
+        konnector: flow?.konnector?.slug
       },
       ...flow.trigger
     }

--- a/packages/cozy-harvest-lib/src/components/FlowProvider.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/FlowProvider.spec.jsx
@@ -127,7 +127,8 @@ describe('FlowProvider', () => {
     expect(onLoginSuccess).toHaveBeenCalledWith(
       expect.objectContaining({
         message: {
-          account: 'account-id'
+          account: 'account-id',
+          konnector: 'konnectorslug'
         }
       })
     )


### PR DESCRIPTION
This information is needed by a b2c app
