### PR TITLE
Empty content for installed connectors

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Home/Content.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/Content.jsx
@@ -9,7 +9,13 @@ import HomeCloud from '../../assets/icons/HomeCloud.svg'
 import ResultForSearch from './ResultForSearch'
 import PaperGroup from '../Papers/PaperGroup'
 
-const Content = ({ contacts, papers, selectedTheme, searchValue }) => {
+const Content = ({
+  contacts,
+  papers,
+  konnectors,
+  selectedTheme,
+  searchValue
+}) => {
   const { t } = useI18n()
 
   const papersByCategories = useMemo(
@@ -40,12 +46,18 @@ const Content = ({ contacts, papers, selectedTheme, searchValue }) => {
       />
     )
 
-  return <PaperGroup papersByCategories={papersByCategories} />
+  return (
+    <PaperGroup
+      papersByCategories={papersByCategories}
+      konnectors={konnectors}
+    />
+  )
 }
 
 Content.propTypes = {
   contacts: PropTypes.array,
   papers: PropTypes.array,
+  konnectors: PropTypes.array,
   selectedTheme: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   searchValue: PropTypes.string
 }

--- a/packages/cozy-mespapiers-lib/src/components/Home/HomeLayout.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/HomeLayout.jsx
@@ -12,7 +12,7 @@ import HomeToolbar from './HomeToolbar'
 import SearchHeader from './SearchHeader'
 import Content from './Content'
 
-const HomeLayout = ({ contacts, papers }) => {
+const HomeLayout = ({ contacts, papers, konnectors }) => {
   const [selectedTheme, setSelectedTheme] = useState('')
   const [searchValue, setSearchValue] = useState('')
   const { isMultiSelectionActive } = useMultiSelection()
@@ -47,6 +47,7 @@ const HomeLayout = ({ contacts, papers }) => {
       <Content
         contacts={contacts}
         papers={papers}
+        konnectors={konnectors}
         selectedTheme={selectedTheme}
         searchValue={searchValue}
       />
@@ -59,7 +60,8 @@ const HomeLayout = ({ contacts, papers }) => {
 
 HomeLayout.propTypes = {
   contacts: PropTypes.array,
-  papers: PropTypes.array
+  papers: PropTypes.array,
+  konnectors: PropTypes.array
 }
 
 export default HomeLayout

--- a/packages/cozy-mespapiers-lib/src/components/Papers/CategoryItemByKonnector.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/CategoryItemByKonnector.jsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { useQuery, isQueryLoading } from 'cozy-client'
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
+import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+
+import { buildAccountsQueryBySlug } from '../../helpers/queries'
+import { useScannerI18n } from '../Hooks/useScannerI18n'
+import { addAccountsToKonnectors, makeIsLast } from './helpers'
+import styles from './styles.styl'
+
+const CategoryItemByKonnector = ({
+  konnectorsWithAccounts,
+  konnector,
+  onClick
+}) => {
+  const scannerT = useScannerI18n()
+
+  const queryAccounts = buildAccountsQueryBySlug(konnector.slug)
+  const { data: accounts, ...accountsQueryLeft } = useQuery(
+    queryAccounts.definition,
+    queryAccounts.options
+  )
+  const isLoading = isQueryLoading(accountsQueryLeft)
+
+  if (isLoading) return null
+
+  addAccountsToKonnectors({
+    konnectorsWithAccounts,
+    konnector,
+    accounts
+  })
+
+  if (accounts?.length === 0) {
+    return null
+  }
+
+  const isLast = makeIsLast(konnectorsWithAccounts, konnector)
+
+  return (
+    <>
+      <ListItem
+        button
+        onClick={() => onClick(konnector.qualification_labels[0])}
+      >
+        <ListItemIcon>
+          <div className={styles['emptyKonnectorIcon']} />
+        </ListItemIcon>
+        <ListItemText
+          primary={scannerT(`items.${konnector.qualification_labels[0]}`)}
+        />
+        <Icon icon="right" />
+      </ListItem>
+      {!isLast && <Divider variant="inset" component="li" />}
+    </>
+  )
+}
+
+CategoryItemByKonnector.propTypes = {
+  konnectorsWithAccounts: PropTypes.array,
+  konnector: PropTypes.object,
+  onClick: PropTypes.func
+}
+
+export default CategoryItemByKonnector

--- a/packages/cozy-mespapiers-lib/src/components/Papers/CategoryItemByKonnector.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/CategoryItemByKonnector.jsx
@@ -1,58 +1,25 @@
-import React from 'react'
 import PropTypes from 'prop-types'
+import React from 'react'
 
-import { useQuery, isQueryLoading } from 'cozy-client'
-import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
-import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
+import Icon from 'cozy-ui/transpiled/react/Icon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
-import Icon from 'cozy-ui/transpiled/react/Icon'
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
+import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
 
-import { buildAccountsQueryBySlug } from '../../helpers/queries'
-import { useScannerI18n } from '../Hooks/useScannerI18n'
-import { addAccountsToKonnectors, makeIsLast } from './helpers'
 import styles from './styles.styl'
+import { useScannerI18n } from '../Hooks/useScannerI18n'
 
-const CategoryItemByKonnector = ({
-  konnectorsWithAccounts,
-  konnector,
-  onClick
-}) => {
+const CategoryItemByKonnector = ({ qualificationLabel, isLast, onClick }) => {
   const scannerT = useScannerI18n()
-
-  const queryAccounts = buildAccountsQueryBySlug(konnector.slug)
-  const { data: accounts, ...accountsQueryLeft } = useQuery(
-    queryAccounts.definition,
-    queryAccounts.options
-  )
-  const isLoading = isQueryLoading(accountsQueryLeft)
-
-  if (isLoading) return null
-
-  addAccountsToKonnectors({
-    konnectorsWithAccounts,
-    konnector,
-    accounts
-  })
-
-  if (accounts?.length === 0) {
-    return null
-  }
-
-  const isLast = makeIsLast(konnectorsWithAccounts, konnector)
 
   return (
     <>
-      <ListItem
-        button
-        onClick={() => onClick(konnector.qualification_labels[0])}
-      >
+      <ListItem button onClick={() => onClick(qualificationLabel)}>
         <ListItemIcon>
           <div className={styles['emptyKonnectorIcon']} />
         </ListItemIcon>
-        <ListItemText
-          primary={scannerT(`items.${konnector.qualification_labels[0]}`)}
-        />
+        <ListItemText primary={scannerT(`items.${qualificationLabel}`)} />
         <Icon icon="right" />
       </ListItem>
       {!isLast && <Divider variant="inset" component="li" />}
@@ -61,8 +28,8 @@ const CategoryItemByKonnector = ({
 }
 
 CategoryItemByKonnector.propTypes = {
-  konnectorsWithAccounts: PropTypes.array,
-  konnector: PropTypes.object,
+  qualificationLabel: PropTypes.string,
+  isLast: PropTypes.bool,
   onClick: PropTypes.func
 }
 

--- a/packages/cozy-mespapiers-lib/src/components/Papers/CategoryItemByPaper.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/CategoryItemByPaper.jsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { useClient } from 'cozy-client'
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
+import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
+import MuiCardMedia from 'cozy-ui/transpiled/react/CardMedia'
+import { FileImageLoader } from 'cozy-ui/transpiled/react/FileImageLoader'
+
+import { useScannerI18n } from '../Hooks/useScannerI18n'
+
+const CategoryItemByPaper = ({ paper, isLast, onClick }) => {
+  const client = useClient()
+  const scannerT = useScannerI18n()
+
+  const category = paper?.metadata?.qualification?.label
+
+  return (
+    <>
+      <ListItem button onClick={() => onClick(category)}>
+        <ListItemIcon>
+          <FileImageLoader
+            client={client}
+            file={paper}
+            linkType="tiny"
+            render={src => (
+              <MuiCardMedia
+                component="img"
+                width={32}
+                height={32}
+                image={src}
+              />
+            )}
+            renderFallback={() => <Icon icon="file-type-image" size={32} />}
+          />
+        </ListItemIcon>
+        <ListItemText primary={scannerT(`items.${category}`)} />
+        <Icon icon="right" />
+      </ListItem>
+      {!isLast && <Divider variant="inset" component="li" />}
+    </>
+  )
+}
+
+CategoryItemByPaper.propTypes = {
+  paper: PropTypes.object,
+  isLast: PropTypes.bool,
+  onClick: PropTypes.func
+}
+
+export default CategoryItemByPaper

--- a/packages/cozy-mespapiers-lib/src/components/Papers/KonnectorsCategories.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/KonnectorsCategories.jsx
@@ -1,0 +1,43 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import { useQuery, isQueryLoading, hasQueryBeenLoaded } from 'cozy-client'
+
+import CategoryItemByKonnector from './CategoryItemByKonnector'
+import { queryAccounts } from '../../helpers/queries'
+
+const KonnectorsCategories = ({ konnectors, onClick }) => {
+  const { data: accounts, ...accountsQueryLeft } = useQuery(
+    queryAccounts.definition,
+    queryAccounts.options
+  )
+  const isLoading =
+    isQueryLoading(accountsQueryLeft) && !hasQueryBeenLoaded(accountsQueryLeft)
+
+  if (isLoading) return null
+
+  const konnectorsWithAccounts = konnectors.filter(({ konnector }) =>
+    accounts.some(account => account.account_type === konnector.slug)
+  )
+
+  return konnectorsWithAccounts.map(
+    ({ konnectorQualifLabelsWithoutFile }, index) =>
+      konnectorQualifLabelsWithoutFile?.map(qualificationLabel => {
+        return (
+          <CategoryItemByKonnector
+            key={`${index} - ${qualificationLabel}`}
+            qualificationLabel={qualificationLabel}
+            isLast={index === konnectorsWithAccounts.length - 1}
+            onClick={onClick}
+          />
+        )
+      })
+  )
+}
+
+KonnectorsCategories.propTypes = {
+  konnectors: PropTypes.arrayOf(PropTypes.object),
+  onClick: PropTypes.func
+}
+
+export default KonnectorsCategories

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
@@ -1,15 +1,15 @@
-import React from 'react'
 import PropTypes from 'prop-types'
+import React from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
 import ListSubheader from 'cozy-ui/transpiled/react/MuiCozyTheme/ListSubheader'
-import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
-import { useMultiSelection } from '../Hooks/useMultiSelection'
 import CategoryItemByPaper from './CategoryItemByPaper'
-import CategoryItemByKonnector from './CategoryItemByKonnector'
+import KonnectorsCategories from './KonnectorsCategories'
+import { useMultiSelection } from '../Hooks/useMultiSelection'
 
 const PaperGroup = ({ papersByCategories, konnectors }) => {
   const navigate = useNavigate()
@@ -17,7 +17,6 @@ const PaperGroup = ({ papersByCategories, konnectors }) => {
   const { isMultiSelectionActive, setSelectedThemeLabel } = useMultiSelection()
 
   const hasPapers = papersByCategories.length > 0
-  const konnectorsWithAccounts = JSON.parse(JSON.stringify(konnectors))
 
   const goPapersList = category => {
     if (isMultiSelectionActive) {
@@ -51,14 +50,7 @@ const PaperGroup = ({ papersByCategories, konnectors }) => {
             onClick={goPapersList}
           />
         ))}
-      {konnectorsWithAccounts.map((konnector, index) => (
-        <CategoryItemByKonnector
-          key={index}
-          konnectorsWithAccounts={konnectorsWithAccounts}
-          konnector={konnector}
-          onClick={goPapersList}
-        />
-      ))}
+      <KonnectorsCategories konnectors={konnectors} onClick={goPapersList} />
     </List>
   )
 }

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
@@ -9,13 +9,15 @@ import Typography from 'cozy-ui/transpiled/react/Typography'
 
 import { useMultiSelection } from '../Hooks/useMultiSelection'
 import CategoryItemByPaper from './CategoryItemByPaper'
+import CategoryItemByKonnector from './CategoryItemByKonnector'
 
-const PaperGroup = ({ papersByCategories }) => {
+const PaperGroup = ({ papersByCategories, konnectors }) => {
   const navigate = useNavigate()
   const { t } = useI18n()
   const { isMultiSelectionActive, setSelectedThemeLabel } = useMultiSelection()
 
   const hasPapers = papersByCategories.length > 0
+  const konnectorsWithAccounts = JSON.parse(JSON.stringify(konnectors))
 
   const goPapersList = category => {
     if (isMultiSelectionActive) {
@@ -43,16 +45,27 @@ const PaperGroup = ({ papersByCategories }) => {
           <CategoryItemByPaper
             key={paper.id}
             paper={paper}
-            isLast={index === papersByCategories.length - 1}
+            isLast={
+              index === papersByCategories.length - 1 && konnectors.length === 0
+            }
             onClick={goPapersList}
           />
         ))}
+      {konnectorsWithAccounts.map((konnector, index) => (
+        <CategoryItemByKonnector
+          key={index}
+          konnectorsWithAccounts={konnectorsWithAccounts}
+          konnector={konnector}
+          onClick={goPapersList}
+        />
+      ))}
     </List>
   )
 }
 
 PaperGroup.propTypes = {
-  papersByCategories: PropTypes.arrayOf(PropTypes.object)
+  papersByCategories: PropTypes.arrayOf(PropTypes.object),
+  konnectors: PropTypes.arrayOf(PropTypes.object)
 }
 
 export default PaperGroup

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
@@ -1,29 +1,21 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { useNavigate } from 'react-router-dom'
 
-import { useClient } from 'cozy-client'
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
 import ListSubheader from 'cozy-ui/transpiled/react/MuiCozyTheme/ListSubheader'
-import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
-import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
-import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
-import MuiCardMedia from 'cozy-ui/transpiled/react/CardMedia'
-import { FileImageLoader } from 'cozy-ui/transpiled/react/FileImageLoader'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
-import { useScannerI18n } from '../Hooks/useScannerI18n'
 import { useMultiSelection } from '../Hooks/useMultiSelection'
+import CategoryItemByPaper from './CategoryItemByPaper'
 
 const PaperGroup = ({ papersByCategories }) => {
   const navigate = useNavigate()
-  const client = useClient()
   const { t } = useI18n()
-  const scannerT = useScannerI18n()
   const { isMultiSelectionActive, setSelectedThemeLabel } = useMultiSelection()
+
+  const hasPapers = papersByCategories.length > 0
 
   const goPapersList = category => {
     if (isMultiSelectionActive) {
@@ -34,57 +26,27 @@ const PaperGroup = ({ papersByCategories }) => {
   }
 
   return (
-    <List className="u-pv-0">
-      <ListSubheader>{t('PapersList.subheader')}</ListSubheader>
-      <div className="u-pv-half">
-        {papersByCategories.length === 0 ? (
-          <Typography
-            className="u-ml-1 u-mv-1"
-            variant="body2"
-            color="textSecondary"
-          >
-            {t('PapersList.empty')}
-          </Typography>
-        ) : (
-          papersByCategories.map((paper, index) => {
-            const category = paper?.metadata?.qualification?.label
-
-            return (
-              <Fragment key={paper.id}>
-                <ListItem button onClick={() => goPapersList(category)}>
-                  <ListItemIcon>
-                    <FileImageLoader
-                      client={client}
-                      file={paper}
-                      linkType="tiny"
-                      render={src => (
-                        <MuiCardMedia
-                          component="img"
-                          width={32}
-                          height={32}
-                          image={src}
-                        />
-                      )}
-                      renderFallback={() => (
-                        <Icon icon="file-type-image" size={32} />
-                      )}
-                    />
-                  </ListItemIcon>
-                  <ListItemText primary={scannerT(`items.${category}`)} />
-                  <Icon
-                    icon="right"
-                    size={16}
-                    color="var(--secondaryTextColor)"
-                  />
-                </ListItem>
-                {index !== papersByCategories.length - 1 && (
-                  <Divider variant="inset" component="li" />
-                )}
-              </Fragment>
-            )
-          })
-        )}
-      </div>
+    <List
+      subheader={<ListSubheader>{t('PapersList.subheader')}</ListSubheader>}
+    >
+      {!hasPapers && (
+        <Typography
+          className="u-ml-1 u-mv-1"
+          variant="body2"
+          color="textSecondary"
+        >
+          {t('PapersList.empty')}
+        </Typography>
+      )}
+      {hasPapers &&
+        papersByCategories.map((paper, index) => (
+          <CategoryItemByPaper
+            key={paper.id}
+            paper={paper}
+            isLast={index === papersByCategories.length - 1}
+            onClick={goPapersList}
+          />
+        ))}
     </List>
   )
 }

--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
@@ -219,3 +219,28 @@ export const makeAccountFromPapers = (papers, accounts) => {
 
   return account
 }
+
+export const addAccountsToKonnectors = ({
+  konnectorsWithAccounts,
+  konnector,
+  accounts
+}) => {
+  const konnectorWithAccounts = konnectorsWithAccounts.find(
+    konnectorWithAccounts => konnectorWithAccounts._id === konnector._id
+  )
+  konnectorWithAccounts.accounts = accounts
+}
+
+export const makeIsLast = (konnectorsWithAccounts, konnector) => {
+  const konnectorsWithAccountsFilteredByAccounts =
+    konnectorsWithAccounts.filter(konnectorWithAccount =>
+      Boolean(konnectorWithAccount.account)
+    )
+
+  return (
+    konnectorsWithAccountsFilteredByAccounts.findIndex(
+      el => el._id === konnector._id
+    ) ===
+    konnectorsWithAccountsFilteredByAccounts.length - 1
+  )
+}

--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
@@ -219,28 +219,3 @@ export const makeAccountFromPapers = (papers, accounts) => {
 
   return account
 }
-
-export const addAccountsToKonnectors = ({
-  konnectorsWithAccounts,
-  konnector,
-  accounts
-}) => {
-  const konnectorWithAccounts = konnectorsWithAccounts.find(
-    konnectorWithAccounts => konnectorWithAccounts._id === konnector._id
-  )
-  konnectorWithAccounts.accounts = accounts
-}
-
-export const makeIsLast = (konnectorsWithAccounts, konnector) => {
-  const konnectorsWithAccountsFilteredByAccounts =
-    konnectorsWithAccounts.filter(konnectorWithAccount =>
-      Boolean(konnectorWithAccount.account)
-    )
-
-  return (
-    konnectorsWithAccountsFilteredByAccounts.findIndex(
-      el => el._id === konnector._id
-    ) ===
-    konnectorsWithAccountsFilteredByAccounts.length - 1
-  )
-}

--- a/packages/cozy-mespapiers-lib/src/components/Papers/styles.styl
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/styles.styl
@@ -1,0 +1,5 @@
+.emptyKonnectorIcon
+  border 1px dashed var(--borderMainColor)
+  border-radius 8px
+  width 2rem
+  height 2rem

--- a/packages/cozy-mespapiers-lib/src/components/Views/Home.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/Home.jsx
@@ -11,6 +11,7 @@ import {
 import { getContactsRefIdsByFiles } from '../Papers/helpers'
 import { usePapersDefinitions } from '../Hooks/usePapersDefinitions'
 import HomeLayout from '../Home/HomeLayout'
+import { makePapers, makeQualificationLabelWithoutFiles } from './helpers'
 
 const Home = () => {
   const { papersDefinitions } = usePapersDefinitions()
@@ -28,11 +29,8 @@ const Home = () => {
   const isLoadingFiles = isQueryLoading(queryResult) || queryResult.hasMore
 
   const papers = useMemo(
-    () =>
-      filesWithQualificationLabel?.filter(file =>
-        papersDefinitionsLabels.includes(file?.metadata?.qualification?.label)
-      ) || [],
-    [filesWithQualificationLabel, papersDefinitionsLabels]
+    () => makePapers(papersDefinitionsLabels, filesWithQualificationLabel),
+    [papersDefinitionsLabels, filesWithQualificationLabel]
   )
 
   const contactIds = getContactsRefIdsByFiles(papers)
@@ -47,13 +45,9 @@ const Home = () => {
   const isLoadingContacts =
     isQueryLoading(contactQueryResult) || contactQueryResult.hasMore
 
-  const qualificationLabelWithoutFiles = papersDefinitionsLabels.filter(
-    paperDefinitionLabel =>
-      !papers.some(
-        paper =>
-          paper.attributes?.metadata?.qualification?.label ===
-          paperDefinitionLabel
-      )
+  const qualificationLabelWithoutFiles = useMemo(
+    () => makeQualificationLabelWithoutFiles(papersDefinitionsLabels, papers),
+    [papersDefinitionsLabels, papers]
   )
   const konnectorsQueryByQualificationLabels =
     buildKonnectorsQueryByQualificationLabels(qualificationLabelWithoutFiles)

--- a/packages/cozy-mespapiers-lib/src/components/Views/Home.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/Home.jsx
@@ -15,7 +15,7 @@ const Home = () => {
   const { papersDefinitions } = usePapersDefinitions()
 
   const papersDefinitionsLabels = useMemo(
-    () => papersDefinitions.map(paper => paper.label),
+    () => papersDefinitions.map(paperDefinition => paperDefinition.label),
     [papersDefinitions]
   )
 

--- a/packages/cozy-mespapiers-lib/src/components/Views/Home.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/Home.jsx
@@ -4,14 +4,18 @@ import { isQueryLoading, useQueryAll } from 'cozy-client'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import {
+  makePapers,
+  makeQualificationLabelWithoutFiles,
+  makeKonnectorsAndQualificationLabelWithoutFiles
+} from './helpers'
+import {
   buildContactsQueryByIds,
   buildFilesQueryWithQualificationLabel,
   buildKonnectorsQueryByQualificationLabels
 } from '../../helpers/queries'
-import { getContactsRefIdsByFiles } from '../Papers/helpers'
-import { usePapersDefinitions } from '../Hooks/usePapersDefinitions'
 import HomeLayout from '../Home/HomeLayout'
-import { makePapers, makeQualificationLabelWithoutFiles } from './helpers'
+import { usePapersDefinitions } from '../Hooks/usePapersDefinitions'
+import { getContactsRefIdsByFiles } from '../Papers/helpers'
 
 const Home = () => {
   const { papersDefinitions } = usePapersDefinitions()
@@ -67,8 +71,18 @@ const Home = () => {
     )
   }
 
+  const konnectorsAndQualificationLabelWithoutFiles =
+    makeKonnectorsAndQualificationLabelWithoutFiles(
+      konnectors,
+      qualificationLabelWithoutFiles
+    )
+
   return (
-    <HomeLayout contacts={contacts} papers={papers} konnectors={konnectors} />
+    <HomeLayout
+      contacts={contacts}
+      papers={papers}
+      konnectors={konnectorsAndQualificationLabelWithoutFiles}
+    />
   )
 }
 

--- a/packages/cozy-mespapiers-lib/src/components/Views/Home.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/Home.jsx
@@ -5,7 +5,8 @@ import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import {
   buildContactsQueryByIds,
-  buildFilesQueryWithQualificationLabel
+  buildFilesQueryWithQualificationLabel,
+  buildKonnectorsQueryByQualificationLabels
 } from '../../helpers/queries'
 import { getContactsRefIdsByFiles } from '../Papers/helpers'
 import { usePapersDefinitions } from '../Hooks/usePapersDefinitions'
@@ -46,7 +47,24 @@ const Home = () => {
   const isLoadingContacts =
     isQueryLoading(contactQueryResult) || contactQueryResult.hasMore
 
-  if (isLoadingFiles || isLoadingContacts) {
+  const qualificationLabelWithoutFiles = papersDefinitionsLabels.filter(
+    paperDefinitionLabel =>
+      !papers.some(
+        paper =>
+          paper.attributes?.metadata?.qualification?.label ===
+          paperDefinitionLabel
+      )
+  )
+  const konnectorsQueryByQualificationLabels =
+    buildKonnectorsQueryByQualificationLabels(qualificationLabelWithoutFiles)
+  const { data: konnectors, ...konnectorsQueryResult } = useQueryAll(
+    konnectorsQueryByQualificationLabels.definition,
+    konnectorsQueryByQualificationLabels.options
+  )
+  const isLoadingKonnectors =
+    isQueryLoading(konnectorsQueryResult) || konnectorsQueryResult.hasMore
+
+  if (isLoadingFiles || isLoadingContacts || isLoadingKonnectors) {
     return (
       <Spinner
         size="xxlarge"
@@ -55,7 +73,9 @@ const Home = () => {
     )
   }
 
-  return <HomeLayout contacts={contacts} papers={papers} />
+  return (
+    <HomeLayout contacts={contacts} papers={papers} konnectors={konnectors} />
+  )
 }
 
 export default Home

--- a/packages/cozy-mespapiers-lib/src/components/Views/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Views/helpers.js
@@ -16,3 +16,15 @@ export const makeQualificationLabelWithoutFiles = (
         paper => paper.metadata?.qualification?.label === paperDefinitionLabel
       )
   )
+
+export const makeKonnectorsAndQualificationLabelWithoutFiles = (
+  konnectors,
+  qualificationLabelWithoutFiles
+) =>
+  konnectors.map(konnector => ({
+    konnector,
+    konnectorQualifLabelsWithoutFile:
+      konnector.qualification_labels?.filter(qualificationLabel =>
+        qualificationLabelWithoutFiles.includes(qualificationLabel)
+      ) || []
+  }))

--- a/packages/cozy-mespapiers-lib/src/components/Views/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Views/helpers.js
@@ -1,0 +1,18 @@
+export const makePapers = (
+  papersDefinitionsLabels,
+  filesWithQualificationLabel
+) =>
+  filesWithQualificationLabel?.filter(file =>
+    papersDefinitionsLabels.includes(file?.metadata?.qualification?.label)
+  ) || []
+
+export const makeQualificationLabelWithoutFiles = (
+  papersDefinitionsLabels,
+  papers
+) =>
+  papersDefinitionsLabels.filter(
+    paperDefinitionLabel =>
+      !papers.some(
+        paper => paper.metadata?.qualification?.label === paperDefinitionLabel
+      )
+  )

--- a/packages/cozy-mespapiers-lib/src/components/Views/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Views/helpers.spec.js
@@ -1,0 +1,56 @@
+import { makePapers, makeQualificationLabelWithoutFiles } from './helpers'
+
+const papersDefinitionsLabels = ['caf', 'isp_invoice', 'resume']
+
+describe('makePapers', () => {
+  it('should return only file with matched qualification label', () => {
+    const files = [
+      { metadata: { qualification: { label: 'caf' } } },
+      { metadata: { qualification: { label: 'lease' } } }
+    ]
+    const res = makePapers(papersDefinitionsLabels, files)
+
+    expect(res).toStrictEqual([
+      { metadata: { qualification: { label: 'caf' } } }
+    ])
+  })
+
+  it('should return empty array if no match', () => {
+    const files = [
+      { metadata: { qualification: { label: 'house_insurance' } } },
+      { metadata: { qualification: { label: 'lease' } } }
+    ]
+    const res = makePapers(papersDefinitionsLabels, files)
+
+    expect(res).toStrictEqual([])
+  })
+})
+
+describe('makeQualificationLabelWithoutFiles', () => {
+  it('should return labels for which there is no associated paper', () => {
+    const files = [
+      { metadata: { qualification: { label: 'caf' } } },
+      { metadata: { qualification: { label: 'lease' } } }
+    ]
+    const res = makeQualificationLabelWithoutFiles(
+      papersDefinitionsLabels,
+      files
+    )
+
+    expect(res).toStrictEqual(['isp_invoice', 'resume'])
+  })
+
+  it('should return empty array if no paper left', () => {
+    const files = [
+      { metadata: { qualification: { label: 'caf' } } },
+      { metadata: { qualification: { label: 'isp_invoice' } } },
+      { metadata: { qualification: { label: 'resume' } } }
+    ]
+    const res = makeQualificationLabelWithoutFiles(
+      papersDefinitionsLabels,
+      files
+    )
+
+    expect(res).toStrictEqual([])
+  })
+})

--- a/packages/cozy-mespapiers-lib/src/components/Views/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Views/helpers.spec.js
@@ -1,4 +1,8 @@
-import { makePapers, makeQualificationLabelWithoutFiles } from './helpers'
+import {
+  makePapers,
+  makeQualificationLabelWithoutFiles,
+  makeKonnectorsAndQualificationLabelWithoutFiles
+} from './helpers'
 
 const papersDefinitionsLabels = ['caf', 'isp_invoice', 'resume']
 
@@ -52,5 +56,52 @@ describe('makeQualificationLabelWithoutFiles', () => {
     )
 
     expect(res).toStrictEqual([])
+  })
+})
+
+describe('makeKonnectorsAndQualificationLabelWithoutFiles', () => {
+  it('should return konnectors with their qualification labels for which there is no file', () => {
+    const konnectors = [
+      { qualification_labels: ['caf', 'isp_invoice'] },
+      { qualification_labels: ['lease'] }
+    ]
+    const qualificationLabelWithoutFiles = ['caf', 'phone_invoice']
+
+    const res = makeKonnectorsAndQualificationLabelWithoutFiles(
+      konnectors,
+      qualificationLabelWithoutFiles
+    )
+
+    expect(res).toStrictEqual([
+      {
+        konnector: { qualification_labels: ['caf', 'isp_invoice'] },
+        konnectorQualifLabelsWithoutFile: ['caf']
+      },
+      {
+        konnector: { qualification_labels: ['lease'] },
+        konnectorQualifLabelsWithoutFile: []
+      }
+    ])
+  })
+
+  it('should return empty array in konnectorQualifLabelsWithoutFile if no qualification_labels attributes on konnectors', () => {
+    const konnectors = [{ _id: '01' }, { _id: '02' }]
+    const qualificationLabelWithoutFiles = ['caf', 'phone_invoice']
+
+    const res = makeKonnectorsAndQualificationLabelWithoutFiles(
+      konnectors,
+      qualificationLabelWithoutFiles
+    )
+
+    expect(res).toStrictEqual([
+      {
+        konnector: { _id: '01' },
+        konnectorQualifLabelsWithoutFile: []
+      },
+      {
+        konnector: { _id: '02' },
+        konnectorQualifLabelsWithoutFile: []
+      }
+    ])
   })
 })

--- a/packages/cozy-mespapiers-lib/src/helpers/queries.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/queries.js
@@ -148,3 +148,11 @@ export const buildAccountsQueryBySlug = (slug, enabled = true) => ({
     enabled
   }
 })
+
+export const queryAccounts = {
+  definition: Q(ACCOUNTS_DOCTYPE),
+  options: {
+    as: `accounts`,
+    fetchPolicy: defaultFetchPolicy
+  }
+}

--- a/packages/cozy-mespapiers-lib/src/helpers/queries.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/queries.js
@@ -48,18 +48,19 @@ export const buildFilesQueryWithQualificationLabel = () => {
 }
 
 export const buildFilesQueryByLabel = label => ({
-  definition: Q(FILES_DOCTYPE)
-    .where({
-      'metadata.qualification': {
-        label: label
-      }
-    })
-    .partialIndex({
-      type: 'file',
-      trashed: false
-    })
-    .indexFields(['created_at', 'metadata.qualification'])
-    .sortBy([{ created_at: 'desc' }]),
+  definition: () =>
+    Q(FILES_DOCTYPE)
+      .where({
+        'metadata.qualification': {
+          label: label
+        }
+      })
+      .partialIndex({
+        type: 'file',
+        trashed: false
+      })
+      .indexFields(['created_at', 'metadata.qualification'])
+      .sortBy([{ created_at: 'desc' }]),
   options: {
     as: `${FILES_DOCTYPE}/${label}`,
     fetchPolicy: defaultFetchPolicy
@@ -75,7 +76,7 @@ export const getOnboardingStatus = {
 }
 
 export const buildContactsQueryByIds = (ids = []) => ({
-  definition: Q(CONTACTS_DOCTYPE).getByIds(ids),
+  definition: () => Q(CONTACTS_DOCTYPE).getByIds(ids),
   options: {
     as: `${CONTACTS_DOCTYPE}/${ids.join('')}`,
     fetchPolicy: defaultFetchPolicy
@@ -83,7 +84,7 @@ export const buildContactsQueryByIds = (ids = []) => ({
 })
 
 export const buildFilesQueryById = id => ({
-  definition: Q(FILES_DOCTYPE).getById(id),
+  definition: () => Q(FILES_DOCTYPE).getById(id),
   options: {
     as: `${FILES_DOCTYPE}/${id}`,
     fetchPolicy: defaultFetchPolicy
@@ -91,11 +92,12 @@ export const buildFilesQueryById = id => ({
 })
 
 export const buildTriggersQueryByConnectorSlug = (slug, enabled) => ({
-  definition: Q(TRIGGERS_DOCTYPE)
-    .where({
-      'message.konnector': slug
-    })
-    .indexFields(['message.konnector']),
+  definition: () =>
+    Q(TRIGGERS_DOCTYPE)
+      .where({
+        'message.konnector': slug
+      })
+      .indexFields(['message.konnector']),
   options: {
     as: `${TRIGGERS_DOCTYPE}/slug/${slug}`,
     fetchPolicy: defaultFetchPolicy,
@@ -104,7 +106,7 @@ export const buildTriggersQueryByConnectorSlug = (slug, enabled) => ({
 })
 
 export const buildConnectorsQueryById = (id, enabled = true) => ({
-  definition: Q(KONNECTORS_DOCTYPE).getById(id),
+  definition: () => Q(KONNECTORS_DOCTYPE).getById(id),
   options: {
     as: `${KONNECTORS_DOCTYPE}/id/${id}`,
     fetchPolicy: defaultFetchPolicy,
@@ -116,9 +118,10 @@ export const buildKonnectorsQueryByQualificationLabels = (
   labels,
   enabled = true
 ) => ({
-  definition: Q(KONNECTORS_DOCTYPE)
-    .where({ qualification_labels: { $in: labels } })
-    .indexFields(['qualification_labels']),
+  definition: () =>
+    Q(KONNECTORS_DOCTYPE)
+      .where({ qualification_labels: { $in: labels } })
+      .indexFields(['qualification_labels']),
   options: {
     as: `${KONNECTORS_DOCTYPE}/qualificationLabels/${JSON.stringify(labels)}`,
     fetchPolicy: defaultFetchPolicy,
@@ -127,9 +130,10 @@ export const buildKonnectorsQueryByQualificationLabels = (
 })
 
 export const buildConnectorsQueryByQualificationLabel = label => ({
-  definition: Q(KONNECTORS_DOCTYPE)
-    .where({ qualification_labels: { $in: [label] } })
-    .indexFields(['qualification_labels']),
+  definition: () =>
+    Q(KONNECTORS_DOCTYPE)
+      .where({ qualification_labels: { $in: [label] } })
+      .indexFields(['qualification_labels']),
   options: {
     as: `${KONNECTORS_DOCTYPE}/qualificationLabel/${label}`,
     fetchPolicy: defaultFetchPolicy
@@ -137,11 +141,12 @@ export const buildConnectorsQueryByQualificationLabel = label => ({
 })
 
 export const buildAccountsQueryBySlug = (slug, enabled = true) => ({
-  definition: Q(ACCOUNTS_DOCTYPE)
-    .where({
-      account_type: slug
-    })
-    .indexFields(['account_type']),
+  definition: () =>
+    Q(ACCOUNTS_DOCTYPE)
+      .where({
+        account_type: slug
+      })
+      .indexFields(['account_type']),
   options: {
     as: `${ACCOUNTS_DOCTYPE}/slug/${slug}`,
     fetchPolicy: defaultFetchPolicy,
@@ -150,7 +155,7 @@ export const buildAccountsQueryBySlug = (slug, enabled = true) => ({
 })
 
 export const queryAccounts = {
-  definition: Q(ACCOUNTS_DOCTYPE),
+  definition: () => Q(ACCOUNTS_DOCTYPE),
   options: {
     as: `accounts`,
     fetchPolicy: defaultFetchPolicy

--- a/packages/cozy-mespapiers-lib/src/helpers/queries.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/queries.js
@@ -112,6 +112,20 @@ export const buildConnectorsQueryById = (id, enabled = true) => ({
   }
 })
 
+export const buildKonnectorsQueryByQualificationLabels = (
+  labels,
+  enabled = true
+) => ({
+  definition: Q(KONNECTORS_DOCTYPE)
+    .where({ qualification_labels: { $in: labels } })
+    .indexFields(['qualification_labels']),
+  options: {
+    as: `${KONNECTORS_DOCTYPE}/qualificationLabels/${JSON.stringify(labels)}`,
+    fetchPolicy: defaultFetchPolicy,
+    enabled
+  }
+})
+
 export const buildConnectorsQueryByQualificationLabel = label => ({
   definition: Q(KONNECTORS_DOCTYPE)
     .where({ qualification_labels: { $in: [label] } })


### PR DESCRIPTION
Dans le cas d'un connecteur installé avec un compte associé, on souhaite pouvoir afficher la catégorie du connecteur même s'il n'y a aucun document récupéré. Dans ces cas là, la catégorie s'affiche sur la home, et un bloc "empty" est affiché à la place des documents