### PR TITLE
feat: Return also readOnly status from getSharedDocument

### DIFF
--- a/packages/cozy-sharing/src/getSharedDocument.js
+++ b/packages/cozy-sharing/src/getSharedDocument.js
@@ -1,15 +1,23 @@
-import get from 'lodash/get'
+import { isReadOnly } from 'cozy-client/dist/models/permission'
 
+/**
+ * Get the first shared document for the current shared token
+ *
+ * @param {CozyClient} client
+ * @returns {{id, isReadOnly}} id of the document and the readOnly status
+ */
 const getSharedDocument = async client => {
   const { data: permissionsData } = await client
     .collection('io.cozy.permissions')
     .getOwnPermissions()
 
-  const permissions = permissionsData.attributes.permissions
+  const permissions = Object.values(permissionsData.attributes.permissions)
   // permissions contains several named keys, but the one to use depends on the situation. Using the first one is what we want in all known cases.
-  const sharedDocumentId = get(Object.values(permissions), '0.values.0')
-
-  return sharedDocumentId
+  const perm = permissions[0]
+  return {
+    id: perm.values[0],
+    isReadOnly: isReadOnly(perm)
+  }
 }
 
 export default getSharedDocument

--- a/packages/cozy-sharing/src/getSharedDocument.spec.js
+++ b/packages/cozy-sharing/src/getSharedDocument.spec.js
@@ -1,7 +1,7 @@
 import getSharedDocument from './getSharedDocument'
 
-describe('Getting the shared document id', () => {
-  const mockClient = {
+function setupClient(verbs = []) {
+  return {
     collection: () => ({
       getOwnPermissions: jest.fn().mockReturnValue({
         data: {
@@ -9,14 +9,14 @@ describe('Getting the shared document id', () => {
             permissions: {
               collection: {
                 type: 'io.cozy.photos.albums',
-                verbs: ['GET'],
+                verbs,
                 values: ['myshareid']
               },
               files: {
                 selector: 'referenced_by',
                 type: 'io.cozy.files',
                 values: ['io.cozy.photos.albums/myshareid'],
-                verbs: ['GET']
+                verbs
               }
             }
           }
@@ -24,9 +24,30 @@ describe('Getting the shared document id', () => {
       })
     })
   }
+}
 
+describe('Getting the shared document', () => {
   it('should get the id', async () => {
-    const id = await getSharedDocument(mockClient)
+    const client = setupClient(['GET'])
+    const { id } = await getSharedDocument(client)
     expect(id).toEqual('myshareid')
+  })
+
+  it('should return isReadOnly is true when we have only a GET permission', async () => {
+    const client = setupClient(['GET'])
+    const { isReadOnly } = await getSharedDocument(client)
+    expect(isReadOnly).toBeTruthy()
+  })
+
+  it('should return isReadOnly is false when we have an ALL permission', async () => {
+    const client = setupClient(['ALL'])
+    const { isReadOnly } = await getSharedDocument(client)
+    expect(isReadOnly).toBeFalsy()
+  })
+
+  it('should return isReadOnly is false when we have a PATCH permission', async () => {
+    const client = setupClient(['GET', 'PATCH', 'PUT'])
+    const { isReadOnly } = await getSharedDocument(client)
+    expect(isReadOnly).toBeFalsy()
   })
 })

--- a/packages/cozy-sharing/src/state.js
+++ b/packages/cozy-sharing/src/state.js
@@ -349,18 +349,14 @@ const getApps = state => state.apps
 
 export const hasSharedParent = (state, documentPath) => {
   if (!state.sharedPaths) {
-    // eslint-disable-next-line
-    console.log('hasSharedParent should not occur', state, documentPath)
-    return false
+    return false // hasSharedParent should not occur
   }
   return state.sharedPaths.some(path => documentPath.indexOf(`${path}/`) === 0)
 }
 
 export const hasSharedChild = (state, documentPath) => {
   if (!state.sharedPaths) {
-    // eslint-disable-next-line
-    console.log('hasSharedChild should not occur', state, documentPath)
-    return false
+    return false // hasSharedChild should not occur
   }
   const ret = state.sharedPaths.some(
     path => path.indexOf(`${documentPath}/`) === 0


### PR DESCRIPTION
The `getSharedDocument` function is only used in cozy-drive at the moment.  Cozy-notes has its own version that comes close to these changes. It may be possible to use the same for both applications in the future.

BREAKING CHANGE: The function now returns the id encapsulated in an object. You can extract the id like this `const { id } = getSharedDocument(client)`