### PR TITLE
Fix/duplicate owner in sharing

### DIFF
--- a/packages/cozy-sharing/src/components/Recipient/OwnerRecipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/OwnerRecipient.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+import { useClient, useQuery, hasQueryBeenLoaded } from 'cozy-client'
+
+import Recipient from './Recipient'
+import { buildInstanceSettingsQuery } from '../../queries/queries'
+
+const OwnerRecipient = () => {
+  const client = useClient()
+
+  const instanceSettingsQuery = buildInstanceSettingsQuery()
+  const instanceSettingsResult = useQuery(
+    instanceSettingsQuery.definition,
+    instanceSettingsQuery.options
+  )
+
+  const public_name = instanceSettingsResult?.data?.attributes?.public_name
+
+  return (
+    hasQueryBeenLoaded(instanceSettingsResult) && (
+      <Recipient
+        isOwner={true}
+        status="owner"
+        instance={client.options.uri}
+        public_name={public_name}
+      />
+    )
+  )
+}
+
+export default OwnerRecipient

--- a/packages/cozy-sharing/src/components/Recipient/OwnerRecipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/OwnerRecipient.jsx
@@ -1,31 +1,23 @@
 import React from 'react'
-
-import { useClient, useQuery, hasQueryBeenLoaded } from 'cozy-client'
+import PropTypes from 'prop-types'
 
 import Recipient from './Recipient'
-import { buildInstanceSettingsQuery } from '../../queries/queries'
+import OwnerRecipientDefault from './OwnerRecipientDefault'
 
