### PR TITLE
fix: Colors for shared withMe

### DIFF
--- a/packages/cozy-sharing/src/components/badge.styl
+++ b/packages/cozy-sharing/src/components/badge.styl
@@ -1,4 +1,4 @@
-@require 'settings/palette.styl'
+palette=json('settings/palette.json', { hash: true })
 
 .shared-badge
     display flex
@@ -8,7 +8,8 @@
     background-clip padding-box
 
     &.--small
-        border .125rem solid var(--white)
+        border .125rem solid 
+        border-color: palette['white']
         width 1.5rem
         height 1.5rem
 
@@ -17,7 +18,8 @@
             height .75rem
 
     &.--xsmall
-        border .0625rem solid var(--white)
+        border .0625rem solid 
+        border-color: palette['white']
         width .75rem
         height .75rem
 
@@ -26,7 +28,7 @@
             height .375rem
 
     &.--by-me
-        background-color var(--emerald)
+        background-color: palette['emerald']
 
     &.--with-me
-        background-color #9169F2
+        background-color: palette['portage']

--- a/packages/cozy-sharing/src/components/button.styl
+++ b/packages/cozy-sharing/src/components/button.styl
@@ -1,23 +1,22 @@
-@require 'settings/palette.styl'
-
+palette=json('settings/palette.json', { hash: true })
 .coz-btn-shared
-    border-color     var(--emerald)
-    background-color var(--emerald)
-    color            var(--white)
+    border-color: palette['emerald']
+    background-color: palette['emerald']
+    color: palette['white']
     transition all .2s ease-out
 
     &:focus
     &:not([disabled]):not([aria-disabled=true]):hover
-        border-color var(--malachite)
-        background-color var(--malachite)
+        border-color: palette['malachite']
+        background-color: palette['malachite']
 
 .coz-btn-sharedWithMe
-    border-color     var(--lightishPurple)
-    background-color var(--lightishPurple)
-    color            var(--white)
+    border-color: palette['lightishPurple']
+    background-color: palette['lightishPurple']
+    color: palette['white']
     transition all .2s ease-out
 
     &:focus
     &:not([disabled]):not([aria-disabled=true]):hover
-        border-color var(--barney)
-        background-color var(--barney)
+        border-color: palette['barney']
+        background-color: palette['barney']


### PR DESCRIPTION
Since the removal of the cozy-bar v7, Drive
don't load an old version of cozy-ui. These
variables are not defined anymore

see https://github.com/cozy/cozy-ui/pull/1743

The best way to use absolute color is to
import them from the palette.json
```
palette=json('settings/palette.json', { hash: true })
```
and use this way
```
background-color: palette['barney']
```

I needed to add the `:` because sometimes I had
compilations errors, sometime it was compiling in
cozy-sharing but the classname was not present
in the final bundle...