### PR TITLE
fix: Migrate transifex from client to cli

### DIFF
--- a/packages/cozy-ci/transifex.sh
+++ b/packages/cozy-ci/transifex.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-curl -fsSL https://bootstrap.pypa.io/get-pip.py | python - --user
-pip install --user transifex-client==0.12.5
+curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
 install -m0644 .transifexrc.tpl ~/.transifexrc
 echo "password = $TX_PASSWD" >> ~/.transifexrc


### PR DESCRIPTION
Since API v3, [transifex-client](https://github.com/transifex/transifex-client) has been replaced by a [new cli](https://github.com/transifex/cli) (cc: [docs](https://developers.transifex.com/docs/cli))