### PR TITLE
fix(harvest): Use react-router 6 API in viewer route

### DIFF
--- a/packages/cozy-harvest-lib/src/components/Routes/RoutesV6.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes/RoutesV6.jsx
@@ -154,9 +154,7 @@ const RoutesV6 = ({
 
       <Route
         path="viewer/:accountId/:folderToSaveId/:fileIndex"
-        element={routeComponentProps => (
-          <ViewerModal {...routeComponentProps} />
-        )}
+        element={<ViewerModal />}
       />
 
       {/* Redirections */}

--- a/packages/cozy-harvest-lib/src/datacards/ViewerModal.jsx
+++ b/packages/cozy-harvest-lib/src/datacards/ViewerModal.jsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react'
+import { useParams } from 'react-router-dom'
 
 import Overlay from 'cozy-ui/transpiled/react/Overlay'
 import Viewer from 'cozy-ui/transpiled/react/Viewer'
@@ -6,13 +7,10 @@ import Viewer from 'cozy-ui/transpiled/react/Viewer'
 import { useDataCardFiles } from './useDataCardFiles'
 import { MountPointContext } from '../components/MountPointContext'
 
-export const ViewerModal = ({
-  match: {
-    params: { accountId, folderToSaveId, fileIndex }
-  }
-}) => {
+export const ViewerModal = () => {
   const { pushHistory, replaceHistory } = useContext(MountPointContext)
   const { data, fetchStatus } = useDataCardFiles(accountId, folderToSaveId)
+  const { accountId, folderToSaveId, fileIndex } = useParams()
 
   const handleCloseViewer = () => replaceHistory(`/accounts/${accountId}`)
   const handleFileChange = (_file, newIndex) =>


### PR DESCRIPTION
It seems the route used the old router API,
which doesn't work with rr6.
Thus, the viewer would never work.
It is fixed by using the correct rr6 API with useParams hook.

Please note I encountered a rare bug that I was unable to reproduce, might be a problem with hot reloading. But at some point I had a memory leak in ViewerModal and clicking on a file would not update router state unless a page reload occurs