### PR TITLE
fix(mespapiers): Harvest banner wasn't refresh  after deco or reconnect

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/MesPapiersLibLayout.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/MesPapiersLibLayout.jsx
@@ -9,6 +9,7 @@ import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 
+import { FILES_DOCTYPE, TRIGGERS_DOCTYPE, SETTINGS_DOCTYPE } from '../doctypes'
 import { ModalStack } from './Contexts/ModalProvider'
 import { usePapersDefinitions } from './Hooks/usePapersDefinitions'
 
@@ -35,9 +36,9 @@ export const MesPapiersLibLayout = () => {
       ) : (
         <Outlet />
       )}
-      <RealTimeQueries doctype="io.cozy.files" />
-      <RealTimeQueries doctype="io.cozy.triggers" />
-      <RealTimeQueries doctype="io.cozy.mespapiers.settings" />
+      <RealTimeQueries doctype={FILES_DOCTYPE} />
+      <RealTimeQueries doctype={TRIGGERS_DOCTYPE} />
+      <RealTimeQueries doctype={SETTINGS_DOCTYPE} />
       <Alerter t={t} />
       <ModalStack />
     </>

--- a/packages/cozy-mespapiers-lib/src/components/Papers/HarvestBanner.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/HarvestBanner.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { useQuery, isQueryLoading } from 'cozy-client'
 import { LaunchTriggerCard } from 'cozy-harvest-lib'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
@@ -10,6 +10,8 @@ import {
 } from '../../helpers/queries'
 
 const HarvestBanner = ({ papers }) => {
+  const [triggerId, setTriggerId] = useState(undefined)
+  const [hasTriggerChanged, setHasTriggerChanged] = useState(false)
   const {
     createdByApp: connectorSlug,
     sourceAccountIdentifier: connectorAccountIdentifier
@@ -50,13 +52,25 @@ const HarvestBanner = ({ papers }) => {
   const isKonnectorsLoading = isQueryLoading(konnectorsQueryLeft)
   const konnector = konnectors?.[0]
 
+  useEffect(() => {
+    setTriggerId(trigger?._id)
+
+    if (trigger?._id !== triggerId) {
+      setHasTriggerChanged(true)
+    } else {
+      setHasTriggerChanged(false)
+    }
+  }, [trigger, triggerId, hasTriggerChanged])
+
   if (
     !konnector ||
+    hasTriggerChanged ||
     isAccountsLoading ||
     isTriggersLoading ||
     isKonnectorsLoading
-  )
+  ) {
     return null
+  }
 
   return (
     <>


### PR DESCRIPTION
Le problème est que lors du render de LaunchTriggerCard on utilise FlowProvider en wrapper qui instancie un connectionFlow https://github.com/cozy/cozy-libs/blob/master/packages/cozy-harvest-lib/src/components/FlowProvider.jsx#L54. S'il n'y a pas démontage/remontage de LaunchTriggerCard, il n'y a pas de nouvelle instanciation d'un nouveau connectionFlow, et FlowProvider n'est pas prévu pour gérer le cas de props changeantes (initialTrigger notamment). Donc même si le trigger change (notre cas ici) le connectionFlow reste le même avec l'ancien trigger.

Il faut donc démonter et remonter LaunchTriggerCard pour que ça fonctionne.

Pour faire avancer le sujet côté app (dont on aimerait faire une beta, ceci est le dernier sujet bloquant), je suis donc simplement passé par un state.

@doubleface @Crash-- je vous ping pour faire remonter l'info.
- Je ne sais pas si à terme ce serait intéressant que connectionFlow puisse gérer le cas d'un initialTrigger changeant ? (étant donné le nom, initialTrigger, c'est probable que la réponse soit non 🤔 )