### PR TITLE
feat(harvest-lib): Add missing props to new Account modal

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/AccountModalContentWrapper.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/AccountModalContentWrapper.jsx
@@ -9,7 +9,13 @@ import TriggerError from './TriggerError'
 
 const AccountModalContentWrapper = ({ children }) => {
   const { isMobile } = useBreakpoints()
-  const { trigger, account, konnector } = useOutletContext()
+  const {
+    konnector,
+    account,
+    trigger,
+    intentsApi,
+    innerAccountModalOverrides
+  } = useOutletContext()
 
   return (
     <DialogContent className={isMobile ? 'u-p-0' : 'u-pt-0'}>
@@ -21,10 +27,17 @@ const AccountModalContentWrapper = ({ children }) => {
               konnector={konnector}
               account={account}
               trigger={trigger}
+              intentsApi={intentsApi}
             />
             {React.Children.map(children, child =>
               React.isValidElement(child)
-                ? React.cloneElement(child, { flow, trigger, account })
+                ? React.cloneElement(child, {
+                    flow,
+                    account,
+                    trigger,
+                    intentsApi,
+                    innerAccountModalOverrides
+                  })
                 : null
             )}
           </>

--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/AccountModalWithoutTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/AccountModalWithoutTabs.jsx
@@ -11,11 +11,17 @@ import { withMountPointProps } from '../MountPointContext'
 import { getMatchingTrigger } from './helpers'
 import AccountModalHeader from './AccountModalHeader'
 import Error from './Error'
+import {
+  innerAccountModalOverridesProptype,
+  intentsApiProptype
+} from '../../helpers/proptypes'
 
 const AccountModalWithoutTabs = ({
   accountsAndTriggers,
   konnector,
-  accountId
+  accountId,
+  intentsApi,
+  innerAccountModalOverrides
 }) => {
   const matchingTrigger = getMatchingTrigger(accountsAndTriggers, accountId)
   const matchingAccountId = matchingTrigger ? accountId : undefined
@@ -57,7 +63,15 @@ const AccountModalWithoutTabs = ({
         </DialogContent>
       )}
       {!isError && !isLoading && (
-        <Outlet context={{ trigger: matchingTrigger, account, konnector }} />
+        <Outlet
+          context={{
+            trigger: matchingTrigger,
+            account,
+            konnector,
+            intentsApi,
+            innerAccountModalOverrides
+          }}
+        />
       )}
     </>
   )
@@ -74,7 +88,9 @@ AccountModalWithoutTabs.propTypes = {
       trigger: PropTypes.object.isRequired
     })
   ).isRequired,
-  accountId: PropTypes.string.isRequired
+  accountId: PropTypes.string.isRequired,
+  intentsApi: intentsApiProptype,
+  innerAccountModalOverrides: innerAccountModalOverridesProptype
 }
 
 export default withMountPointProps(AccountModalWithoutTabs)

--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/FovV4Router/AccountModalContentWrapper.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/FovV4Router/AccountModalContentWrapper.jsx
@@ -1,16 +1,23 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import DialogContent from '@material-ui/core/DialogContent'
 
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 import FlowProvider from '../../FlowProvider'
 import TriggerError from '../TriggerError'
+import {
+  innerAccountModalOverridesProptype,
+  intentsApiProptype
+} from '../../../helpers/proptypes'
 
 const AccountModalContentWrapper = ({
   children,
   trigger,
   account,
-  konnector
+  konnector,
+  intentsApi,
+  innerAccountModalOverrides
 }) => {
   const { isMobile } = useBreakpoints()
 
@@ -24,10 +31,17 @@ const AccountModalContentWrapper = ({
               konnector={konnector}
               account={account}
               trigger={trigger}
+              intentsApi={intentsApi}
             />
             {React.Children.map(children, child =>
               React.isValidElement(child)
-                ? React.cloneElement(child, { flow, trigger, account })
+                ? React.cloneElement(child, {
+                    flow,
+                    account,
+                    trigger,
+                    intentsApi,
+                    innerAccountModalOverrides
+                  })
                 : null
             )}
           </>
@@ -35,6 +49,14 @@ const AccountModalContentWrapper = ({
       </FlowProvider>
     </DialogContent>
   )
+}
+
+AccountModalContentWrapper.propTypes = {
+  konnector: PropTypes.object.isRequired,
+  trigger: PropTypes.object.isRequired,
+  account: PropTypes.object.isRequired,
+  intentsApi: intentsApiProptype,
+  innerAccountModalOverrides: innerAccountModalOverridesProptype
 }
 
 export default AccountModalContentWrapper

--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/FovV4Router/AccountModalWithoutTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/FovV4Router/AccountModalWithoutTabs.jsx
@@ -10,11 +10,17 @@ import { withMountPointProps } from '../../MountPointContext'
 import { getMatchingTrigger } from '../helpers'
 import AccountModalHeader from '../AccountModalHeader'
 import Error from '../Error'
+import {
+  innerAccountModalOverridesProptype,
+  intentsApiProptype
+} from '../../../helpers/proptypes'
 
 const AccountModalWithoutTabs = ({
   accountsAndTriggers,
   konnector,
   accountId,
+  intentsApi,
+  innerAccountModalOverrides,
   children
 }) => {
   const matchingTrigger = getMatchingTrigger(accountsAndTriggers, accountId)
@@ -63,7 +69,9 @@ const AccountModalWithoutTabs = ({
             ? React.cloneElement(child, {
                 trigger: matchingTrigger,
                 account,
-                konnector
+                konnector,
+                intentsApi,
+                innerAccountModalOverrides
               })
             : null
         )}
@@ -82,7 +90,9 @@ AccountModalWithoutTabs.propTypes = {
       trigger: PropTypes.object.isRequired
     })
   ).isRequired,
-  accountId: PropTypes.string.isRequired
+  accountId: PropTypes.string.isRequired,
+  intentsApi: intentsApiProptype,
+  innerAccountModalOverrides: innerAccountModalOverridesProptype
 }
 
 export default withMountPointProps(AccountModalWithoutTabs)

--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/OpenOAuthWindowButton.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/OpenOAuthWindowButton.jsx
@@ -5,13 +5,16 @@ import flag from 'cozy-flags'
 import { useClient } from 'cozy-client'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Button } from 'cozy-ui/transpiled/react/Button'
