### PR TITLE
feat: Use OAuthService in OAuthForm and KonnectorAccountTabs

### DIFF
--- a/packages/cozy-harvest-lib/src/components/OAuthForm.spec.js
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.spec.js
@@ -39,6 +39,12 @@ describe('OAuthForm', () => {
   } = {}) => {
     const client = new CozyClient({ uri: 'http://cozy.localhost:8080' })
     client.fetchQueryAndGetFromState = jest.fn()
+    client.plugins = {
+      realtime: {
+        subscribe: jest.fn(),
+        unsubscribe: jest.fn()
+      }
+    }
     const konnector = {}
     const flow = new ConnectionFlow(client, null, konnector)
     flow.getState = jest.fn().mockReturnValue(flowState)
@@ -57,7 +63,7 @@ describe('OAuthForm', () => {
     // Wait for next tick so the effects of useOAuthExtraParams are done
     await act(() => new Promise(setImmediate))
 
-    return { root }
+    return { root, client }
   }
 
   it('should render', async () => {
@@ -74,10 +80,10 @@ describe('OAuthForm', () => {
   })
 
   it('should call policy fetchExtraOAuthUrlParams with proper params', async () => {
-    await setup({ account: fixtures.account })
+    const { client } = await setup({ account: fixtures.account })
     expect(fetchExtraOAuthUrlParams).toHaveBeenCalledWith({
       account: fixtures.account,
-      client: undefined,
+      client,
       konnector: fixtures.konnector,
       reconnect: false
     })

--- a/packages/cozy-harvest-lib/src/components/OAuthService.js
+++ b/packages/cozy-harvest-lib/src/components/OAuthService.js
@@ -12,6 +12,10 @@ import { openWindow } from './PopupService'
 const OAUTH_POPUP_HEIGHT = 800
 const OAUTH_POPUP_WIDTH = 800
 
+export const OAUTH_SERVICE_CLOSED = 'CLOSED'
+export const OAUTH_SERVICE_ERROR = 'ERROR'
+export const OAUTH_SERVICE_OK = 'OK'
+
 /**
  * Monitor URL changes for mobile apps and in app browsers
  * @param  {import('cozy-client/types/types').KonnectorsDoctype} konnector
@@ -70,7 +74,7 @@ function handleOAuthData(data, konnector, resolve) {
   }
 
   resolve({
-    result: 'OK',
+    result: OAUTH_SERVICE_OK,
     key: data.key,
     data
   })
@@ -106,7 +110,8 @@ function extractOAuthDataFromUrl(url) {
 
 /**
  * @typedef OAuthServiceResult
- * @property {"OK"|"CLOSED"|"DISMISSED"|"ERROR"} result
+ * @property {"OK"|"CLOSED"|"ERROR"} result
+ * @property {String} [error]
  * @property {OAuthData} [data]
  */
 
@@ -151,16 +156,16 @@ async function openWebviewIntentInAppBrowser({
         // @ts-ignore wrong return type associated to webviewIntent.call
         if (result?.type !== 'dismiss' && result?.type !== 'cancel') {
           // @ts-ignore wrong return type associated to webviewIntent.call
-          resolve({ result: 'ERROR', error: result })
+          resolve({ result: OAUTH_SERVICE_ERROR, error: result })
           return
         }
 
         webviewIntent.call('closeInAppBrowser')
-        resolve({ result: 'CLOSED' })
+        resolve({ result: OAUTH_SERVICE_CLOSED })
         return
       } catch (err) {
         webviewIntent.call('closeInAppBrowser')
-        resolve({ result: 'ERROR', error: err })
+        resolve({ result: OAUTH_SERVICE_ERROR, error: err })
         return
       }
     }
@@ -223,9 +228,9 @@ function openIntentsApiInAppBrowser({
         logger.debug('url to open: ', urlToOpen)
         const result = await showInAppBrowser(urlToOpen)
         if (result?.state !== 'dismiss' && result?.state !== 'cancel') {
-          return resolve({ result: 'ERROR', error: result })
+          return resolve({ result: OAUTH_SERVICE_ERROR, error: result })
         }
-        return resolve({ result: 'CLOSED' })
+        return resolve({ result: OAUTH_SERVICE_CLOSED })
       } catch (err) {
         return resolve({ result: 'ERROR', error: err })
       }

--- a/packages/cozy-harvest-lib/src/components/OAuthService.spec.js
+++ b/packages/cozy-harvest-lib/src/components/OAuthService.spec.js
@@ -1,6 +1,6 @@
 import MicroEE from 'microee'
 import util from 'util'
-import { openOAuthWindow } from 'components/OAuthService'
+import { openOAuthWindow, OAUTH_SERVICE_OK } from 'components/OAuthService'
 import { isMobileApp, isFlagshipApp } from 'cozy-device-helper'
 
 import PopupMock from '../helpers/windowWrapperMocks'
@@ -120,7 +120,7 @@ describe('OAuthService', () => {
         )
         const result = await promise
         expect(result).toStrictEqual({
-          result: 'OK',
+          result: OAUTH_SERVICE_OK,
           key: null,
           data: {
             error: null,
@@ -179,7 +179,7 @@ describe('OAuthService', () => {
         )
         const result = await promise
         expect(result).toStrictEqual({
-          result: 'OK',
+          result: OAUTH_SERVICE_OK,
           key: null,
           data: {
             error: null,
@@ -231,7 +231,7 @@ describe('OAuthService', () => {
         )
         const result = await promise
         expect(result).toStrictEqual({
-          result: 'OK',
+          result: OAUTH_SERVICE_OK,
           key: null,
           data: {
             error: null,

--- a/packages/cozy-harvest-lib/src/components/PopupService.js
+++ b/packages/cozy-harvest-lib/src/components/PopupService.js
@@ -5,7 +5,7 @@ import { windowOpen } from '../helpers/windowWrapper'
 
 /**
  * @typedef OpenWindowResult
- * @property {"CLOSED"|"DISMISSED"} result
+ * @property {"CLOSED"} result
  */
 
 /**


### PR DESCRIPTION
Instead of OAuthWindow component

The OAuthService service is not subject to multiple rerenders of the component tree.
In this case, it especially avoids calling the display of inApp Browser multiple times in b2c app depending on rerenders of OAuthForm component

- docs: Fix PopupService jsdoc
- refactor: Export constants for OAuthService result types
- feat: Use OAuthService in OAuthForm
- feat: Use OAuthService in KonnectorAccountTabs
