### PR TITLE
Vertically center harvest dialog when not using tabs

### DIFF
--- a/packages/cozy-harvest-lib/src/components/Routes.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
 
+import flag from 'cozy-flags'
 import { useVaultUnlockContext, VaultUnlockPlaceholder } from 'cozy-keys-lib'
 import { withStyles } from 'cozy-ui/transpiled/react/styles'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
@@ -23,20 +24,35 @@ import { MountPointProvider } from './MountPointContext'
 import DialogContext from './DialogContext'
 import { isRouterV6 } from './hoc/withRouter'
 
-/**
- * Dialog will not be centered vertically since we need the modal to "stay in place"
- * when changing tabs. Since tabs content's height is not the same between the data
- * tab and the configuration, having the modal vertically centered makes it "jump"
- * when changing tabs.
- */
-const HarvestDialog = withStyles({
-  scrollPaper: {
-    alignItems: 'start'
-  },
+const withHarvestDialogStyles = () => {
+  /**
+   * When this flag is enabled, tabs are removed, and the layout shift between
+   * data and configuration screens is not as disturbing as with tabs. So we do
+   * not need to customize styles to align the dialog at the top anymore and we
+   * can just return the identity function. This whole HOC should be able to be
+   * removed at the same time as the flag. See the next comment for the former
+   * behavior.
+   */
+  if (flag('harvest.inappconnectors.enabled')) {
+    return component => component
+  }
+  /**
+   * Dialog will not be centered vertically since we need the modal to "stay in
+   * place" when changing tabs. Since tabs content's height is not the same
+   * between the data tab and the configuration, having the modal vertically
+   * centered makes it "jump" when changing tabs.
+   */
+  return withStyles({
+    scrollPaper: {
+      alignItems: 'start'
+    },
 
-  // Necessary to prevent warnings at runtime
-  paper: {}
-})(props => {
+    // Necessary to prevent warnings at runtime
+    paper: {}
+  })
+}
+
+const HarvestDialog = withHarvestDialogStyles()(props => {
   const { showingUnlockForm } = useVaultUnlockContext()
   if (showingUnlockForm) {
     return null


### PR DESCRIPTION
This vertically centers the dialog when the flag `harvest.inappconnectors.enabled` is set.
Initially it was aligned at the top to prevent having layout shift when switching tabs, but tabs have been removed behind the flag.
The top alignment is kept when the flag is not set.