### PR TITLE
Use `formatLocallyDistanceToNowStrict` for expiration annotations

### DIFF
--- a/packages/cozy-mespapiers-lib/package.json
+++ b/packages/cozy-mespapiers-lib/package.json
@@ -23,7 +23,7 @@
     "cozy-intent": "^2.7.0",
     "cozy-realtime": "^4.2.9",
     "cozy-sharing": "^4.9.0",
-    "cozy-ui": "^78.0.0",
+    "cozy-ui": "^79.1.0",
     "jest-environment-jsdom-sixteen": "2.0.0",
     "react-router-dom": "6.4.5"
   },
@@ -44,7 +44,7 @@
     "cozy-intent": ">=2.2.0",
     "cozy-realtime": ">=4.2.0",
     "cozy-sharing": ">=4.3.0",
-    "cozy-ui": ">=78.0.0",
+    "cozy-ui": ">=79.1.0",
     "react-router-dom": ">=6.4.5"
   }
 }

--- a/packages/cozy-mespapiers-lib/src/components/Papers/ExpirationAnnotation.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/ExpirationAnnotation.jsx
@@ -5,7 +5,7 @@ import { models } from 'cozy-client'
 
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
-import { formatLocallyDistanceToNow } from 'cozy-ui/transpiled/react/I18n/format'
+import { formatLocallyDistanceToNowStrict } from 'cozy-ui/transpiled/react/I18n/format'
 
 const { computeExpirationDate, isExpired } = models.paper
 
@@ -25,7 +25,7 @@ const ExpirationAnnotation = ({ file }) => {
   return (
     <Typography component="span" variant="inherit" className="u-warning">
       {t('PapersList.expiresIn', {
-        duration: formatLocallyDistanceToNow(expirationDate)
+        duration: formatLocallyDistanceToNowStrict(expirationDate)
       })}
     </Typography>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -7207,10 +7207,10 @@ cozy-ui@^77.9.0:
     react-swipeable-views "^0.13.3"
     rooks "^5.11.2"
 
-cozy-ui@^78.0.0:
-  version "78.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-78.0.0.tgz#3109d83f7f288c738e48f8e93de0eedac5c3f697"
-  integrity sha512-2q+TIWcCpXo57gtmIac4NeNePDJaJcyOUTWqczPnopgzXrd0D1oKOuuULnOoWiun7+6becpviPeutuxo4WBGIw==
+cozy-ui@^79.1.0:
+  version "79.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-79.1.0.tgz#3a9d8fedcaa44abba32beaafdbe27e3c5b49674b"
+  integrity sha512-0UicUBRwirTNc0yqL7UsorHitCShROqvn0KCO1g+fLViIo2N+Hdkb7Wm2AFz5MOLypm5hic/2K6N+SHgFF7keQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"


### PR DESCRIPTION
This basically removes the "about" / "environ" before some durations.