### PR TITLE
test: Remove not needed mock

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/EditContract.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/EditContract.spec.jsx
@@ -17,14 +17,6 @@ jest.mock(
     }
 )
 
-jest.mock('cozy-flags', () => name => {
-  if (name == 'harvest.toggle-contract-sync') {
-    return true
-  } else {
-    return false
-  }
-})
-
 describe('EditContract', () => {
   const setup = ({ konnector } = {}) => {
     const client = new CozyClient({})


### PR DESCRIPTION
We don't use `harvest.toggle-contract-sync` anymore. 