### PR TITLE
Feat(Harvest): Split Modal Account into 2 separate routes

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/AccountModalContentWrapper.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/AccountModalContentWrapper.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { useOutletContext } from 'react-router-dom'
+import DialogContent from '@material-ui/core/DialogContent'
+
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+import FlowProvider from '../FlowProvider'
+import TriggerError from './TriggerError'
+
+const AccountModalContentWrapper = ({ children }) => {
+  const { isMobile } = useBreakpoints()
+  const { trigger, account, konnector } = useOutletContext()
+
+  return (
+    <DialogContent className={isMobile ? 'u-p-0' : 'u-pt-0'}>
+      <FlowProvider initialTrigger={trigger} konnector={konnector}>
+        {({ flow }) => (
+          <>
+            <TriggerError
+              flow={flow}
+              konnector={konnector}
+              account={account}
+              trigger={trigger}
+            />
+            {React.Children.map(children, child =>
+              React.isValidElement(child)
+                ? React.cloneElement(child, { flow, trigger, account })
+                : null
+            )}
+          </>
+        )}
+      </FlowProvider>
+    </DialogContent>
+  )
+}
+
+export default AccountModalContentWrapper

--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/AccountModalHeader.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/AccountModalHeader.jsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import AccountSelectBox from '../AccountSelectBox/AccountSelectBox'
+import KonnectorModalHeader from '../KonnectorModalHeader'
+import { withMountPointProps } from '../MountPointContext'
+
+export const AccountModalHeader = ({
+  konnector,
+  account,
+  accountsAndTriggers,
+  showAccountSelection,
+  pushHistory
+}) => {
+  return (
+    <KonnectorModalHeader konnector={konnector}>
+      {showAccountSelection && (
+        <AccountSelectBox
+          loading={!account}
+          selectedAccount={account}
+          accountsAndTriggers={accountsAndTriggers}
+          onChange={option => {
+            pushHistory(`/accounts/${option.account._id}`)
+          }}
+          onCreate={() => {
+            pushHistory('/new')
+          }}
+        />
+      )}
+    </KonnectorModalHeader>
+  )
+}
+
+AccountModalHeader.defaultProps = {
+  showAccountSelection: true
+}
+AccountModalHeader.propTypes = {
+  konnector: PropTypes.object.isRequired,
+  account: PropTypes.object,
+  accountsAndTriggers: PropTypes.array.isRequired,
+  showAccountSelection: PropTypes.bool,
+  pushHistory: PropTypes.func.isRequired
+}
+
+export default withMountPointProps(AccountModalHeader)

--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/AccountModalWithoutTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/AccountModalWithoutTabs.jsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Outlet } from 'react-router-dom'
+import DialogContent from '@material-ui/core/DialogContent'
+
+import { useQuery, isQueryLoading } from 'cozy-client'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+
+import { buildAccountQueryById } from '../../connections/accounts'
+import { withMountPointProps } from '../MountPointContext'
+import { getMatchingTrigger } from './helpers'
+import AccountModalHeader from './AccountModalHeader'
+import Error from './Error'
+
+const AccountModalWithoutTabs = ({
+  accountsAndTriggers,
+  konnector,
+  accountId
+}) => {
+  const matchingTrigger = getMatchingTrigger(accountsAndTriggers, accountId)
+  const matchingAccountId = matchingTrigger ? accountId : undefined
+
+  const { definition, options } = buildAccountQueryById(matchingAccountId)
+  const { data: accounts, ...accountQueryResult } = useQuery(
+    definition,
+    options
+  )
+
+  const isLoading =
+    isQueryLoading(accountQueryResult) || accountQueryResult.hasMore
+
+  const isError =
+    !isLoading && (!matchingTrigger || !accounts || accounts?.length === 0)
+
+  const account = accounts?.[0]
+
+  return (
+    <>
+      <AccountModalHeader
+        konnector={konnector}
+        account={account}
+        accountsAndTriggers={accountsAndTriggers}
+      />
+      {(isError || isLoading) && (
+        <DialogContent className="u-pb-2">
+          {isError && (
+            <Error
+              accountId={accountId}
+              accountsAndTriggers={accountsAndTriggers}
+              trigger={matchingTrigger}
+              lastError={accountQueryResult.lastError}
+            />
+          )}
+          {isLoading && (
+            <Spinner className="u-flex u-flex-justify-center" size="xxlarge" />
+          )}
+        </DialogContent>
+      )}
+      {!isError && !isLoading && (
+        <Outlet context={{ trigger: matchingTrigger, account, konnector }} />
+      )}
+    </>
+  )
+}
+
+AccountModalWithoutTabs.propTypes = {
+  konnector: PropTypes.object.isRequired,
+  /**
+   * @type {{ account: 'io.cozy.accounts', trigger: 'io.cozy.triggers' }[]} - An array of objects containing an account and its associated trigger
+   */
+  accountsAndTriggers: PropTypes.arrayOf(
+    PropTypes.shape({
+      account: PropTypes.object.isRequired,
+      trigger: PropTypes.object.isRequired
+    })
+  ).isRequired,
+  accountId: PropTypes.string.isRequired
+}
+
+export default withMountPointProps(AccountModalWithoutTabs)

