### PR TITLE
refactor: Harmonizes file metadata names

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Contexts/PapersDefinitionsProvider.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Contexts/PapersDefinitionsProvider.jsx
@@ -1,16 +1,18 @@
 import React, { createContext, useEffect, useState } from 'react'
 
+import { useClient } from 'cozy-client'
+import flag from 'cozy-flags'
 import useFlag from 'cozy-flags/dist/useFlag'
 import log from 'cozy-logger'
-import { useClient } from 'cozy-client'
-import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
-import papersJSON from '../../constants/papersDefinitions.json'
-import { fetchCustomPaperDefinitions } from '../../utils/fetchCustomPaperDefinitions'
-import { fetchContentFileToJson } from '../../utils/fetchContentFileToJson'
-import { useScannerI18n } from '../Hooks/useScannerI18n'
+import papersJSONWithNewMetadata from '../../constants/papersDefinitions.json'
+import papersJSON from '../../constants/papersDefinitionsOld.json'
 import { buildPapersDefinitions } from '../../helpers/buildPapersDefinitions'
+import { fetchContentFileToJson } from '../../utils/fetchContentFileToJson'
+import { fetchCustomPaperDefinitions } from '../../utils/fetchCustomPaperDefinitions'
+import { useScannerI18n } from '../Hooks/useScannerI18n'
 
 const PapersDefinitionsContext = createContext()
 
@@ -69,8 +71,11 @@ const PapersDefinitionsProvider = ({ children }) => {
           name: '',
           path: ''
         })
