### PR TITLE
Add `LaunchTriggerAlert` menu with the first action

### DIFF
--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
@@ -1,10 +1,15 @@
-import React, { useState, useEffect } from 'react'
+import React, { useRef, useState, useEffect } from 'react'
 
+import ActionMenu, { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu'
 import Alert from 'cozy-ui/transpiled/react/Alert'
 import Button from 'cozy-ui/transpiled/react/Buttons'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import IconButton from 'cozy-ui/transpiled/react/IconButton'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Snackbar from 'cozy-ui/transpiled/react/Snackbar'
+import DotsIcon from 'cozy-ui/transpiled/react/Icons/Dots'
+import SyncIcon from 'cozy-ui/transpiled/react/Icons/Sync'
 
 import { getLastSuccessDate, getKonnectorSlug } from '../../helpers/triggers'
 import { isRunnable } from '../../helpers/konnectors'
@@ -21,6 +26,8 @@ export const LaunchTriggerAlert = ({ flow, f, t, disabled }) => {
 
   const lastSuccessDate = getLastSuccessDate(trigger)
   const isKonnectorRunnable = isRunnable({ win: window, konnector })
+  const anchorRef = useRef()
+  const [showOptions, setShowOptions] = useState(false)
 
   useEffect(() => {
     if (status === SUCCESS) {
@@ -44,13 +51,41 @@ export const LaunchTriggerAlert = ({ flow, f, t, disabled }) => {
         }
         action={
           isKonnectorRunnable && (
-            <Button
-              variant="text"
-              size="small"
-              disabled={running || disabled}
-              label={t('card.launchTrigger.button.label')}
-              onClick={() => launch({ autoSuccessTimer: false })}
-            />
+            <>
+              <Button
+                variant="text"
+                size="small"
+                disabled={running || disabled}
+                label={t('card.launchTrigger.button.label')}
+                onClick={() => launch({ autoSuccessTimer: false })}
+              />
+              <IconButton
+                ref={anchorRef}
+                onClick={() => setShowOptions(true)}
+                className="u-p-half"
+              >
+                <Icon icon={DotsIcon} />
+              </IconButton>
+              {showOptions && (
+                <ActionMenu
+                  anchorElRef={anchorRef}
+                  autoclose={true}
+                  onClose={() => setShowOptions(false)}
+                >
+                  {!running && !disabled && (
+                    <ActionMenuItem
+                      left={<Icon icon={SyncIcon} />}
+                      onClick={() => {
+                        launch({ autoSuccessTimer: false })
+                        setShowOptions(false)
+                      }}
+                    >
+                      {t('card.launchTrigger.button.label')}
+                    </ActionMenuItem>
+                  )}
+                </ActionMenu>
+              )}
+            </>
           )
         }
       >


### PR DESCRIPTION
This adds a menu to the new `LaunchTriggerAlert`. The only action in the menu for now is "Synchronize" (still called "Run again now") which does the same thing as the button that is already in the alert. More actions will be added such as "Configure".