### PR TITLE
feat(flag): Find value from parameter with nested part into JSON content

### DIFF
--- a/packages/cozy-flags/src/store.js
+++ b/packages/cozy-flags/src/store.js
@@ -1,4 +1,5 @@
 import MicroEE from 'microee'
+
 import lsAdapter from './ls-adapter'
 
 /**
@@ -34,10 +35,30 @@ class FlagStore {
 
   get(name) {
     // eslint-disable-next-line no-prototype-builtins
-    if (!this.store.hasOwnProperty(name)) {
-      this.store[name] = null
+    if (this.store.hasOwnProperty(name)) {
+      return this.store[name]
     }
-    return this.store[name]
+
+    if (typeof name === 'string') {
+      const nameElements = name.split('.')
+      const size = nameElements.length
+      for (let idx = size - 1; idx > 0; idx--) {
+        const currentKey = nameElements.slice(0, idx).join('.')
+        // eslint-disable-next-line no-prototype-builtins
+        if (this.store.hasOwnProperty(currentKey)) {
+          return nameElements
+            .slice(idx, size)
+            .reduce((previousValue, currentValue) => {
+              // eslint-disable-next-line no-prototype-builtins
+              return previousValue && previousValue.hasOwnProperty(currentValue)
+                ? previousValue[currentValue]
+                : null
+            }, this.store[currentKey])
+        }
+      }
+    }
+
+    return null
   }
 
   set(name, value) {

--- a/packages/cozy-flags/src/tests.js
+++ b/packages/cozy-flags/src/tests.js
@@ -1,5 +1,6 @@
-import CozyClient from 'cozy-client'
 import util from 'util'
+
+import CozyClient from 'cozy-client'
 
 export default function testFlagAPI(flag) {
   afterEach(() => {
@@ -30,6 +31,45 @@ export default function testFlagAPI(flag) {
         })
       })
     }
+
+    describe('part of the parameter is embedded in a json content', () => {
+      beforeEach(() => {
+        flag('test.obj1', {
+          obj2: true,
+          obj3: {
+            obj4: {
+              obj5: {
+                obj6: {
+                  test: true
+                },
+                obj7: {
+                  test: null
+                }
+              }
+            }
+          }
+        })
+      })
+
+      it('should return the requested value when a part of the parameter is embedded', () => {
+        expect(flag('test.obj1.obj2')).toBe(true)
+      })
+
+      it('should return the requested value when multiple part of the parameter is embedded', () => {
+        expect(flag('test.obj1.obj3.obj4.obj5')).toStrictEqual({
+          obj6: {
+            test: true
+          },
+          obj7: {
+            test: null
+          }
+        })
+      })
+
+      it('should return null when parameter not found', () => {
+        expect(flag('test.obj2.obj3')).toBe(null)
+      })
+    })
   })
 
   describe('listFlags', () => {


### PR DESCRIPTION
This commit allows to find value directly in the JSON content of a flag. For example `flag(‘drive.office.enabled’)` will return true if we set `drive.office` with the JSON content `{enabled: true}`