### PR TITLE
fix(harvest): Update wording for Bank disconnect dialog close button

### DIFF
--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -384,7 +384,7 @@
     "deleteBIConnection": {
       "title": "Bank disconnect",
       "description": "Your request has been recorded. It will be effective in a short moment. Previously imported data will not be deleted.",
-      "confirm-deletion": "Confirm deletion"
+      "confirm-deletion": "Close"
     },
     "deleteAccount": {
       "title": "Disconnection",

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -384,7 +384,7 @@
     "deleteBIConnection": {
       "title": "Déconnexion de votre banque",
       "description": "La déconnexion de votre banque a bien été prise en compte et sera effective dans quelques instants. Les données précédemment importées seront conservées.",
-      "confirm-deletion": "Confirmer la suppression"
+      "confirm-deletion": "Fermer"
     },
     "deleteAccount": {
       "title": "Déconnexion",


### PR DESCRIPTION
As said in the dialog description, the deletion is made in parallel to the dialog opening.