### PR TITLE
fix(harvest): LaunchTriggerAlert text vertical alignement

### DIFF
--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
@@ -24,7 +24,9 @@ import { makeLabel } from './helpers'
 const styles = {
   // tricks to put 48px wide button inside 32px height container
   // without enlarging the container
-  iconButtonWrapper: { height: 32, width: 46 }
+  iconButtonWrapper: { height: 32, width: 46 },
+  // Alert is not designed to use 12px text, so this is necessary for now
+  typography: { paddingTop: 2 }
 }
 
 export const LaunchTriggerAlert = ({
@@ -118,7 +120,7 @@ export const LaunchTriggerAlert = ({
           )
         }
       >
-        <Typography variant="caption">
+        <Typography style={styles.typography} variant="caption">
           {makeLabel({
             t,
             f,


### PR DESCRIPTION
A better way to do this would be to initially see in the mockups that
the Alert component was not used as proposed by cozy-ui. Since this
is an isolated case (and we don't have time to review the specs and fix
it on the cozy-ui side) for now let's do an application side fix.