### PR TITLE
feat(mespapiers-lib): Change wording on information step for invoices

### DIFF
--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -318,12 +318,12 @@
           "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
-          "text": "PaperJSON.generic.referencedDate.text",
+          "text": "PaperJSON.invoice.referencedDate.text",
           "attributes": [
             {
               "name": "referencedDate",
               "type": "date",
-              "inputLabel": "PaperJSON.generic.referencedDate.inputLabel"
+              "inputLabel": "PaperJSON.invoice.referencedDate.inputLabel"
             }
           ]
         },
@@ -468,12 +468,12 @@
           "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
-          "text": "PaperJSON.generic.referencedDate.text",
+          "text": "PaperJSON.invoice.referencedDate.text",
           "attributes": [
             {
               "name": "referencedDate",
               "type": "date",
-              "inputLabel": "PaperJSON.generic.referencedDate.inputLabel"
+              "inputLabel": "PaperJSON.invoice.referencedDate.inputLabel"
             }
           ]
         },
@@ -1135,12 +1135,12 @@
           "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
-          "text": "PaperJSON.generic.referencedDate.text",
+          "text": "PaperJSON.invoice.referencedDate.text",
           "attributes": [
             {
               "name": "referencedDate",
               "type": "date",
-              "inputLabel": "PaperJSON.generic.referencedDate.inputLabel"
+              "inputLabel": "PaperJSON.invoice.referencedDate.inputLabel"
             }
           ]
         },
@@ -1553,12 +1553,12 @@
           "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
-          "text": "PaperJSON.generic.referencedDate.text",
+          "text": "PaperJSON.invoice.referencedDate.text",
           "attributes": [
             {
               "name": "referencedDate",
               "type": "date",
-              "inputLabel": "PaperJSON.generic.referencedDate.inputLabel"
+              "inputLabel": "PaperJSON.invoice.referencedDate.inputLabel"
             }
           ]
         },
@@ -1805,12 +1805,12 @@
           "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
-          "text": "PaperJSON.otherInvoice.referencedDate.text",
+          "text": "PaperJSON.invoice.referencedDate.text",
           "attributes": [
             {
               "name": "referencedDate",
               "type": "date",
-              "inputLabel": "PaperJSON.otherInvoice.referencedDate.inputLabel"
+              "inputLabel": "PaperJSON.invoice.referencedDate.inputLabel"
             }
           ]
         },

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -183,7 +183,7 @@
         "endAdornment": "day before |||| days before"
       }
     },
-    "otherInvoice": {
+    "invoice": {
       "referencedDate": {
         "inputLabel": "Referenced date",
         "text": "What is the date of this document?"

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -183,7 +183,7 @@
         "endAdornment": "jour avant |||| jours avant"
       }
     },
-    "otherInvoice": {
+    "invoice": {
       "referencedDate": {
         "inputLabel": "Date de référence",
         "text": "Quelle est la date de ce document ?"


### PR DESCRIPTION
Apply the same text present in the information step (referencedDate) of otherInvoice for all invoices