### PR TITLE
MesPapiers: Refactor HarvestBanner and add Emptys component

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import UiEmpty from 'cozy-ui/transpiled/react/Empty'
+
+import HomeCloud from '../../../assets/icons/HomeCloud.svg'
+import EmptyWithConnector from './EmptyWithConnector'
+
+const Empty = ({ connector, accounts }) => {
+  const { t } = useI18n()
+
+  if (!connector) {
+    return (
+      <UiEmpty
+        className="u-ph-1"
+        icon={HomeCloud}
+        iconSize="large"
+        title={t('Home.Empty.title')}
+        text={t('Home.Empty.text')}
+      />
+    )
+  }
+
+  return <EmptyWithConnector connector={connector} accounts={accounts} />
+}
+
+Empty.propTypes = {
+  connector: PropTypes.object,
+  accounts: PropTypes.array
+}
+
+export default Empty

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.spec.js
@@ -1,0 +1,85 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import flag from 'cozy-flags'
+
+import AppLike from '../../../../test/components/AppLike'
+import Empty from './Empty'
+
+jest.mock('cozy-flags')
+jest.mock('../HarvestBanner', () => () => <div data-testid="HarvestBanner" />)
+
+const setup = ({ connector, accounts } = {}) => {
+  return render(
+    <AppLike>
+      <Empty connector={connector} accounts={accounts} />
+    </AppLike>
+  )
+}
+
+describe('MesPapiersLibProviders', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should display basic text without harvest banner', () => {
+    const { queryByTestId, getByText } = setup({
+      connector: undefined,
+      accounts: undefined
+    })
+
+    expect(queryByTestId('HarvestBanner')).toBeFalsy()
+    expect(getByText('Add your personal documents'))
+  })
+
+  it('should display specific text', () => {
+    const { queryByTestId, getByText } = setup({
+      connector: {},
+      accounts: [{}]
+    })
+
+    expect(queryByTestId('HarvestBanner')).toBeFalsy()
+    expect(getByText('Add manually'))
+  })
+
+  it('should display specific text and harvest banner', () => {
+    flag.mockReturnValue(true)
+
+    const { queryByTestId, getByText } = setup({
+      connector: {},
+      accounts: [{}]
+    })
+
+    expect(queryByTestId('HarvestBanner')).toBeTruthy()
+    expect(getByText('Add manually'))
+  })
+
+  it('should display logins', () => {
+    const { queryByTestId, getByText } = setup({
+      connector: {},
+      accounts: [
+        { auth: { login: 'myLogin' } },
+        { auth: { login: 'myOtherLogin' } }
+      ]
+    })
+
+    expect(queryByTestId('HarvestBanner')).toBeFalsy()
+    expect(getByText('myLogin'))
+    expect(getByText('myOtherLogin'))
+  })
+
+  it('should display logins and harvest banner', () => {
+    flag.mockReturnValue(true)
+
+    const { queryAllByTestId, getByText } = setup({
+      connector: {},
+      accounts: [
+        { auth: { login: 'myLogin' } },
+        { auth: { login: 'myOtherLogin' } }
+      ]
+    })
+
+    expect(queryAllByTestId('HarvestBanner')).toBeTruthy()
+    expect(getByText('myLogin'))
+    expect(getByText('myOtherLogin'))
+  })
+})

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyNoHeader.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyNoHeader.jsx
@@ -9,23 +9,12 @@ import Empty from 'cozy-ui/transpiled/react/Empty'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import PapersIcon from 'cozy-ui/transpiled/react/Icons/Papers'
 
-import { findPlaceholderByLabelAndCountry } from '../../../helpers/findPlaceholders'
 import { useMultiSelection } from '../../Hooks/useMultiSelection'
 import { usePapersDefinitions } from '../../Hooks/usePapersDefinitions'
+import { makeCountrySearchParam } from './helpers'
 import { getCurrentFileTheme } from '../helpers'
 import HarvestBanner from '../HarvestBanner'
 import styles from './styles.styl'