+import { useWebviewIntent } from 'cozy-intent'
 
 import useOAuthExtraParams from '../hooks/useOAuthExtraParams'
 import { OAUTH_SERVICE_OK, openOAuthWindow } from '../OAuthService'
+import { intentsApiProptype } from '../../helpers/proptypes'
 
-const OpenOAuthWindowButton = ({ flow, account, konnector }) => {
+const OpenOAuthWindowButton = ({ flow, account, konnector, intentsApi }) => {
   const { t } = useI18n()
   const client = useClient()
+  const webviewIntent = useWebviewIntent()
 
   const { extraParams } = useOAuthExtraParams({
     account,
@@ -26,6 +29,8 @@ const OpenOAuthWindowButton = ({ flow, account, konnector }) => {
       konnector,
       account,
       extraParams,
+      intentsApi,
+      webviewIntent,
       reconnect: true
     })
 
@@ -35,7 +40,7 @@ const OpenOAuthWindowButton = ({ flow, account, konnector }) => {
     ) {
       flow.expectTriggerLaunch()
     }
-  }, [account, client, extraParams, flow, konnector])
+  }, [account, client, extraParams, flow, konnector, webviewIntent, intentsApi])
 
   return (
     <Button
@@ -52,7 +57,8 @@ const OpenOAuthWindowButton = ({ flow, account, konnector }) => {
 OpenOAuthWindowButton.propTypes = {
   flow: PropTypes.object.isRequired,
   account: PropTypes.object.isRequired,
-  konnector: PropTypes.object.isRequired
+  konnector: PropTypes.object.isRequired,
+  intentsApi: intentsApiProptype
 }
 
 export default OpenOAuthWindowButton

--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/TriggerError.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/TriggerError.jsx
@@ -6,8 +6,9 @@ import { useClient } from 'cozy-client'
 import useMaintenanceStatus from '../hooks/useMaintenanceStatus'
 import TriggerErrorInfo from '../infos/TriggerErrorInfo'
 import TriggerErrorAction from './TriggerErrorAction'
+import { intentsApiProptype } from '../../helpers/proptypes'
 
-const TriggerError = ({ flow, konnector, account, trigger }) => {
+const TriggerError = ({ flow, konnector, account, trigger, intentsApi }) => {
   const client = useClient()
   const flowState = flow.getState()
   const { error } = flowState
@@ -29,6 +30,7 @@ const TriggerError = ({ flow, konnector, account, trigger }) => {
           konnector={konnector}
           account={account}
           trigger={trigger}
+          intentsApi={intentsApi}
         />
       }
       className="u-mt-1"
@@ -42,5 +44,6 @@ TriggerError.propTypes = {
   flow: PropTypes.object.isRequired,
   konnector: PropTypes.object.isRequired,
   account: PropTypes.object,
-  trigger: PropTypes.object
+  trigger: PropTypes.object,
+  intentsApi: intentsApiProptype
 }

--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/TriggerErrorAction.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/TriggerErrorAction.jsx
@@ -4,8 +4,16 @@ import PropTypes from 'prop-types'
 import { findKonnectorPolicy } from '../../konnector-policies'
 import RedirectToAccountFormButton from '../RedirectToAccountFormButton'
 import OpenOAuthWindowButton from './OpenOAuthWindowButton'
+import { intentsApiProptype } from '../../helpers/proptypes'
 
-const TriggerErrorAction = ({ flow, konnector, account, trigger, error }) => {
+const TriggerErrorAction = ({
+  flow,
+  konnector,
+  account,
+  trigger,
+  error,
+  intentsApi
+}) => {
   const konnectorPolicy = findKonnectorPolicy(konnector)
 
   if (!error.isSolvableViaReconnect()) return null
@@ -16,6 +24,7 @@ const TriggerErrorAction = ({ flow, konnector, account, trigger, error }) => {
         flow={flow}
         account={account}
         konnector={konnector}
+        intentsApi={intentsApi}
       />
     )
 
@@ -27,7 +36,8 @@ TriggerErrorAction.propTypes = {
   konnector: PropTypes.object.isRequired,
   account: PropTypes.object,
   trigger: PropTypes.object,
-  error: PropTypes.object.isRequired
+  error: PropTypes.object.isRequired,
+  intentsApi: intentsApiProptype
 }
 
 export default TriggerErrorAction


### PR DESCRIPTION
Il manquait dans la nouvelle version de l'AccountModal des props utiles pour une app cliente.

Il aurait sans doute été préférable d'utiliser un contexte depuis ce point d'entrée (`AccountModalWithoutTabs`).
A revoir si/quand on repassera dessus @doubleface @JF-Cozy 