### PR TITLE
fix: Color for badge with me

### DIFF
--- a/packages/cozy-sharing/src/components/badge.styl
+++ b/packages/cozy-sharing/src/components/badge.styl
@@ -29,4 +29,4 @@
         background-color var(--emerald)
 
     &.--with-me
-        background-color var(--portage)
+        background-color #9169F2


### PR DESCRIPTION
The portage color has been remove from cozy-ui (cc: https://github.com/cozy/cozy-ui/commit/5fd473af94b9febeef8523bdc42375930cdea11c)