### PR TITLE
fix: Recipient import path not updated in last update

### DIFF
--- a/packages/cozy-sharing/src/components/ConfirmTrustedRecipientsDialog.jsx
+++ b/packages/cozy-sharing/src/components/ConfirmTrustedRecipientsDialog.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
-import Recipient from './Recipient'
+import Recipient from './Recipient/Recipient'
 
 import ShareDialogTwoStepsConfirmationContainer from './ShareDialogTwoStepsConfirmationContainer'
 


### PR DESCRIPTION
Due to rsync misunderstandings, I forgot to update an import of a file I moved.