### PR TITLE
Fix: Dsiplay harvest banner

### DIFF
--- a/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
+++ b/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
@@ -19,7 +19,7 @@
   - `[konnectorCriteria]`: {object} Allows to propose the installation of a konnector before the steps of creation of a paper.
     - - *Only one of the following properties is accepted:*
       - `name`: {string} Name of the konnector.
-      - `category`: {string} Connector category.
+      - `category`: {string} Konnector category.
   - [`acquisitionSteps`](#steps-of-the-acquisitionsteps-property): {object\[]} Contains the steps of the creation process.
     - [`scan`](#step-scan) {object} Step to select a file (image/pdf).
     - [`[information]`](#step-information) {object} Step to get more informations about this file.

--- a/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
+++ b/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
@@ -16,9 +16,9 @@
       - *`name`: Value of the attribute present in the [`information`](#information-field-attributes) step.*
       - *`labelGivenByUser`: Value of the attribute present in the [`information`](#information-field-attributes) step.*
   - `maxDisplay`: {number} Specifies the number of this type of paper to be displayed once created.
-  - `[connectorCriteria]`: {object} Allows to propose the installation of a connector before the steps of creation of a paper.
+  - `[konnectorCriteria]`: {object} Allows to propose the installation of a konnector before the steps of creation of a paper.
     - - *Only one of the following properties is accepted:*
-      - `name`: {string} Name of the connector.
+      - `name`: {string} Name of the konnector.
       - `category`: {string} Connector category.
   - [`acquisitionSteps`](#steps-of-the-acquisitionsteps-property): {object\[]} Contains the steps of the creation process.
     - [`scan`](#step-scan) {object} Step to select a file (image/pdf).

--- a/packages/cozy-mespapiers-lib/src/components/ImportDropdown/ImportDropdown.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ImportDropdown/ImportDropdown.jsx
@@ -51,7 +51,7 @@ ImportDropdown.propTypes = {
     label: PropTypes.string.isRequired,
     icon: iconPropType.isRequired,
     acquisitionSteps: PropTypes.array.isRequired,
-    connectorCriteria: PropTypes.shape({
+    konnectorCriteria: PropTypes.shape({
       name: PropTypes.string,
       category: PropTypes.string
     })

--- a/packages/cozy-mespapiers-lib/src/components/ImportDropdown/ImportDropdownItems.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ImportDropdown/ImportDropdownItems.jsx
@@ -39,7 +39,7 @@ const ImportDropdownItems = ({ placeholder, onClick }) => {
   const styles = useStyles()
   const {
     acquisitionSteps: { length: acquisitionStepsLength },
-    connectorCriteria: {
+    konnectorCriteria: {
       category: konnectorCategory,
       name: konnectorName
     } = {},
@@ -127,7 +127,7 @@ ImportDropdownItems.propTypes = {
     label: PropTypes.string,
     icon: iconPropType,
     acquisitionSteps: PropTypes.array.isRequired,
-    connectorCriteria: PropTypes.shape({
+    konnectorCriteria: PropTypes.shape({
       name: PropTypes.string,
       category: PropTypes.string
     })

--- a/packages/cozy-mespapiers-lib/src/components/MesPapiersLibRoutes.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/MesPapiersLibRoutes.jsx
@@ -33,12 +33,12 @@ const OutletWrapper = ({ Component }) => (
 const MesPapiersLibRoutes = ({ lang, components }) => {
   const location = useLocation()
   const [searchParams] = useSearchParams()
-  const connectorSlug = searchParams.get('connectorSlug')
+  const konnectorSlug = searchParams.get('connectorSlug')
 
   // usefull when getting connectorSlug from Store after rerouting process
   // because of redirectAfterInstall
-  if (connectorSlug) {
-    return <Navigate replace to={`${location.pathname}${connectorSlug}`} />
+  if (konnectorSlug) {
+    return <Navigate replace to={`${location.pathname}${konnectorSlug}`} />
   }
 
   return (

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.jsx
@@ -1,11 +1,11 @@
-import React from 'react'
 import PropTypes from 'prop-types'
+import React from 'react'
 
-import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import UiEmpty from 'cozy-ui/transpiled/react/Empty'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
+import EmptyWithKonnector from './EmptyWithKonnector'
 import HomeCloud from '../../../assets/icons/HomeCloud.svg'
-import EmptyWithConnector from './EmptyWithConnector'
 
 const Empty = ({ connector, accounts }) => {
   const { t } = useI18n()
@@ -22,7 +22,7 @@ const Empty = ({ connector, accounts }) => {
     )
   }
 
-  return <EmptyWithConnector connector={connector} accounts={accounts} />
+  return <EmptyWithKonnector connector={connector} accounts={accounts} />
 }
 
 Empty.propTypes = {

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.jsx
@@ -7,10 +7,10 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import EmptyWithKonnector from './EmptyWithKonnector'
 import HomeCloud from '../../../assets/icons/HomeCloud.svg'
 
-const Empty = ({ connector, accounts }) => {
+const Empty = ({ konnector, accounts }) => {
   const { t } = useI18n()
 
-  if (!connector) {
+  if (!konnector) {
     return (
       <UiEmpty
         className="u-ph-1"
@@ -22,11 +22,11 @@ const Empty = ({ connector, accounts }) => {
     )
   }
 
-  return <EmptyWithKonnector connector={connector} accounts={accounts} />
+  return <EmptyWithKonnector konnector={konnector} accounts={accounts} />
 }
 
 Empty.propTypes = {
-  connector: PropTypes.object,
+  konnector: PropTypes.object,
   accounts: PropTypes.array
 }
 

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.spec.js
@@ -1,17 +1,18 @@
-import React from 'react'
 import { render } from '@testing-library/react'
+import React from 'react'
+
 import flag from 'cozy-flags'
 
-import AppLike from '../../../../test/components/AppLike'
 import Empty from './Empty'
+import AppLike from '../../../../test/components/AppLike'
 
 jest.mock('cozy-flags')
 jest.mock('../HarvestBanner', () => () => <div data-testid="HarvestBanner" />)
 
-const setup = ({ connector, accounts } = {}) => {
+const setup = ({ konnector, accounts } = {}) => {
   return render(
     <AppLike>
-      <Empty connector={connector} accounts={accounts} />
+      <Empty konnector={konnector} accounts={accounts} />
     </AppLike>
   )
 }
@@ -23,7 +24,7 @@ describe('MesPapiersLibProviders', () => {
 
   it('should display basic text without harvest banner', () => {
     const { queryByTestId, getByText } = setup({
-      connector: undefined,
+      konnector: undefined,
       accounts: undefined
     })
 
@@ -33,7 +34,7 @@ describe('MesPapiersLibProviders', () => {
 
   it('should display specific text', () => {
     const { queryByTestId, getByText } = setup({
-      connector: {},
+      konnector: {},
       accounts: [{}]
     })
 
@@ -45,7 +46,7 @@ describe('MesPapiersLibProviders', () => {
     flag.mockReturnValue(true)
 
     const { queryByTestId, getByText } = setup({
-      connector: {},
+      konnector: {},
       accounts: [{}]
     })
 
@@ -55,7 +56,7 @@ describe('MesPapiersLibProviders', () => {
 
   it('should display logins', () => {
     const { queryByTestId, getByText } = setup({
-      connector: {},
+      konnector: {},
       accounts: [
         { auth: { login: 'myLogin' } },
         { auth: { login: 'myOtherLogin' } }
@@ -71,7 +72,7 @@ describe('MesPapiersLibProviders', () => {
     flag.mockReturnValue(true)
 
     const { queryAllByTestId, getByText } = setup({
-      connector: {},
+      konnector: {},
       accounts: [
         { auth: { login: 'myLogin' } },
         { auth: { login: 'myOtherLogin' } }

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyNoHeader.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyNoHeader.jsx
@@ -1,20 +1,19 @@
-import React from 'react'
 import PropTypes from 'prop-types'
+import React from 'react'
 import { useNavigate, useParams, useLocation } from 'react-router-dom'
 
 import flag from 'cozy-flags'
-import { useI18n } from 'cozy-ui/transpiled/react/I18n'
-
-import Empty from 'cozy-ui/transpiled/react/Empty'
 import Button from 'cozy-ui/transpiled/react/Buttons'
+import Empty from 'cozy-ui/transpiled/react/Empty'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import PapersIcon from 'cozy-ui/transpiled/react/Icons/Papers'
 
+import { makeCountrySearchParam } from './helpers'
+import styles from './styles.styl'
 import { useMultiSelection } from '../../Hooks/useMultiSelection'
 import { usePapersDefinitions } from '../../Hooks/usePapersDefinitions'
-import { makeCountrySearchParam } from './helpers'
-import { getCurrentFileTheme } from '../helpers'
 import HarvestBanner from '../HarvestBanner'
-import styles from './styles.styl'
+import { getCurrentFileTheme } from '../helpers'
 
 const EmptyNoHeader = ({ konnector, accounts }) => {
   const { t } = useI18n()
@@ -44,7 +43,7 @@ const EmptyNoHeader = ({ konnector, accounts }) => {
         <HarvestBanner konnector={konnector} account={accounts?.[0]} />
       )}
       <Empty
-        className={`${styles['emptyWithConnector']} u-ph-1`}
+        className={`${styles['emptyWithKonnector']} u-ph-1`}
         icon={PapersIcon}
         iconSize="normal"
         title={t('Empty.konnector.title')}

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyNoHeader.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyNoHeader.jsx
@@ -16,7 +16,7 @@ import { getCurrentFileTheme } from '../helpers'
 import HarvestBanner from '../HarvestBanner'
 import styles from './styles.styl'
 
-const EmptyNoHeader = ({ connector, accounts }) => {
+const EmptyNoHeader = ({ konnector, accounts }) => {
   const { t } = useI18n()
   const params = useParams()
   const { search, pathname } = useLocation()
@@ -41,25 +41,25 @@ const EmptyNoHeader = ({ connector, accounts }) => {
   return (
     <>
       {flag('harvest.inappconnectors.enabled') && (
-        <HarvestBanner connector={connector} account={accounts?.[0]} />
+        <HarvestBanner konnector={konnector} account={accounts?.[0]} />
       )}
       <Empty
         className={`${styles['emptyWithConnector']} u-ph-1`}
         icon={PapersIcon}
         iconSize="normal"
-        title={t('Empty.connector.title')}
-        text={t('Empty.connector.text', {
-          connectorSlug: connector?.slug?.toUpperCase()
+        title={t('Empty.konnector.title')}
+        text={t('Empty.konnector.text', {
+          konnectorSlug: konnector?.slug?.toUpperCase()
         })}
       >
-        <Button label={t('Empty.connector.button')} onClick={handleClick} />
+        <Button label={t('Empty.konnector.button')} onClick={handleClick} />
       </Empty>
     </>
   )
 }
 
 EmptyNoHeader.propTypes = {
-  connector: PropTypes.object,
+  konnector: PropTypes.object,
   accounts: PropTypes.array
 }
 

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithHeader.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithHeader.jsx
@@ -11,7 +11,7 @@ import ListSubheader from 'cozy-ui/transpiled/react/MuiCozyTheme/ListSubheader'
 
 import HarvestBanner from '../HarvestBanner'
 
-const EmptyWithHeader = ({ connector, account }) => {
+const EmptyWithHeader = ({ konnector, account }) => {
   const { t } = useI18n()
 
   return (
@@ -23,14 +23,14 @@ const EmptyWithHeader = ({ connector, account }) => {
       }
     >
       {flag('harvest.inappconnectors.enabled') && (
-        <HarvestBanner connector={connector} account={account} />
+        <HarvestBanner konnector={konnector} account={account} />
       )}
       <ListItem>
         <ListItemText
           ellipsis={false}
-          primary={t('Empty.connector.title')}
-          secondary={t('Empty.connector.text', {
-            connectorSlug: connector?.slug?.toUpperCase()
+          primary={t('Empty.konnector.title')}
+          secondary={t('Empty.konnector.text', {
+            konnectorSlug: konnector?.slug?.toUpperCase()
           })}
         />
       </ListItem>
@@ -39,7 +39,7 @@ const EmptyWithHeader = ({ connector, account }) => {
 }
 
 EmptyWithHeader.propTypes = {
-  connector: PropTypes.object,
+  konnector: PropTypes.object,
   account: PropTypes.object.isRequired
 }
 

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithKonnector.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithKonnector.jsx
@@ -1,10 +1,10 @@
-import React from 'react'
 import PropTypes from 'prop-types'
+import React from 'react'
 
-import EmptyWithHeader from './EmptyWithHeader'
 import EmptyNoHeader from './EmptyNoHeader'
+import EmptyWithHeader from './EmptyWithHeader'
 
-const EmptyWithConnector = ({ connector, accounts }) => {
+const EmptyWithKonnector = ({ connector, accounts }) => {
   if (accounts?.length > 1) {
     return accounts.map((account, index) => (
       <EmptyWithHeader key={index} connector={connector} account={account} />
@@ -14,9 +14,9 @@ const EmptyWithConnector = ({ connector, accounts }) => {
   return <EmptyNoHeader connector={connector} accounts={accounts} />
 }
 
-EmptyWithConnector.propTypes = {
+EmptyWithKonnector.propTypes = {
   connector: PropTypes.object,
   accounts: PropTypes.array
 }
 
-export default EmptyWithConnector
+export default EmptyWithKonnector

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithKonnector.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithKonnector.jsx
@@ -4,18 +4,18 @@ import React from 'react'
 import EmptyNoHeader from './EmptyNoHeader'
 import EmptyWithHeader from './EmptyWithHeader'
 
-const EmptyWithKonnector = ({ connector, accounts }) => {
+const EmptyWithKonnector = ({ konnector, accounts }) => {
   if (accounts?.length > 1) {
     return accounts.map((account, index) => (
-      <EmptyWithHeader key={index} connector={connector} account={account} />
+      <EmptyWithHeader key={index} konnector={konnector} account={account} />
     ))
   }
 
-  return <EmptyNoHeader connector={connector} accounts={accounts} />
+  return <EmptyNoHeader konnector={konnector} accounts={accounts} />
 }
 
 EmptyWithKonnector.propTypes = {
-  connector: PropTypes.object,
+  konnector: PropTypes.object,
   accounts: PropTypes.array
 }
 

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/styles.styl
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/styles.styl
@@ -1,4 +1,4 @@
-.emptyWithConnector
+.emptyWithKonnector
   position fixed
   top 50%
   transform translateY(-50%)

--- a/packages/cozy-mespapiers-lib/src/components/Papers/HarvestBanner.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/HarvestBanner.jsx
@@ -5,12 +5,12 @@ import { useQuery, isQueryLoading } from 'cozy-client'
 import { LaunchTriggerCard } from 'cozy-harvest-lib'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 
-import { buildTriggersQueryByConnectorSlug } from '../../helpers/queries'
+import { buildTriggersQueryByKonnectorSlug } from '../../helpers/queries'
 
 const HarvestBanner = ({ konnector, account }) => {
   const konnectorSlug = konnector?.slug
 
-  const queryTriggers = buildTriggersQueryByConnectorSlug(
+  const queryTriggers = buildTriggersQueryByKonnectorSlug(
     konnectorSlug,
     Boolean(konnectorSlug) && Boolean(account)
   )

--- a/packages/cozy-mespapiers-lib/src/components/Papers/HarvestBanner.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/HarvestBanner.jsx
@@ -7,12 +7,12 @@ import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 
 import { buildTriggersQueryByConnectorSlug } from '../../helpers/queries'
 
-const HarvestBanner = ({ connector, account }) => {
-  const connectorSlug = connector?.slug
+const HarvestBanner = ({ konnector, account }) => {
+  const konnectorSlug = konnector?.slug
 
   const queryTriggers = buildTriggersQueryByConnectorSlug(
-    connectorSlug,
-    Boolean(connectorSlug) && Boolean(account)
+    konnectorSlug,
+    Boolean(konnectorSlug) && Boolean(account)
   )
   const { data: triggers, ...triggersQueryLeft } = useQuery(
     queryTriggers.definition,
@@ -24,15 +24,15 @@ const HarvestBanner = ({ connector, account }) => {
     trigger => trigger.message.account === account?._id
   )
 
-  if (!connector || !account || isTriggersLoading) {
+  if (!konnector || !account || isTriggersLoading) {
     return null
   }
 
   return (
     <>
       <LaunchTriggerCard
-        flowProps={{ initialTrigger: trigger, konnector: connector }}
-        konnectorRoot={`harvest/${connectorSlug}`}
+        flowProps={{ initialTrigger: trigger, konnector }}
+        konnectorRoot={`harvest/${konnectorSlug}`}
       />
       <Divider />
     </>
@@ -40,7 +40,7 @@ const HarvestBanner = ({ connector, account }) => {
 }
 
 HarvestBanner.propTypes = {
-  connector: PropTypes.object,
+  konnector: PropTypes.object,
   account: PropTypes.object
 }
 

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PapersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PapersList.jsx
@@ -19,7 +19,7 @@ import { useMultiSelection } from '../Hooks/useMultiSelection'
 import HarvestBanner from './HarvestBanner'
 import { makeAccountFromPapers } from './helpers'
 
-const PapersList = ({ papers, connector, accounts, isLast }) => {
+const PapersList = ({ papers, konnector, accounts, isLast }) => {
   const client = useClient()
   const { t } = useI18n()
   const { pushModal, popModal } = useModal()
@@ -62,7 +62,7 @@ const PapersList = ({ papers, connector, accounts, isLast }) => {
   return (
     <>
       {flag('harvest.inappconnectors.enabled') && (
-        <HarvestBanner connector={connector} account={account} />
+        <HarvestBanner konnector={konnector} account={account} />
       )}
       {papers.list.map(
         (paper, idx) =>
@@ -100,7 +100,7 @@ PapersList.propTypes = {
     maxDisplay: PropTypes.number,
     list: PropTypes.arrayOf(PropTypes.object)
   }),
-  connector: PropTypes.object,
+  konnector: PropTypes.object,
   accounts: PropTypes.array,
   isLast: PropTypes.bool
 }

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PapersListByContact.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PapersListByContact.jsx
@@ -1,5 +1,5 @@
-import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
+import React, { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
@@ -8,13 +8,13 @@ import ListSubheader from 'cozy-ui/transpiled/react/MuiCozyTheme/ListSubheader'
 
 import { DEFAULT_MAX_FILES_DISPLAYED } from '../../constants/const'
 import { usePapersDefinitions } from '../Hooks/usePapersDefinitions'
-import { buildFilesByContacts, getCurrentFileTheme } from '../Papers/helpers'
 import PapersList from '../Papers/PapersList'
+import { buildFilesByContacts, getCurrentFileTheme } from '../Papers/helpers'
 
 const PapersListByContact = ({
   selectedThemeLabel,
   files,
-  konnector,
+  konnectors,
   accounts,
   contacts
 }) => {
@@ -33,33 +33,36 @@ const PapersListByContact = ({
     () =>
       buildFilesByContacts({
         files,
+        konnectors,
         contacts,
         maxDisplay:
           currentDefinition?.maxDisplay || DEFAULT_MAX_FILES_DISPLAYED,
         t
       }),
-    [contacts, currentDefinition, files, t]
+    [contacts, konnectors, currentDefinition, files, t]
   )
 
-  return paperslistByContact.map(({ withHeader, contact, papers }, idx) => (
-    <List
-      key={idx}
-      subheader={
-        withHeader && (
-          <ListSubheader>
-            <div className="u-ellipsis">{contact}</div>
-          </ListSubheader>
-        )
-      }
-    >
-      <PapersList
-        papers={papers}
-        konnector={konnector}
-        accounts={accounts}
-        isLast={files.length === 1}
-      />
-    </List>
-  ))
+  return paperslistByContact.map(
+    ({ withHeader, contact, konnector, papers }, idx) => (
+      <List
+        key={idx}
+        subheader={
+          withHeader && (
+            <ListSubheader>
+              <div className="u-ellipsis">{contact}</div>
+            </ListSubheader>
+          )
+        }
+      >
+        <PapersList
+          papers={papers}
+          konnector={konnector}
+          accounts={accounts}
+          isLast={files.length === 1}
+        />
+      </List>
+    )
+  )
 }
 
 PapersListByContact.propTypes = {

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PapersListByContact.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PapersListByContact.jsx
@@ -14,7 +14,7 @@ import PapersList from '../Papers/PapersList'
 const PapersListByContact = ({
   selectedThemeLabel,
   files,
-  connector,
+  konnector,
   accounts,
   contacts
 }) => {
@@ -54,7 +54,7 @@ const PapersListByContact = ({
     >
       <PapersList
         papers={papers}
-        connector={connector}
+        konnector={konnector}
         accounts={accounts}
         isLast={files.length === 1}
       />
@@ -65,7 +65,7 @@ const PapersListByContact = ({
 PapersListByContact.propTypes = {
   selectedThemeLabel: PropTypes.string,
   files: PropTypes.arrayOf(PropTypes.object),
-  connector: PropTypes.object,
+  konnector: PropTypes.object,
   accounts: PropTypes.array,
   contacts: PropTypes.arrayOf(PropTypes.object)
 }

--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
@@ -9,7 +9,7 @@ import { filterWithRemaining } from '../../helpers/filterWithRemaining'
 const { getDisplayName } = models.contact
 
 const hasContactsInFile = file => file.contacts.length > 0
-const isFromConnector = file => Boolean(file.cozyMetadata?.sourceAccount)
+const isFromKonnector = file => Boolean(file.cozyMetadata?.sourceAccount)
 
 /**
  * Get all contact ids referenced on files
@@ -98,7 +98,7 @@ export const groupFilesByContacts = (filesArg, contactsArg) => {
 /**
  * Group files together if they come from the same contact
  * or the same list of contacts,
- * or the same sourceAccountIdentifier of the same Connector.
+ * or the same sourceAccountIdentifier of the same Konnector.
  * The rest is grouped together at the end in the same list.
  * @property {object[]} files - Array of IOCozyFile
  * @property {object[]} contacts - Array of IOCozyContact
@@ -116,18 +116,18 @@ export const buildFilesByContacts = ({
   const result = []
 
   const {
-    itemsFound: filesCreatedByConnectors,
-    remainingItems: filesNotCreatedByConnectors
-  } = filterWithRemaining(files, isFromConnector)
+    itemsFound: filesCreatedByKonnectors,
+    remainingItems: filesNotCreatedByKonnectors
+  } = filterWithRemaining(files, isFromKonnector)
 
-  if (filesCreatedByConnectors.length > 0) {
-    const filesByConnectors = groupBy(
-      filesCreatedByConnectors,
+  if (filesCreatedByKonnectors.length > 0) {
+    const filesByKonnectors = groupBy(
+      filesCreatedByKonnectors,
       file =>
         `${file.cozyMetadata.uploadedBy.slug}-${file.cozyMetadata.sourceAccountIdentifier}`
     )
 
-    const unsortedlistByConnector = Object.values(filesByConnectors).map(
+    const unsortedlistByKonnector = Object.values(filesByKonnectors).map(
       value => ({
         withHeader: true,
         konnector: konnectors?.find(
@@ -144,15 +144,15 @@ export const buildFilesByContacts = ({
       })
     )
 
-    const listByConnector = unsortedlistByConnector.sort((a, b) =>
+    const listByKonnector = unsortedlistByKonnector.sort((a, b) =>
       a.contact.localeCompare(b.contact)
     )
 
-    result.push(...listByConnector)
+    result.push(...listByKonnector)
   }
 
   const filesByContacts = groupFilesByContacts(
-    filesNotCreatedByConnectors,
+    filesNotCreatedByKonnectors,
     contacts
   )
 

--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
@@ -105,7 +105,13 @@ export const groupFilesByContacts = (filesArg, contactsArg) => {
  * @property {Function} t - i18n function
  * @returns {{ withHeader: boolean, contact: string, papers: { maxDisplay: number, list: IOCozyFile[] } }[]}
  */
-export const buildFilesByContacts = ({ files, contacts, maxDisplay, t }) => {
+export const buildFilesByContacts = ({
+  files,
+  contacts,
+  konnectors = [],
+  maxDisplay,
+  t
+}) => {
   const result = []
 
   const {
@@ -123,6 +129,9 @@ export const buildFilesByContacts = ({ files, contacts, maxDisplay, t }) => {
     const unsortedlistByConnector = Object.values(filesByConnectors).map(
       value => ({
         withHeader: true,
+        konnector: konnectors?.find(
+          konnector => konnector.slug === value[0].cozyMetadata.uploadedBy.slug
+        ),
         contact: t('PapersList.accountName', {
           name: value[0].cozyMetadata.createdByApp,
           identifier: value[0].cozyMetadata.sourceAccountIdentifier

--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
@@ -1,6 +1,7 @@
 import groupBy from 'lodash/groupBy'
 
 import { models, getReferencedBy } from 'cozy-client'
+import { getAccountName } from 'cozy-client/dist/models/account'
 
 import { CONTACTS_DOCTYPE } from '../../doctypes'
 import { filterWithRemaining } from '../../helpers/filterWithRemaining'
@@ -223,7 +224,7 @@ export const getCurrentFileTheme = (params, selectedThemeLabel) =>
 export const makeAccountFromPapers = (papers, accounts) => {
   const accountLogin = papers?.list?.[0]?.cozyMetadata?.sourceAccountIdentifier
   const account = accountLogin
-    ? accounts?.find(account => account?.auth?.login === accountLogin)
+    ? accounts?.find(account => getAccountName(account) === accountLogin)
     : undefined
 
   return account

--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.spec.js
@@ -281,7 +281,7 @@ describe('helpers Papers', () => {
       expect(result).toStrictEqual(expected)
     })
 
-    it('should return object with all papers filtered by connector', () => {
+    it('should return object with all papers filtered by konnector', () => {
       const result = buildFilesByContacts({
         files: [...mockFilesWithSourceAccount, ...mockUnspecifiedFiles],
         contacts: [],

--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.spec.js
@@ -70,10 +70,10 @@ const mockFilesWithSourceAccount = [
     _id: 'fileId05',
     name: 'file05.pdf',
     cozyMetadata: {
-      sourceAccount: 'ConnectorAccountId01',
+      sourceAccount: 'KonnectorAccountId01',
       sourceAccountIdentifier: 'Account 1',
       uploadedBy: {
-        slug: 'ConnectorOne'
+        slug: 'KonnectorOne'
       }
     }
   },
@@ -81,10 +81,10 @@ const mockFilesWithSourceAccount = [
     _id: 'fileId06',
     name: 'file06.pdf',
     cozyMetadata: {
-      sourceAccount: 'ConnectorAccountId01',
+      sourceAccount: 'KonnectorAccountId01',
       sourceAccountIdentifier: 'Account 1',
       uploadedBy: {
-        slug: 'ConnectorOne'
+        slug: 'KonnectorOne'
       }
     }
   },
@@ -92,10 +92,10 @@ const mockFilesWithSourceAccount = [
     _id: 'fileId07',
     name: 'file07.pdf',
     cozyMetadata: {
-      sourceAccount: 'ConnectorAccountId02',
+      sourceAccount: 'KonnectorAccountId02',
       sourceAccountIdentifier: 'Account 2',
       uploadedBy: {
-        slug: 'ConnectorTwo'
+        slug: 'KonnectorTwo'
       }
     }
   }
@@ -106,10 +106,10 @@ const mockFilesWithContactsAndSourceAccount = [
     _id: 'fileId09',
     name: 'file09pdf',
     cozyMetadata: {
-      sourceAccount: 'ConnectorAccountId02',
+      sourceAccount: 'KonnectorAccountId02',
       sourceAccountIdentifier: 'Account 2',
       uploadedBy: {
-        slug: 'ConnectorTwo'
+        slug: 'KonnectorTwo'
       }
     },
     relationships: {
@@ -286,7 +286,7 @@ describe('helpers Papers', () => {
     it('should return object with all papers filtered by konnector', () => {
       const result = buildFilesByContacts({
         files: [...mockFilesWithSourceAccount, ...mockUnspecifiedFiles],
-        konnectors: [{ slug: 'ConnectorOne' }, { slug: 'ConnectorTwo' }],
+        konnectors: [{ slug: 'KonnectorOne' }, { slug: 'KonnectorTwo' }],
         contacts: [],
         maxDisplay: 3,
         t: jest.fn(key => key)
@@ -295,7 +295,7 @@ describe('helpers Papers', () => {
       const expected = [
         {
           withHeader: true,
-          konnector: { slug: 'ConnectorOne' },
+          konnector: { slug: 'KonnectorOne' },
           contact: 'PapersList.accountName',
           papers: {
             maxDisplay: 3,
@@ -304,7 +304,7 @@ describe('helpers Papers', () => {
         },
         {
           withHeader: true,
-          konnector: { slug: 'ConnectorTwo' },
+          konnector: { slug: 'KonnectorTwo' },
           contact: 'PapersList.accountName',
           papers: {
             maxDisplay: 3,
@@ -331,7 +331,7 @@ describe('helpers Papers', () => {
           ...mockFilesWithSourceAccount,
           ...mockFilesWithContactsAndSourceAccount
         ],
-        konnectors: [{ slug: 'ConnectorOne' }, { slug: 'ConnectorTwo' }],
+        konnectors: [{ slug: 'KonnectorOne' }, { slug: 'KonnectorTwo' }],
         contacts: mockContacts00,
         maxDisplay: 3,
         t: jest.fn(key => key)
@@ -340,7 +340,7 @@ describe('helpers Papers', () => {
       const expected = [
         {
           withHeader: true,
-          konnector: { slug: 'ConnectorOne' },
+          konnector: { slug: 'KonnectorOne' },
           contact: 'PapersList.accountName',
           papers: {
             maxDisplay: 3,
@@ -349,7 +349,7 @@ describe('helpers Papers', () => {
         },
         {
           withHeader: true,
-          konnector: { slug: 'ConnectorTwo' },
+          konnector: { slug: 'KonnectorTwo' },
           contact: 'PapersList.accountName',
           papers: {
             maxDisplay: 3,

--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.spec.js
@@ -251,6 +251,7 @@ describe('helpers Papers', () => {
 
       const result = buildFilesByContacts({
         files: [...mockFilesWithContacts, ...mockUnspecifiedFiles],
+        konnectors: undefined,
         contacts: mockContacts00,
         maxDisplay: 3,
         t: jest.fn(key => key)
@@ -273,6 +274,7 @@ describe('helpers Papers', () => {
 
       const result = buildFilesByContacts({
         files: mockUnspecifiedFiles,
+        konnector: undefined,
         contacts: mockContacts00,
         maxDisplay: 3,
         t: jest.fn(key => key)
@@ -284,6 +286,7 @@ describe('helpers Papers', () => {
     it('should return object with all papers filtered by konnector', () => {
       const result = buildFilesByContacts({
         files: [...mockFilesWithSourceAccount, ...mockUnspecifiedFiles],
+        konnectors: [{ slug: 'ConnectorOne' }, { slug: 'ConnectorTwo' }],
         contacts: [],
         maxDisplay: 3,
         t: jest.fn(key => key)
@@ -292,6 +295,7 @@ describe('helpers Papers', () => {
       const expected = [
         {
           withHeader: true,
+          konnector: { slug: 'ConnectorOne' },
           contact: 'PapersList.accountName',
           papers: {
             maxDisplay: 3,
@@ -300,6 +304,7 @@ describe('helpers Papers', () => {
         },
         {
           withHeader: true,
+          konnector: { slug: 'ConnectorTwo' },
           contact: 'PapersList.accountName',
           papers: {
             maxDisplay: 3,
@@ -326,6 +331,7 @@ describe('helpers Papers', () => {
           ...mockFilesWithSourceAccount,
           ...mockFilesWithContactsAndSourceAccount
         ],
+        konnectors: [{ slug: 'ConnectorOne' }, { slug: 'ConnectorTwo' }],
         contacts: mockContacts00,
         maxDisplay: 3,
         t: jest.fn(key => key)
@@ -334,6 +340,7 @@ describe('helpers Papers', () => {
       const expected = [
         {
           withHeader: true,
+          konnector: { slug: 'ConnectorOne' },
           contact: 'PapersList.accountName',
           papers: {
             maxDisplay: 3,
@@ -342,6 +349,7 @@ describe('helpers Papers', () => {
         },
         {
           withHeader: true,
+          konnector: { slug: 'ConnectorTwo' },
           contact: 'PapersList.accountName',
           papers: {
             maxDisplay: 3,

--- a/packages/cozy-mespapiers-lib/src/components/PapersFab/PaperFabUI.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/PapersFab/PaperFabUI.jsx
@@ -1,14 +1,14 @@
-import React from 'react'
 import PropTypes from 'prop-types'
+import React from 'react'
 
-import ActionMenuImportDropdown from '../Placeholders/ActionMenuImportDropdown'
 import ActionMenuWrapper from '../Actions/ActionMenuWrapper'
 import { ActionsItems } from '../Actions/ActionsItems'
+import ActionMenuImportDropdown from '../Placeholders/ActionMenuImportDropdown'
 
 const PaperFabUI = React.forwardRef(
-  ({ PapersFabOverrided, generalMenuProps, connectorMenuProps }, ref) => {
+  ({ PapersFabOverrided, generalMenuProps, konnectorMenuProps }, ref) => {
     const { show: showGeneralMenu, onClose, actions } = generalMenuProps
-    const { show: showConnectorMenu } = connectorMenuProps
+    const { show: showConnectorMenu } = konnectorMenuProps
 
     return (
       <>
@@ -23,7 +23,7 @@ const PaperFabUI = React.forwardRef(
           <ActionMenuImportDropdown
             isOpened
             anchorElRef={ref}
-            {...connectorMenuProps}
+            {...konnectorMenuProps}
           />
         )}
       </>
@@ -39,7 +39,7 @@ PaperFabUI.propTypes = {
     actions: PropTypes.arrayOf(PropTypes.object),
     onClose: PropTypes.func
   }),
-  connectorMenuProps: PropTypes.shape({
+  konnectorMenuProps: PropTypes.shape({
     show: PropTypes.bool,
     placeholder: PropTypes.object,
     onClose: PropTypes.func,

--- a/packages/cozy-mespapiers-lib/src/components/PapersFab/PaperFabUI.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/PapersFab/PaperFabUI.jsx
@@ -8,7 +8,7 @@ import ActionMenuImportDropdown from '../Placeholders/ActionMenuImportDropdown'
 const PaperFabUI = React.forwardRef(
   ({ PapersFabOverrided, generalMenuProps, konnectorMenuProps }, ref) => {
     const { show: showGeneralMenu, onClose, actions } = generalMenuProps
-    const { show: showConnectorMenu } = konnectorMenuProps
+    const { show: showKonnectorMenu } = konnectorMenuProps
 
     return (
       <>
@@ -19,7 +19,7 @@ const PaperFabUI = React.forwardRef(
             <ActionsItems actions={actions} />
           </ActionMenuWrapper>
         )}
-        {showConnectorMenu && (
+        {showKonnectorMenu && (
           <ActionMenuImportDropdown
             isOpened
             anchorElRef={ref}

--- a/packages/cozy-mespapiers-lib/src/components/PapersFab/PapersFabWrapper.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/PapersFab/PapersFabWrapper.jsx
@@ -46,7 +46,7 @@ const PapersFabWrapper = ({ children }) => {
   }
 
   const showImportDropdown = paperDefinition => {
-    if (paperDefinition.connectorCriteria) {
+    if (paperDefinition.konnectorCriteria) {
       setShowConnectorMenu(true)
     } else {
       redirectPaperCreation(paperDefinition)
@@ -79,7 +79,7 @@ const PapersFabWrapper = ({ children }) => {
       actions,
       onClose: hideGeneralMenu
     },
-    connectorMenuProps: {
+    konnectorMenuProps: {
       show: showConnectorMenu,
       placeholder: paperDefinition,
       onClose: () => setShowConnectorMenu(false),

--- a/packages/cozy-mespapiers-lib/src/components/PapersFab/PapersFabWrapper.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/PapersFab/PapersFabWrapper.jsx
@@ -14,7 +14,7 @@ import PaperFabUI from './PaperFabUI'
 
 const PapersFabWrapper = ({ children }) => {
   const [showGeneralMenu, setShowGeneralMenu] = useState(false)
-  const [showConnectorMenu, setShowConnectorMenu] = useState(false)
+  const [showKonnectorMenu, setShowKonnectorMenu] = useState(false)
   const actionBtnRef = useRef()
   const client = useClient()
   const { fileTheme } = useParams()
@@ -35,7 +35,7 @@ const PapersFabWrapper = ({ children }) => {
   )[0]
 
   const redirectPaperCreation = placeholder => {
-    setShowConnectorMenu(false)
+    setShowKonnectorMenu(false)
     const countrySearchParam = `${
       placeholder.country ? `country=${placeholder.country}` : ''
     }`
@@ -47,7 +47,7 @@ const PapersFabWrapper = ({ children }) => {
 
   const showImportDropdown = paperDefinition => {
     if (paperDefinition.konnectorCriteria) {
-      setShowConnectorMenu(true)
+      setShowKonnectorMenu(true)
     } else {
       redirectPaperCreation(paperDefinition)
     }
@@ -80,9 +80,9 @@ const PapersFabWrapper = ({ children }) => {
       onClose: hideGeneralMenu
     },
     konnectorMenuProps: {
-      show: showConnectorMenu,
+      show: showKonnectorMenu,
       placeholder: paperDefinition,
-      onClose: () => setShowConnectorMenu(false),
+      onClose: () => setShowKonnectorMenu(false),
       onClick: () => redirectPaperCreation(paperDefinition)
     }
   }

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/ActionMenuImportDropdown.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/ActionMenuImportDropdown.jsx
@@ -44,7 +44,7 @@ ActionMenuImportDropdown.propTypes = {
     label: PropTypes.string.isRequired,
     icon: iconPropType.isRequired,
     acquisitionSteps: PropTypes.array,
-    connectorCriteria: PropTypes.shape({
+    konnectorCriteria: PropTypes.shape({
       name: PropTypes.string,
       category: PropTypes.string
     })

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/FeaturedPlaceholdersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/FeaturedPlaceholdersList.jsx
@@ -35,7 +35,7 @@ const FeaturedPlaceholdersList = ({ featuredPlaceholders }) => {
   }
 
   const showImportDropdown = idx => placeholder => {
-    if (placeholder.connectorCriteria) {
+    if (placeholder.konnectorCriteria) {
       actionBtnRef.current = actionBtnRefs.current[idx]
       setIsImportDropdownDisplayed(true)
       setPlaceholder(placeholder)

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/FeaturedPlaceholdersList.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/FeaturedPlaceholdersList.spec.jsx
@@ -1,8 +1,8 @@
-import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
+import React from 'react'
 
-import AppLike from '../../../test/components/AppLike'
 import FeaturedPlaceholdersList from './FeaturedPlaceholdersList'
+import AppLike from '../../../test/components/AppLike'
 
 const fakePlaceholders = [
   {
@@ -12,7 +12,7 @@ const fakePlaceholders = [
     featureDate: 'referencedDate',
     maxDisplay: 3,
     acquisitionSteps: [],
-    connectorCriteria: {
+    konnectorCriteria: {
       name: 'impots'
     }
   },
@@ -46,7 +46,7 @@ jest.mock('./Placeholder', () => ({ onClick }) => {
     featureDate: 'referencedDate',
     maxDisplay: 3,
     acquisitionSteps: [],
-    connectorCriteria: {
+    konnectorCriteria: {
       name: 'impots'
     }
   }

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/Placeholder.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/Placeholder.spec.jsx
@@ -1,9 +1,9 @@
 'use strict'
-import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
+import React from 'react'
 
-import AppLike from '../../../test/components/AppLike'
 import Placeholder from './Placeholder'
+import AppLike from '../../../test/components/AppLike'
 
 const fakePlaceholders = [
   {
@@ -13,7 +13,7 @@ const fakePlaceholders = [
     featureDate: 'referencedDate',
     maxDisplay: 3,
     acquisitionSteps: [],
-    connectorCriteria: {
+    konnectorCriteria: {
       name: 'impots'
     }
   },

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/PlaceholderListModal/PlaceholdersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/PlaceholderListModal/PlaceholdersList.jsx
@@ -72,7 +72,7 @@ const PlaceholdersList = ({ currentQualifItems }) => {
   }
 
   const showImportDropdown = placeholder => {
-    if (placeholder.connectorCriteria) {
+    if (placeholder.konnectorCriteria) {
       setIsImportDropdownDisplayed(true)
       setPlaceholderSelected(placeholder)
     } else {
@@ -86,7 +86,7 @@ const PlaceholdersList = ({ currentQualifItems }) => {
         {allPlaceholders.map((placeholder, idx) => {
           const validPlaceholder =
             placeholder.acquisitionSteps.length > 0 ||
-            placeholder.connectorCriteria
+            placeholder.konnectorCriteria
 
           return (
             <ListItem

--- a/packages/cozy-mespapiers-lib/src/components/Views/HarvestRoutes.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/HarvestRoutes.jsx
@@ -6,8 +6,8 @@ import { Routes } from 'cozy-harvest-lib'
 import datacardOptions from 'cozy-harvest-lib/dist/datacards/datacardOptions'
 
 import {
-  buildTriggersQueryByConnectorSlug,
-  buildConnectorsQueryById
+  buildTriggersQueryByKonnectorSlug,
+  buildKonnectorsQueryById
 } from '../../helpers/queries'
 import ExtraContent from '../Harvest/CannotConnectModal/ExtraContent'
 
@@ -15,7 +15,7 @@ const HarvestRoutes = () => {
   const { connectorSlug } = useParams()
   const navigate = useNavigate()
 
-  const queryTriggers = buildTriggersQueryByConnectorSlug(
+  const queryTriggers = buildTriggersQueryByKonnectorSlug(
     connectorSlug,
     Boolean(connectorSlug)
   )
@@ -25,7 +25,7 @@ const HarvestRoutes = () => {
   )
   const trigger = triggers?.[0]
 
-  const queryKonnector = buildConnectorsQueryById(
+  const queryKonnector = buildKonnectorsQueryById(
     `io.cozy.konnectors/${connectorSlug}`,
     Boolean(trigger)
   )

--- a/packages/cozy-mespapiers-lib/src/components/Views/PapersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/PapersList.jsx
@@ -8,7 +8,7 @@ import {
   buildContactsQueryByIds,
   buildFilesQueryByLabel,
   buildConnectorsQueryByQualificationLabel,
-  buildAccountsQueryBySlug
+  buildAccountsQueryBySlugs
 } from '../../helpers/queries'
 import { useMultiSelection } from '../Hooks/useMultiSelection'
 import Empty from '../Papers/Empty/Empty'
@@ -52,19 +52,15 @@ const PapersList = () => {
     queryKonnector.options
   )
   const isKonnectorsLoading = isQueryLoading(konnectorsQueryLeft)
-  const konnector = konnectors?.[0]
-  const konnectorSlug = konnector?.slug
+  const hasKonnector = konnectors?.length > 0
+  const konnectorSlugs = konnectors?.map(konnector => konnector.slug)
 
-  const queryAccounts = buildAccountsQueryBySlug(
-    konnectorSlug,
-    Boolean(konnectorSlug)
-  )
+  const queryAccounts = buildAccountsQueryBySlugs(konnectorSlugs, hasKonnector)
   const { data: accounts, ...accountsQueryLeft } = useQuery(
     queryAccounts.definition,
     queryAccounts.options
   )
-  const isAccountsLoading =
-    Boolean(konnectorSlug) && isQueryLoading(accountsQueryLeft)
+  const isAccountsLoading = hasKonnector && isQueryLoading(accountsQueryLeft)
 
   const isLoading =
     isLoadingFiles ||
@@ -88,11 +84,11 @@ const PapersList = () => {
               selectedThemeLabel={selectedThemeLabel}
               files={files}
               contacts={contacts}
-              konnector={konnector}
+              konnectors={konnectors}
               accounts={accounts}
             />
           )}
-          {!hasFiles && <Empty konnector={konnector} accounts={accounts} />}
+          {!hasFiles && <Empty konnector={konnectors[0]} accounts={accounts} />}
         </>
       )}
     </>

--- a/packages/cozy-mespapiers-lib/src/components/Views/PapersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/PapersList.jsx
@@ -7,7 +7,7 @@ import { Spinner } from 'cozy-ui/transpiled/react/Spinner'
 import {
   buildContactsQueryByIds,
   buildFilesQueryByLabel,
-  buildConnectorsQueryByQualificationLabel,
+  buildKonnectorsQueryByQualificationLabel,
   buildAccountsQueryBySlugs
 } from '../../helpers/queries'
 import { useMultiSelection } from '../Hooks/useMultiSelection'
@@ -46,7 +46,7 @@ const PapersList = () => {
     isQueryLoading(contactQueryResult) || contactQueryResult.hasMore
 
   const queryKonnector =
-    buildConnectorsQueryByQualificationLabel(currentFileTheme)
+    buildKonnectorsQueryByQualificationLabel(currentFileTheme)
   const { data: konnectors, ...konnectorsQueryLeft } = useQuery(
     queryKonnector.definition,
     queryKonnector.options

--- a/packages/cozy-mespapiers-lib/src/components/Views/PapersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/PapersList.jsx
@@ -45,31 +45,31 @@ const PapersList = () => {
   const isLoadingContacts =
     isQueryLoading(contactQueryResult) || contactQueryResult.hasMore
 
-  const queryConnector =
+  const queryKonnector =
     buildConnectorsQueryByQualificationLabel(currentFileTheme)
-  const { data: connectors, ...connectorsQueryLeft } = useQuery(
-    queryConnector.definition,
-    queryConnector.options
+  const { data: konnectors, ...konnectorsQueryLeft } = useQuery(
+    queryKonnector.definition,
+    queryKonnector.options
   )
-  const isConnectorsLoading = isQueryLoading(connectorsQueryLeft)
-  const connector = connectors?.[0]
-  const connectorSlug = connector?.slug
+  const isKonnectorsLoading = isQueryLoading(konnectorsQueryLeft)
+  const konnector = konnectors?.[0]
+  const konnectorSlug = konnector?.slug
 
   const queryAccounts = buildAccountsQueryBySlug(
-    connectorSlug,
-    Boolean(connectorSlug)
+    konnectorSlug,
+    Boolean(konnectorSlug)
   )
   const { data: accounts, ...accountsQueryLeft } = useQuery(
     queryAccounts.definition,
     queryAccounts.options
   )
   const isAccountsLoading =
-    Boolean(connectorSlug) && isQueryLoading(accountsQueryLeft)
+    Boolean(konnectorSlug) && isQueryLoading(accountsQueryLeft)
 
   const isLoading =
     isLoadingFiles ||
     isLoadingContacts ||
-    isConnectorsLoading ||
+    isKonnectorsLoading ||
     isAccountsLoading
 
   return (
@@ -88,11 +88,11 @@ const PapersList = () => {
               selectedThemeLabel={selectedThemeLabel}
               files={files}
               contacts={contacts}
-              connector={connector}
+              konnector={konnector}
               accounts={accounts}
             />
           )}
-          {!hasFiles && <Empty connector={connector} accounts={accounts} />}
+          {!hasFiles && <Empty konnector={konnector} accounts={accounts} />}
         </>
       )}
     </>

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -169,7 +169,7 @@
           "text": "PaperJSON.generic.owner.text"
         }
       ],
-      "connectorCriteria": {
+      "konnectorCriteria": {
         "name": "caf"
       }
     },
@@ -348,7 +348,7 @@
           "text": "PaperJSON.generic.owner.text"
         }
       ],
-      "connectorCriteria": {
+      "konnectorCriteria": {
         "category": "energy"
       }
     },
@@ -498,7 +498,7 @@
           "text": "PaperJSON.generic.owner.text"
         }
       ],
-      "connectorCriteria": {
+      "konnectorCriteria": {
         "category": "isp"
       }
     },
@@ -1227,7 +1227,7 @@
           "text": "PaperJSON.generic.owner.text"
         }
       ],
-      "connectorCriteria": {
+      "konnectorCriteria": {
         "name": "caf"
       }
     },
@@ -1265,7 +1265,7 @@
           "text": "PaperJSON.generic.owner.text"
         }
       ],
-      "connectorCriteria": {
+      "konnectorCriteria": {
         "category": "isp"
       }
     },
@@ -1500,7 +1500,7 @@
           "text": "PaperJSON.generic.owner.text"
         }
       ],
-      "connectorCriteria": {
+      "konnectorCriteria": {
         "name": "impots"
       }
     },
@@ -1538,7 +1538,7 @@
           "text": "PaperJSON.generic.owner.text"
         }
       ],
-      "connectorCriteria": {
+      "konnectorCriteria": {
         "name": "impots"
       }
     },
@@ -1575,7 +1575,7 @@
           "text": "PaperJSON.generic.owner.text"
         }
       ],
-      "connectorCriteria": {
+      "konnectorCriteria": {
         "name": "poleemploi"
       }
     },
@@ -1910,7 +1910,7 @@
           "text": "PaperJSON.generic.owner.text"
         }
       ],
-      "connectorCriteria": {
+      "konnectorCriteria": {
         "name": "impots"
       }
     },
@@ -2045,7 +2045,7 @@
           "text": "PaperJSON.generic.owner.text"
         }
       ],
-      "connectorCriteria": {
+      "konnectorCriteria": {
         "name": "poleemploi"
       }
     },

--- a/packages/cozy-mespapiers-lib/src/helpers/buildPapersDefinitions.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/buildPapersDefinitions.js
@@ -1,7 +1,7 @@
 /**
  * Sort paperDefinitions list alphabetical order then:
- * - Papers with acquisitionSteps or with connectorCriteria (papersUsedList)
- * - Papers without acquisitionSteps and without connectorCriteria (papersUnUsedList)
+ * - Papers with acquisitionSteps or with konnectorCriteria (papersUsedList)
+ * - Papers without acquisitionSteps and without konnectorCriteria (papersUnUsedList)
  * - Papers of type "other_identity_document" etc (otherPaperList)
  *
  * @param {Object[]} papersDefList - Array of Papers
@@ -25,7 +25,7 @@ export const buildPapersDefinitions = (papersDefList, scannerT) => {
         }
 
         return currentPaperDef.acquisitionSteps.length > 0 ||
-          currentPaperDef.connectorCriteria
+          currentPaperDef.konnectorCriteria
           ? [[...used, currentPaperDef], unUsed, other]
           : [used, [...unUsed, currentPaperDef], other]
       },

--- a/packages/cozy-mespapiers-lib/src/helpers/buildPapersDefinitions.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/buildPapersDefinitions.spec.js
@@ -18,7 +18,7 @@ describe('buildPapersDefinitions', () => {
       label: 'two',
       acquisitionSteps: [],
       konnectorCriteria: {
-        name: 'myConnector'
+        name: 'myKonnector'
       }
     },
     {
@@ -29,7 +29,7 @@ describe('buildPapersDefinitions', () => {
         }
       ],
       konnectorCriteria: {
-        name: 'myConnector'
+        name: 'myKonnector'
       }
     },
 
@@ -45,7 +45,7 @@ describe('buildPapersDefinitions', () => {
         }
       ],
       konnectorCriteria: {
-        name: 'myConnector'
+        name: 'myKonnector'
       }
     }
   ]
@@ -59,14 +59,14 @@ describe('buildPapersDefinitions', () => {
         }
       ],
       konnectorCriteria: {
-        name: 'myConnector'
+        name: 'myKonnector'
       }
     },
     {
       label: 'two',
       acquisitionSteps: [],
       konnectorCriteria: {
-        name: 'myConnector'
+        name: 'myKonnector'
       }
     },
     {
@@ -77,7 +77,7 @@ describe('buildPapersDefinitions', () => {
         }
       ],
       konnectorCriteria: {
-        name: 'myConnector'
+        name: 'myKonnector'
       }
     },
     {

--- a/packages/cozy-mespapiers-lib/src/helpers/buildPapersDefinitions.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/buildPapersDefinitions.spec.js
@@ -17,7 +17,7 @@ describe('buildPapersDefinitions', () => {
     {
       label: 'two',
       acquisitionSteps: [],
-      connectorCriteria: {
+      konnectorCriteria: {
         name: 'myConnector'
       }
     },
@@ -28,7 +28,7 @@ describe('buildPapersDefinitions', () => {
           stepIndex: 1
         }
       ],
-      connectorCriteria: {
+      konnectorCriteria: {
         name: 'myConnector'
       }
     },
@@ -44,7 +44,7 @@ describe('buildPapersDefinitions', () => {
           stepIndex: 1
         }
       ],
-      connectorCriteria: {
+      konnectorCriteria: {
         name: 'myConnector'
       }
     }
@@ -58,14 +58,14 @@ describe('buildPapersDefinitions', () => {
           stepIndex: 1
         }
       ],
-      connectorCriteria: {
+      konnectorCriteria: {
         name: 'myConnector'
       }
     },
     {
       label: 'two',
       acquisitionSteps: [],
-      connectorCriteria: {
+      konnectorCriteria: {
         name: 'myConnector'
       }
     },
@@ -76,7 +76,7 @@ describe('buildPapersDefinitions', () => {
           stepIndex: 1
         }
       ],
-      connectorCriteria: {
+      konnectorCriteria: {
         name: 'myConnector'
       }
     },

--- a/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
@@ -45,7 +45,7 @@ export const hasNoFileWithSameQualificationLabel = (files, paperDefinition) => {
  */
 export const isPaperEnabled = paperDefinition =>
   paperDefinition.acquisitionSteps.length > 0 ||
-  paperDefinition.connectorCriteria
+  paperDefinition.konnectorCriteria
 
 /**
  * Filters and sorts the list of featured Placeholders.

--- a/packages/cozy-mespapiers-lib/src/helpers/getStoreWebLinkByKonnector.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/getStoreWebLinkByKonnector.js
@@ -4,10 +4,10 @@ import log from 'cozy-logger'
 /**
  * @param {object} param
  * @param {CozyClient} param.client - Instance of CozyClient
- * @param {string} [param.konnectorName] - Name of Connector
- * @param {string} [param.konnectorCategory] - Category of Connector
- * @param {string} [param.redirectionPath] - Path to redirect from Store after connector installation
- * @returns {string} - Link of Store where the Connector is
+ * @param {string} [param.konnectorName] - Name of konnector
+ * @param {string} [param.konnectorCategory] - Category of konnector
+ * @param {string} [param.redirectionPath] - Path to redirect from Store after konnector installation
+ * @returns {string} - Link of Store where the konnector is
  */
 export const getStoreWebLinkByKonnector = ({
   client,

--- a/packages/cozy-mespapiers-lib/src/helpers/queries.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/queries.js
@@ -105,7 +105,7 @@ export const buildFilesQueryById = id => ({
   }
 })
 
-export const buildTriggersQueryByConnectorSlug = (slug, enabled) => ({
+export const buildTriggersQueryByKonnectorSlug = (slug, enabled) => ({
   definition: () =>
     Q(TRIGGERS_DOCTYPE)
       .where({
@@ -119,7 +119,7 @@ export const buildTriggersQueryByConnectorSlug = (slug, enabled) => ({
   }
 })
 
-export const buildConnectorsQueryById = (id, enabled = true) => ({
+export const buildKonnectorsQueryById = (id, enabled = true) => ({
   definition: () => Q(KONNECTORS_DOCTYPE).getById(id),
   options: {
     as: `${KONNECTORS_DOCTYPE}/id/${id}`,
@@ -143,7 +143,7 @@ export const buildKonnectorsQueryByQualificationLabels = (
   }
 })
 
-export const buildConnectorsQueryByQualificationLabel = label => ({
+export const buildKonnectorsQueryByQualificationLabel = label => ({
   definition: () =>
     Q(KONNECTORS_DOCTYPE)
       .where({ qualification_labels: { $in: [label] } })

--- a/packages/cozy-mespapiers-lib/src/helpers/queries.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/queries.js
@@ -154,15 +154,15 @@ export const buildConnectorsQueryByQualificationLabel = label => ({
   }
 })
 
-export const buildAccountsQueryBySlug = (slug, enabled = true) => ({
+export const buildAccountsQueryBySlugs = (slugs, enabled = true) => ({
   definition: () =>
     Q(ACCOUNTS_DOCTYPE)
       .where({
-        account_type: slug
+        account_type: { $in: slugs }
       })
       .indexFields(['account_type']),
   options: {
-    as: `${ACCOUNTS_DOCTYPE}/slug/${slug}`,
+    as: `${ACCOUNTS_DOCTYPE}/slugs/${JSON.stringify(slugs)}`,
     fetchPolicy: defaultFetchPolicy,
     enabled
   }

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -368,9 +368,9 @@
     }
   },
   "Empty": {
-    "connector": {
+    "konnector": {
       "title": "No paper",
-      "text": "%{connectorSlug} has not yet published the paper on its site. It will be retrieved here automatically once published by %{connectorSlug}.",
+      "text": "%{konnectorSlug} has not yet published the paper on its site. It will be retrieved here automatically once published by %{konnectorSlug}.",
       "button": "Add manually"
     }
   }

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -368,9 +368,9 @@
     }
   },
   "Empty": {
-    "connector": {
+    "konnector": {
       "title": "Aucun papier",
-      "text": "%{connectorSlug} n’a pas encore publié le papier sur son site. Il sera récupéré ici automatiquement une fois publié par %{connectorSlug}.",
+      "text": "%{konnectorSlug} n’a pas encore publié le papier sur son site. Il sera récupéré ici automatiquement une fois publié par %{konnectorSlug}.",
       "button": "Ajouter manuellement"
     }
   }

--- a/packages/cozy-mespapiers-lib/test/mockPaperDefinitions.js
+++ b/packages/cozy-mespapiers-lib/test/mockPaperDefinitions.js
@@ -32,7 +32,7 @@ export const mockPapersDefinitions = [
         text: 'PaperJSON.generic.owner.text'
       }
     ],
-    connectorCriteria: {
+    konnectorCriteria: {
       category: 'isp'
     }
   },
@@ -68,7 +68,7 @@ export const mockPapersDefinitions = [
         text: 'PaperJSON.generic.owner.text'
       }
     ],
-    connectorCriteria: {
+    konnectorCriteria: {
       name: 'impots'
     }
   },
@@ -87,7 +87,7 @@ export const mockPapersDefinitions = [
     featureDate: 'referencedDate',
     maxDisplay: 3,
     acquisitionSteps: [],
-    connectorCriteria: {
+    konnectorCriteria: {
       name: 'impots'
     }
   },


### PR DESCRIPTION
Lorsque que l'on avait plusieurs konnectors partageant le même label de qualification (`qualifications_labels`), la bannière de synchro harvest n'apparaissait que sur une des listes de fichiers.

Ce fix permet de bien afficher la bannière pour chaque liste de fichiers de chaque konnector
