### PR TITLE
Add configuration menu in LaunchTriggerAlert

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/FovV4Router/AccountModalContentWrapper.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/FovV4Router/AccountModalContentWrapper.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import DialogContent from '@material-ui/core/DialogContent'
+
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+import FlowProvider from '../../FlowProvider'
+import TriggerError from '../TriggerError'
+
+const AccountModalContentWrapper = ({
+  children,
+  trigger,
+  account,
+  konnector
+}) => {
+  const { isMobile } = useBreakpoints()
+
+  return (
+    <DialogContent className={isMobile ? 'u-p-0' : 'u-pt-0'}>
+      <FlowProvider initialTrigger={trigger} konnector={konnector}>
+        {({ flow }) => (
+          <>
+            <TriggerError
+              flow={flow}
+              konnector={konnector}
+              account={account}
+              trigger={trigger}
+            />
+            {React.Children.map(children, child =>
+              React.isValidElement(child)
+                ? React.cloneElement(child, { flow, trigger, account })
+                : null
+            )}
+          </>
+        )}
+      </FlowProvider>
+    </DialogContent>
+  )
+}
+
+export default AccountModalContentWrapper

--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/FovV4Router/AccountModalWithoutTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/FovV4Router/AccountModalWithoutTabs.jsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import DialogContent from '@material-ui/core/DialogContent'
+
+import { useQuery, isQueryLoading } from 'cozy-client'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+
+import { buildAccountQueryById } from '../../../connections/accounts'
+import { withMountPointProps } from '../../MountPointContext'
+import { getMatchingTrigger } from '../helpers'
+import AccountModalHeader from '../AccountModalHeader'
+import Error from '../Error'
+
+const AccountModalWithoutTabs = ({
+  accountsAndTriggers,
+  konnector,
+  accountId,
+  children
+}) => {
+  const matchingTrigger = getMatchingTrigger(accountsAndTriggers, accountId)
+  const matchingAccountId = matchingTrigger ? accountId : undefined
+
+  const { definition, options } = buildAccountQueryById(matchingAccountId)
+  const { data: accounts, ...accountQueryResult } = useQuery(
+    definition,
+    options
+  )
+
+  const isLoading =
+    isQueryLoading(accountQueryResult) || accountQueryResult.hasMore
+
+  const isError =
+    !isLoading && (!matchingTrigger || !accounts || accounts?.length === 0)
+
+  const account = accounts?.[0]
+
+  return (
+    <>
+      <AccountModalHeader
+        konnector={konnector}
+        account={account}
+        accountsAndTriggers={accountsAndTriggers}
+      />
+      {(isError || isLoading) && (
+        <DialogContent className="u-pb-2">
+          {isError && (
+            <Error
+              accountId={accountId}
+              accountsAndTriggers={accountsAndTriggers}
+              trigger={matchingTrigger}
+              lastError={accountQueryResult.lastError}
+            />
+          )}
+          {isLoading && (
+            <Spinner className="u-flex u-flex-justify-center" size="xxlarge" />
+          )}
+        </DialogContent>
+      )}
+      {!isError &&
+        !isLoading &&
+        React.Children.map(children, child =>
+          React.isValidElement(child)
+            ? React.cloneElement(child, {
+                trigger: matchingTrigger,
+                account,
+                konnector
+              })
+            : null
+        )}
+    </>
+  )
+}
+
+AccountModalWithoutTabs.propTypes = {
+  konnector: PropTypes.object.isRequired,
+  /**
+   * @type {{ account: 'io.cozy.accounts', trigger: 'io.cozy.triggers' }[]} - An array of objects containing an account and its associated trigger
+   */
+  accountsAndTriggers: PropTypes.arrayOf(
+    PropTypes.shape({
+      account: PropTypes.object.isRequired,
+      trigger: PropTypes.object.isRequired
+    })
+  ).isRequired,
+  accountId: PropTypes.string.isRequired
+}
+
+export default withMountPointProps(AccountModalWithoutTabs)

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
@@ -233,7 +233,7 @@ const ConfigurationTab = ({
 
 ConfigurationTab.propTypes = {
   konnector: PropTypes.object.isRequired,
-  account: PropTypes.object.isRequired,
+  account: PropTypes.object,
   error: PropTypes.object,
   flow: PropTypes.object,
   addAccount: PropTypes.func.isRequired,

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
@@ -26,7 +26,14 @@ const styles = {
   }
 }
 
-export const DataTab = ({ konnector, trigger, client, flow, account }) => {
+export const DataTab = ({
+  konnector,
+  konnectorRoot,
+  trigger,
+  client,
+  flow,
+  account
+}) => {
   const { isMobile } = useBreakpoints()
   const flowState = flow.getState()
   const { error } = flowState
@@ -51,7 +58,11 @@ export const DataTab = ({ konnector, trigger, client, flow, account }) => {
     <div>
       {flag('harvest.inappconnectors.enabled') && (
         <>
-          <LaunchTriggerCard flow={flow} disabled={isInMaintenance} />
+          <LaunchTriggerCard
+            konnectorRoot={konnectorRoot}
+            flow={flow}
+            disabled={isInMaintenance}
+          />
           {isMobile && <Divider style={styles.divider} />}
         </>
       )}

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
@@ -101,8 +101,11 @@ export const DataTab = ({
 
 DataTab.propTypes = {
   konnector: PropTypes.object.isRequired,
+  konnectorRoot: PropTypes.string,
   trigger: PropTypes.object.isRequired,
-  client: PropTypes.object.isRequired
+  client: PropTypes.object.isRequired,
+  flow: PropTypes.object,
+  account: PropTypes.object
 }
 
 export default withClient(DataTab)

--- a/packages/cozy-harvest-lib/src/components/Routes/RoutesV4.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes/RoutesV4.jsx
@@ -9,11 +9,17 @@ import NewAccountModal from '../NewAccountModal'
 import EditAccountModal from '../EditAccountModal'
 import KonnectorSuccess from '../KonnectorSuccess'
 import HarvestModalRoot from '../HarvestModalRoot'
+import AccountModalWithoutTabs from '../AccountModalWithoutTabs/FovV4Router/AccountModalWithoutTabs'
+import AccountModalContentWrapper from '../AccountModalWithoutTabs/FovV4Router/AccountModalContentWrapper'
+import DataTab from '../KonnectorConfiguration/DataTab'
+import ConfigurationTab from '../KonnectorConfiguration/ConfigurationTab'
+import withAdaptiveRouter from '../hoc/withRouter'
 
 const RoutesV4 = ({
   konnectorRoot,
   konnectorWithTriggers,
   accountsAndTriggers,
+  historyAction,
   onSuccess,
   onDismiss
 }) => {
@@ -29,20 +35,74 @@ const RoutesV4 = ({
           />
         )}
       />
-      <Route
-        path={`${konnectorRoot}/accounts/:accountId`}
-        exact
-        render={({ match }) => (
-          <AccountModal
-            konnector={konnectorWithTriggers}
-            accountId={match.params.accountId}
-            accountsAndTriggers={accountsAndTriggers}
-            onDismiss={onDismiss}
-            showNewAccountButton={!konnectorWithTriggers.clientSide}
-            showAccountSelection={!konnectorWithTriggers.clientSide}
+      {flag('harvest.inappconnectors.enabled') ? (
+        <>
+          <Route
+            path={`${konnectorRoot}/accounts/:accountId`}
+            exact
+            render={({ match }) => (
+              <AccountModalWithoutTabs
+                konnector={konnectorWithTriggers}
+                accountId={match.params.accountId}
+                accountsAndTriggers={accountsAndTriggers}
+                showNewAccountButton={!konnectorWithTriggers.clientSide}
+                showAccountSelection={!konnectorWithTriggers.clientSide}
+                onDismiss={onDismiss}
+              >
+                <AccountModalContentWrapper>
+                  <DataTab
+                    konnectorRoot={`${konnectorRoot}/accounts/${match.params.accountId}`}
+                    konnector={konnectorWithTriggers}
+                    showNewAccountButton={!konnectorWithTriggers.clientSide}
+                    onDismiss={onDismiss}
+                  />
+                </AccountModalContentWrapper>
+              </AccountModalWithoutTabs>
+            )}
           />
-        )}
-      />
+          <Route
+            path={`${konnectorRoot}/accounts/:accountId/config`}
+            exact
+            render={({ match }) => (
+              <AccountModalWithoutTabs
+                konnector={konnectorWithTriggers}
+                accountId={match.params.accountId}
+                accountsAndTriggers={accountsAndTriggers}
+                showNewAccountButton={!konnectorWithTriggers.clientSide}
+                showAccountSelection={!konnectorWithTriggers.clientSide}
+                onDismiss={onDismiss}
+              >
+                <AccountModalContentWrapper>
+                  <ConfigurationTab
+                    konnector={konnectorWithTriggers}
+                    showNewAccountButton={!konnectorWithTriggers.clientSide}
+                    onAccountDeleted={onDismiss}
+                    addAccount={() =>
+                      historyAction(`${konnectorRoot}/new`, 'replace')
+                    }
+                  />
+                </AccountModalContentWrapper>
+              </AccountModalWithoutTabs>
+            )}
+          />
+        </>
+      ) : (
+        <Route
+          path={`${konnectorRoot}/accounts/:accountId`}
+          exact
+          render={({ match }) => (
+            <AccountModal
+              konnector={konnectorWithTriggers}
+              accountId={match.params.accountId}
+              accountsAndTriggers={accountsAndTriggers}
+              onDismiss={onDismiss}
+              showNewAccountButton={!konnectorWithTriggers.clientSide}
+              showAccountSelection={!konnectorWithTriggers.clientSide}
+            />
+          )}
+        />
+      )}
+
       <Route
         path={`${konnectorRoot}/accounts/:accountId/edit`}
         exact
@@ -91,4 +151,4 @@ const RoutesV4 = ({
   )
 }
 
-export default RoutesV4
+export default withAdaptiveRouter(RoutesV4)

--- a/packages/cozy-harvest-lib/src/components/Routes/RoutesV6.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes/RoutesV6.jsx
@@ -1,5 +1,11 @@
 import React from 'react'
-import { Routes, Route, Navigate, useParams } from 'react-router-dom'
+import {
+  Routes,
+  Route,
+  Navigate,
+  useParams,
+  useNavigate
+} from 'react-router-dom'
 
 import flag from 'cozy-flags'
 
@@ -25,6 +31,8 @@ const RoutesV6 = ({
   onSuccess,
   onDismiss
 }) => {
+  const navigate = useNavigate()
+
   return (
     <Routes>
       <Route
@@ -85,7 +93,8 @@ const RoutesV6 = ({
                 <ConfigurationTab
                   konnector={konnectorWithTriggers}
                   showNewAccountButton={!konnectorWithTriggers.clientSide}
-                  onDismiss={onDismiss}
+                  onAccountDeleted={onDismiss}
+                  addAccount={() => navigate('new', { replace: true })}
                 />
               </AccountModalContentWrapper>
             }

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
@@ -10,15 +10,30 @@ import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Snackbar from 'cozy-ui/transpiled/react/Snackbar'
 import DotsIcon from 'cozy-ui/transpiled/react/Icons/Dots'
 import SyncIcon from 'cozy-ui/transpiled/react/Icons/Sync'
+import GearIcon from 'cozy-ui/transpiled/react/Icons/Gear'
 
 import { getLastSuccessDate, getKonnectorSlug } from '../../helpers/triggers'
 import { isRunnable } from '../../helpers/konnectors'
 import { useFlowState } from '../../models/withConnectionFlow'
 import { SUCCESS } from '../../models/flowEvents'
+import withAdaptiveRouter from '../hoc/withRouter'
 import KonnectorIcon from '../KonnectorIcon'
 import { makeLabel } from './helpers'
 
-export const LaunchTriggerAlert = ({ flow, f, t, disabled }) => {
+const styles = {
+  // tricks to put 48px wide button inside 32px height container
+  // without enlarging the container
+  iconButtonWrapper: { height: 32, width: 46 }
+}
+
+export const LaunchTriggerAlert = ({
+  flow,
+  f,
+  t,
+  disabled,
+  konnectorRoot,
+  historyAction
+}) => {
   const [showSuccessSnackbar, setShowSuccessSnackbar] = useState(false)
   const { trigger, running, expectingTriggerLaunch, status } =
     useFlowState(flow)
@@ -38,6 +53,7 @@ export const LaunchTriggerAlert = ({ flow, f, t, disabled }) => {
   return (
     <>
       <Alert
+        className="u-pr-half"
         color="var(--paperBackground)"
         icon={
           running ? (
@@ -59,13 +75,17 @@ export const LaunchTriggerAlert = ({ flow, f, t, disabled }) => {
                 label={t('card.launchTrigger.button.label')}
                 onClick={() => launch({ autoSuccessTimer: false })}
               />
-              <IconButton
-                ref={anchorRef}
-                onClick={() => setShowOptions(true)}
-                className="u-p-half"
+              <div
+                className="u-flex u-flex-items-center"
+                style={styles.iconButtonWrapper}
               >
-                <Icon icon={DotsIcon} />
-              </IconButton>
+                <IconButton
+                  ref={anchorRef}
+                  onClick={() => setShowOptions(true)}
+                >
+                  <Icon icon={DotsIcon} />
+                </IconButton>
+              </div>
               {showOptions && (
                 <ActionMenu
                   anchorElRef={anchorRef}
@@ -83,6 +103,14 @@ export const LaunchTriggerAlert = ({ flow, f, t, disabled }) => {
                       {t('card.launchTrigger.button.label')}
                     </ActionMenuItem>
                   )}
+                  <ActionMenuItem
+                    left={<Icon icon={GearIcon} />}
+                    onClick={() =>
+                      historyAction(`${konnectorRoot}/config`, 'push')
+                    }
+                  >
+                    {t('card.launchTrigger.configure')}
+                  </ActionMenuItem>
                 </ActionMenu>
               )}
             </>
@@ -116,4 +144,8 @@ export const LaunchTriggerAlert = ({ flow, f, t, disabled }) => {
   )
 }
 
-export default LaunchTriggerAlert
+LaunchTriggerAlert.defaultProps = {
+  konnectorRoot: ''
+}
+
+export default withAdaptiveRouter(LaunchTriggerAlert)

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
 
 import ActionMenu, { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu'
 import Alert from 'cozy-ui/transpiled/react/Alert'
@@ -146,6 +147,15 @@ export const LaunchTriggerAlert = ({
 
 LaunchTriggerAlert.defaultProps = {
   konnectorRoot: ''
+}
+
+LaunchTriggerAlert.propTypes = {
+  flow: PropTypes.object,
+  f: PropTypes.function,
+  t: PropTypes.function,
+  disabled: PropTypes.bool,
+  konnectorRoot: PropTypes.string,
+  historyAction: PropTypes.function
 }
 
 export default withAdaptiveRouter(LaunchTriggerAlert)

--- a/packages/cozy-harvest-lib/src/components/hoc/withRouter.jsx
+++ b/packages/cozy-harvest-lib/src/components/hoc/withRouter.jsx
@@ -16,8 +16,9 @@ export const historyAction = (props, historyOrNavigate) => (route, method) => {
     return historyOrNavigate(path, { replace: method === 'replace' })
   }
 
+  const splitBaseRoute = baseRoute?.split('/') || []
   const segments = '/'.concat(
-    baseRoute.split('/').concat(route.split('/')).filter(Boolean).join('/')
+    splitBaseRoute.concat(route.split('/')).filter(Boolean).join('/')
   )
 
   return historyOrNavigate[method](segments)

--- a/packages/cozy-harvest-lib/src/components/hoc/withRouter.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/hoc/withRouter.spec.jsx
@@ -48,4 +48,10 @@ describe('historyAction', () => {
     expect(historyMock.replace).toHaveBeenCalledWith('/base/route/one/two')
     historyMock.replace.mockReset()
   })
+
+  it('should handle even if no base route', () => {
+    setup({ baseRoute: undefined, route: '/one' })
+    expect(historyMock.replace).toHaveBeenCalledWith('/one')
+    historyMock.replace.mockReset()
+  })
 })

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -77,6 +77,7 @@
       "button": {
         "label": "Run again now"
       },
+      "configure": "Configure",
       "success": "Successful synchronization",
       "error": "An error occured.",
       "frequency": {

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -92,6 +92,7 @@
         "syncing": "Data recovery…",
         "unknown": "Unknown",
         "afterSomeTimes": "Sync. %{times} ago",
+        "format": "MM/DD/YYYY",
         "justNow": "Sync. just now"
       }
     },

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -77,6 +77,7 @@
       "button": {
         "label": "Mettre à jour"
       },
+      "configure": "Configurer",
       "success": "Synchronisation réussie",
       "error": "Une erreur est survenue.",
       "frequency": {

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -92,6 +92,7 @@
         "syncing": "Récupération des données…",
         "unknown": "Indéterminée",
         "afterSomeTimes": "Sync. il y a %{times}",
+        "format": "DD/MM/YYYY",
         "justNow": "Sync. à l'instant"
       }
     },


### PR DESCRIPTION
On souhaite ajouter dans le menu des options de bandeau d'état d'un connecteur, 
le possibilité d'afficher les configurations. Or nous avons précédemment 
découpé le composant pour rendre la partie data et config accessible via une 
route, mais uniquement pour le router v6. Ici il a fallut donc faire de même 
pour la v4 du router avant d'ajouter l'option.