### PR TITLE
Query expiration attributes for search and theme

### DIFF
--- a/packages/cozy-mespapiers-lib/src/helpers/queries.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/queries.js
@@ -20,9 +20,14 @@ export const buildFilesQueryWithQualificationLabel = () => {
         .indexFields(['metadata.qualification.label'])
         .select([
           'name',
-          'metadata.datetime',
           'referenced_by',
+          'metadata.country',
+          'metadata.datetime',
+          'metadata.expirationDate',
+          'metadata.noticePeriod',
           'metadata.qualification.label',
+          'metadata.referencedDate',
+          'created_at',
           'updated_at',
           'type',
           'trashed'


### PR DESCRIPTION
This allows to display expiration annotations in paper items while searching or filtering by theme without having to open them first to populate the file objects with these attributes.