### PR TITLE
fix: Set connection id of current bank's accounts

### DIFF
--- a/packages/cozy-doctypes/src/banking/BankAccount.js
+++ b/packages/cozy-doctypes/src/banking/BankAccount.js
@@ -9,6 +9,8 @@ const matching = require('./matching-accounts')
 const { getSlugFromInstitutionLabel } = require('./slug-account')
 const Document = require('../Document')
 
+const connectionId = account => account?.relationships?.connection?.data?._id
+
 class BankAccount extends Document {
   /**
    * Adds _id of existing accounts to fetched accounts
@@ -65,10 +67,7 @@ class BankAccount extends Document {
       const foundInMatchedAccounts = Boolean(
         matchedAccountIds[localAccount._id]
       )
-      const newAccountId =
-        replacedCozyAccountIds[
-          localAccount?.relationships?.connection?.data?._id
-        ]
+      const newAccountId = replacedCozyAccountIds[connectionId(localAccount)]
       if (foundInMatchedAccounts || !newAccountId) {
         continue
       }
@@ -104,11 +103,9 @@ class BankAccount extends Document {
     for (const matching of matchings) {
       if (
         matching.match &&
-        matching?.account?.relationships?.connection?.data?._id !==
-          matching?.match?.relationships?.connection?.data?._id
+        connectionId(matching?.account) !== connectionId(matching?.match)
       ) {
-        result[matching?.match?.relationships?.connection?.data?._id] =
-          matching?.account?.relationships?.connection?.data?._id
+        result[connectionId(matching?.match)] = connectionId(matching?.account)
       }
     }
     return result

--- a/packages/cozy-doctypes/src/banking/BankAccount.js
+++ b/packages/cozy-doctypes/src/banking/BankAccount.js
@@ -64,13 +64,26 @@ class BankAccount extends Document {
     const matchings = [...previousMatchings]
     const matchedAccountIds = keyBy(matchings, 'match._id')
     for (const localAccount of localAccounts) {
+      if (connectionId(localAccount) == null) {
+        // XXX: don't try to update the connectionId of local accounts which
+        // don't have any as they're probably not from the same bank.
+        // If they are, their connectionId should be updated via a match with a
+        // fetched account.
+        continue
+      }
+
       const foundInMatchedAccounts = Boolean(
         matchedAccountIds[localAccount._id]
       )
-      const newAccountId = replacedCozyAccountIds[connectionId(localAccount)]
-      if (foundInMatchedAccounts || !newAccountId) {
+      if (foundInMatchedAccounts) {
         continue
       }
+
+      const newAccountId = replacedCozyAccountIds[connectionId(localAccount)]
+      if (newAccountId == null) {
+        continue
+      }
+
       matchings.push({
         forcedReplace: true,
         account: {

--- a/packages/cozy-doctypes/src/banking/BankAccount.js
+++ b/packages/cozy-doctypes/src/banking/BankAccount.js
@@ -1,11 +1,13 @@
-const groupBy = require('lodash/groupBy')
 const get = require('lodash/get')
+const groupBy = require('lodash/groupBy')
 const keyBy = require('lodash/keyBy')
 const merge = require('lodash/merge')
-const Document = require('../Document')
+
+const log = require('cozy-logger').namespace('BankAccount')
+
 const matching = require('./matching-accounts')
 const { getSlugFromInstitutionLabel } = require('./slug-account')
-const log = require('cozy-logger').namespace('BankAccount')
+const Document = require('../Document')
 
 class BankAccount extends Document {
   /**

--- a/packages/cozy-doctypes/src/banking/BankAccount.spec.js
+++ b/packages/cozy-doctypes/src/banking/BankAccount.spec.js
@@ -1,11 +1,26 @@
 const BankAccount = require('./BankAccount')
 
 describe('account reconciliation', () => {
-  it('should update relationship of disabled accounts associated to the same relationship as updated anabled accounts even with accounts without connection relationship', () => {
+  it('should update connection of disabled accounts without connection with the one of matching fetched accounts', () => {
     const newAccounts = [
       {
         number: '1',
         balance: 100,
+        relationships: {
+          connection: {
+            data: {
+              _id: 'cozyaccountnew',
+              _type: 'io.cozy.accounts'
+            }
+          }
+        },
+        metadata: {
+          updatedAt: '2020-11-30'
+        }
+      },
+      {
+        number: '10',
+        balance: 33,
         relationships: {
           connection: {
             data: {
@@ -66,6 +81,15 @@ describe('account reconciliation', () => {
         metadata: {
           updatedAt: '2012-11-30'
         }
+      },
+      {
+        _id: 'otheraccountnorelationship',
+        number: '20',
+        balance: 130,
+        relationships: {},
+        metadata: {
+          updatedAt: '2012-11-30'
+        }
       }
     ]
     const matchedAccounts = BankAccount.reconciliate(
@@ -92,6 +116,28 @@ describe('account reconciliation', () => {
         }
       },
       {
+        _id: 'oldaccountnorelationship',
+        number: '10',
+        rawNumber: '10',
+        balance: 33,
+        relationships: {
+          connection: {
+            data: {
+              _id: 'cozyaccountnew',
+              _type: 'io.cozy.accounts'
+            }
+          },
+          other: {
+            data: {
+              some: 'data'
+            }
+          }
+        },
+        metadata: {
+          updatedAt: '2020-11-30'
+        }
+      },
+      {
         _id: 'a2',
         number: '2',
         balance: 300,
@@ -110,6 +156,7 @@ describe('account reconciliation', () => {
       }
     ])
   })
+
   it('should correctly match linxo accounts to cozy accounts through number', () => {
     const newAccounts = [
       {


### PR DESCRIPTION
When (re-)connecting a bank, we try to match existing accounts with
newly fetched ones.
When we find matches, we update the existing accounts with the fresh
data and set the connection id with the new one.
We also update the connection id of other bank accounts that were
sharing the same old connection id with the matching bank account.

e.g. :

  Say we have
  - bank account `#1` with connection id A
  - bank account `#2` with connection id A
  - bank account `#3` with connection id B

  And we fetch
  - bank account `#1` connection id C

  Then we'll make these updates
  - bank account `#1` gets connection id C
  - bank account `#2` gets connection id C

Now, if an existing bank account matches with a fetched one but did
not have a connection id anymore, we'll use the new connection id as
well.

However, the way we were doing so resulted in the update of all bank
accounts without connection ids whenever one of them would match a
newly fetched one.
This means that bank accounts from different banks could get
associated with the same connection.

To avoid this, we now prevent connection id updates for bank accounts
missing one unless they have a match in the newly fetched bank
accounts.