### PR TITLE
Authentication: Pass the `history` object back to `onAuthenticated`

### DIFF
--- a/packages/cozy-authentication/src/MobileRouter.jsx
+++ b/packages/cozy-authentication/src/MobileRouter.jsx
@@ -283,7 +283,7 @@ export class MobileRouter extends Component {
 
   async afterAuthentication() {
     if (this.props.onAuthenticated) {
-      await this.props.onAuthenticated()
+      await this.props.onAuthenticated({ history: this.props.history })
     }
 
     await credentials.saveFromClient(this.props.client)
@@ -303,7 +303,7 @@ export class MobileRouter extends Component {
     this.props.history.replace(this.props.logoutPath)
     await credentials.clear()
     if (this.props.onLogout) {
-      this.props.onLogout()
+      this.props.onLogout({ history: this.props.history })
     }
   }
 


### PR DESCRIPTION
Apps may want to redirect the user once logged in or logged out.
They need the `history` object for that, so it is passed back to `onAuthenticated` (for Banks and Drive) and `onLogout` (for Drive).