### PR TITLE
feat(mesPapiers): Change the wording of the parpersList header

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
@@ -145,7 +145,10 @@ export const buildFilesByContacts = ({ files, contacts, maxDisplay, t }) => {
       const unsortedlistByConnector = Object.values(filesByConnectors).map(
         value => ({
           withHeader: true,
-          contact: value[0].cozyMetadata.sourceAccountIdentifier,
+          contact: t('PapersList.accountName', {
+            name: value[0].cozyMetadata.createdByApp,
+            identifier: value[0].cozyMetadata.sourceAccountIdentifier
+          }),
           papers: {
             maxDisplay,
             list: value

--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.spec.js
@@ -311,7 +311,7 @@ describe('helpers Papers', () => {
       const expected = [
         {
           withHeader: true,
-          contact: 'Account 1',
+          contact: 'PapersList.accountName',
           papers: {
             maxDisplay: 3,
             list: [
@@ -342,7 +342,7 @@ describe('helpers Papers', () => {
         },
         {
           withHeader: true,
-          contact: 'Account 2',
+          contact: 'PapersList.accountName',
           papers: {
             maxDisplay: 3,
             list: [
@@ -376,7 +376,7 @@ describe('helpers Papers', () => {
       const expected = [
         {
           withHeader: true,
-          contact: 'Account 1',
+          contact: 'PapersList.accountName',
           papers: {
             maxDisplay: 3,
             list: [
@@ -407,7 +407,7 @@ describe('helpers Papers', () => {
         },
         {
           withHeader: true,
-          contact: 'Account 2',
+          contact: 'PapersList.accountName',
           papers: {
             maxDisplay: 3,
             list: [

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -259,6 +259,7 @@
     }
   },
   "PapersList": {
+    "accountName": "Account %{name} : %{identifier}",
     "contactMerged": "%{firstGivenName} and %{secondGivenName} %{familyName}",
     "defaultName": "Contact not specified",
     "label": {

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -259,6 +259,7 @@
     }
   },
   "PapersList": {
+    "accountName": "Compte %{name} : %{identifier}",
     "contactMerged": "%{firstGivenName} et %{secondGivenName} %{familyName}",
     "defaultName": "Contact non spécifié",
     "label": {


### PR DESCRIPTION
Changement du texte d'en-tête présent dans la liste des papiers pour les fichiers provenant de connecteur (et n'ayant pas de contacts associés)