### PR TITLE
fix: Remove Fab button on onboarding page

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/MesPapiersLibProviders.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/MesPapiersLibProviders.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import { useQuery } from 'cozy-client'
 import { I18n, initTranslation } from 'cozy-ui/transpiled/react/I18n'
 
 import { ModalProvider } from './Contexts/ModalProvider'
@@ -13,10 +14,18 @@ import { MesPapiersLibLayout } from './MesPapiersLibLayout'
 import PapersFabWrapper from './PapersFab/PapersFabWrapper'
 import { FILES_DOCTYPE, CONTACTS_DOCTYPE } from '../doctypes'
 import { getComponents } from '../helpers/defaultComponent'
+import { getOnboardingStatus } from '../helpers/queries'
 
 export const MesPapiersLibProviders = ({ lang, components }) => {
   const polyglot = initTranslation(lang, lang => require(`../locales/${lang}`))
   const { PapersFab, Onboarding } = getComponents(components)
+
+  const { data: settingsData } = useQuery(
+    getOnboardingStatus.definition,
+    getOnboardingStatus.options
+  )
+
+  const isOnboarded = settingsData?.[0]?.onboarded
 
   return (
     <I18n lang={lang} polyglot={polyglot}>
@@ -28,7 +37,7 @@ export const MesPapiersLibProviders = ({ lang, components }) => {
                 <OnboardingProvider OnboardingComponent={Onboarding}>
                   <MesPapiersLibLayout />
                 </OnboardingProvider>
-                {PapersFab && (
+                {PapersFab && isOnboarded && (
                   <PapersFabWrapper>
                     <PapersFab />
                   </PapersFabWrapper>

--- a/packages/cozy-mespapiers-lib/src/components/MesPapiersLibProviders.test.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/MesPapiersLibProviders.test.jsx
@@ -1,5 +1,8 @@
-import React from 'react'
+import '@testing-library/jest-dom'
 import { render } from '@testing-library/react'
+import React from 'react'
+
+import { useQuery } from 'cozy-client'
 
 import { MesPapiersLibProviders } from './MesPapiersLibProviders'
 import AppLike from '../../test/components/AppLike'
@@ -9,8 +12,12 @@ jest.mock('./PapersFab/PapersFabWrapper', () => () => (
   <div data-testid="PapersFabWrapper" />
 ))
 /* eslint-enable react/display-name */
+jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
 
-const setup = ({ components } = {}) => {
+const setup = ({ components, onboarded = true } = {}) => {
+  useQuery.mockReturnValue({
+    data: [{ onboarded }]
+  })
   return render(
     <AppLike>
       <MesPapiersLibProviders {...(components && { components: components })} />
@@ -19,15 +26,24 @@ const setup = ({ components } = {}) => {
 }
 
 describe('MesPapiersLibProviders', () => {
-  it('should display PapersFabWrapper & PapersFab by default', () => {
-    const { getByTestId } = setup()
+  describe('If onboarding is done', () => {
+    it('should display PapersFabWrapper & PapersFab', () => {
+      const { getByTestId } = setup()
 
-    expect(getByTestId('PapersFabWrapper'))
+      expect(getByTestId('PapersFabWrapper')).toBeInTheDocument()
+    })
+    it('should not display PapersFabWrapper & PapersFab', () => {
+      const { queryByTestId } = setup({ components: { PapersFab: null } })
+
+      expect(queryByTestId('PapersFabWrapper')).toBeNull()
+    })
   })
 
-  it('should not display PapersFabWrapper & PapersFab', () => {
-    const { queryByTestId } = setup({ components: { PapersFab: null } })
+  describe('If the onboarding is not finished', () => {
+    it('should not display PapersFabWrapper & PapersFab by default', () => {
+      const { queryByTestId } = setup({ onboarded: false })
 
-    expect(queryByTestId('PapersFabWrapper')).toBeNull()
+      expect(queryByTestId('PapersFabWrapper')).toBeNull()
+    })
   })
 })


### PR DESCRIPTION
As long as the user has not validated his onboarding, via the "Let's go!" button, he will not be able to access the features of the app.