--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/Error.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/Error.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+import { useClient } from 'cozy-client'
+import Infos from 'cozy-ui/transpiled/react/Infos'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+import { loadSelectedAccountId } from '../../helpers/accounts'
+import withLocales from '../hoc/withLocales'
+
+const Error = ({ accountId, accountsAndTriggers, trigger, lastError }) => {
+  const { t } = useI18n()
+  const client = useClient()
+
+  const error = !trigger ? new Error('No matching trigger found') : lastError
+
+  const handleClick = () => {
+    loadSelectedAccountId(client, accountId, accountsAndTriggers)
+  }
+
+  return (
+    <Infos
+      actionButton={
+        <Button
+          label={t('modal.konnector.error.button')}
+          color="error"
+          onClick={handleClick}
+        />
+      }
+      title={t('modal.konnector.error.title')}
+      text={t('modal.konnector.error.description', error)}
+      icon="warning"
+      isImportant
+    />
+  )
+}
+
+export default withLocales(Error)

--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/OpenOAuthWindowButton.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/OpenOAuthWindowButton.jsx
@@ -1,0 +1,58 @@
+import React, { useCallback } from 'react'
+import PropTypes from 'prop-types'
+
+import flag from 'cozy-flags'
+import { useClient } from 'cozy-client'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import { Button } from 'cozy-ui/transpiled/react/Button'
+
+import useOAuthExtraParams from '../hooks/useOAuthExtraParams'
+import { OAUTH_SERVICE_OK, openOAuthWindow } from '../OAuthService'
+
+const OpenOAuthWindowButton = ({ flow, account, konnector }) => {
+  const { t } = useI18n()
+  const client = useClient()
+
+  const { extraParams } = useOAuthExtraParams({
+    account,
+    client,
+    konnector,
+    reconnect: true
+  })
+
+  const handleClick = useCallback(async () => {
+    const response = await openOAuthWindow({
+      client,
+      konnector,
+      account,
+      extraParams,
+      reconnect: true
+    })
+
+    if (
+      response.result === OAUTH_SERVICE_OK &&
+      flag('harvest.bi.fullwebhooks')
+    ) {
+      flow.expectTriggerLaunch()
+    }
+  }, [account, client, extraParams, flow, konnector])
+
+  return (
+    <Button
+      className="u-ml-0"
+      variant="secondary"
+      label={t('error.reconnect-via-form')}
+      onClick={handleClick}
+      disabled={!extraParams}
+      busy={!extraParams}
+    />
+  )
+}
+
+OpenOAuthWindowButton.propTypes = {
+  flow: PropTypes.object.isRequired,
+  account: PropTypes.object.isRequired,
+  konnector: PropTypes.object.isRequired
+}
+
+export default OpenOAuthWindowButton

