### PR TITLE
Deal with disconnected account in LaunchTriggerAlert

### DIFF
--- a/packages/cozy-harvest-lib/src/components/Routes/RoutesV4.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes/RoutesV4.jsx
@@ -78,7 +78,7 @@ const RoutesV4 = ({
               >
                 <AccountModalContentWrapper>
                   <DataTab
-                    konnectorRoot={`${konnectorRoot}/accounts/${match.params.accountId}`}
+                    konnectorRoot={konnectorRoot}
                     konnector={konnectorWithTriggers}
                     showNewAccountButton={!konnectorWithTriggers.clientSide}
                     onDismiss={onDismiss}

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
@@ -11,7 +11,7 @@ import Snackbar from 'cozy-ui/transpiled/react/Snackbar'
 import WrenchCircleIcon from 'cozy-ui/transpiled/react/Icons/WrenchCircle'
 import { makeStyles } from 'cozy-ui/transpiled/react/styles'
 
-import { getLastSuccessDate, getKonnectorSlug } from '../../helpers/triggers'
+import { getKonnectorSlug } from '../../helpers/triggers'
 import { isRunnable } from '../../helpers/konnectors'
 import { useFlowState } from '../../models/withConnectionFlow'
 import { SUCCESS } from '../../models/flowEvents'
@@ -40,25 +40,23 @@ const useStyles = makeStyles({
 
 export const LaunchTriggerAlert = ({
   flow,
-  f,
   t,
   konnectorRoot,
   historyAction,
   withDescription
 }) => {
-  const [showSuccessSnackbar, setShowSuccessSnackbar] = useState(false)
   const client = useClient()
+  const [showSuccessSnackbar, setShowSuccessSnackbar] = useState(false)
   const { error, trigger, running, expectingTriggerLaunch, status } =
     useFlowState(flow)
-  const { launch, konnector } = flow
   const {
     data: { isInMaintenance, messages: maintenanceMessages }
   } = useMaintenanceStatus(client, konnector)
-  const isInError = !!error
-  const block = withDescription && (isInError || isInMaintenance)
   const styles = useStyles({ block })
 
-  const lastSuccessDate = getLastSuccessDate(trigger)
+  const { launch, konnector } = flow
+  const isInError = !!error
+  const block = withDescription && (isInError || isInMaintenance)
   const isKonnectorRunnable = isRunnable({ win: window, konnector })
 
   useEffect(() => {
@@ -146,10 +144,9 @@ export const LaunchTriggerAlert = ({
             >
               {makeLabel({
                 t,
-                f,
+                trigger,
                 running,
-                expectingTriggerLaunch,
-                lastSuccessDate
+                expectingTriggerLaunch
               })}
             </Typography>
             {block && (
@@ -205,7 +202,6 @@ LaunchTriggerAlert.defaultProps = {
 
 LaunchTriggerAlert.propTypes = {
   flow: PropTypes.object,
-  f: PropTypes.func,
   t: PropTypes.func,
   konnectorRoot: PropTypes.string,
   historyAction: PropTypes.func,

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
@@ -90,6 +90,7 @@ export const LaunchTriggerAlert = ({
           ) : (
             <KonnectorIcon
               className="u-w-1 u-h-1"
+              konnector={konnector}
               konnectorSlug={getKonnectorSlug(trigger)}
             />
           )

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
@@ -12,7 +12,7 @@ import WrenchCircleIcon from 'cozy-ui/transpiled/react/Icons/WrenchCircle'
 import { makeStyles } from 'cozy-ui/transpiled/react/styles'
 
 import { getKonnectorSlug } from '../../helpers/triggers'
-import { isRunnable } from '../../helpers/konnectors'
+import { isRunnable, isDisconnected } from '../../helpers/konnectors'
 import { useFlowState } from '../../models/withConnectionFlow'
 import { SUCCESS } from '../../models/flowEvents'
 import withAdaptiveRouter from '../hoc/withRouter'
@@ -49,15 +49,16 @@ export const LaunchTriggerAlert = ({
   const [showSuccessSnackbar, setShowSuccessSnackbar] = useState(false)
   const { error, trigger, running, expectingTriggerLaunch, status } =
     useFlowState(flow)
+  const { launch, konnector } = flow
   const {
     data: { isInMaintenance, messages: maintenanceMessages }
   } = useMaintenanceStatus(client, konnector)
   const styles = useStyles({ block })
 
-  const { launch, konnector } = flow
   const isInError = !!error
   const block = withDescription && (isInError || isInMaintenance)
   const isKonnectorRunnable = isRunnable({ win: window, konnector })
+  const isKonnectorDisconnected = isDisconnected(konnector, trigger)
 
   useEffect(() => {
     if (status === SUCCESS) {
@@ -96,7 +97,7 @@ export const LaunchTriggerAlert = ({
         action={
           isKonnectorRunnable && (
             <>
-              {!isInMaintenance && (
+              {!isInMaintenance && !isKonnectorDisconnected && (
                 <Button
                   variant="text"
                   color={isInError ? 'error' : undefined}
@@ -115,7 +116,6 @@ export const LaunchTriggerAlert = ({
                   <LaunchTriggerAlertMenu
                     flow={flow}
                     t={t}
-                    isInMaintenance={isInMaintenance}
                     konnectorRoot={konnectorRoot}
                     historyAction={historyAction}
                   />
@@ -159,7 +159,6 @@ export const LaunchTriggerAlert = ({
                 <LaunchTriggerAlertMenu
                   flow={flow}
                   t={t}
-                  isInMaintenance={isInMaintenance}
                   konnectorRoot={konnectorRoot}
                   historyAction={historyAction}
                 />

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
@@ -144,6 +144,7 @@ export const LaunchTriggerAlert = ({
             >
               {makeLabel({
                 t,
+                konnector,
                 trigger,
                 running,
                 expectingTriggerLaunch

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlertMenu.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlertMenu.jsx
@@ -10,6 +10,7 @@ import SyncIcon from 'cozy-ui/transpiled/react/Icons/Sync'
 import GearIcon from 'cozy-ui/transpiled/react/Icons/Gear'
 
 import { useFlowState } from '../../models/withConnectionFlow'
+import { getAccountId } from '../../helpers/triggers'
 import { isDisconnected } from '../../helpers/konnectors'
 import withAdaptiveRouter from '../hoc/withRouter'
 import useMaintenanceStatus from '../hooks/useMaintenanceStatus'
@@ -51,7 +52,16 @@ const LaunchTriggerAlertMenu = ({ flow, t, konnectorRoot, historyAction }) => {
           {!isKonnectorDisconnected && (
             <ActionMenuItem
               left={<Icon icon={GearIcon} />}
-              onClick={() => historyAction(`${konnectorRoot}/config`, 'push')}
+              onClick={() =>
+                historyAction(
+                  konnectorRoot
+                    ? `${konnectorRoot}/accounts/${getAccountId(
+                        trigger
+                      )}/config`
+                    : '/config',
+                  'push'
+                )
+              }
             >
               {t('card.launchTrigger.configure')}
             </ActionMenuItem>

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlertMenu.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlertMenu.jsx
@@ -10,16 +10,18 @@ import SyncIcon from 'cozy-ui/transpiled/react/Icons/Sync'
 import GearIcon from 'cozy-ui/transpiled/react/Icons/Gear'
 
 import { useFlowState } from '../../models/withConnectionFlow'
+import { isDisconnected } from '../../helpers/konnectors'
 import withAdaptiveRouter from '../hoc/withRouter'
 import useMaintenanceStatus from '../hooks/useMaintenanceStatus'
 
 const LaunchTriggerAlertMenu = ({ flow, t, konnectorRoot, historyAction }) => {
   const client = useClient()
-  const { running } = useFlowState(flow)
+  const { running, trigger } = useFlowState(flow)
   const { launch, konnector } = flow
   const {
     data: { isInMaintenance }
   } = useMaintenanceStatus(client, konnector)
+  const isKonnectorDisconnected = isDisconnected(konnector, trigger)
 
   const anchorRef = useRef()
   const [showOptions, setShowOptions] = useState(false)
@@ -35,7 +37,7 @@ const LaunchTriggerAlertMenu = ({ flow, t, konnectorRoot, historyAction }) => {
           autoclose={true}
           onClose={() => setShowOptions(false)}
         >
-          {!running && !isInMaintenance && (
+          {!running && !isInMaintenance && !isKonnectorDisconnected && (
             <ActionMenuItem
               left={<Icon icon={SyncIcon} />}
               onClick={() => {
@@ -46,12 +48,22 @@ const LaunchTriggerAlertMenu = ({ flow, t, konnectorRoot, historyAction }) => {
               {t('card.launchTrigger.button.label')}
             </ActionMenuItem>
           )}
-          <ActionMenuItem
-            left={<Icon icon={GearIcon} />}
-            onClick={() => historyAction(`${konnectorRoot}/config`, 'push')}
-          >
-            {t('card.launchTrigger.configure')}
-          </ActionMenuItem>
+          {!isKonnectorDisconnected && (
+            <ActionMenuItem
+              left={<Icon icon={GearIcon} />}
+              onClick={() => historyAction(`${konnectorRoot}/config`, 'push')}
+            >
+              {t('card.launchTrigger.configure')}
+            </ActionMenuItem>
+          )}
+          {isKonnectorDisconnected && (
+            <ActionMenuItem
+              left={<Icon icon={GearIcon} />}
+              onClick={() => historyAction(`${konnectorRoot}/new`, 'push')}
+            >
+              {t('card.launchTrigger.connect')}
+            </ActionMenuItem>
+          )}
         </ActionMenu>
       )}
     </>

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
@@ -90,8 +90,6 @@ export const DumbLaunchTriggerCard = ({ flow, className, f, t, disabled }) => {
         </ul>
         {isKonnectorRunnable && (
           <div>
-            {/* TODO: Extract this directly in Cozy-UI
-            (either with an utility class or a Button prop) */}
             <Button
               label={t('card.launchTrigger.button.label')}
               icon={<Icon focusable="false" icon={SyncIcon} spin={running} />}

--- a/packages/cozy-harvest-lib/src/components/cards/helpers.js
+++ b/packages/cozy-harvest-lib/src/components/cards/helpers.js
@@ -1,6 +1,7 @@
 import { formatLocallyDistanceToNow } from 'cozy-ui/transpiled/react/I18n/format'
 
 import { getLastSuccessDate } from '../../helpers/triggers'
+import { isDisconnected } from '../../helpers/konnectors'
 
 const DEFAULT_TIME = 300_000 // To milliseconds (5 minutes)
 
@@ -41,7 +42,7 @@ export const makeLabel = ({
     })
   }
 
-  if (konnector && !trigger) {
+  if (isDisconnected(konnector, trigger)) {
     return t('card.launchTrigger.lastSync.disconnected')
   }
 

--- a/packages/cozy-harvest-lib/src/components/cards/helpers.js
+++ b/packages/cozy-harvest-lib/src/components/cards/helpers.js
@@ -11,13 +11,20 @@ const getDifferenceInMinutes = date => {
 /**
  * @param {object} options
  * @param {object} options.t - i18n function
+ * @param {object} options.konnector - Associated Connector
  * @param {object} options.trigger - Associated trigger
  * @param {object} options.running - If the connector is running
  * @param {object} options.expectingTriggerLaunch - If the trigger is waiting to be launched
  * @param {object} options.lastSuccessDate - The last date when the trigger was successfully executed
  * @returns {string}
  */
-export const makeLabel = ({ t, trigger, running, expectingTriggerLaunch }) => {
+export const makeLabel = ({
+  t,
+  konnector,
+  trigger,
+  running,
+  expectingTriggerLaunch
+}) => {
   const lastSuccessDate = getLastSuccessDate(trigger)
 
   if (running || expectingTriggerLaunch) {
@@ -32,6 +39,10 @@ export const makeLabel = ({ t, trigger, running, expectingTriggerLaunch }) => {
     return t('card.launchTrigger.lastSync.afterSomeTimes', {
       times: formatLocallyDistanceToNow(lastSuccessDate)
     })
+  }
+
+  if (konnector && !trigger) {
+    return t('card.launchTrigger.lastSync.disconnected')
   }
 
   return t('card.launchTrigger.lastSync.unknown')

--- a/packages/cozy-harvest-lib/src/components/cards/helpers.js
+++ b/packages/cozy-harvest-lib/src/components/cards/helpers.js
@@ -1,5 +1,7 @@
 import { formatLocallyDistanceToNow } from 'cozy-ui/transpiled/react/I18n/format'
 
+import { getLastSuccessDate } from '../../helpers/triggers'
+
 const DEFAULT_TIME = 300_000 // To milliseconds (5 minutes)
 
 const getDifferenceInMinutes = date => {
@@ -9,17 +11,15 @@ const getDifferenceInMinutes = date => {
 /**
  * @param {object} options
  * @param {object} options.t - i18n function
+ * @param {object} options.trigger - Associated trigger
  * @param {object} options.running - If the connector is running
  * @param {object} options.expectingTriggerLaunch - If the trigger is waiting to be launched
  * @param {object} options.lastSuccessDate - The last date when the trigger was successfully executed
  * @returns {string}
  */
-export const makeLabel = ({
-  t,
-  running,
-  expectingTriggerLaunch,
-  lastSuccessDate
-}) => {
+export const makeLabel = ({ t, trigger, running, expectingTriggerLaunch }) => {
+  const lastSuccessDate = getLastSuccessDate(trigger)
+
   if (running || expectingTriggerLaunch) {
     return t('card.launchTrigger.lastSync.syncing')
   }

--- a/packages/cozy-harvest-lib/src/components/cards/helpers.spec.js
+++ b/packages/cozy-harvest-lib/src/components/cards/helpers.spec.js
@@ -97,5 +97,16 @@ describe('makeLabel', () => {
 
       expect(res).toBe('Unknown')
     })
+
+    it('should return "Disconnected" if no trigger but a konnector', () => {
+      const res = makeLabel({
+        t,
+        konnector: {},
+        running: false,
+        expectingTriggerLaunch: false
+      })
+
+      expect(res).toBe('Disconnected')
+    })
   })
 })

--- a/packages/cozy-harvest-lib/src/components/cards/helpers.spec.js
+++ b/packages/cozy-harvest-lib/src/components/cards/helpers.spec.js
@@ -5,17 +5,14 @@ import enLocales from '../../locales/en.json'
 import { makeLabel } from './helpers'
 
 const t = x => get(enLocales, x)
-const f = x => x
 
 describe('makeLabel', () => {
   describe('it should return "Data recovery…"', () => {
     it('when running is true', () => {
       const res = makeLabel({
         t,
-        f,
         running: true,
-        expectingTriggerLaunch: false,
-        lastSuccessDate: '2021'
+        expectingTriggerLaunch: false
       })
 
       expect(res).toBe('Data recovery…')
@@ -24,10 +21,8 @@ describe('makeLabel', () => {
     it('when runggin and expectingTriggerLaunch are true', () => {
       const res = makeLabel({
         t,
-        f,
         running: true,
-        expectingTriggerLaunch: true,
-        lastSuccessDate: '2021'
+        expectingTriggerLaunch: true
       })
 
       expect(res).toBe('Data recovery…')
@@ -36,10 +31,8 @@ describe('makeLabel', () => {
     it('when expectingTriggerLaunch is true', () => {
       const res = makeLabel({
         t,
-        f,
         running: false,
-        expectingTriggerLaunch: true,
-        lastSuccessDate: '2021'
+        expectingTriggerLaunch: true
       })
 
       expect(res).toBe('Data recovery…')
@@ -48,10 +41,8 @@ describe('makeLabel', () => {
     it('when lastSuccessDate is null', () => {
       const res = makeLabel({
         t,
-        f,
         running: true,
-        expectingTriggerLaunch: true,
-        lastSuccessDate: null
+        expectingTriggerLaunch: true
       })
 
       expect(res).toBe('Data recovery…')
@@ -69,10 +60,11 @@ describe('makeLabel', () => {
     it('should return "Sync. ago..." if lastSuccessDate is defined and > 5 minutes', () => {
       const res = makeLabel({
         t,
-        f,
+        trigger: {
+          current_state: { last_success: '2020-12-25T11:55:00.000Z' }
+        },
         running: false,
-        expectingTriggerLaunch: false,
-        lastSuccessDate: '2020-12-25T11:55:00.000Z'
+        expectingTriggerLaunch: false
       })
 
       expect(res).toContain(
@@ -83,10 +75,11 @@ describe('makeLabel', () => {
     it('should return "Sync. just now" if lastSuccessDate is defined and < 5 minutes', () => {
       const res = makeLabel({
         t,
-        f,
+        trigger: {
+          current_state: { last_success: '2020-12-25T11:55:01.000Z' }
+        },
         running: false,
-        expectingTriggerLaunch: false,
-        lastSuccessDate: '2020-12-25T11:55:01.000Z'
+        expectingTriggerLaunch: false
       })
 
       expect(res).toBe(`${t('card.launchTrigger.lastSync.justNow')}`)
@@ -95,10 +88,11 @@ describe('makeLabel', () => {
     it('should return "Unknown" if lastSuccessDate is null', () => {
       const res = makeLabel({
         t,
-        f,
+        trigger: {
+          current_state: { last_success: null }
+        },
         running: false,
-        expectingTriggerLaunch: false,
-        lastSuccessDate: null
+        expectingTriggerLaunch: false
       })
 
       expect(res).toBe('Unknown')

--- a/packages/cozy-harvest-lib/src/helpers/konnectors.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectors.js
@@ -387,6 +387,17 @@ export const isRunnable = ({ win, konnector = {} }) => {
   return Boolean(!konnector.clientSide || getLauncher({ win }))
 }
 
+/**
+ * Define if konnector is disconnected or not
+ *
+ * @param {Object} konnector - The io.cozy.konnectors object for the current konnector
+ * @param {Object} trigger - Associated trigger
+ * @returns {Boolean}
+ */
+export const isDisconnected = (konnector, trigger) => {
+  return !!konnector && !trigger
+}
+
 export default {
   KonnectorJobError,
   buildFolderPath,

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -94,6 +94,7 @@
         "unknown": "Unknown",
         "afterSomeTimes": "Sync. %{times} ago",
         "format": "MM/DD/YYYY",
+        "disconnected": "Disconnected",
         "justNow": "Sync. just now"
       }
     },

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -78,6 +78,7 @@
         "label": "Synchronize"
       },
       "configure": "Configure",
+      "connect": "Connect",
       "success": "Successful synchronization",
       "error": "An error occured.",
       "frequency": {

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -78,6 +78,7 @@
         "label": "Synchroniser"
       },
       "configure": "Configurer",
+      "connect": "Se connecter",
       "success": "Synchronisation réussie",
       "error": "Une erreur est survenue.",
       "frequency": {

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -94,6 +94,7 @@
         "unknown": "Indéterminée",
         "afterSomeTimes": "Sync. il y a %{times}",
         "format": "DD/MM/YYYY",
+        "disconnected": "Déconnecté",
         "justNow": "Sync. à l'instant"
       }
     },


### PR DESCRIPTION
On souhaite pouvoir afficher le bandeau du connecteur même pour les comptes déconnectés. Dans ce cas on s'attend à certains comportements et wording. Cette PR traite ce sujet.