### PR TITLE
fix(SharingBanner): Add custom previewPath

### DIFF
--- a/packages/cozy-sharing/src/SharingBanner/hooks/useSharingInfos.jsx
+++ b/packages/cozy-sharing/src/SharingBanner/hooks/useSharingInfos.jsx
@@ -12,7 +12,7 @@ const getSharingId = permission => {
   return sharingId
 }
 
-export const useSharingInfos = () => {
+export const useSharingInfos = (previewPath = '/preview') => {
   const client = useClient()
 
   const [discoveryLink, setDiscoveryLink] = useState()
@@ -52,12 +52,12 @@ export const useSharingInfos = () => {
       }
     }
 
-    if (window.location.pathname === '/preview') {
+    if (window.location.pathname === previewPath) {
       loadSharingDiscoveryLink()
     } else {
       setLoading(false)
     }
-  }, [client])
+  }, [client, previewPath])
 
   return {
     sharing,

--- a/packages/cozy-sharing/src/SharingBanner/index.jsx
+++ b/packages/cozy-sharing/src/SharingBanner/index.jsx
@@ -1,13 +1,17 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import withLocales from '../withLocales'
 import { useSharingInfos } from './hooks/useSharingInfos'
 import { SharingBanner } from './components/SharingBanner'
 
-const Plugin = () => {
-  const sharingInfos = useSharingInfos()
-
+const Plugin = ({ previewPath }) => {
+  const sharingInfos = useSharingInfos(previewPath)
   return <SharingBanner sharingInfos={sharingInfos} />
+}
+
+Plugin.propTypes = {
+  previewPath: PropTypes.string
 }
 
 export const SharingBannerPlugin = withLocales(Plugin)


### PR DESCRIPTION
By default, previewPath is /preview but we needed to be /preview/ into cozy-notes. That's why, we can add previewPath to SharingBanner