### PR TITLE
fix: Redirect link to Drive

### DIFF
--- a/packages/cozy-mespapiers-lib/src/helpers/queries.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/queries.js
@@ -26,6 +26,7 @@ export const buildFilesQueryWithQualificationLabel = () => {
     'metadata.contractType',
     'metadata.refTaxIncome',
     'created_at',
+    'dir_id',
     'updated_at',
     'type',
     'trashed'


### PR DESCRIPTION
In the `viewInDrive` action, we need the `dir_id` attribute of the file.
The files retrieved by the `buildFilesQueryWithQualificationLabel` query being those used during the search, this attribute must be included in the `select`