### PR TITLE
fix(mespapiers): Group papers by connector identifier

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
@@ -138,7 +138,8 @@ export const buildFilesByContacts = ({ files, contacts, maxDisplay, t }) => {
     if (filesCreatedByConnectors.length > 0) {
       const filesByConnectors = groupBy(
         filesCreatedByConnectors,
-        file => file.cozyMetadata.sourceAccount
+        file =>
+          `${file.cozyMetadata.uploadedBy.slug}-${file.cozyMetadata.sourceAccountIdentifier}`
       )
 
       const unsortedlistByConnector = Object.values(filesByConnectors).map(

--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.spec.js
@@ -73,24 +73,33 @@ const mockFilesWithSourceAccount = [
     _id: 'fileId05',
     name: 'file05.pdf',
     cozyMetadata: {
-      sourceAccount: 'ConnectorOne',
-      sourceAccountIdentifier: 'Account 1'
+      sourceAccount: 'ConnectorAccountId01',
+      sourceAccountIdentifier: 'Account 1',
+      uploadedBy: {
+        slug: 'ConnectorOne'
+      }
     }
   },
   {
     _id: 'fileId06',
     name: 'file06.pdf',
     cozyMetadata: {
-      sourceAccount: 'ConnectorOne',
-      sourceAccountIdentifier: 'Account 1'
+      sourceAccount: 'ConnectorAccountId01',
+      sourceAccountIdentifier: 'Account 1',
+      uploadedBy: {
+        slug: 'ConnectorOne'
+      }
     }
   },
   {
     _id: 'fileId07',
     name: 'file07.pdf',
     cozyMetadata: {
-      sourceAccount: 'ConnectorTwo',
-      sourceAccountIdentifier: 'Account 2'
+      sourceAccount: 'ConnectorAccountId02',
+      sourceAccountIdentifier: 'Account 2',
+      uploadedBy: {
+        slug: 'ConnectorTwo'
+      }
     }
   }
 ]
@@ -291,7 +300,7 @@ describe('helpers Papers', () => {
       expect(result).toStrictEqual(expected)
     })
 
-    it('should filter files without contact by sourceAccount', () => {
+    it('should filter files without contact by connectors', () => {
       const result = buildFilesByContacts({
         files: mockFilesWithSourceAccount,
         contacts: [],
@@ -310,16 +319,22 @@ describe('helpers Papers', () => {
                 _id: 'fileId05',
                 name: 'file05.pdf',
                 cozyMetadata: {
-                  sourceAccount: 'ConnectorOne',
-                  sourceAccountIdentifier: 'Account 1'
+                  sourceAccount: 'ConnectorAccountId01',
+                  sourceAccountIdentifier: 'Account 1',
+                  uploadedBy: {
+                    slug: 'ConnectorOne'
+                  }
                 }
               },
               {
                 _id: 'fileId06',
                 name: 'file06.pdf',
                 cozyMetadata: {
-                  sourceAccount: 'ConnectorOne',
-                  sourceAccountIdentifier: 'Account 1'
+                  sourceAccount: 'ConnectorAccountId01',
+                  sourceAccountIdentifier: 'Account 1',
+                  uploadedBy: {
+                    slug: 'ConnectorOne'
+                  }
                 }
               }
             ]
@@ -335,8 +350,11 @@ describe('helpers Papers', () => {
                 _id: 'fileId07',
                 name: 'file07.pdf',
                 cozyMetadata: {
-                  sourceAccount: 'ConnectorTwo',
-                  sourceAccountIdentifier: 'Account 2'
+                  sourceAccount: 'ConnectorAccountId02',
+                  sourceAccountIdentifier: 'Account 2',
+                  uploadedBy: {
+                    slug: 'ConnectorTwo'
+                  }
                 }
               }
             ]
@@ -366,16 +384,22 @@ describe('helpers Papers', () => {
                 _id: 'fileId05',
                 name: 'file05.pdf',
                 cozyMetadata: {
-                  sourceAccount: 'ConnectorOne',
-                  sourceAccountIdentifier: 'Account 1'
+                  sourceAccount: 'ConnectorAccountId01',
+                  sourceAccountIdentifier: 'Account 1',
+                  uploadedBy: {
+                    slug: 'ConnectorOne'
+                  }
                 }
               },
               {
                 _id: 'fileId06',
                 name: 'file06.pdf',
                 cozyMetadata: {
-                  sourceAccount: 'ConnectorOne',
-                  sourceAccountIdentifier: 'Account 1'
+                  sourceAccount: 'ConnectorAccountId01',
+                  sourceAccountIdentifier: 'Account 1',
+                  uploadedBy: {
+                    slug: 'ConnectorOne'
+                  }
                 }
               }
             ]
@@ -391,8 +415,11 @@ describe('helpers Papers', () => {
                 _id: 'fileId07',
                 name: 'file07.pdf',
                 cozyMetadata: {
-                  sourceAccount: 'ConnectorTwo',
-                  sourceAccountIdentifier: 'Account 2'
+                  sourceAccount: 'ConnectorAccountId02',
+                  sourceAccountIdentifier: 'Account 2',
+                  uploadedBy: {
+                    slug: 'ConnectorTwo'
+                  }
                 }
               }
             ]


### PR DESCRIPTION
We initially grouped by `sourceAccount` which is the id of the account used by a connector. However, if we disconnect an account from a connector, it is deleted. So when you reconnect, you create a new account, with a new `sourceAccount`. So we can't gather the documents according to this.

We now rely on the slug of the connector and the `sourceAccountIdentifier` (which is usually the login of the account) to avoid gathering documents with the same login but from different connectors.