--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/TriggerError.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/TriggerError.jsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { useClient } from 'cozy-client'
+
+import useMaintenanceStatus from '../hooks/useMaintenanceStatus'
+import TriggerErrorInfo from '../infos/TriggerErrorInfo'
+import TriggerErrorAction from './TriggerErrorAction'
+
+const TriggerError = ({ flow, konnector, account, trigger }) => {
+  const client = useClient()
+  const flowState = flow.getState()
+  const { error } = flowState
+
+  const {
+    data: { isInMaintenance }
+  } = useMaintenanceStatus(client, konnector)
+
+  if (!error || isInMaintenance) return null
+
+  return (
+    <TriggerErrorInfo
+      error={error}
+      konnector={konnector}
+      action={
+        <TriggerErrorAction
+          error={error}
+          flow={flow}
+          konnector={konnector}
+          account={account}
+          trigger={trigger}
+        />
+      }
+      className="u-mt-1"
+    />
+  )
+}
+
+export default TriggerError
+
+TriggerError.propTypes = {
+  flow: PropTypes.object.isRequired,
+  konnector: PropTypes.object.isRequired,
+  account: PropTypes.object,
+  trigger: PropTypes.object
+}

--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/TriggerErrorAction.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/TriggerErrorAction.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { findKonnectorPolicy } from '../../konnector-policies'
+import RedirectToAccountFormButton from '../RedirectToAccountFormButton'
+import OpenOAuthWindowButton from './OpenOAuthWindowButton'
+
+const TriggerErrorAction = ({ flow, konnector, account, trigger, error }) => {
+  const konnectorPolicy = findKonnectorPolicy(konnector)
+
+  if (!error.isSolvableViaReconnect()) return null
+
+  if (konnectorPolicy.isBIWebView)
+    return (
+      <OpenOAuthWindowButton
+        flow={flow}
+        account={account}
+        konnector={konnector}
+      />
+    )
+
+  return <RedirectToAccountFormButton konnector={konnector} trigger={trigger} />
+}
+
+TriggerErrorAction.propTypes = {
+  flow: PropTypes.object.isRequired,
+  konnector: PropTypes.object.isRequired,
+  account: PropTypes.object,
+  trigger: PropTypes.object,
+  error: PropTypes.object.isRequired
+}
+
+export default TriggerErrorAction

--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/helpers.js
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/helpers.js
@@ -1,0 +1,10 @@
+import get from 'lodash/get'
+
+export const getMatchingTrigger = (accountsAndTriggers, accountId) => {
+  return get(
+    accountsAndTriggers.find(
+      accountAndTrigger => accountAndTrigger.account._id === accountId
+    ),
+    'trigger'
+  )
+}

--- a/packages/cozy-harvest-lib/src/components/Routes/RoutesV6.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes/RoutesV6.jsx
@@ -5,10 +5,14 @@ import flag from 'cozy-flags'
 
 import { ViewerModal } from '../../datacards/ViewerModal'
 import AccountModal from '../AccountModal'
+import AccountModalWithoutTabs from '../AccountModalWithoutTabs/AccountModalWithoutTabs'
+import AccountModalContentWrapper from '../AccountModalWithoutTabs/AccountModalContentWrapper'
 import NewAccountModal from '../NewAccountModal'
 import EditAccountModal from '../EditAccountModal'
 import KonnectorSuccess from '../KonnectorSuccess'
 import HarvestModalRoot from '../HarvestModalRoot'
