### PR TITLE
fix(mes-papiers-lib): Check file's `lastModified` field on file upload

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/AcquisitionResult.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/AcquisitionResult.jsx
@@ -17,6 +17,7 @@ import { useStepperDialog } from '../Hooks/useStepperDialog'
 import { useFormData } from '../Hooks/useFormData'
 import { PaperDefinitionsStepPropTypes } from '../../constants/PaperDefinitionsPropTypes'
 import { KEYS } from '../../constants/const'
+import { isSameFile } from './helpers'
 
 const isPDF = file => file.type === 'application/pdf'
 
@@ -42,8 +43,7 @@ const AcquisitionResult = ({ currentFile, setCurrentFile, currentStep }) => {
 
   const changeSelectedFile = () => {
     const newData = formData.data.filter(
-      data =>
-        data.file.name !== currentFile.name || data.file.id !== currentFile.id
+      data => !isSameFile(currentFile, data.file)
     )
 
     setFormData(prev => ({

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/AcquisitionResult.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/AcquisitionResult.jsx
@@ -42,7 +42,8 @@ const AcquisitionResult = ({ currentFile, setCurrentFile, currentStep }) => {
 
   const changeSelectedFile = () => {
     const newData = formData.data.filter(
-      data => data.file.name !== currentFile.name
+      data =>
+        data.file.name !== currentFile.name || data.file.id !== currentFile.id
     )
 
     setFormData(prev => ({

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/AcquisitionResult.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/AcquisitionResult.jsx
@@ -42,7 +42,10 @@ const AcquisitionResult = ({ currentFile, setCurrentFile, currentStep }) => {
 
   useEffect(() => {
     const hasAlreadyFile = formData.data.some(
-      d => d.stepIndex === stepIndex && d.file.name === currentFile.name
+      d =>
+        d.stepIndex === stepIndex &&
+        d.file.name === currentFile.name &&
+        d.file.lastModified === currentFile.lastModified
     )
     if (!hasAlreadyFile) {
       setFormData(prev => ({

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/AcquisitionResult.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/AcquisitionResult.jsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useEffect } from 'react'
+import React, { memo, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
@@ -38,32 +38,7 @@ const AcquisitionResult = ({ currentFile, setCurrentFile, currentStep }) => {
   const { isMobile } = useBreakpoints()
   const { nextStep } = useStepperDialog()
   const { setFormData, formData } = useFormData()
-  const { page, multipage, stepIndex } = currentStep
-
-  useEffect(() => {
-    const hasAlreadyFile = formData.data.some(
-      d =>
-        d.stepIndex === stepIndex &&
-        d.file.name === currentFile.name &&
-        d.file.lastModified === currentFile.lastModified
-    )
-    if (!hasAlreadyFile) {
-      setFormData(prev => ({
-        ...prev,
-        data: [
-          ...prev.data,
-          {
-            file: currentFile,
-            stepIndex,
-            fileMetadata: {
-              page: !multipage ? page : '',
-              multipage
-            }
-          }
-        ]
-      }))
-    }
-  }, [formData.data, stepIndex, currentFile, multipage, page, setFormData])
+  const { multipage } = currentStep
 
   const changeSelectedFile = () => {
     const newData = formData.data.filter(

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/AcquisitionResult.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/AcquisitionResult.spec.jsx
@@ -149,13 +149,6 @@ describe('AcquisitionResult component:', () => {
   })
 
   describe('setFormData', () => {
-    it('should setFormData must be called once when component is mounted', () => {
-      const mockSetFormData = jest.fn()
-      setup({ setFormData: mockSetFormData })
-
-      expect(mockSetFormData).toHaveBeenCalledTimes(1)
-    })
-
     it('should setFormData must not be called when component is mounted if file already exists on same stepIndex', () => {
       const mockSetFormData = jest.fn()
       setup({
@@ -174,12 +167,12 @@ describe('AcquisitionResult component:', () => {
       const mockSetFormData = jest.fn()
       const { getByTestId } = setup({ setFormData: mockSetFormData })
 
-      expect(mockSetFormData).toHaveBeenCalledTimes(1)
+      expect(mockSetFormData).toHaveBeenCalledTimes(0)
 
       const btn = getByTestId('retry-button')
       fireEvent.click(btn)
 
-      expect(mockSetFormData).toHaveBeenCalledTimes(2)
+      expect(mockSetFormData).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/helpers.js
@@ -9,6 +9,13 @@ export const isFileAlreadySelected = (formData, stepIndex, currentFile) => {
   for (const data of formData.data) {
     if (data.stepIndex === stepIndex) {
       if (
+        currentFile.constructor.name === 'Blob' &&
+        data.file.id === currentFile.id
+      ) {
+        return true
+      }
+      if (
+        currentFile.constructor.name === 'File' &&
         data.file.name === currentFile.name &&
         data.file.lastModified === currentFile.lastModified
       ) {

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/helpers.js
@@ -1,0 +1,20 @@
+/**
+ * Check if a file is already selected in the state of the FormDataProvider
+ * @param {object} formData - State of the FormDataProvider
+ * @param {number} stepIndex - Used to know if the file is already selected for this step (Some paper have two Scan steps)
+ * @param {File|Blob} currentFile - File or Blob object
+ * @returns
+ */
+export const isFileAlreadySelected = (formData, stepIndex, currentFile) => {
+  for (const data of formData.data) {
+    if (data.stepIndex === stepIndex) {
+      if (
+        data.file.name === currentFile.name &&
+        data.file.lastModified === currentFile.lastModified
+      ) {
+        return true
+      }
+    }
+  }
+  return false
+}

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/helpers.js
@@ -8,20 +8,29 @@
 export const isFileAlreadySelected = (formData, stepIndex, currentFile) => {
   for (const data of formData.data) {
     if (data.stepIndex === stepIndex) {
-      if (
-        currentFile.constructor.name === 'Blob' &&
-        data.file.id === currentFile.id
-      ) {
-        return true
-      }
-      if (
-        currentFile.constructor.name === 'File' &&
-        data.file.name === currentFile.name &&
-        data.file.lastModified === currentFile.lastModified
-      ) {
+      if (isSameFile(currentFile, data.file)) {
         return true
       }
     }
+  }
+  return false
+}
+
+/**
+ * @param {File|Blob} currentFile - File or Blob object
+ * @param {File|Blob} currentFile - File or Blob object
+ * @returns {boolean}
+ */
+export const isSameFile = (currentFile, file) => {
+  if (currentFile.constructor.name === 'Blob' && file.id === currentFile.id) {
+    return true
+  }
+  if (
+    currentFile.constructor.name === 'File' &&
+    file.name === currentFile.name &&
+    file.lastModified === currentFile.lastModified
+  ) {
+    return true
   }
   return false
 }

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/helpers.spec.js
@@ -14,6 +14,20 @@ describe('isFileAlreadySelected', () => {
     )
   })
 
+  it('should return true if the Blob is already selected in the same step', () => {
+    const blob = new Blob([])
+    blob.id = '001'
+    const formData = {
+      data: [{ stepIndex: 1, file: blob }]
+    }
+    const currentStepIndex = 1
+    const currentFile = blob
+
+    expect(isFileAlreadySelected(formData, currentStepIndex, currentFile)).toBe(
+      true
+    )
+  })
+
   it('should return false if the file is not already selected in the same step', () => {
     const file01 = new File([], 'abc.pdf', { lastModified: 123456789 })
     const formData = {
@@ -29,6 +43,21 @@ describe('isFileAlreadySelected', () => {
     expect(
       isFileAlreadySelected(formData, currentStepIndex, currentFile02)
     ).toBe(false)
+  })
+
+  it('should return false if the Blob is not already selected in the same step', () => {
+    const blob = new Blob([])
+    blob.id = '001'
+    const formData = {
+      data: [{ stepIndex: 1, file: blob }]
+    }
+    const currentStepIndex = 1
+    const currentFile = new Blob([])
+    currentFile.id = '002'
+
+    expect(isFileAlreadySelected(formData, currentStepIndex, currentFile)).toBe(
+      false
+    )
   })
 
   it('should return false if the File is already selected in another step', () => {

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/helpers.spec.js
@@ -1,0 +1,46 @@
+import { isFileAlreadySelected } from './helpers'
+
+describe('isFileAlreadySelected', () => {
+  it('should return true if the File is already selected in the same step', () => {
+    const file = new File([], 'abc.pdf')
+    const formData = {
+      data: [{ stepIndex: 1, file }]
+    }
+    const currentStepIndex = 1
+    const currentFile = file
+
+    expect(isFileAlreadySelected(formData, currentStepIndex, currentFile)).toBe(
+      true
+    )
+  })
+
+  it('should return false if the file is not already selected in the same step', () => {
+    const file01 = new File([], 'abc.pdf', { lastModified: 123456789 })
+    const formData = {
+      data: [{ stepIndex: 1, file: file01 }]
+    }
+    const currentStepIndex = 1
+    const currentFile01 = new File([], 'abc.pdf', { lastModified: 987654321 })
+    const currentFile02 = new File([], 'xyz.pdf', { lastModified: 123456789 })
+
+    expect(
+      isFileAlreadySelected(formData, currentStepIndex, currentFile01)
+    ).toBe(false)
+    expect(
+      isFileAlreadySelected(formData, currentStepIndex, currentFile02)
+    ).toBe(false)
+  })
+
+  it('should return false if the File is already selected in another step', () => {
+    const file = new File([], 'abc.pdf')
+    const formData = {
+      data: [{ stepIndex: 1, file }]
+    }
+    const currentStepIndex = 2
+    const currentFile = file
+
+    expect(isFileAlreadySelected(formData, currentStepIndex, currentFile)).toBe(
+      false
+    )
+  })
+})


### PR DESCRIPTION
On iOS, taking a photo with `FileInput capture="environment" />` will always return a file named `image.jpg`

In previous implementation we compared the image's name to prevent duplication which would not work on iOS as all files would have the same name. Result is that we wouldn't be able to upload multiple photo

To prevent this we also want to compare the image's `lastModified` field that should be unique for each photo capture