### PR TITLE
feat(eslint-config-cozy-app): Update rules

### DIFF
--- a/packages/eslint-config-cozy-app/basics.js
+++ b/packages/eslint-config-cozy-app/basics.js
@@ -45,6 +45,11 @@ module.exports = {
             pattern: '{cozy-*,cozy-*/**}',
             group: 'external',
             position: 'after'
+          },
+          {
+            pattern: '**/*.styles',
+            group: 'index',
+            position: 'after'
           }
         ],
         distinctGroup: true,
@@ -53,8 +58,6 @@ module.exports = {
         warnOnUnassignedImports: true
       }
     ],
-    'import/no-extraneous-dependencies': ['warn'],
-    'promise/prefer-await-to-then': 'warn',
-    'promise/prefer-await-to-callbacks': 'warn'
+    'import/no-extraneous-dependencies': ['warn']
   }
 }


### PR DESCRIPTION
- `prefer async/await to callbacks` **removed** (after using it in a real-world project, it felt like a bad addition)
- `prefer async/await to promises` **removed** (after using it in a real-world project, it felt like a bad addition)
- `**/*.styles` files are now the last group in the import order (this is following cozy-guidelines)