### PR TITLE
feat: Send account and trigger to the launcher

### DIFF
--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -617,6 +617,15 @@ export class ConnectionFlow {
    */
   async launch({ autoSuccessTimer = true } = {}) {
     const konnectorPolicy = findKonnectorPolicy(this.konnector)
+
+    const computedAutoSuccessTimer = autoSuccessTimer
+
+    logger.info('ConnectionFlow: Launching job...')
+    this.setState({ status: PENDING })
+
+    if (this.trigger) {
+      this.account = await prepareTriggerAccount(this.client, this.trigger)
+    }
     if (konnectorPolicy.onLaunch) {
       konnectorPolicy.onLaunch({
         konnector: this.konnector,
@@ -627,13 +636,6 @@ export class ConnectionFlow {
     if (!konnectorPolicy.needsTriggerLaunch) {
       return
     }
-
-    const computedAutoSuccessTimer = autoSuccessTimer
-
-    logger.info('ConnectionFlow: Launching job...')
-    this.setState({ status: PENDING })
-
-    this.account = await prepareTriggerAccount(this.client, this.trigger)
     this.realtime.subscribe(
       'updated',
       ACCOUNTS_DOCTYPE,

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.spec.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.spec.js
@@ -356,7 +356,7 @@ describe('ConnectionFlow', () => {
         fixtures.clientKonnector
       )
       window.cozy = {
-        ClientConnectorLauncher: 'react-native'
+        ClientKonnectorLauncher: 'react-native'
       }
       window.ReactNativeWebView = {
         postMessage: jest.fn()
@@ -368,6 +368,7 @@ describe('ConnectionFlow', () => {
           message: 'startLauncher',
           value: {
             connector: fixtures.clientKonnector,
+            konnector: fixtures.clientKonnector,
             account: fixtures.existingAccount,
             trigger: fixtures.existingTrigger
           }
@@ -546,7 +547,7 @@ describe('ConnectionFlow', () => {
         fixtures.clientKonnector
       )
       window.cozy = {
-        ClientConnectorLauncher: 'react-native'
+        ClientKonnectorLauncher: 'react-native'
       }
       window.ReactNativeWebView = {
         postMessage: jest.fn()
@@ -557,7 +558,8 @@ describe('ConnectionFlow', () => {
         JSON.stringify({
           message: 'startLauncher',
           value: {
-            connector: fixtures.clientKonnector
+            connector: fixtures.clientKonnector,
+            konnector: fixtures.clientKonnector
           }
         })
       )

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.spec.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.spec.js
@@ -340,6 +340,46 @@ describe('ConnectionFlow', () => {
     })
   })
 
+  describe('launch', () => {
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should call the launcher when needed with existing account and trigger', async () => {
+      prepareTriggerAccount.mockImplementation(
+        async () => fixtures.existingAccount
+      )
+      const { client } = setup()
+      const flow = new ConnectionFlow(
+        client,
+        fixtures.existingTrigger,
+        fixtures.clientKonnector
+      )
+      window.cozy = {
+        ClientConnectorLauncher: 'react-native'
+      }
+      window.ReactNativeWebView = {
+        postMessage: jest.fn()
+      }
+
+      await flow.launch()
+      expect(window.ReactNativeWebView.postMessage).toHaveBeenCalledWith(
+        JSON.stringify({
+          message: 'startLauncher',
+          value: {
+            connector: fixtures.clientKonnector,
+            account: fixtures.existingAccount,
+            trigger: fixtures.existingTrigger
+          }
+        })
+      )
+      expect(launchTrigger).not.toHaveBeenCalled()
+
+      delete window.cozy
+      delete window.ReactNativeWebView
+    })
+  })
+
   describe('handleFormSubmit', () => {
     const isSubmitting = flow => {
       return flow.getState().running === true

--- a/packages/cozy-harvest-lib/src/policies/clisk.js
+++ b/packages/cozy-harvest-lib/src/policies/clisk.js
@@ -6,7 +6,7 @@
 import logger from '../logger'
 
 /**
- * Check if the given konnector is a client side connector
+ * Check if the given konnector is a client side konnector
  * @param {import('cozy-client/types/types').KonnectorsDoctype} konnector - konnector object
  * @returns {Boolean}
  */
@@ -19,7 +19,9 @@ const isCCC = konnector => Boolean(konnector.clientSide)
  */
 export const getLauncher = () =>
   // @ts-ignore
-  window?.cozy?.ClientConnectorLauncher || null
+  window?.cozy?.ClientConnectorLauncher ||
+  window?.cozy?.ClientKonnectorLauncher ||
+  null
 
 function isRunnable() {
   return Boolean(getLauncher())
@@ -44,7 +46,8 @@ function onLaunch({ konnector, account, trigger }) {
       JSON.stringify({
         message: 'startLauncher',
         value: {
-          connector: konnector,
+          connector: konnector, // deprecated
+          konnector,
           account,
           trigger
         }

--- a/packages/cozy-harvest-lib/src/policies/clisk.js
+++ b/packages/cozy-harvest-lib/src/policies/clisk.js
@@ -31,7 +31,7 @@ function isRunnable() {
  * @param {Object} options - options object
  * @param {import('cozy-client/types/types').KonnectorsDoctype} options.konnector - konnector object
  */
-function onLaunch({ konnector }) {
+function onLaunch({ konnector, account, trigger }) {
   const launcher = getLauncher()
   if (launcher) {
     logger.debug('Found a launcher', launcher)
@@ -44,7 +44,9 @@ function onLaunch({ konnector }) {
       JSON.stringify({
         message: 'startLauncher',
         value: {
-          connector: konnector
+          connector: konnector,
+          account,
+          trigger
         }
       })
     )

--- a/packages/cozy-harvest-lib/src/policies/clisk.spec.js
+++ b/packages/cozy-harvest-lib/src/policies/clisk.spec.js
@@ -3,7 +3,7 @@ import { getLauncher, konnectorPolicy } from './clisk'
 describe('getLauncher', () => {
   it('should get the current Launcher from the given window object', () => {
     const cozy = {
-      ClientConnectorLauncher: 'test-react-native'
+      ClientKonnectorLauncher: 'test-react-native'
     }
     window.cozy = cozy
     expect(getLauncher()).toEqual('test-react-native')
@@ -16,7 +16,7 @@ describe('getLauncher', () => {
 
 describe('isRunnable', () => {
   const cozy = {
-    ClientConnectorLauncher: 'test-react-native'
+    ClientKonnectorLauncher: 'test-react-native'
   }
   it('should return true if a launcher is available', () => {
     window.cozy = cozy
@@ -30,7 +30,7 @@ describe('isRunnable', () => {
 
 describe('onLaunch', () => {
   const cozy = {
-    ClientConnectorLauncher: 'react-native'
+    ClientKonnectorLauncher: 'react-native'
   }
   beforeEach(() => {
     window.cozy = cozy
@@ -52,7 +52,8 @@ describe('onLaunch', () => {
       JSON.stringify({
         message: 'startLauncher',
         value: {
-          connector: { slug: 'testkonnectorslug' }
+          connector: { slug: 'testkonnectorslug' },
+          konnector: { slug: 'testkonnectorslug' }
         }
       })
     )
@@ -71,6 +72,7 @@ describe('onLaunch', () => {
         message: 'startLauncher',
         value: {
           connector: { slug: 'testkonnectorslug' },
+          konnector: { slug: 'testkonnectorslug' },
           account: { _id: 'testaccountid' },
           trigger: { _id: 'testtriggerid' }
         }

--- a/packages/cozy-harvest-lib/src/policies/clisk.spec.js
+++ b/packages/cozy-harvest-lib/src/policies/clisk.spec.js
@@ -27,3 +27,54 @@ describe('isRunnable', () => {
     expect(konnectorPolicy.isRunnable()).toBe(false)
   })
 })
+
+describe('onLaunch', () => {
+  const cozy = {
+    ClientConnectorLauncher: 'react-native'
+  }
+  beforeEach(() => {
+    window.cozy = cozy
+    window.ReactNativeWebView = {
+      postMessage: jest.fn()
+    }
+  })
+  afterEach(() => {
+    delete window.cozy
+    jest.clearAllMocks()
+    delete window.ReactNativeWebView
+  })
+
+  it('should send konnector when launcher is react-native', () => {
+    konnectorPolicy.onLaunch({
+      konnector: { slug: 'testkonnectorslug' }
+    })
+    expect(window.ReactNativeWebView.postMessage).toHaveBeenCalledWith(
+      JSON.stringify({
+        message: 'startLauncher',
+        value: {
+          connector: { slug: 'testkonnectorslug' }
+        }
+      })
+    )
+  })
+
+  it('should also send account and trigger when available when launcher is react-native', () => {
+    konnectorPolicy.onLaunch({
+      konnector: {
+        slug: 'testkonnectorslug'
+      },
+      account: { _id: 'testaccountid' },
+      trigger: { _id: 'testtriggerid' }
+    })
+    expect(window.ReactNativeWebView.postMessage).toHaveBeenCalledWith(
+      JSON.stringify({
+        message: 'startLauncher',
+        value: {
+          connector: { slug: 'testkonnectorslug' },
+          account: { _id: 'testaccountid' },
+          trigger: { _id: 'testtriggerid' }
+        }
+      })
+    )
+  })
+})


### PR DESCRIPTION
When launching an existing trigger

Or else the launcher will recreate a new account and trigger each time
