### PR TITLE
fix: Document methods work with both clients

### DIFF
--- a/packages/cozy-doctypes/src/Document.js
+++ b/packages/cozy-doctypes/src/Document.js
@@ -1,21 +1,23 @@
 /* eslint-disable node/no-unsupported-features/es-syntax */
-const omit = require('lodash/omit')
-const pick = require('lodash/pick')
-const size = require('lodash/size')
-const omitBy = require('lodash/omitBy')
-const isUndefined = require('lodash/isUndefined')
-const fromPairs = require('lodash/fromPairs')
-const pickBy = require('lodash/pickBy')
+const querystring = require('querystring')
+
 const flatMap = require('lodash/flatMap')
-const groupBy = require('lodash/groupBy')
-const sortBy = require('lodash/sortBy')
+const fromPairs = require('lodash/fromPairs')
 const get = require('lodash/get')
-const { parallelMap } = require('./utils')
+const groupBy = require('lodash/groupBy')
+const isUndefined = require('lodash/isUndefined')
+const omit = require('lodash/omit')
+const omitBy = require('lodash/omitBy')
+const pick = require('lodash/pick')
+const pickBy = require('lodash/pickBy')
+const size = require('lodash/size')
+const sortBy = require('lodash/sortBy')
+
 const CozyClient = require('cozy-client/dist/CozyClient').default
 const Q = require('cozy-client/dist/queries/dsl').Q
-
 const log = require('cozy-logger').namespace('Document')
-const querystring = require('querystring')
+
+const { parallelMap } = require('./utils')
 
 const DATABASE_DOES_NOT_EXIST = 'Database does not exist.'
 

--- a/packages/cozy-doctypes/src/Document.spec.js
+++ b/packages/cozy-doctypes/src/Document.spec.js
@@ -1,7 +1,9 @@
 const MockDate = require('mockdate')
+
+const logger = require('cozy-logger')
+
 const Document = require('./Document')
 const { cozyClientJS, cozyClient } = require('./testUtils')
-const logger = require('cozy-logger')
 
 class Simpson extends Document {}
 Simpson.doctype = 'io.cozy.simpsons'
@@ -448,7 +450,7 @@ describe('Document used with CozyClient', () => {
             cozyMetadata: { updatedAt: new Date('2019-11-20') }
           }
         ])
-        jest.spyOn(cozyClient, 'save').mockReturnValueOnce()
+        jest.spyOn(cozyClient, 'save').mockReturnValueOnce({ data: {} })
         jest.spyOn(Simpson, 'deleteAll').mockReturnValueOnce()
       })
 
@@ -507,7 +509,7 @@ describe('Document used with CozyClient', () => {
 
     it('should update the document if it already exists', async () => {
       jest.spyOn(Simpson, 'queryAll').mockReturnValueOnce([{ name: 'Marge' }])
-      jest.spyOn(cozyClient, 'save').mockReturnValueOnce()
+      jest.spyOn(cozyClient, 'save').mockReturnValueOnce({ data: {} })
 
       await Simpson.createOrUpdate({ name: 'Marge', son: 'Bart' })
 
@@ -523,7 +525,9 @@ describe('Document used with CozyClient', () => {
     })
 
     it('should create the document with the given attributes', async () => {
-      jest.spyOn(cozyClient, 'create').mockImplementation(() => {})
+      jest.spyOn(cozyClient, 'create').mockImplementation(() => {
+        return { data: {} }
+      })
 
       const marge = { name: 'Marge' }
       await Simpson.create(marge)


### PR DESCRIPTION
The `Document` methods make different internal calls depending on the
client being used (i.e. `cozy-client` or `cozy-client-js`).
However, the `cozy-client` calls' responses don't have the same
signature as the `cozy-client-js` ones and were not transformed
leading to errors in (at least) the `BankingReconciliator` when trying
to match transactions with their account.

We now make sure that the `cozy-client` calls returning an object with
a `data` attribute are transformed so that the `Document` methods
always return the content of that attribute (`cozy-client-js` already
does that).