### PR TITLE
Remove the ability to close the connection backdrop

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/ConnectionBackdrop.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/ConnectionBackdrop.jsx
@@ -1,12 +1,8 @@
 import React from 'react'
-import cx from 'classnames'
 
 import { makeStyles } from 'cozy-ui/transpiled/react/styles'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Backdrop from 'cozy-ui/transpiled/react/Backdrop'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import IconButton from 'cozy-ui/transpiled/react/IconButton'
-import CrossMediumIcon from 'cozy-ui/transpiled/react/Icons/CrossMedium'
 import LinearProgress from 'cozy-ui/transpiled/react/LinearProgress'
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 import Typography from 'cozy-ui/transpiled/react/Typography'
@@ -16,13 +12,10 @@ const useStyles = makeStyles({
     position: 'fixed',
     zIndex: 'var(--zIndex-modal)',
     inset: 0
-  },
-  iconButton: {
-    position: 'absolute'
   }
 })
 
-const ConnectionBackdrop = ({ name, onClose }) => {
+const ConnectionBackdrop = ({ name }) => {
   const styles = useStyles()
   const { t } = useI18n()
 
@@ -30,13 +23,6 @@ const ConnectionBackdrop = ({ name, onClose }) => {
     <MuiCozyTheme variant="inverted">
       <div className={styles.container}>
         <Backdrop open className="u-p-2">
-          <IconButton
-            size="large"
-            onClick={onClose}
-            className={cx('u-right-0 u-top-0 u-m-1 u-m-0-s', styles.iconButton)}
-          >
-            <Icon icon={CrossMediumIcon} />
-          </IconButton>
           <div className="u-w-6 u-w-100-s">
             <Typography variant="h4" className="u-ta-center">
               {t('connectionBackdrop.connecting')}

--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -48,8 +48,7 @@ export class AccountForm extends PureComponent {
 
     this.state = {
       showConfirmationModal: false,
-      showCannotConnectModal: false,
-      showConnectionBackdrop: false
+      showCannotConnectModal: false
     }
 
     this.inputs = {}
@@ -63,8 +62,6 @@ export class AccountForm extends PureComponent {
     this.hideConfirmationModal = this.hideConfirmationModal.bind(this)
     this.showCannotConnectModal = this.showCannotConnectModal.bind(this)
     this.hideCannotConnectModal = this.hideCannotConnectModal.bind(this)
-    this.showConnectionBackdrop = this.showConnectionBackdrop.bind(this)
-    this.hideConnectionBackdrop = this.hideConnectionBackdrop.bind(this)
   }
 
   /**
@@ -166,7 +163,6 @@ export class AccountForm extends PureComponent {
     form.reset(values)
     onSubmit(values)
     this.hideConfirmationModal()
-    this.showConnectionBackdrop()
   }
 
   /**
@@ -212,14 +208,6 @@ export class AccountForm extends PureComponent {
 
   hideCannotConnectModal() {
     this.setState(prev => ({ ...prev, showCannotConnectModal: false }))
-  }
-
-  showConnectionBackdrop() {
-    this.setState(prev => ({ ...prev, showConnectionBackdrop: true }))
-  }
-
-  hideConnectionBackdrop() {
-    this.setState(prev => ({ ...prev, showConnectionBackdrop: false }))
   }
 
   manageSecretFieldOptions = () => {
@@ -326,11 +314,7 @@ export class AccountForm extends PureComponent {
                   </Link>
                 )}
                 <Button
-                  busy={
-                    submitting &&
-                    (!flag('harvest.inappconnectors.enabled') ||
-                      !this.state.showConnectionBackdrop)
-                  }
+                  busy={submitting && !flag('harvest.inappconnectors.enabled')}
                   className="u-mt-2 u-mb-1-half"
                   disabled={
                     submitting ||
@@ -341,14 +325,9 @@ export class AccountForm extends PureComponent {
                   onClick={() => this.handleSubmit(values, form)}
                   data-testid="submit-btn"
                 />
-                {submitting &&
-                  flag('harvest.inappconnectors.enabled') &&
-                  this.state.showConnectionBackdrop && (
-                    <ConnectionBackdrop
-                      name={name}
-                      onClose={this.hideConnectionBackdrop}
-                    />
-                  )}
+                {submitting && flag('harvest.inappconnectors.enabled') && (
+                  <ConnectionBackdrop name={name} />
+                )}
               </>
             ) : (
               <>


### PR DESCRIPTION
Remove the close icon button introduced in #1929 and thus the ability to close the connection backdrop.