### PR TITLE
fix(harvest): Check for file infos before fetch

### DIFF
--- a/packages/cozy-harvest-lib/src/datacards/ViewerModal.jsx
+++ b/packages/cozy-harvest-lib/src/datacards/ViewerModal.jsx
@@ -8,10 +8,9 @@ import { useDataCardFiles } from './useDataCardFiles'
 import { MountPointContext } from '../components/MountPointContext'
 
 export const ViewerModal = () => {
+  const { accountId, folderToSaveId, fileIndex } = useParams()
   const { pushHistory, replaceHistory } = useContext(MountPointContext)
   const { data, fetchStatus } = useDataCardFiles(accountId, folderToSaveId)
-  const { accountId, folderToSaveId, fileIndex } = useParams()
-
   const handleCloseViewer = () => replaceHistory(`/accounts/${accountId}`)
   const handleFileChange = (_file, newIndex) =>
     pushHistory(`/viewer/${accountId}/${folderToSaveId}/${newIndex}`)

--- a/packages/cozy-harvest-lib/src/datacards/useDataCardFiles.js
+++ b/packages/cozy-harvest-lib/src/datacards/useDataCardFiles.js
@@ -74,6 +74,9 @@ const getResponse = (folderToSaveFiles, sourceAccountFiles) => {
 }
 
 export const useDataCardFiles = (accountId, folderToSaveId) => {
+  if (!accountId || !folderToSaveId)
+    throw new Error('Missing arguments in useDataCardFiles, cannot fetch files')
+
   const folderToSaveFiles = useFolderToSaveFiles(folderToSaveId)
   const sourceAccountFiles = useSourceAccountFiles(accountId)
 


### PR DESCRIPTION
We had a bug because `useDataCardFiles`
was called with `(undefined, undefined)`
This bug happened because `useParams` was used after `useDataCardFiles`

But it still returned some fallback values due to query cache.
So we always defaulted to some files the useQuery was able to get.

Now we will throw if the hook is called without arguments.
This case wasn't supposed to exist,
as such it should be treated as an error

It would be difficult to know what to do with empty arguments.
Are they coming later? never?

On the other hand I'm not sure at this moment if
there are scenarios where that error can happen.
We have no elegant error handler for it as of this commit.