### PR TITLE
fix: Reactive share modal for all apps

### DIFF
--- a/packages/cozy-sharing/src/components/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal.jsx
@@ -30,64 +30,54 @@ export const ShareModal = ({
   sharingDesc,
   twoStepsConfirmationMethods
 }) => {
-  const showShareCozyToCozyForNotes =
-    flag('notes.sharing-cozy-to-cozy') !== null &&
-    flag('notes.sharing-cozy-to-cozy') &&
-    documentType === 'Notes'
+  const shareDialogOnlyByLink =
+    (documentType === 'Notes' && !flag('notes.sharing-cozy-to-cozy')) ||
+    documentType === 'Albums'
 
-  const showShareByEmail =
-    showShareCozyToCozyForNotes &&
-    documentType !== 'Albums' &&
-    !hasSharedParent &&
-    !hasSharedChild
+  const showShareByEmail = !hasSharedParent && !hasSharedChild
   const showShareByLink = documentType !== 'Organizations'
   const showShareOnlyByLink = hasSharedParent || hasSharedChild
   const showWhoHasAccess = documentType !== 'Albums'
 
-  return (
-    <>
-      {(!showShareCozyToCozyForNotes || documentType === 'Albums') && (
-        <ShareDialogOnlyByLink
-          document={document}
-          documentType={documentType}
-          link={link}
-          onClose={onClose}
-          onRevokeLink={onRevokeLink}
-          onShareByLink={onShareByLink}
-          onUpdateShareLinkPermissions={onUpdateShareLinkPermissions}
-          permissions={permissions}
-        />
-      )}
-      {showShareCozyToCozyForNotes && documentType !== 'Albums' && (
-        <ShareDialogCozyToCozy
-          contacts={contacts}
-          createContact={createContact}
-          document={document}
-          documentType={documentType}
-          groups={groups}
-          hasSharedParent={hasSharedParent}
-          isOwner={isOwner}
-          link={link}
-          needsContactsPermission={needsContactsPermission}
-          onClose={onClose}
-          onRevoke={onRevoke}
-          onRevokeLink={onRevokeLink}
-          onRevokeSelf={onRevokeSelf}
-          onShare={onShare}
-          onShareByLink={onShareByLink}
-          onUpdateShareLinkPermissions={onUpdateShareLinkPermissions}
-          permissions={permissions}
-          recipients={recipients}
-          sharing={sharing}
-          sharingDesc={sharingDesc}
-          showShareByEmail={showShareByEmail}
-          showShareByLink={showShareByLink}
-          showShareOnlyByLink={showShareOnlyByLink}
-          showWhoHasAccess={showWhoHasAccess}
-          twoStepsConfirmationMethods={twoStepsConfirmationMethods}
-        />
-      )}
-    </>
+  return shareDialogOnlyByLink ? (
+    <ShareDialogOnlyByLink
+      document={document}
+      documentType={documentType}
+      link={link}
+      onClose={onClose}
+      onRevokeLink={onRevokeLink}
+      onShareByLink={onShareByLink}
+      onUpdateShareLinkPermissions={onUpdateShareLinkPermissions}
+      permissions={permissions}
+    />
+  ) : (
+    <ShareDialogCozyToCozy
+      contacts={contacts}
+      createContact={createContact}
+      document={document}
+      documentType={documentType}
+      groups={groups}
+      hasSharedParent={hasSharedParent}
+      isOwner={isOwner}
+      link={link}
+      needsContactsPermission={needsContactsPermission}
+      onClose={onClose}
+      onRevoke={onRevoke}
+      onRevokeLink={onRevokeLink}
+      onRevokeSelf={onRevokeSelf}
+      onShare={onShare}
+      onShareByLink={onShareByLink}
+      onUpdateShareLinkPermissions={onUpdateShareLinkPermissions}
+      permissions={permissions}
+      recipients={recipients}
+      sharing={sharing}
+      sharingDesc={sharingDesc}
+      showShareByEmail={showShareByEmail}
+      showShareByLink={showShareByLink}
+      showShareOnlyByLink={showShareOnlyByLink}
+      showWhoHasAccess={showWhoHasAccess}
+      twoStepsConfirmationMethods={twoStepsConfirmationMethods}
+    />
   )
 }
 

--- a/packages/cozy-sharing/src/components/ShareModal.spec.js
+++ b/packages/cozy-sharing/src/components/ShareModal.spec.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { ShareModal } from './ShareModal'
+import AppLike from '../../test/AppLike'
+import flag from 'cozy-flags'
+
+jest.mock('./ShareDialogCozyToCozy', () => () => <>ShareDialogCozyToCozy</>)
+jest.mock('./ShareDialogOnlyByLink', () => () => <>ShareDialogOnlyByLink</>)
+
+jest.mock('cozy-flags')
+
+describe('ShareModal component', () => {
+  const setup = props => {
+    return render(
+      <AppLike>
+        <ShareModal {...props} />
+      </AppLike>
+    )
+  }
+
+  beforeEach(() => {
+    flag.mockImplementation(() => null)
+  })
+
+  it('should render ShareDialogCozyToCozy if type is Document', () => {
+    const root = setup({ documentType: 'Document' })
+
+    expect(root.getByText('ShareDialogCozyToCozy'))
+  })
+
+  it('should render ShareDialogOnlyByLink if type is Albums', () => {
+    const root = setup({ documentType: 'Albums' })
+
+    expect(root.getByText('ShareDialogOnlyByLink'))
+  })
+
+  it('should render ShareDialogCozyToCozy if type is Notes and notes.sharing-cozy-to-cozy flag enabled', () => {
+    flag.mockImplementation(() => true)
+    const root = setup({ documentType: 'Notes' })
+
+    expect(root.getByText('ShareDialogCozyToCozy'))
+  })
+
+  it('should render ShareDialogOnlyByLink if type is Notes and notes.sharing-cozy-to-cozy flag disabled', () => {
+    const root = setup({ documentType: 'Notes' })
+
+    expect(root.getByText('ShareDialogOnlyByLink'))
+  })
+})


### PR DESCRIPTION
The previous check was too strong and the Share modal disappeared in some apps like Drive.

I also added unit test to check the good behavior because it can make crazy.