### PR TITLE
fix: Detect also Flagship app with isMobileApp

### DIFF
--- a/packages/cozy-device-helper/README.md
+++ b/packages/cozy-device-helper/README.md
@@ -18,7 +18,7 @@ To know the platform:
 
 - `getPlatform()`: return `ios`, `android` or `web`
 - `isWebApp()`: return `boolean`
-- `isMobileApp()`: return `boolean`
+- `isMobileApp()`: return `boolean` (check if it's based on an app on cordova or on the flagship app)
 - `isIOSApp()`: return `boolean`
 - `isAndroidApp()`: return `boolean`
 - `isAndroid()`: return `boolean` (check if the user is on an android smartphone (native & browser))
@@ -32,6 +32,14 @@ import { getDeviceName } from 'cozy-device-helper'
 ```
 
 To know device name `getDeviceName()`.
+
+### Cordova
+
+```
+import { isCordova } from 'cozy-device-helper'
+```
+
+To know if your app is based on Cordova.
 
 ### Cordova Plugins
 

--- a/packages/cozy-device-helper/src/platform.spec.ts
+++ b/packages/cozy-device-helper/src/platform.spec.ts
@@ -1,3 +1,4 @@
+import { isFlagshipApp as isFlagshipAppOriginal } from './flagship'
 import {
   isWebApp,
   isMobileApp,
@@ -5,6 +6,9 @@ import {
   isAndroidApp,
   getPlatform
 } from './platform'
+
+const isFlagshipApp = isFlagshipAppOriginal as jest.Mock
+jest.mock('./flagship')
 
 describe('platforms', () => {
   it('should identify is a web application', () => {
@@ -15,6 +19,10 @@ describe('platforms', () => {
     window.cordova = true
     expect(isMobileApp()).toBeTruthy()
     window.cordova = undefined
+    expect(isMobileApp()).toBeFalsy()
+    isFlagshipApp.mockReturnValue(true)
+    expect(isMobileApp()).toBeTruthy()
+    isFlagshipApp.mockReturnValue(false)
     expect(isMobileApp()).toBeFalsy()
   })
   it('should identify is an iOS or Android application', () => {

--- a/packages/cozy-device-helper/src/platform.ts
+++ b/packages/cozy-device-helper/src/platform.ts
@@ -1,4 +1,5 @@
 import { isCordova } from './cordova'
+import { isFlagshipApp } from './flagship'
 
 const ANDROID_PLATFORM = 'android'
 const IOS_PLATFORM = 'ios'
@@ -15,7 +16,7 @@ const isPlatform = (platform: PLATFORM): boolean => getPlatform() === platform
 export const isIOSApp = (): boolean => isPlatform(IOS_PLATFORM)
 export const isAndroidApp = (): boolean => isPlatform(ANDROID_PLATFORM)
 export const isWebApp = (): boolean => isPlatform(WEB_PLATFORM)
-export const isMobileApp = (): boolean => isCordova()
+export const isMobileApp = (): boolean => isCordova() || isFlagshipApp()
 
 // return if is on an Android Device (native or browser)
 export const isAndroid = (): boolean =>


### PR DESCRIPTION
  For me there is a mismatch between the name `isMobileApp` and what it actually does. I therefore propose to also check if it is a flagship app in this function. To check cordova we can do it with `isCordova`

BREAKING CHANGE: Now `isMobileApp` also checks if it is on the Flagship app. If you only want to check if the application you are running is based on Cordova, you can use `isCordova`