### PR TITLE
fix(cozy-ci): Use token instead password into .transifexrc

### DIFF
--- a/packages/cozy-ci/README.md
+++ b/packages/cozy-ci/README.md
@@ -16,9 +16,7 @@ Requires a file named `.transifexrc.tpl` at the root of the project. The usual c
 
 ```
 [https://www.transifex.com]
-hostname = https://www.transifex.com
-username = cozy
-token =
+rest_hostname = https://rest.api.transifex.com
 ```
 
-Also requires an env var named `TX_PASSWD` which contains the password/token for the account referenced in the `.transifexrc.tpl` file.
+Also requires an env var named `TX_TOKEN` which contains the token for your transifex accound in the `.transifexrc.tpl` file.

--- a/packages/cozy-ci/transifex.sh
+++ b/packages/cozy-ci/transifex.sh
@@ -2,4 +2,4 @@
 
 curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
 install -m0644 .transifexrc.tpl ~/.transifexrc
-echo "password = $TX_PASSWD" >> ~/.transifexrc
+echo "token = $TX_TOKEN" >> ~/.transifexrc


### PR DESCRIPTION
You can find more infos on .transifexrc and their config in [transifex cli code](https://github.com/transifex/cli/blob/devel/examples/exampleconf/.transifexrc)