### PR TITLE
Fix(harvest): handle navback from edit dialog

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/ConfigurationTab/index.jsx
@@ -79,7 +79,7 @@ const ConfigurationTab = ({
 }) => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
-  const { replaceHistory } = useContext(MountPointContext)
+  const { pushHistory } = useContext(MountPointContext)
   const client = useClient()
   const vaultClient = useVaultClient()
   const [deleting, setDeleting] = useSafeState(false)
@@ -162,7 +162,7 @@ const ConfigurationTab = ({
             <ListItem
               button
               divider
-              onClick={() => replaceHistory(`/accounts/${account._id}/edit`)}
+              onClick={() => pushHistory(`/accounts/${account._id}/edit`)}
             >
               <ListItemIcon>
                 <Icon icon={KeyIcon} color={palette['slateGrey']} />

--- a/packages/cozy-harvest-lib/src/datacards/FileDataCard.jsx
+++ b/packages/cozy-harvest-lib/src/datacards/FileDataCard.jsx
@@ -52,7 +52,7 @@ const FileListItem = ({ divider, file, onClick, style }) => {
       </ListItemIcon>
       <ListItemText
         primary={file.name}
-        primaryClassName="u-ellipsis"
+        classes={{ primary: 'u-ellipsis' }}
         secondary={
           <Typography variant="caption">
             {t('datacards.files.imported', {


### PR DESCRIPTION
Previously the history was mutated so we couldn't go back. Now it's correctly updated so we can go back