### PR TITLE
fix(mespapiers-lib): Use the trigger corresponding to the account

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Papers/PapersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PapersList.jsx
@@ -24,7 +24,8 @@ import {
 } from '../../helpers/queries'
 
 const ConnectorItem = ({ papers }) => {
-  const connectorSlug = papers?.list?.[0]?.cozyMetadata?.createdByApp
+  const { createdByApp: connectorSlug, sourceAccount: connectorAccount } =
+    papers?.list?.[0]?.cozyMetadata || {}
   const queryTriggers = buildTriggersQueryByConnectorSlug(
     connectorSlug,
     Boolean(connectorSlug)
@@ -33,8 +34,9 @@ const ConnectorItem = ({ papers }) => {
     queryTriggers.definition,
     queryTriggers.options
   )
-  const trigger = triggers?.[0]
-  const connectorAccount = trigger?.message?.account
+  const trigger = triggers?.find(
+    trigger => trigger.message.account === connectorAccount
+  )
 
   const queryKonnector = buildConnectorsQueryById(
     `io.cozy.konnectors/${connectorSlug}`,


### PR DESCRIPTION
There can be several Accounts on the same Connector, therefore several Triggers.
It is therefore necessary to be able to differentiate each Account with its respective list of papers.