### PR TITLE
feat(cozy-tsconfig): Add `dist` as default outDir/declarationDir

### DIFF
--- a/packages/cozy-tsconfig/readme.md
+++ b/packages/cozy-tsconfig/readme.md
@@ -60,6 +60,8 @@ If you want to use TypeScript in your CI/CD pipeline (for instance if you just r
 
 To emit declaration files, create a **new** file in the root of your project, for instance `tsconfig-build.json`.<br/>
 
+By default, this configuration will emit declaration files in the `dist` directory, but you can overwrite it by providing a `declarationDir` option in the `compilerOptions` field.<br/>
+
 This file will be used to emit declarations, it will extend the base config but only include the files you want to actually emit declarations for.<br/>
 
 Here is a basic example of what you can do:
@@ -80,7 +82,10 @@ Here is a basic example of what you can do:
     "**/*.test.ts",
     "**/*.test.tsx",
     "tests"
-  ]
+  ],
+  "compilerOptions": {
+    "declarationDir": "build" // If your lib directory is not named `dist`, you can overwrite it here
+  }
 }
 ```
 

--- a/packages/cozy-tsconfig/tsconfig.json
+++ b/packages/cozy-tsconfig/tsconfig.json
@@ -12,7 +12,7 @@
     "allowJs": true, // Disable if you don't have any .js files or if you have too many errors
     "allowSyntheticDefaultImports": true,
     "declaration": true,
-    // "declarationDir": "./dist", - Paths related properties don't work when extending from a package
+    "declarationDir": "dist", // Included by default but won't emit anything as long as `tsc` is not run, can be overwritten
     "emitDeclarationOnly": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
@@ -26,6 +26,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
+    "outDir": "dist", // Best to include it by default to avoid errors like "Cannot write file 'src/foobar.d.ts' because it would overwrite input file."
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true, // Disable if you have too many errors


### PR DESCRIPTION
This is important to avoid annoying error messages when consuming
the config (like TS complaining about overwriting d.ts files).
It will not compile anything though. It just helps you write less
in the tsconfig.json especially if your build dir is named `dist`.
You still can overwrite what you want.