### PR TITLE
[WIP] fix: Reconnect WebSocket

### DIFF
--- a/packages/cozy-realtime/src/CozyRealtime.js
+++ b/packages/cozy-realtime/src/CozyRealtime.js
@@ -546,9 +546,10 @@ class CozyRealtime {
     // We however can't assert that the token sent was not expired.
     // If this happenned, we should throw the socket and reconnect.
     //  Let's do that in all cases, as it won't be frequent anyways.
-    if (this.hasWebSocket()) {
-      this.revokeWebSocket()
-    }
+    // We can also have lost the WS connexion because of a sleep or
+    // else. Like that, if the client is refreshed, we try reconnect
+    // the WS in order to be sure to be connected.
+    this.reconnect({ immediate: true })
   }
 
   /**
@@ -660,7 +661,15 @@ class CozyRealtime {
   onVisibilityChange() {
     if (document.visibilityState && document.visibilityState === 'visible') {
       // if we have a reconnect waiting, do it immediatly
-      this.retryManager.stopCurrentAttemptWaitingTime()
+      if (this.retryManager.waiting) {
+        this.retryManager.stopCurrentAttemptWaitingTime()
+      } else {
+        // If the current websocket is closed but we missed the closing state
+        // because of a sleep or something else, let's try to reconnect
+        if (this.websocket.readyState === WebSocket.CLOSED) {
+          this.reconnect({ immediate: true })
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
If an application is opened for a long time, aka in a long life browser's tab and you never close the browser and that the client can go on a sleep or else, WS can not be connected.

So we try 2 things here:
- First is to reconnect after a refreshedToken. It can be useful because CozyClient will try to refresh the token after 24h. So if the token is refreshed, it means that the client has an internet connexion and just make a request so it's the right time to reconnect with this new token

- Second is to play with the visibility API. Before, the reconnexion was not very aggressive. We only tried if we were in a process to trying to reconnect by accelerating the reconnexion process. Now we try to reconnect also if the current websocket is closed.