### PR TITLE
Fix(mespapiers-lib)/Activation condition of contact query at Home component

### DIFF
--- a/packages/cozy-mespapiers-lib/package.json
+++ b/packages/cozy-mespapiers-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-mespapiers-lib",
-  "version": "17.0.0",
+  "version": "17.1.0",
   "description": "Cozy Mes papiers lib",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
@@ -16,7 +16,7 @@
     "@testing-library/react": "11.2.7",
     "babel-preset-cozy-app": "2.0.1",
     "cozy-bar": "7.16.0",
-    "cozy-client": "^34.8.0",
+    "cozy-client": "^34.10.1",
     "cozy-device-helper": "^2.6.0",
     "cozy-doctypes": "^1.86.1",
     "cozy-harvest-lib": "^12.4.0",
@@ -36,7 +36,7 @@
     "react-input-mask": "3.0.0-alpha.2"
   },
   "peerDependencies": {
-    "cozy-client": ">=34.8.0",
+    "cozy-client": ">=34.10.1",
     "cozy-device-helper": ">=2.6.0",
     "cozy-doctypes": ">=1.83.8",
     "cozy-harvest-lib": ">=12.3.0",

--- a/packages/cozy-mespapiers-lib/src/components/Views/Home.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/Home.jsx
@@ -69,7 +69,7 @@ const Home = ({ setSelectedThemeLabel }) => {
   )
 
   const isLoadingFiles = isQueryLoading(queryResult) || queryResult.hasMore
-  const isSearching = searchValue.length > 0 || selectedTheme
+  const isSearching = searchValue.length > 0 || !!selectedTheme
 
   const allPapersByCategories = useMemo(
     () =>
@@ -127,7 +127,7 @@ const Home = ({ setSelectedThemeLabel }) => {
     setIsThemesFilterDisplayed(isDisplayed)
   }
 
-  if (isLoadingFiles || isLoadingContacts) {
+  if (isLoadingFiles || (isSearching && isLoadingContacts)) {
     return (
       <Spinner
         size="xxlarge"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6904,16 +6904,16 @@ cozy-client@^32.2.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^34.2.0:
-  version "34.5.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-34.5.0.tgz#862e62d3cb545fa34a66fdc0457521bc2959cb3b"
-  integrity sha512-oqrJZTg1UtqtsPBMuk4alJP/D3A2JLh0ofzAmikmnxS/wYlsP0Dn6T4Rl6FUWU4udg7wZ+3AU9PkusIWpe4zrg==
+cozy-client@^34.10.1:
+  version "34.10.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-34.10.1.tgz#406560b071386cfa15b7119f736caa031344ddcf"
+  integrity sha512-nBkKWG8DqNSJaebC0LCDDRm/2HDy5qt4HsFT1BLJnn0tSsMoTZ11A9lA7dy4O7Ms53YpSvPIAIU16diekTJ28g==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^34.1.5"
+    cozy-stack-client "^34.7.3"
     date-fns "2.29.3"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
@@ -6929,16 +6929,16 @@ cozy-client@^34.2.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^34.8.0:
-  version "34.8.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-34.8.0.tgz#137178608c5c6b3807c3ce2aa04fb8bd43ea3a97"
-  integrity sha512-eNkb22NtrmEe3IjWACKbzXUyudqCO3eE5THdnaHXd1HsnHMzCTgqh3dEjEsampPDrUF/KyFflxMCtWUvKnx47g==
+cozy-client@^34.2.0:
+  version "34.5.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-34.5.0.tgz#862e62d3cb545fa34a66fdc0457521bc2959cb3b"
+  integrity sha512-oqrJZTg1UtqtsPBMuk4alJP/D3A2JLh0ofzAmikmnxS/wYlsP0Dn6T4Rl6FUWU4udg7wZ+3AU9PkusIWpe4zrg==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^34.7.3"
+    cozy-stack-client "^34.1.5"
     date-fns "2.29.3"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
@@ -14731,17 +14731,6 @@ msgpack5@^4.0.2:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
-
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
-  version "1.0.8"
-  uid "3dc4c2a245ab39079bc2f73546bccf80847be14c"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
-  dependencies:
-    "@juggle/resize-observer" "^3.1.3"
-    jest-environment-jsdom-sixteen "^1.0.3"
-    react-spring "9.0.0-rc.3"
-    react-use-gesture "^7.0.8"
-    react-use-measure "^2.0.0"
 
 "mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"


### PR DESCRIPTION
Depuis [cozy-client@34.6.2](https://github.com/cozy/cozy-client/releases/tag/v34.6.2), envoyer une valeur non booléenne à l'option `enabled` de useQuery cause une erreur.

Ce fix sur cozy-client permettra de mieux comprendre et cibler la cause de l'erreur
https://github.com/cozy/cozy-client/pull/1306