-const OwnerRecipient = () => {
-  const client = useClient()
-
-  const instanceSettingsQuery = buildInstanceSettingsQuery()
-  const instanceSettingsResult = useQuery(
-    instanceSettingsQuery.definition,
-    instanceSettingsQuery.options
+const OwnerRecipient = ({ recipients }) => {
+  const ownerRecipient = recipients.find(
+    recipient => recipient.status === 'owner'
   )
 
-  const public_name = instanceSettingsResult?.data?.attributes?.public_name
+  if (ownerRecipient) {
+    return <Recipient {...ownerRecipient} />
+  }
 
-  return (
-    hasQueryBeenLoaded(instanceSettingsResult) && (
-      <Recipient
-        isOwner={true}
-        status="owner"
-        instance={client.options.uri}
-        public_name={public_name}
-      />
-    )
-  )
+  return <OwnerRecipientDefault />
+}
+
+OwnerRecipient.propTypes = {
+  recipients: PropTypes.array.isRequired
 }
 
 export default OwnerRecipient

--- a/packages/cozy-sharing/src/components/Recipient/OwnerRecipientDefault.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/OwnerRecipientDefault.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+import { useClient, useQuery, hasQueryBeenLoaded } from 'cozy-client'
+
+import Recipient from './Recipient'
+import { buildInstanceSettingsQuery } from '../../queries/queries'
+
+const OwnerRecipientDefault = () => {
+  const client = useClient()
+
+  const instanceSettingsQuery = buildInstanceSettingsQuery()
+  const instanceSettingsResult = useQuery(
+    instanceSettingsQuery.definition,
+    instanceSettingsQuery.options
+  )
+
+  return (
+    hasQueryBeenLoaded(instanceSettingsResult) && (
+      <Recipient
+        isOwner={true}
+        status="owner"
+        instance={client.options.uri}
+        public_name={instanceSettingsResult?.data?.attributes?.public_name}
+      />
+    )
+  )
+}
+
+export default OwnerRecipientDefault

--- a/packages/cozy-sharing/src/components/Recipient/RecipientStatus.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/RecipientStatus.jsx
@@ -14,7 +14,7 @@ const RecipientStatus = ({ status, isMe, instance }) => {
   const { t } = useI18n()
 
   const isSendingEmail = !isMe && status === 'mail-not-sent'
-  const isReady = isMe || status === 'ready'
+  const isReady = isMe || status === 'ready' || status === 'owner'
   let text, icon
   if (isReady) {
     text = instance

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
@@ -8,7 +8,8 @@ import { act, render, fireEvent } from '@testing-library/react'
 jest.mock('cozy-client', () => ({
   ...jest.requireActual('cozy-client'),
   useQuery: jest.fn().mockReturnValue({ data: { public_name: 'Alice' } }),
-  hasQueryBeenLoaded: jest.fn().mockReturnValue(true)
+  hasQueryBeenLoaded: jest.fn().mockReturnValue(true),
+  useClient: () => ({ options: { uri: mockRecipientAlice.instance } })
 }))
 
 describe('ShareDialogCozyToCozy', () => {
@@ -54,9 +55,9 @@ describe('ShareDialogCozyToCozy', () => {
     await act(async () => {
       resolve([
         {
-          name: recipientBob.public_name,
+          name: mockRecipientBob.public_name,
           id: 'SOME_ID',
-          email: recipientBob.email
+          email: mockRecipientBob.email
         }
       ])
       await promise
@@ -81,9 +82,9 @@ describe('ShareDialogCozyToCozy', () => {
     await act(async () => {
       resolve([
         {
-          name: recipientBob.public_name,
+          name: mockRecipientBob.public_name,
           id: 'SOME_ID',
-          email: recipientBob.email
+          email: mockRecipientBob.email
         }
       ])
       await promise
@@ -111,14 +112,14 @@ describe('ShareDialogCozyToCozy', () => {
     await act(async () => {
       resolve([
         {
-          name: recipientBob.public_name,
+          name: mockRecipientBob.public_name,
           id: 'SOME_ID',
-          email: recipientBob.email
+          email: mockRecipientBob.email
         },
         {
-          name: recipientClaude.public_name,
+          name: mockRecipientClaude.public_name,
           id: 'SOME_OTHER_ID',
-          email: recipientClaude.email
+          email: mockRecipientClaude.email
         }
       ])
       await promise
@@ -173,9 +174,9 @@ describe('ShareDialogCozyToCozy', () => {
     await act(async () => {
       resolve([
         {
-          name: recipientBob.public_name,
+          name: mockRecipientBob.public_name,
           id: 'SOME_ID',
-          email: recipientBob.email,
+          email: mockRecipientBob.email,
           fingerprintPhrase: 'SOME_FINGERPRINT_PHRASE'
         }
       ])
@@ -192,7 +193,7 @@ describe('ShareDialogCozyToCozy', () => {
 
     expect(
       getByText(
-        `Do you really want to reject contact ${recipientBob.public_name} (${recipientBob.email})?`
+        `Do you really want to reject contact ${mockRecipientBob.public_name} (${mockRecipientBob.email})?`
       )
     ).toBeTruthy()
 
@@ -203,7 +204,7 @@ describe('ShareDialogCozyToCozy', () => {
   })
 })
 
-const recipientAlice = {
+const mockRecipientAlice = {
   status: 'owner',
   public_name: 'Alice',
   email: 'me@alice.cozy.localhost',
@@ -214,7 +215,7 @@ const recipientAlice = {
   avatarPath: '/sharings/SOME_SHARING_ID/recipients/0/avatar'
 }
 
-const recipientBob = {
+const mockRecipientBob = {
   status: 'ready',
   public_name: 'Claude',
   email: 'me@claude.cozy.localhost',
@@ -225,7 +226,7 @@ const recipientBob = {
   avatarPath: '/sharings/SOME_SHARING_ID/recipients/1/avatar'
 }
 
-const recipientClaude = {
+const mockRecipientClaude = {
   status: 'ready',
   public_name: 'Bob',
   email: 'me@bob.cozy.localhost',
@@ -333,9 +334,9 @@ const getMockProps = () => {
     link: null,
     permissions: [],
     recipients: [
-      recipientAlice,
-      recipientBob,
-      recipientClaude,
+      mockRecipientAlice,
+      mockRecipientBob,
+      mockRecipientClaude,
       {
         status: 'pending',
         email: 'me@ben.cozy.localhost',

--- a/packages/cozy-sharing/src/components/WhoHasAccess.jsx
+++ b/packages/cozy-sharing/src/components/WhoHasAccess.jsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { useClient, useQuery, hasQueryBeenLoaded } from 'cozy-client'
 import Recipient from './Recipient/Recipient'
 import LinkRecipient from './Recipient/LinkRecipient'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
 
-import { buildInstanceSettingsQuery } from '../queries/queries'
 import { filterAndReworkRecipients } from '../helpers/recipients'
 import { usePrevious } from '../helpers/hooks'
+import OwnerRecipient from './Recipient/OwnerRecipient'
 
 /**
  * Displays a warning if some contacts are waiting for confirmation of their sharing
@@ -42,14 +41,6 @@ const WhoHasAccess = ({
   onUpdateShareLinkPermissions,
   onRevokeLink
 }) => {
-  const client = useClient()
-
-  const instanceSettingsQuery = buildInstanceSettingsQuery()
-  const instanceSettingsResult = useQuery(
-    instanceSettingsQuery.definition,
-    instanceSettingsQuery.options
-  )
-
   const previousLink = usePrevious(link)
   const previousRecipients = usePrevious(recipients)
 
@@ -59,8 +50,6 @@ const WhoHasAccess = ({
     recipients,
     previousRecipients
   )
-
-  const public_name = instanceSettingsResult?.data?.attributes?.public_name
 
   return (
     <div className={className}>
@@ -82,14 +71,7 @@ const WhoHasAccess = ({
           />
         )}
 
-        {hasQueryBeenLoaded(instanceSettingsResult) && (
-          <Recipient
-            isOwner={true}
-            status="owner"
-            instance={client.options.uri}
-            public_name={public_name}
-          />
-        )}
+        <OwnerRecipient />
 
         {recipientsToDisplay.map(recipient => {
           const recipientConfirmationData = recipientsToBeConfirmed.find(

--- a/packages/cozy-sharing/src/components/WhoHasAccess.jsx
+++ b/packages/cozy-sharing/src/components/WhoHasAccess.jsx
@@ -71,7 +71,7 @@ const WhoHasAccess = ({
           />
         )}
 
-        <OwnerRecipient />
+        <OwnerRecipient recipients={recipients} />
 
         {recipientsToDisplay.map(recipient => {
           const recipientConfirmationData = recipientsToBeConfirmed.find(


### PR DESCRIPTION
 fix: Display correctly owner recipient when receiving sharing

Previously, we always displayed "You" as the owner. So when you received a sharing, you saw "You" two times : one for the owner, and one for you. Now, we correctly display the owner, whether it is you or not.

fix: Display always instance address as secondary text for owner

When we received a sharing, the owner was displayed as owner but with "invitation sent" status. Now, we consider that an owner is always "ready", so we always display the instance address instead of the status if it is an owner.