### PR TITLE
fix(harvest): Show account name in header for CCC

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModal.jsx
@@ -4,10 +4,12 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
 import { withClient } from 'cozy-client'
+import { Account } from 'cozy-doctypes'
 import Button from 'cozy-ui/transpiled/react/Button'
 import DialogContent from 'cozy-ui/transpiled/react/DialogContent'
 import Infos from 'cozy-ui/transpiled/react/Infos'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
+import Typography from 'cozy-ui/transpiled/react/Typography'
 import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
 
 import AccountSelectBox from './AccountSelectBox/AccountSelectBox'
@@ -127,7 +129,7 @@ export class AccountModal extends Component {
     return (
       <>
         <KonnectorModalHeader konnector={konnector}>
-          {showAccountSelection && (
+          {showAccountSelection ? (
             <AccountSelectBox
               loading={!account}
               selectedAccount={account}
@@ -139,6 +141,8 @@ export class AccountModal extends Component {
                 pushHistory('/new')
               }}
             />
+          ) : (
+            <Typography>{Account.getAccountName(account)}</Typography>
           )}
         </KonnectorModalHeader>
         {(error || fetching) && (


### PR DESCRIPTION
It was hidden, now we fetch the account name
with the Account model from cozy-doctypes.
It is tied to `showAccountSelection` prop, not to clientSide.
Must be wary of that in the future if changing something in this scope

![image](https://user-images.githubusercontent.com/12577784/228764757-dc606436-02f5-4f9a-be5e-2e99a9f5fd45.png)
