### PR TITLE
fix: Error on bank accounts without connection relationship

### DIFF
--- a/packages/cozy-doctypes/src/banking/BankAccount.js
+++ b/packages/cozy-doctypes/src/banking/BankAccount.js
@@ -64,7 +64,9 @@ class BankAccount extends Document {
         matchedAccountIds[localAccount._id]
       )
       const newAccountId =
-        replacedCozyAccountIds[localAccount.relationships.connection.data._id]
+        replacedCozyAccountIds[
+          localAccount?.relationships?.connection?.data?._id
+        ]
       if (foundInMatchedAccounts || !newAccountId) {
         continue
       }

--- a/packages/cozy-doctypes/src/banking/BankAccount.spec.js
+++ b/packages/cozy-doctypes/src/banking/BankAccount.spec.js
@@ -1,7 +1,7 @@
 const BankAccount = require('./BankAccount')
 
 describe('account reconciliation', () => {
-  it('should update relationship of disabled accounts associated to the same relationship as updated anabled accounts', () => {
+  it('should update relationship of disabled accounts associated to the same relationship as updated anabled accounts even with accounts without connection relationship', () => {
     const newAccounts = [
       {
         number: '1',
@@ -50,6 +50,21 @@ describe('account reconciliation', () => {
         },
         metadata: {
           updatedAt: '2020-11-30'
+        }
+      },
+      {
+        _id: 'oldaccountnorelationship',
+        number: '10',
+        balance: 0,
+        relationships: {
+          other: {
+            data: {
+              some: 'data'
+            }
+          }
+        },
+        metadata: {
+          updatedAt: '2012-11-30'
         }
       }
     ]


### PR DESCRIPTION
Some old bank accounts, without any associated running connector, may
have no "connection" relationship.

Adding a protection against this.
