### PR TITLE
KonnectorsCategories wasn't relied on search filter

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Home/Content.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/Content.jsx
@@ -1,12 +1,12 @@
-import React, { useMemo } from 'react'
-import PropTypes from 'prop-types'
 import uniqBy from 'lodash/uniqBy'
+import PropTypes from 'prop-types'
+import React, { useMemo } from 'react'
 
 import Empty from 'cozy-ui/transpiled/react/Empty'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
-import HomeCloud from '../../assets/icons/HomeCloud.svg'
 import ResultForSearch from './ResultForSearch'
+import HomeCloud from '../../assets/icons/HomeCloud.svg'
 import PaperGroup from '../Papers/PaperGroup'
 
 const Content = ({
@@ -50,6 +50,7 @@ const Content = ({
     <PaperGroup
       papersByCategories={papersByCategories}
       konnectors={konnectors}
+      selectedTheme={selectedTheme}
     />
   )
 }

--- a/packages/cozy-mespapiers-lib/src/components/Home/ContentFlexsearch.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/ContentFlexsearch.jsx
@@ -1,16 +1,8 @@
-import uniqBy from 'lodash/uniqBy'
 import PropTypes from 'prop-types'
-import React, { useMemo } from 'react'
+import React from 'react'
 
-import Empty from 'cozy-ui/transpiled/react/Empty'
-import { useI18n } from 'cozy-ui/transpiled/react/I18n'
-
-import HomeCloud from '../../assets/icons/HomeCloud.svg'
-import SearchEmpty from '../../assets/icons/SearchEmpty.svg'
-import { useMultiSelection } from '../Hooks/useMultiSelection'
-import PaperGroup from '../Papers/PaperGroup'
-import { useSearch } from '../Search/SearchProvider'
-import FlexsearchResult from '../SearchResult/FlexsearchResult'
+import ContentWhenNotSearching from './ContentWhenNotSearching'
+import ContentWhenSearching from './ContentWhenSearching'
 
 const ContentFlexsearch = ({
   contacts,
@@ -19,66 +11,27 @@ const ContentFlexsearch = ({
   selectedTheme,
   searchValue
 }) => {
-  const { t } = useI18n()
-  const { search } = useSearch()
-  const { isMultiSelectionActive } = useMultiSelection()
-
   const isSearching = searchValue.length > 0 || Boolean(selectedTheme)
-  const showListByGroup = searchValue?.length === 0
-  const allDocs = useMemo(() => papers.concat(contacts), [papers, contacts])
-  const docsToBeSearched = isMultiSelectionActive ? papers : allDocs
-  const papersByCategories = useMemo(
-    () => uniqBy(papers, 'metadata.qualification.label'),
-    [papers]
-  )
-  const { filteredDocs, firstSearchResultMatchingAttributes } = isSearching
-    ? search({
-        docs: docsToBeSearched,
-        value: searchValue,
-        tag: selectedTheme?.label
-      })
-    : {}
 
-  const hasDocs = allDocs?.length > 0
-  const hasSearchResult = filteredDocs?.length > 0
-
-  if (!hasDocs && !isSearching) {
+  if (isSearching) {
     return (
-      <Empty
-        className="u-ph-1"
-        icon={HomeCloud}
-        iconSize="large"
-        title={t('Home.Empty.title')}
-        text={t('Home.Empty.text')}
-      />
-    )
-  }
-
-  if (!hasSearchResult && isSearching) {
-    return (
-      <Empty
-        className="u-ph-1"
-        icon={SearchEmpty}
-        iconSize="large"
-        title={t('Search.empty.title')}
-        text={t('Search.empty.text')}
-      />
-    )
-  }
-
-  if (showListByGroup) {
-    return (
-      <PaperGroup
-        papersByCategories={papersByCategories}
+      <ContentWhenSearching
+        papers={papers}
+        contacts={contacts}
         konnectors={konnectors}
+        searchValue={searchValue}
+        selectedTheme={selectedTheme}
       />
     )
   }
 
   return (
-    <FlexsearchResult
-      filteredDocs={filteredDocs}
-      firstSearchResultMatchingAttributes={firstSearchResultMatchingAttributes}
+    <ContentWhenNotSearching
+      papers={papers}
+      contacts={contacts}
+      konnectors={konnectors}
+      searchValue={searchValue}
+      selectedTheme={selectedTheme}
     />
   )
 }

--- a/packages/cozy-mespapiers-lib/src/components/Home/ContentWhenNotSearching.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/ContentWhenNotSearching.jsx
@@ -1,0 +1,48 @@
+import uniqBy from 'lodash/uniqBy'
+import PropTypes from 'prop-types'
+import React, { useMemo } from 'react'
+
+import Empty from 'cozy-ui/transpiled/react/Empty'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+import HomeCloud from '../../assets/icons/HomeCloud.svg'
+import PaperGroup from '../Papers/PaperGroup'
+
+const ContentWhenNotSearching = ({ papers, contacts, konnectors }) => {
+  const { t } = useI18n()
+
+  const allDocs = useMemo(() => papers.concat(contacts), [papers, contacts])
+  const hasDocs = allDocs?.length > 0
+
+  const papersByCategories = useMemo(
+    () => uniqBy(papers, 'metadata.qualification.label'),
+    [papers]
+  )
+
+  if (!hasDocs) {
+    return (
+      <Empty
+        className="u-ph-1"
+        icon={HomeCloud}
+        iconSize="large"
+        title={t('Home.Empty.title')}
+        text={t('Home.Empty.text')}
+      />
+    )
+  }
+
+  return (
+    <PaperGroup
+      papersByCategories={papersByCategories}
+      konnectors={konnectors}
+    />
+  )
+}
+
+ContentWhenNotSearching.propTypes = {
+  contacts: PropTypes.array,
+  papers: PropTypes.array,
+  konnectors: PropTypes.array
+}
+
+export default ContentWhenNotSearching

--- a/packages/cozy-mespapiers-lib/src/components/Home/ContentWhenSearching.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/ContentWhenSearching.jsx
@@ -55,6 +55,7 @@ const ContentWhenSearching = ({
       <PaperGroup
         papersByCategories={papersByCategories}
         konnectors={konnectors}
+        selectedTheme={selectedTheme}
       />
     )
   }

--- a/packages/cozy-mespapiers-lib/src/components/Home/ContentWhenSearching.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/ContentWhenSearching.jsx
@@ -1,0 +1,78 @@
+import uniqBy from 'lodash/uniqBy'
+import PropTypes from 'prop-types'
+import React, { useMemo } from 'react'
+
+import Empty from 'cozy-ui/transpiled/react/Empty'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+import SearchEmpty from '../../assets/icons/SearchEmpty.svg'
+import { useMultiSelection } from '../Hooks/useMultiSelection'
+import PaperGroup from '../Papers/PaperGroup'
+import { useSearch } from '../Search/SearchProvider'
+import FlexsearchResult from '../SearchResult/FlexsearchResult'
+
+const ContentWhenSearching = ({
+  papers,
+  contacts,
+  konnectors,
+  searchValue,
+  selectedTheme
+}) => {
+  const { t } = useI18n()
+  const { isMultiSelectionActive } = useMultiSelection()
+  const { search } = useSearch()
+
+  const allDocs = useMemo(() => papers.concat(contacts), [papers, contacts])
+  const showResultByGroup = searchValue?.length === 0
+  const docsToBeSearched =
+    isMultiSelectionActive || showResultByGroup ? papers : allDocs
+
+  const { filteredDocs, firstSearchResultMatchingAttributes } = search({
+    docs: docsToBeSearched,
+    value: searchValue,
+    tag: selectedTheme?.label
+  })
+  const hasResult = filteredDocs?.length > 0
+  const papersByCategories = useMemo(
+    () => uniqBy(filteredDocs, 'metadata.qualification.label'),
+    [filteredDocs]
+  )
+
+  if (!hasResult) {
+    return (
+      <Empty
+        className="u-ph-1"
+        icon={SearchEmpty}
+        iconSize="large"
+        title={t('Search.empty.title')}
+        text={t('Search.empty.text')}
+      />
+    )
+  }
+
+  if (showResultByGroup) {
+    return (
+      <PaperGroup
+        papersByCategories={papersByCategories}
+        konnectors={konnectors}
+      />
+    )
+  }
+
+  return (
+    <FlexsearchResult
+      filteredDocs={filteredDocs}
+      firstSearchResultMatchingAttributes={firstSearchResultMatchingAttributes}
+    />
+  )
+}
+
+ContentWhenSearching.propTypes = {
+  contacts: PropTypes.array,
+  papers: PropTypes.array,
+  konnectors: PropTypes.array,
+  selectedTheme: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  searchValue: PropTypes.string
+}
+
+export default ContentWhenSearching

--- a/packages/cozy-mespapiers-lib/src/components/Papers/CategoryItemByKonnector.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/CategoryItemByKonnector.jsx
@@ -10,11 +10,17 @@ import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
 import styles from './styles.styl'
 import { useScannerI18n } from '../Hooks/useScannerI18n'
 
-const CategoryItemByKonnector = ({ qualificationLabel, isLast, onClick }) => {
+const CategoryItemByKonnector = ({
+  qualificationLabel,
+  isFirst,
+  isLast,
+  onClick
+}) => {
   const scannerT = useScannerI18n()
 
   return (
     <>
+      {isFirst && <Divider variant="inset" component="li" />}
       <ListItem button onClick={() => onClick(qualificationLabel)}>
         <ListItemIcon>
           <div className={styles['emptyKonnectorIcon']} />

--- a/packages/cozy-mespapiers-lib/src/components/Papers/KonnectorsCategories.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/KonnectorsCategories.jsx
@@ -4,9 +4,10 @@ import React from 'react'
 import { useQuery, isQueryLoading, hasQueryBeenLoaded } from 'cozy-client'
 
 import CategoryItemByKonnector from './CategoryItemByKonnector'
+import { makeQualificationLabelsWithoutFiles } from './helpers'
 import { queryAccounts } from '../../helpers/queries'
 
-const KonnectorsCategories = ({ konnectors, onClick }) => {
+const KonnectorsCategories = ({ konnectors, selectedTheme, onClick }) => {
   const { data: accounts, ...accountsQueryLeft } = useQuery(
     queryAccounts.definition,
     queryAccounts.options
@@ -20,23 +21,25 @@ const KonnectorsCategories = ({ konnectors, onClick }) => {
     accounts.some(account => account.account_type === konnector.slug)
   )
 
-  return konnectorsWithAccounts.map(
-    ({ konnectorQualifLabelsWithoutFile }, index) =>
-      konnectorQualifLabelsWithoutFile?.map(qualificationLabel => {
-        return (
-          <CategoryItemByKonnector
-            key={`${index} - ${qualificationLabel}`}
-            qualificationLabel={qualificationLabel}
-            isLast={index === konnectorsWithAccounts.length - 1}
-            onClick={onClick}
-          />
-        )
-      })
+  const qualificationLabelsWithoutFiles = makeQualificationLabelsWithoutFiles(
+    konnectorsWithAccounts,
+    selectedTheme
   )
+
+  return qualificationLabelsWithoutFiles.map((qualificationLabel, index) => (
+    <CategoryItemByKonnector
+      key={`${index} - ${qualificationLabel}`}
+      qualificationLabel={qualificationLabel}
+      isFirst={index === 0}
+      isLast={index === qualificationLabelsWithoutFiles.length - 1}
+      onClick={onClick}
+    />
+  ))
 }
 
 KonnectorsCategories.propTypes = {
   konnectors: PropTypes.arrayOf(PropTypes.object),
+  selectedTheme: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   onClick: PropTypes.func
 }
 

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
@@ -11,7 +11,7 @@ import CategoryItemByPaper from './CategoryItemByPaper'
 import KonnectorsCategories from './KonnectorsCategories'
 import { useMultiSelection } from '../Hooks/useMultiSelection'
 
-const PaperGroup = ({ papersByCategories, konnectors }) => {
+const PaperGroup = ({ papersByCategories, konnectors, selectedTheme }) => {
   const navigate = useNavigate()
   const { t } = useI18n()
   const { isMultiSelectionActive, setSelectedThemeLabel } = useMultiSelection()
@@ -44,20 +44,23 @@ const PaperGroup = ({ papersByCategories, konnectors }) => {
           <CategoryItemByPaper
             key={paper.id}
             paper={paper}
-            isLast={
-              index === papersByCategories.length - 1 && konnectors.length === 0
-            }
+            isLast={index === papersByCategories.length - 1}
             onClick={goPapersList}
           />
         ))}
-      <KonnectorsCategories konnectors={konnectors} onClick={goPapersList} />
+      <KonnectorsCategories
+        konnectors={konnectors}
+        selectedTheme={selectedTheme}
+        onClick={goPapersList}
+      />
     </List>
   )
 }
 
 PaperGroup.propTypes = {
   papersByCategories: PropTypes.arrayOf(PropTypes.object),
-  konnectors: PropTypes.arrayOf(PropTypes.object)
+  konnectors: PropTypes.arrayOf(PropTypes.object),
+  selectedTheme: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
 }
 
 export default PaperGroup

--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
@@ -2,6 +2,7 @@ import groupBy from 'lodash/groupBy'
 
 import { models, getReferencedBy } from 'cozy-client'
 import { getAccountName } from 'cozy-client/dist/models/account'
+import { getThemeByItem } from 'cozy-client/dist/models/document/documentTypeDataHelpers'
 
 import { CONTACTS_DOCTYPE } from '../../doctypes'
 import { filterWithRemaining } from '../../helpers/filterWithRemaining'
@@ -228,4 +229,21 @@ export const makeAccountFromPapers = (papers, accounts) => {
     : undefined
 
   return account
+}
+
+export const makeQualificationLabelsWithoutFiles = (
+  konnectorsWithAccounts,
+  selectedTheme
+) => {
+  return konnectorsWithAccounts
+    .flatMap(({ konnectorQualifLabelsWithoutFile }) => {
+      return konnectorQualifLabelsWithoutFile?.map(qualificationLabel => {
+        const themeLabel = getThemeByItem({ label: qualificationLabel }).label
+        const showCategoryItemByKonnector =
+          !selectedTheme || selectedTheme.label === themeLabel
+
+        return showCategoryItemByKonnector ? qualificationLabel : undefined
+      })
+    })
+    .filter(x => x)
 }


### PR DESCRIPTION
KonnectorsCategories est le composant qui affiche les konnecteur pour lesquels il y a un compte connecté mais aucun fichier.

le code est plus robuste (c'était inline dans un return de composant) mais on pourrait quand même tester `makeQualificationLabelsWithoutFiles` par la suite (manque de temps ici)