### PR TITLE
fix: Don't call PermissionCol.findApps

### DIFF
--- a/packages/cozy-sharing/src/SharingProvider.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.jsx
@@ -35,6 +35,7 @@ import {
   createSharingInStore,
   updateSharingInStore
 } from './helpers/sharings'
+import { fetchApps } from './queries/queries'
 
 const SHARING_DOCTYPE = 'io.cozy.sharings'
 const PERMISSION_DOCTYPE = 'io.cozy.permissions'
@@ -158,7 +159,7 @@ export class SharingProvider extends Component {
     const [sharings, permissions, apps] = await Promise.all([
       this.sharingCol.findByDoctype(doctype),
       this.permissionCol.findLinksByDoctype(doctype),
-      this.permissionCol.findApps()
+      client.query(fetchApps().definition, fetchApps().options)
     ])
     this.dispatch(
       receiveSharings({

--- a/packages/cozy-sharing/src/queries/queries.js
+++ b/packages/cozy-sharing/src/queries/queries.js
@@ -8,6 +8,14 @@ const defaultFetchPolicy = fetchPolicies.olderThan(
   DEFAULT_CACHE_TIMEOUT_QUERIES
 )
 
+export const fetchApps = () => ({
+  definition: Q('io.cozy.apps'),
+  options: {
+    as: 'io.cozy.apps',
+    fetchPolicy: defaultFetchPolicy
+  }
+})
+
 export const buildSharingsByIdQuery = sharingId => ({
   definition: Q('io.cozy.sharings').getById(sharingId),
   options: {


### PR DESCRIPTION
findApps is now deprecated on Cozy-Client
(cozy/cozy-client#1293)

So let's use a named query with a fetchPolicy
in order to leverage CozyClient cache.