### PR TITLE
Realtime: Add _type on returned doc by the handlers

### DIFF
--- a/packages/cozy-realtime/src/CozyRealtime.js
+++ b/packages/cozy-realtime/src/CozyRealtime.js
@@ -456,7 +456,7 @@ class CozyRealtime {
     )
     for (const handler of handlers) {
       try {
-        handler(payload.doc)
+        handler({ ...payload.doc, _type: payload.type })
       } catch (e) {
         logger.error(
           `handler did throw for ${event}, ${payload.type}, ${payload.id}`

--- a/packages/cozy-realtime/src/CozyRealtime.js
+++ b/packages/cozy-realtime/src/CozyRealtime.js
@@ -1,9 +1,16 @@
 import MicroEE from 'microee'
+
 import { hasNetworkInformationPlugin, isCordova } from 'cozy-device-helper'
 
-import logger from './logger'
-import SubscriptionList from './SubscriptionList'
 import RetryManager from './RetryManager'
+import SubscriptionList from './SubscriptionList'
+import {
+  raiseErrorAfterAttempts,
+  timeBeforeSuccessful,
+  baseWaitAfterFirstFailure,
+  maxWaitBetweenRetries
+} from './config'
+import logger from './logger'
 import {
   getUrl,
   getToken,
@@ -12,12 +19,6 @@ import {
   getCozyClientFromOptions,
   isOnline
 } from './utils'
-import {
-  raiseErrorAfterAttempts,
-  timeBeforeSuccessful,
-  baseWaitAfterFirstFailure,
-  maxWaitBetweenRetries
-} from './config'
 
 /**
  * Manage the realtime interactions with a cozy stack

--- a/packages/cozy-realtime/src/CozyRealtime.legacy.spec.js
+++ b/packages/cozy-realtime/src/CozyRealtime.legacy.spec.js
@@ -64,7 +64,7 @@ describe('CozyRealtime', () => {
 
   const type = 'io.cozy.bank.accounts'
   const id = 'doc_id'
-  const fakeDoc = { _id: id, title: 'title1' }
+  const fakeDoc = { _id: id, title: 'title1', _type: type }
 
   describe('subscribe', () => {
     it('should launch handler when document is created', async done => {

--- a/packages/cozy-realtime/src/CozyRealtime.legacy.spec.js
+++ b/packages/cozy-realtime/src/CozyRealtime.legacy.spec.js
@@ -3,11 +3,11 @@
 // be deleted in a near future. All usefull tests below should
 // have counterpart in CozyRealtime.spec.js
 
-import CozyRealtime from './CozyRealtime'
-import { Server } from 'mock-socket'
-import MicroEE from 'microee'
-
 import Minilog from '@cozy/minilog'
+import MicroEE from 'microee'
+import { Server } from 'mock-socket'
+
+import CozyRealtime from './CozyRealtime'
 Minilog.disable()
 
 const COZY_URL = 'http://cozy.tools:8888'

--- a/packages/cozy-realtime/src/CozyRealtime.spec.js
+++ b/packages/cozy-realtime/src/CozyRealtime.spec.js
@@ -21,7 +21,7 @@ const doctype = 'io.cozy.files'
 const type = doctype
 const id = 'my-document-id'
 const message = { message: 'hello' }
-const doc = message
+const doc = { ...message, _type: type }
 const event = 'UPDATED'
 const payload = { type, doc, id }
 

--- a/packages/cozy-realtime/src/CozyRealtime.spec.js
+++ b/packages/cozy-realtime/src/CozyRealtime.spec.js
@@ -1,12 +1,12 @@
-import { Server } from 'mock-socket'
 import MicroEE from 'microee'
+import { Server } from 'mock-socket'
 
 import CozyRealtime from './CozyRealtime'
-import logger from './logger'
 import {
   allowDoubleSubscriptions,
   requireDoubleUnsubscriptions
 } from './config'
+import logger from './logger'
 
 const testLogger = logger.minilog('test/cozy-realtime')
 


### PR DESCRIPTION
dans le document retourné par le realtime, il n'y a pas le _type associé au 
doctype, ce qui nécessite côté app une gymnastique lorsque le realtime est 
branché sur différents doctypes.

Grâce à cette amélioration, il suffit juste d'analyser le document pour savoir 
à quel doctype il est associé.

C'est dans le cas où on branche un même callback sur différent subscribes, on ne discrimine alors plus en amont mais en aval via le doc.

L'autre raison est aussi d'uniformiser par rapport au retour de CC qui lui normalize le doc et ajoute ce _type.

fix https://github.com/cozy/cozy-libs/issues/2023