### PR TITLE
feat: Add triggers realtime to ConnectionFlow

### DIFF
--- a/packages/cozy-harvest-lib/src/models/withConnectionFlow.spec.jsx
+++ b/packages/cozy-harvest-lib/src/models/withConnectionFlow.spec.jsx
@@ -15,6 +15,11 @@ const konnectorFixture = {
   }
 }
 
+const realtimeMock = {
+  subscribe: jest.fn(),
+  unsubscribe: jest.fn()
+}
+
 const DumbTriggerStatus = ({ flowState }) => {
   return <div>{flowState.status.toString()}</div>
 }
@@ -24,6 +29,7 @@ const TriggerStatus = withConnectionFlow()(DumbTriggerStatus)
 describe('with connection flow', () => {
   it('should update correctly', () => {
     const client = new CozyClient({})
+    client.plugins = { realtime: realtimeMock }
     const flow = new ConnectionFlow(client, null, konnectorFixture)
     const root = mount(<TriggerStatus flow={flow} />)
     expect(root.find('div').text()).toBe('IDLE')

--- a/packages/cozy-harvest-lib/src/services/biWebView.spec.js
+++ b/packages/cozy-harvest-lib/src/services/biWebView.spec.js
@@ -29,6 +29,11 @@ jest.mock('./jobUtils', () => ({
   waitForRealtimeEvent: jest.fn()
 }))
 
+const realtimeMock = {
+  subscribe: jest.fn(),
+  unsubscribe: jest.fn()
+}
+
 const TEST_BANK_COZY_ID = '100000'
 
 const konnector = {
@@ -70,6 +75,7 @@ describe('handleOAuthAccount', () => {
     const client = new CozyClient({
       uri: 'http://testcozy.mycozy.cloud'
     })
+    client.plugins = { realtime: realtimeMock }
     const flow = new ConnectionFlow(client, null, konnector)
     flow.account = account
     flow.handleFormSubmit = jest.fn()
@@ -98,6 +104,7 @@ describe('handleOAuthAccount', () => {
     const client = new CozyClient({
       uri: 'http://testcozy.mycozy.cloud'
     })
+    client.plugins = { realtime: realtimeMock }
     const flow = new ConnectionFlow(client, null, konnector)
     flow.account = account
     flow.handleFormSubmit = jest.fn()
@@ -123,6 +130,7 @@ describe('checkBIConnection', () => {
     const client = new CozyClient({
       uri: 'http://testcozy.mycozy.cloud'
     })
+    client.plugins = { realtime: realtimeMock }
     const flow = new ConnectionFlow(client, null, konnector)
     jest.spyOn(client, 'query').mockImplementation(async () => ({ data: [] }))
 
@@ -211,6 +219,7 @@ describe('refreshContracts', () => {
     const client = new CozyClient({
       uri: 'http://testcozy.mycozy.cloud'
     })
+    client.plugins = { realtime: realtimeMock }
     client.store.dispatch = jest.fn()
     client.query = jest
       .fn()

--- a/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
+++ b/packages/cozy-harvest-lib/src/services/budget-insight.spec.js
@@ -789,6 +789,7 @@ describe('handleOAuthAccount', () => {
     const client = new CozyClient({
       uri: 'http://testcozy.mycozy.cloud'
     })
+    client.plugins = { realtime: realtimeMock }
     const flow = new ConnectionFlow(client, null, konnector)
     flow.account = account
     flow.handleFormSubmit = jest.fn()
@@ -820,6 +821,7 @@ describe('setSync', () => {
     const client = new CozyClient({
       uri: 'http://testcozy.mycozy.cloud'
     })
+    client.plugins = { realtime: realtimeMock }
     const flow = new ConnectionFlow(client, null, konnector)
     flow.account = account
     flow.handleFormSubmit = jest.fn()
@@ -857,6 +859,7 @@ describe('updateBIConnectionFromFlow', () => {
     const client = new CozyClient({
       uri: 'http://testcozy.mycozy.cloud'
     })
+    client.plugins = { realtime: realtimeMock }
     const biConnId = 'conn-1337'
     const account = { data: { auth: { bi: { connId: biConnId } } } }
     const flow = new ConnectionFlow(client, null, konnector)
@@ -886,6 +889,7 @@ describe('sendTwoFACode', () => {
     const client = new CozyClient({
       uri: 'http://testcozy.mycozy.cloud'
     })
+    client.plugins = { realtime: realtimeMock }
     const biConnId = 'conn-1337'
     const account = { data: { auth: { bi: { connId: biConnId } } } }
     const flow = new ConnectionFlow(client, null, konnector)
@@ -899,6 +903,7 @@ describe('sendTwoFACode', () => {
     const client = new CozyClient({
       uri: 'http://testcozy.mycozy.cloud'
     })
+    client.plugins = { realtime: realtimeMock }
     const biConnId = 'conn-1337'
     const account = { data: { auth: { bi: { connId: biConnId } } } }
     const flow = new ConnectionFlow(client, null, konnector)

--- a/packages/cozy-harvest-lib/test/fixtures.js
+++ b/packages/cozy-harvest-lib/test/fixtures.js
@@ -123,6 +123,10 @@ const fixtures = {
       status: 'done',
       last_executed_job_id: 'old-job-id'
     },
+    message: {
+      account: 'updated-account-id',
+      konnector: 'konnectest'
+    },
     attributes: {
       arguments: '0 0 0 * * 0',
       type: '@cron',
@@ -139,6 +143,10 @@ const fixtures = {
     current_state: {
       status: 'errored',
       last_error: 'last error message'
+    },
+    message: {
+      account: 'updated-account-id',
+      konnector: 'konnectest'
     },
     attributes: {
       arguments: '0 0 0 * * 0',
@@ -158,6 +166,10 @@ const fixtures = {
       status: 'running',
       last_executed_job_id: 'running-job-id'
     },
+    message: {
+      account: 'updated-account-id',
+      konnector: 'konnectest'
+    },
     attributes: {
       arguments: '0 0 0 * * 0',
       type: '@cron',
@@ -171,6 +183,11 @@ const fixtures = {
   createdTriggerWithFolder: {
     id: 'created-trigger-id',
     _type: 'io.cozy.triggers',
+    message: {
+      account: 'updated-account-id',
+      konnector: 'konnectest',
+      folder_to_save: 'folder-id'
+    },
     attributes: {
       arguments: '0 0 0 * * 0',
       type: '@cron',


### PR DESCRIPTION
Suite à cette PR https://github.com/cozy/cozy-libs/pull/2010, nous nous sommes rendu compte que la class ConnectionFlow n'était pas branchée sur le temps réel de `io.cozy.triggers`.
De ce fait, elle ne savait pas mettre à jour sa propriété `trigger` lorsque celle-ci était supprimée ou créée.

- [x] Ajouter des nouveaux tests
- [ ] Après merge, supprimer ce fix temporaire https://github.com/cozy/cozy-libs/blob/master/packages/cozy-mespapiers-lib/src/components/Papers/HarvestBanner.jsx#L55-L63