-
-const makeCountrySearchParam = ({ papersDefinitions, params, search }) => {
-  const country = new URLSearchParams(search).get('country')
-  const paperDefinition = findPlaceholderByLabelAndCountry(
-    papersDefinitions,
-    params.fileTheme,
-    country
-  )[0]
-
-  return paperDefinition.country ? `country=${paperDefinition.country}` : ''
-}
 
 const EmptyNoHeader = ({ connector, accounts }) => {
   const { t } = useI18n()

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyNoHeader.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyNoHeader.jsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { useNavigate, useParams, useLocation } from 'react-router-dom'
+
+import flag from 'cozy-flags'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+import Empty from 'cozy-ui/transpiled/react/Empty'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import PapersIcon from 'cozy-ui/transpiled/react/Icons/Papers'
+
+import { findPlaceholderByLabelAndCountry } from '../../../helpers/findPlaceholders'
+import { useMultiSelection } from '../../Hooks/useMultiSelection'
+import { usePapersDefinitions } from '../../Hooks/usePapersDefinitions'
+import { getCurrentFileTheme } from '../helpers'
+import HarvestBanner from '../HarvestBanner'
+import styles from './styles.styl'
+
+const makeCountrySearchParam = ({ papersDefinitions, params, search }) => {
+  const country = new URLSearchParams(search).get('country')
+  const paperDefinition = findPlaceholderByLabelAndCountry(
+    papersDefinitions,
+    params.fileTheme,
+    country
+  )[0]
+
+  return paperDefinition.country ? `country=${paperDefinition.country}` : ''
+}
+
+const EmptyNoHeader = ({ connector, accounts }) => {
+  const { t } = useI18n()
+  const params = useParams()
+  const { search, pathname } = useLocation()
+  const navigate = useNavigate()
+  const { selectedThemeLabel } = useMultiSelection()
+  const { papersDefinitions } = usePapersDefinitions()
+
+  const currentFileTheme = getCurrentFileTheme(params, selectedThemeLabel)
+  const countrySearchParam = makeCountrySearchParam({
+    papersDefinitions,
+    params,
+    search
+  })
+
+  const handleClick = () => {
+    navigate({
+      pathname: `${pathname}/create/${currentFileTheme}`,
+      search: `${countrySearchParam}`
+    })
+  }
+
+  return (
+    <>
+      {flag('harvest.inappconnectors.enabled') && (
+        <HarvestBanner connector={connector} account={accounts?.[0]} />
+      )}
+      <Empty
+        className={`${styles['emptyWithConnector']} u-ph-1`}
+        icon={PapersIcon}
+        iconSize="normal"
+        title={t('Empty.connector.title')}
+        text={t('Empty.connector.text', {
+          connectorSlug: connector?.slug?.toUpperCase()
+        })}
+      >
+        <Button label={t('Empty.connector.button')} onClick={handleClick} />
+      </Empty>
+    </>
+  )
+}
+
+EmptyNoHeader.propTypes = {
+  connector: PropTypes.object,
+  accounts: PropTypes.array
+}
+
+export default EmptyNoHeader

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithConnector.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithConnector.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import EmptyWithHeader from './EmptyWithHeader'
+import EmptyNoHeader from './EmptyNoHeader'
+
+const EmptyWithConnector = ({ connector, accounts }) => {
+  if (accounts?.length > 1) {
+    return accounts.map((account, index) => (
+      <EmptyWithHeader key={index} connector={connector} account={account} />
+    ))
+  }
+
+  return <EmptyNoHeader connector={connector} accounts={accounts} />
+}
+
+EmptyWithConnector.propTypes = {
+  connector: PropTypes.object,
+  accounts: PropTypes.array
+}
+
+export default EmptyWithConnector

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithHeader.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithHeader.jsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import flag from 'cozy-flags'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
+import ListSubheader from 'cozy-ui/transpiled/react/MuiCozyTheme/ListSubheader'
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+
+import HarvestBanner from '../HarvestBanner'
+
+const EmptyWithHeader = ({ connector, account }) => {
+  const { t } = useI18n()
+
+  return (
+    <List
+      subheader={
+        <ListSubheader>
+          <div className="u-ellipsis">{account.auth.login}</div>
+        </ListSubheader>
+      }
+    >
+      {flag('harvest.inappconnectors.enabled') && (
+        <HarvestBanner connector={connector} account={account} />
+      )}
+      <ListItem>
+        <ListItemText
+          ellipsis={false}
+          primary={t('Empty.connector.title')}
+          secondary={t('Empty.connector.text', {
+            connectorSlug: connector?.slug?.toUpperCase()
+          })}
+        />
+      </ListItem>
+    </List>
+  )
+}
+
+EmptyWithHeader.propTypes = {
+  connector: PropTypes.object,
+  account: PropTypes.object.isRequired
+}
+
+export default EmptyWithHeader

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/helpers.js
@@ -1,0 +1,17 @@
+import { findPlaceholderByLabelAndCountry } from '../../../helpers/findPlaceholders'
+
+export const makeCountrySearchParam = ({
+  papersDefinitions,
+  params,
+  search
+}) => {
+  const country = new URLSearchParams(search).get('country')
+  const placeholders = findPlaceholderByLabelAndCountry(
+    papersDefinitions,
+    params.fileTheme,
+    country
+  )
+  const placeholder = placeholders?.[0]
+
+  return placeholder?.country ? `country=${placeholder.country}` : ''
+}

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/helpers.spec.js
@@ -1,0 +1,26 @@
+import { makeCountrySearchParam } from './helpers'
+
+// no need to test all cases here
+// already tested on findPlaceholderByLabelAndCountry function
+
+describe('makeCountrySearchParam', () => {
+  it('should return empty string if no match between paperDefinitions and params', () => {
+    const res = makeCountrySearchParam({
+      papersDefinitions: [{ label: 'caf' }],
+      params: { fileTheme: 'isp_invoice' },
+      search: ''
+    })
+
+    expect(res).toBe('')
+  })
+
+  it('should return empty string if no match between paperDefinitions and params even with a search param', () => {
+    const res = makeCountrySearchParam({
+      papersDefinitions: [{ label: 'caf' }],
+      params: { fileTheme: 'isp_invoice' },
+      search: '?country=fr'
+    })
+
+    expect(res).toBe('')
+  })
+})

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/styles.styl
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/styles.styl
@@ -1,0 +1,11 @@
+.emptyWithConnector
+  position fixed
+  top 50%
+  transform translateY(-50%)
+
+  svg
+    path
+      &:first-of-type
+        fill #F8D3F0
+      &:last-of-type
+        fill #E049BF

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PapersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PapersList.jsx
@@ -18,7 +18,7 @@ import { makeActionVariant, makeActions } from '../Actions/utils'
 import { useMultiSelection } from '../Hooks/useMultiSelection'
 import HarvestBanner from './HarvestBanner'
 
-const PapersList = ({ papers, isLast }) => {
+const PapersList = ({ papers, connector, accounts, isLast }) => {
   const client = useClient()
   const { t } = useI18n()
   const { pushModal, popModal } = useModal()
@@ -52,6 +52,10 @@ const PapersList = ({ papers, isLast }) => {
       ),
     [actionVariant, client, addMultiSelectionFile, popModal, pushModal]
   )
+  const accountLogin = papers?.list?.[0]?.cozyMetadata?.sourceAccountIdentifier
+  const account = accounts?.find(
+    account => account?.auth?.login === accountLogin
+  )
 
   const handleClick = () => {
     setMaxDisplay(papers.list.length)
@@ -60,7 +64,7 @@ const PapersList = ({ papers, isLast }) => {
   return (
     <>
       {flag('harvest.inappconnectors.enabled') && (
-        <HarvestBanner papers={papers} />
+        <HarvestBanner connector={connector} account={account} />
       )}
       {papers.list.map(
         (paper, idx) =>
@@ -98,6 +102,8 @@ PapersList.propTypes = {
     maxDisplay: PropTypes.number,
     list: PropTypes.arrayOf(PropTypes.object)
   }),
+  connector: PropTypes.object,
+  accounts: PropTypes.array,
   isLast: PropTypes.bool
 }
 

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PapersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PapersList.jsx
@@ -17,6 +17,7 @@ import { viewInDrive } from '../Actions/Items/viewInDrive'
 import { makeActionVariant, makeActions } from '../Actions/utils'
 import { useMultiSelection } from '../Hooks/useMultiSelection'
 import HarvestBanner from './HarvestBanner'
+import { makeAccountFromPapers } from './helpers'
 
 const PapersList = ({ papers, connector, accounts, isLast }) => {
   const client = useClient()
@@ -26,6 +27,7 @@ const PapersList = ({ papers, connector, accounts, isLast }) => {
   const { addMultiSelectionFile } = useMultiSelection()
   const [paperBeingRenamedId, setPaperBeingRenamedId] = useState(null)
 
+  const account = makeAccountFromPapers(papers, accounts)
   const actionVariant = makeActionVariant()
   const actions = useMemo(
     () =>
@@ -51,10 +53,6 @@ const PapersList = ({ papers, connector, accounts, isLast }) => {
         }
       ),
     [actionVariant, client, addMultiSelectionFile, popModal, pushModal]
-  )
-  const accountLogin = papers?.list?.[0]?.cozyMetadata?.sourceAccountIdentifier
-  const account = accounts?.find(
-    account => account?.auth?.login === accountLogin
   )
 
   const handleClick = () => {

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PapersListByContact.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PapersListByContact.jsx
@@ -11,7 +11,13 @@ import { usePapersDefinitions } from '../Hooks/usePapersDefinitions'
 import { buildFilesByContacts, getCurrentFileTheme } from '../Papers/helpers'
 import PapersList from '../Papers/PapersList'
 
-const PapersListByContact = ({ selectedThemeLabel, files, contacts }) => {
+const PapersListByContact = ({
+  selectedThemeLabel,
+  files,
+  connector,
+  accounts,
+  contacts
+}) => {
   const params = useParams()
   const { t } = useI18n()
   const { papersDefinitions } = usePapersDefinitions()
@@ -46,7 +52,12 @@ const PapersListByContact = ({ selectedThemeLabel, files, contacts }) => {
         )
       }
     >
-      <PapersList papers={papers} isLast={files.length === 1} />
+      <PapersList
+        papers={papers}
+        connector={connector}
+        accounts={accounts}
+        isLast={files.length === 1}
+      />
     </List>
   ))
 }
@@ -54,6 +65,8 @@ const PapersListByContact = ({ selectedThemeLabel, files, contacts }) => {
 PapersListByContact.propTypes = {
   selectedThemeLabel: PropTypes.string,
   files: PropTypes.arrayOf(PropTypes.object),
+  connector: PropTypes.object,
+  accounts: PropTypes.array,
   contacts: PropTypes.arrayOf(PropTypes.object)
 }
 

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PapersListByContact.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PapersListByContact.spec.jsx
@@ -8,6 +8,7 @@ import PapersListByContact from './PapersListByContact'
 import { buildFilesByContacts } from '../Papers/helpers'
 
 jest.mock('../Papers/helpers', () => ({
+  ...jest.requireActual('../Papers/helpers'),
   getCurrentFileTheme: jest.fn(),
   buildFilesByContacts: jest.fn()
 }))

--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
@@ -210,3 +210,12 @@ export const buildFilesWithContacts = ({ files, contacts, t }) => {
 
 export const getCurrentFileTheme = (params, selectedThemeLabel) =>
   params?.fileTheme ?? selectedThemeLabel
+
+export const makeAccountFromPapers = (papers, accounts) => {
+  const accountLogin = papers?.list?.[0]?.cozyMetadata?.sourceAccountIdentifier
+  const account = accountLogin
+    ? accounts?.find(account => account?.auth?.login === accountLogin)
+    : undefined
+
+  return account
+}

--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
@@ -16,7 +16,9 @@ const isFromConnector = file => Boolean(file.cozyMetadata?.sourceAccount)
  * @param {IOCozyFile[]} files - Array of IOCozyFile
  * @returns {string[]} - Array of contact ids
  */
-export const getContactsRefIdsByFiles = (files = []) => {
+export function getContactsRefIdsByFiles(files) {
+  if (!files) return []
+
   return [
     ...new Set(
       files.flatMap(file => {

--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.spec.js
@@ -4,7 +4,8 @@ import {
   buildFilesByContacts,
   getContactsRefIdsByFiles,
   buildFilesWithContacts,
-  getCurrentFileTheme
+  getCurrentFileTheme,
+  makeAccountFromPapers
 } from './helpers'
 
 const mockContacts00 = [
@@ -448,5 +449,64 @@ describe('getCurrentFileTheme', () => {
     const res = getCurrentFileTheme(null, null)
 
     expect(res).toBe(null)
+  })
+})
+
+describe('makeAccountFromPapers', () => {
+  it('should be undefined if no argument', () => {
+    const res = makeAccountFromPapers()
+
+    expect(res).toBe(undefined)
+  })
+
+  it('should be undefined if no papers', () => {
+    const res = makeAccountFromPapers(undefined, [
+      { auth: { login: 'myLogin' } }
+    ])
+
+    expect(res).toBe(undefined)
+  })
+
+  it('should be undefined if papers with no list', () => {
+    const res = makeAccountFromPapers({ list: undefined }, [
+      { auth: { login: 'myLogin' } }
+    ])
+
+    expect(res).toBe(undefined)
+  })
+
+  it('should be undefined if papers with empty list', () => {
+    const res = makeAccountFromPapers({ list: [] }, [
+      { auth: { login: 'myLogin' } }
+    ])
+
+    expect(res).toBe(undefined)
+  })
+
+  it('should be undefined if no accounts', () => {
+    const res = makeAccountFromPapers(
+      { list: [{ cozyMetadata: { sourceAccountIdentifier: 'myLogin' } }] },
+      undefined
+    )
+
+    expect(res).toBe(undefined)
+  })
+
+  it('should be undefined if no match', () => {
+    const res = makeAccountFromPapers(
+      { list: [{ cozyMetadata: { sourceAccountIdentifier: 'myLogin' } }] },
+      [{ auth: { login: 'myOtherLogin' } }]
+    )
+
+    expect(res).toBe(undefined)
+  })
+
+  it('should return the account', () => {
+    const res = makeAccountFromPapers(
+      { list: [{ cozyMetadata: { sourceAccountIdentifier: 'myLogin' } }] },
+      [{ auth: { login: 'myLogin' } }]
+    )
+
+    expect(res).toStrictEqual({ auth: { login: 'myLogin' } })
   })
 })

--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.spec.js
@@ -130,8 +130,14 @@ describe('helpers Papers', () => {
       expect(res).toStrictEqual(['contactId01', 'contactId02'])
     })
 
-    it('should return empty array if has no param', () => {
+    it('should return empty array if param is undefined', () => {
       const res = getContactsRefIdsByFiles()
+
+      expect(res).toStrictEqual([])
+    })
+
+    it('should return empty array if param is null', () => {
+      const res = getContactsRefIdsByFiles(null)
 
       expect(res).toStrictEqual([])
     })

--- a/packages/cozy-mespapiers-lib/src/components/Views/PapersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/PapersList.jsx
@@ -16,6 +16,7 @@ import {
 } from '../Papers/helpers'
 import PapersListToolbar from '../Papers/PapersListToolbar'
 import PapersListByContact from '../Papers/PapersListByContact'
+import Empty from '../Papers/Empty/Empty'
 import { useMultiSelection } from '../Hooks/useMultiSelection'
 
 const PapersList = () => {
@@ -30,8 +31,9 @@ const PapersList = () => {
   )
   const isLoadingFiles =
     isQueryLoading(fileQueryResult) || fileQueryResult.hasMore
+  const hasFiles = files?.length > 0
 
-  const contactIds = !isLoadingFiles ? getContactsRefIdsByFiles(files) : []
+  const contactIds = getContactsRefIdsByFiles(files)
   const contactsQueryByIds = buildContactsQueryByIds(contactIds)
   const { data: contacts, ...contactQueryResult } = useQueryAll(
     contactsQueryByIds.definition,
@@ -70,28 +72,29 @@ const PapersList = () => {
     isConnectorsLoading ||
     isAccountsLoading
 
-  if (isLoading) {
-    return (
-      <>
-        <PapersListToolbar selectedThemeLabel={selectedThemeLabel} />
+  return (
+    <>
+      <PapersListToolbar selectedThemeLabel={selectedThemeLabel} />
+      {isLoading && (
         <Spinner
           className="u-flex u-flex-justify-center u-mt-2 u-h-5"
           size="xxlarge"
         />
-      </>
-    )
-  }
-
-  return (
-    <>
-      <PapersListToolbar selectedThemeLabel={selectedThemeLabel} />
-      <PapersListByContact
-        selectedThemeLabel={selectedThemeLabel}
-        files={files}
-        contacts={contacts}
-        connector={connector}
-        accounts={accounts}
-      />
+      )}
+      {!isLoading && (
+        <>
+          {hasFiles && (
+            <PapersListByContact
+              selectedThemeLabel={selectedThemeLabel}
+              files={files}
+              contacts={contacts}
+              connector={connector}
+              accounts={accounts}
+            />
+          )}
+          {!hasFiles && <Empty connector={connector} accounts={accounts} />}
+        </>
+      )}
     </>
   )
 }

--- a/packages/cozy-mespapiers-lib/src/helpers/queries.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/queries.js
@@ -112,20 +112,24 @@ export const buildConnectorsQueryById = (id, enabled = true) => ({
   }
 })
 
-// There is a limit to this approach of retrieving an account based on the `auth.login` field.
-// This does not cover all cases. Indeed, sometimes we have to refer to the `identifier` key first
-// to know which attribute to retrieve from `auth`. Sometimes this identifier is itself an attribute of `auth`.
-// There is a known concern of lack of homogeneity with connectors, we use here a simple approach which
-// covers most cases. Reference documentation: https://github.com/cozy/cozy-doctypes/blob/master/docs/io.cozy.accounts.md
-export const buildAccountsQueryByLoginAndSlug = ({ login, slug, enabled }) => ({
+export const buildConnectorsQueryByQualificationLabel = label => ({
+  definition: Q(KONNECTORS_DOCTYPE)
+    .where({ qualification_labels: { $in: [label] } })
+    .indexFields(['qualification_labels']),
+  options: {
+    as: `${KONNECTORS_DOCTYPE}/qualificationLabel/${label}`,
+    fetchPolicy: defaultFetchPolicy
+  }
+})
+
+export const buildAccountsQueryBySlug = (slug, enabled = true) => ({
   definition: Q(ACCOUNTS_DOCTYPE)
     .where({
-      'auth.login': login,
       account_type: slug
     })
-    .indexFields(['auth.login', 'account_type']),
+    .indexFields(['account_type']),
   options: {
-    as: `${ACCOUNTS_DOCTYPE}/login/${login}/slug/${slug}`,
+    as: `${ACCOUNTS_DOCTYPE}/slug/${slug}`,
     fetchPolicy: defaultFetchPolicy,
     enabled
   }

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -366,5 +366,12 @@
       "extraContent": "In case of problem, you can always add your documents manually by taking a photo of them or by selecting them from your Cozy or your mobile.",
       "button": "Add manually"
     }
+  },
+  "Empty": {
+    "connector": {
+      "title": "No paper",
+      "text": "%{connectorSlug} has not yet published the paper on its site. It will be retrieved here automatically once published by %{connectorSlug}.",
+      "button": "Add manually"
+    }
   }
 }

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -366,5 +366,12 @@
       "extraContent": "En cas de problème, il vous est toujours possible d’ajouter manuellement vos documents en les prenant en photo ou en les sélectionnant depuis votre Cozy ou votre mobile.",
       "button": "Ajouter manuellement"
     }
+  },
+  "Empty": {
+    "connector": {
+      "title": "Aucun papier",
+      "text": "%{connectorSlug} n’a pas encore publié le papier sur son site. Il sera récupéré ici automatiquement une fois publié par %{connectorSlug}.",
+      "button": "Ajouter manuellement"
+    }
   }
 }


### PR DESCRIPTION
On souhaite afficher du contenu spécifique pour les différents cas "empty" à savoir quand il n'y a pas de contenu. Quelques exemples : 

Pas de document, et pas de connecteur associé
![image](https://user-images.githubusercontent.com/67680939/220854777-7590e0d0-e231-4861-8df1-e234f91257ee.png)

Pas de doc, mais un connecteur avec un seul compte
![image](https://user-images.githubusercontent.com/67680939/220854848-b2544a25-09a4-45cd-bf82-f8723369b0a9.png)

Pas de doc, un connecteur, plusieurs comptes
![image](https://user-images.githubusercontent.com/67680939/220854931-7599822a-1631-46c4-bd1f-d5255e5e4937.png)