+import DataTab from '../KonnectorConfiguration/DataTab'
+import ConfigurationTab from '../KonnectorConfiguration/ConfigurationTab'
 
 const HarvestParamsWrapper = props => {
   const params = useParams()
@@ -44,23 +48,69 @@ const RoutesV6 = ({
         }
       />
 
-      <Route
-        path="accounts/:accountId"
-        element={
-          <HarvestParamsWrapper>
-            {params => (
-              <AccountModal
-                konnector={konnectorWithTriggers}
-                accountId={params.accountId}
-                accountsAndTriggers={accountsAndTriggers}
-                onDismiss={onDismiss}
-                showNewAccountButton={!konnectorWithTriggers.clientSide}
-                showAccountSelection={!konnectorWithTriggers.clientSide}
-              />
-            )}
-          </HarvestParamsWrapper>
-        }
-      />
+      {flag('harvest.inappconnectors.enabled') ? (
+        <Route
+          path="accounts/:accountId"
+          element={
+            <HarvestParamsWrapper>
+              {params => (
+                <AccountModalWithoutTabs
+                  konnector={konnectorWithTriggers}
+                  accountId={params.accountId}
+                  accountsAndTriggers={accountsAndTriggers}
+                  showNewAccountButton={!konnectorWithTriggers.clientSide}
+                  showAccountSelection={!konnectorWithTriggers.clientSide}
+                  onDismiss={onDismiss}
+                />
+              )}
+            </HarvestParamsWrapper>
+          }
+        >
+          <Route
+            index
+            element={
+              <AccountModalContentWrapper>
+                <DataTab
+                  konnector={konnectorWithTriggers}
+                  showNewAccountButton={!konnectorWithTriggers.clientSide}
+                  onDismiss={onDismiss}
+                />
+              </AccountModalContentWrapper>
+            }
+          />
+          <Route
+            path="config"
+            element={
+              <AccountModalContentWrapper>
+                <ConfigurationTab
+                  konnector={konnectorWithTriggers}
+                  showNewAccountButton={!konnectorWithTriggers.clientSide}
+                  onDismiss={onDismiss}
+                />
+              </AccountModalContentWrapper>
+            }
+          />
+        </Route>
+      ) : (
+        <Route
+          path="accounts/:accountId"
+          element={
+            <HarvestParamsWrapper>
+              {params => (
+                <AccountModal
+                  konnector={konnectorWithTriggers}
+                  accountId={params.accountId}
+                  accountsAndTriggers={accountsAndTriggers}
+                  onDismiss={onDismiss}
+                  showNewAccountButton={!konnectorWithTriggers.clientSide}
+                  showAccountSelection={!konnectorWithTriggers.clientSide}
+                />
+              )}
+            </HarvestParamsWrapper>
+          }
+        />
+      )}
+
       <Route
         path="accounts/:accountId/edit"
         element={

--- a/packages/cozy-harvest-lib/src/connections/accounts.js
+++ b/packages/cozy-harvest-lib/src/connections/accounts.js
@@ -22,6 +22,24 @@ export const createAccount = async (client, konnector, attributes) => {
   return data
 }
 
+/**
+ *  Build an account query for the given konnector.
+ * ("getById" throws an error even if the query is not enabled)
+ * @param {string} accountId - io.cozy.accounts document's id
+ * @returns {object} - a query spec
+ */
+export const buildAccountQueryById = accountId => {
+  return {
+    definition: () =>
+      Q(ACCOUNTS_DOCTYPE).where({
+        _id: accountId
+      }),
+    options: {
+      as: `${ACCOUNTS_DOCTYPE}/${accountId}`
+    }
+  }
+}
+
 export const createAccountQuerySpec = accountId => {
   if (!accountId) {
     throw new Error('createAccountQuerySpec called with undefined accountId')


### PR DESCRIPTION
Dans cette PR nous ajoutons 2 routes pour afficher une version de la modale `AccountModal`, sans la navigation par tabs mais par URL (`accounts/:accountId` & `accounts/:accountId/config`).

Ces nouvelles routes ne seront disponibles qu'avec le flag `harvest.inappconnectors.enabled` activé et sur les apps qui seront compatibles avec `react-router-dom@6.x.x`