+        const papers = flag('mespapiers.migrated.metadata')
+          ? papersJSONWithNewMetadata
+          : papersJSON
         setPapersDefinitions(
-          buildPapersDefinitions(papersJSON.papersDefinitions, scannerT)
+          buildPapersDefinitions(papers.papersDefinitions, scannerT)
         )
         log('info', 'PapersDefinitions of the app loaded')
       }

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/helpers.spec.js
@@ -51,7 +51,7 @@ const makeCurrentPaperDefinition = ({ label, country } = {}) => ({
       illustration: 'illuNumber.png',
       attributes: [
         {
-          name: 'cardNumber',
+          name: 'number',
           type: 'text'
         }
       ]
@@ -77,7 +77,7 @@ const makeFakeFile = ({ country, qualificationLabel } = {}) => ({
   id: '123456',
   name: 'fake file',
   metadata: {
-    cardNumber: '454654876789',
+    number: '454654876789',
     datetime: '2022-09-29T11:53:00.000Z',
     datetimeLabel: 'expirationDate',
     expirationDate: '2022-09-29T11:53:00.000Z',
@@ -148,7 +148,7 @@ describe('updateFileMetadata', () => {
       id: '123456',
       name: 'fake file',
       metadata: {
-        cardNumber: '454654876789',
+        number: '454654876789',
         datetime: '2022-09-29T11:53:00.000Z',
         datetimeLabel: 'expirationDate',
         expirationDate: '2022-09-29T11:53:00.000Z',
@@ -163,7 +163,7 @@ describe('updateFileMetadata', () => {
     })
 
     expect(res).toEqual({
-      cardNumber: '454654876789',
+      number: '454654876789',
       datetime: newExpirationDate,
       datetimeLabel: 'expirationDate',
       expirationDate: newExpirationDate,
@@ -176,7 +176,7 @@ describe('updateFileMetadata', () => {
       id: '123456',
       name: 'fake file',
       metadata: {
-        cardNumber: '454654876789',
+        number: '454654876789',
         datetime: '2018-01-01T11:00:00.000Z',
         datetimeLabel: 'referencedDate',
         expirationDate: '2022-09-29T11:53:00.000Z',
@@ -191,7 +191,7 @@ describe('updateFileMetadata', () => {
     })
 
     expect(res).toEqual({
-      cardNumber: '454654876789',
+      number: '454654876789',
       datetime: '2018-01-01T11:00:00.000Z',
       datetimeLabel: 'referencedDate',
       expirationDate: newExpirationDate,
@@ -202,15 +202,15 @@ describe('updateFileMetadata', () => {
 describe('makeCurrentStep', () => {
   const paperDef = makeCurrentPaperDefinition()
   describe('information model', () => {
-    it('should return "information" step with "cardNumber" attribute name', () => {
+    it('should return "information" step with "number" attribute name', () => {
       const res = makeCurrentStep({
         paperDef,
         model: 'information',
-        metadataName: 'cardNumber'
+        metadataName: 'number'
       })
 
       expect(res).toEqual({
-        attributes: [{ name: 'cardNumber', type: 'text' }],
+        attributes: [{ name: 'number', type: 'text' }],
         illustration: 'illuNumber.png',
         model: 'information'
       })

--- a/packages/cozy-mespapiers-lib/src/components/Search/search.js
+++ b/packages/cozy-mespapiers-lib/src/components/Search/search.js
@@ -2,10 +2,30 @@ import { Document } from 'flexsearch'
 
 import { themesList } from 'cozy-client/dist/models/document/documentTypeData'
 import { isFile, hasQualifications } from 'cozy-client/dist/models/file'
+import flag from 'cozy-flags'
 
 import { CONTACTS_DOCTYPE } from '../../doctypes'
 
 const isContact = doc => doc._type === CONTACTS_DOCTYPE
+
+const flexSearchIndex = [
+  'flexsearchProps:translatedQualificationLabel', // io.cozy.files
+  'metadata:number', // io.cozy.files
+  'fullname', // io.cozy.contacts
+  'name', // io.cozy.files, io.cozy.contacts
+  'birthday', // io.cozy.contacts
+  'birthcity', // io.cozy.contacts
+  'email[]:address', // io.cozy.contacts
+  'phone[]:number', // io.cozy.contacts
+  'civility', // io.cozy.contacts
+  'company', // io.cozy.contacts
+  'jobTitle' // io.cozy.contacts
+]
+if (!flag('mespapiers.migrated.metadata')) {
+  flexSearchIndex.splice(1, 0, 'metadata:ibanNumber')
+  flexSearchIndex.splice(3, 0, 'metadata:passportNumber')
+  flexSearchIndex.splice(4, 0, 'metadata:vinNumber')
+}
 
 /** The index document will store _id for each document having the declared indexed fields,
  * coming from both `io.cozy.files` and `io.cozy.contacts`.
@@ -19,22 +39,7 @@ export const index = new Document({
   document: {
     id: '_id',
     tag: 'flexsearchProps:tag',
-    index: [
-      'flexsearchProps:translatedQualificationLabel', // io.cozy.files
-      'metadata:ibanNumber', // io.cozy.files
-      'metadata:number', // io.cozy.files
-      'metadata:passportNumber', // io.cozy.files
-      'metadata:vinNumber', // io.cozy.files
-      'fullname', // io.cozy.contacts
-      'name', // io.cozy.files, io.cozy.contacts
-      'birthday', // io.cozy.contacts
-      'birthcity', // io.cozy.contacts
-      'email[]:address', // io.cozy.contacts
-      'phone[]:number', // io.cozy.contacts
-      'civility', // io.cozy.contacts
-      'company', // io.cozy.contacts
-      'jobTitle' // io.cozy.contacts
-    ]
+    index: flexSearchIndex
   }
 })
 

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitionsOld.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitionsOld.json
@@ -68,13 +68,13 @@
         {
           "stepIndex": 2,
           "model": "information",
-          "text": "PaperJSON.bankDetails.number.text",
+          "text": "PaperJSON.bankDetails.ibanNumber.text",
           "attributes": [
             {
-              "name": "number",
+              "name": "ibanNumber",
               "type": "text",
               "mask": "aa** 9999 9999 99** **** **** *99",
-              "inputLabel": "PaperJSON.bankDetails.number.inputLabel"
+              "inputLabel": "PaperJSON.bankDetails.ibanNumber.inputLabel"
             }
           ]
         },
@@ -139,12 +139,12 @@
           "stepIndex": 2,
           "model": "information",
           "illustration": "IlluCafNumberHelp.png",
-          "text": "PaperJSON.caf.number.text",
+          "text": "PaperJSON.caf.cafFileNumber.text",
           "attributes": [
             {
-              "name": "number",
+              "name": "cafFileNumber",
               "type": "text",
-              "inputLabel": "PaperJSON.caf.number.inputLabel"
+              "inputLabel": "PaperJSON.caf.cafFileNumber.inputLabel"
             }
           ]
         },
@@ -573,7 +573,7 @@
           "text": "PaperJSON.card.number.text",
           "attributes": [
             {
-              "name": "number",
+              "name": "cardNumber",
               "type": "text",
               "maxLength": 12,
               "inputLabel": "PaperJSON.card.number.inputLabel"
@@ -1197,12 +1197,12 @@
           "stepIndex": 2,
           "model": "information",
           "illustration": "IlluCafNumberHelp.png",
-          "text": "PaperJSON.payment_proof_family_allowance.number.text",
+          "text": "PaperJSON.payment_proof_family_allowance.cafFileNumber.text",
           "attributes": [
             {
-              "name": "number",
+              "name": "cafFileNumber",
               "type": "text",
-              "inputLabel": "PaperJSON.payment_proof_family_allowance.number.inputLabel"
+              "inputLabel": "PaperJSON.payment_proof_family_allowance.cafFileNumber.inputLabel"
             }
           ]
         },
@@ -1338,7 +1338,7 @@
           "text": "PaperJSON.card.number.text",
           "attributes": [
             {
-              "name": "number",
+              "name": "cardNumber",
               "type": "number",
               "maxLength": 12,
               "inputLabel": "PaperJSON.card.number.inputLabel"
@@ -1643,13 +1643,13 @@
         {
           "stepIndex": 2,
           "model": "information",
-          "text": "PaperJSON.vehicleRegistration.number.text",
+          "text": "PaperJSON.vehicleRegistration.vinNumber.text",
           "attributes": [
             {
-              "name": "number",
+              "name": "vinNumber",
               "type": "text",
               "mask": "*** ****** ********",
-              "inputLabel": "PaperJSON.vehicleRegistration.number.inputLabel"
+              "inputLabel": "PaperJSON.vehicleRegistration.vinNumber.inputLabel"
             }
           ]
         },
@@ -1721,32 +1721,19 @@
         {
           "stepIndex": 2,
           "model": "information",
-          "illustration": "IlluGenericInputDate.png",
-          "text": "PaperJSON.passport.country.text",
+          "illustration": "IlluPassportNumber.png",
+          "text": "PaperJSON.passport.information.passportNumber.text",
           "attributes": [
             {
-              "name": "country",
+              "name": "passportNumber",
               "type": "text",
-              "inputLabel": "PaperJSON.passport.country.inputLabel"
+              "maxLength": 12,
+              "inputLabel": "PaperJSON.passport.information.passportNumber.inputLabel"
             }
           ]
         },
         {
           "stepIndex": 3,
-          "model": "information",
-          "illustration": "IlluPassportNumber.png",
-          "text": "PaperJSON.passport.information.number.text",
-          "attributes": [
-            {
-              "name": "number",
-              "type": "text",
-              "maxLength": 12,
-              "inputLabel": "PaperJSON.passport.information.number.inputLabel"
-            }
-          ]
-        },
-        {
-          "stepIndex": 4,
           "model": "information",
           "illustration": "IlluPassportDate.png",
           "text": "PaperJSON.passport.information.expirationDate.text",
@@ -1759,7 +1746,7 @@
           ]
         },
         {
-          "stepIndex": 5,
+          "stepIndex": 4,
           "model": "information",
           "illustration": "IlluGenericAlert.svg",
           "illustrationSize": "small",
@@ -1777,7 +1764,7 @@
           ]
         },
         {
-          "stepIndex": 6,
+          "stepIndex": 5,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"

--- a/packages/cozy-mespapiers-lib/src/helpers/makeInputsInformationStep.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/makeInputsInformationStep.spec.js
@@ -1,10 +1,10 @@
+import { makeInputsInformationStep } from './makeInputsInformationStep'
 import InputDateAdapter from '../components/ModelSteps/widgets/InputDateAdapter'
 import InputTextAdapter from '../components/ModelSteps/widgets/InputTextAdapter'
-import { makeInputsInformationStep } from './makeInputsInformationStep'
 
 const attributes = [
   {
-    name: 'cardNumber',
+    name: 'number',
     type: 'text',
     maxLength: 12,
     inputLabel: 'PaperJSON.card.number.inputLabel'
@@ -21,7 +21,7 @@ const inputTextExpected = {
   attrs: {
     inputLabel: 'PaperJSON.card.number.inputLabel',
     maxLength: 12,
-    name: 'cardNumber',
+    name: 'number',
     type: 'text'
   }
 }

--- a/packages/cozy-mespapiers-lib/src/helpers/queries.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/queries.js
@@ -1,4 +1,5 @@
 import { Q, fetchPolicies } from 'cozy-client'
+import flag from 'cozy-flags'
 
 import {
   CONTACTS_DOCTYPE,
@@ -12,6 +13,27 @@ import {
 const defaultFetchPolicy = fetchPolicies.olderThan(86_400_000) // 24 hours
 
 export const buildFilesQueryWithQualificationLabel = () => {
+  const select = [
+    'name',
+    'referenced_by',
+    'metadata.country',
+    'metadata.datetime',
+    'metadata.expirationDate',
+    'metadata.noticePeriod',
+    'metadata.qualification.label',
+    'metadata.referencedDate',
+    'metadata.number',
+    'created_at',
+    'updated_at',
+    'type',
+    'trashed'
+  ]
+  if (!flag('mespapiers.migrated.metadata')) {
+    select.splice(8, 0, 'metadata:ibanNumber')
+    select.splice(10, 0, 'metadata:passportNumber')
+    select.splice(11, 0, 'metadata:vinNumber')
+  }
+
   return {
     definition: () =>
       Q(FILES_DOCTYPE)
@@ -25,24 +47,7 @@ export const buildFilesQueryWithQualificationLabel = () => {
           }
         })
         .indexFields(['metadata.qualification.label'])
-        .select([
-          'name',
-          'referenced_by',
-          'metadata.country',
-          'metadata.datetime',
-          'metadata.expirationDate',
-          'metadata.noticePeriod',
-          'metadata.qualification.label',
-          'metadata.referencedDate',
-          'metadata.ibanNumber',
-          'metadata.number',
-          'metadata.passportNumber',
-          'metadata.vinNumber',
-          'created_at',
-          'updated_at',
-          'type',
-          'trashed'
-        ])
+        .select(select)
         .limitBy(1000),
     options: {
       as: `${FILES_DOCTYPE}/metadata_qualification_label`,

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -194,10 +194,18 @@
       "ibanNumber": {
         "inputLabel": "IBAN",
         "text": "Enter your IBAN number"
+      },
+      "number": {
+        "inputLabel": "IBAN",
+        "text": "Enter your IBAN number"
       }
     },
     "vehicleRegistration": {
       "vinNumber": {
+        "inputLabel": "Number in position E. of your vehicle registration",
+        "text": "Enter the Vehicle Identification Number (VIN)"
+      },
+      "number": {
         "inputLabel": "Number in position E. of your vehicle registration",
         "text": "Enter the Vehicle Identification Number (VIN)"
       }
@@ -262,6 +270,10 @@
           "inputLabel": "Passport number",
           "text": "Enter your passport number"
         },
+        "number": {
+          "inputLabel": "Passport number",
+          "text": "Enter your passport number"
+        },
         "expirationDate": {
           "inputLabel": "Expiration date",
           "text": "When does your passport expire?"
@@ -277,10 +289,18 @@
       "cafFileNumber": {
         "inputLabel": "CAF file number",
         "text": "Enter you CAF file number"
+      },
+      "number": {
+        "inputLabel": "CAF file number",
+        "text": "Enter you CAF file number"
       }
     },
     "payment_proof_family_allowance": {
       "cafFileNumber": {
+        "inputLabel": "CAF file number",
+        "text": "Enter you CAF file number"
+      },
+      "number": {
         "inputLabel": "CAF file number",
         "text": "Enter you CAF file number"
       }

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -194,10 +194,18 @@
       "ibanNumber": {
         "inputLabel": "IBAN",
         "text": "Saisissez votre numéro d'IBAN"
+      },
+      "number": {
+        "inputLabel": "IBAN",
+        "text": "Saisissez votre numéro d'IBAN"
       }
     },
     "vehicleRegistration": {
       "vinNumber": {
+        "inputLabel": "Numéro en position E. de votre carte crise",
+        "text": "Saisissez le Numéro d'identification du véhicule (VIN)"
+      },
+      "number": {
         "inputLabel": "Numéro en position E. de votre carte crise",
         "text": "Saisissez le Numéro d'identification du véhicule (VIN)"
       }
@@ -262,6 +270,10 @@
           "inputLabel": "Numéro du passeport",
           "text": "Saisir le numéro de votre passeport"
         },
+        "number": {
+          "inputLabel": "Numéro du passeport",
+          "text": "Saisir le numéro de votre passeport"
+        },
         "expirationDate": {
           "inputLabel": "Date d'expiration",
           "text": "Quelle est la date d'expiration du passeport ?"
@@ -277,10 +289,18 @@
       "cafFileNumber": {
         "inputLabel": "Numéro de dossier CAF",
         "text": "Saisissez votre numéro de dossier CAF"
+      },
+      "number": {
+        "inputLabel": "Numéro de dossier CAF",
+        "text": "Saisissez votre numéro de dossier CAF"
       }
     },
     "payment_proof_family_allowance": {
       "cafFileNumber": {
+        "inputLabel": "Numéro de dossier CAF",
+        "text": "Saisissez votre numéro de dossier CAF"
+      },
+      "number": {
         "inputLabel": "Numéro de dossier CAF",
         "text": "Saisissez votre numéro de dossier CAF"
       }


### PR DESCRIPTION
Replace `cafFileNumber`, `cardNumber`, `vinNumber`, `ibanNumber` & `passportNumber` by `number`.

And add flag for synchronize migration with other libs/konnectors
