### PR TITLE
fix: Allow content to go full size in share by email select box

### DIFF
--- a/packages/cozy-sharing/src/share.styl
+++ b/packages/cozy-sharing/src/share.styl
@@ -78,10 +78,6 @@
     .react-select__option:active
         background-color var(--paleGrey) !important
 
-    @media (max-width 32em)
-        .react-select__menu
-            width 100% !important
-
 input[type=text]
     width 100%
 


### PR DESCRIPTION
When it was displayed on mobile, the content was limited to the size of the button which not enough. Not it is limited to the size of the button wrapper.