### PR TITLE
feat(harvest): Update config page header

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/AccountModalHeader.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/AccountModalHeader.jsx
@@ -1,7 +1,9 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import { useMatch } from 'react-router-dom'
 
 import AccountSelectBox from '../AccountSelectBox/AccountSelectBox'
+import { AccountSelectorHeader } from '../AccountSelectBox/AccountSelectorHeader'
 import KonnectorModalHeader from '../KonnectorModalHeader'
 import { withMountPointProps } from '../MountPointContext'
 
@@ -12,6 +14,20 @@ export const AccountModalHeader = ({
   showAccountSelection,
   pushHistory
 }) => {
+  const isConfig = useMatch(
+    `/connected/${konnector.slug}/accounts/:accountId/config`
+  )
+
+  if (isConfig)
+    return (
+      <AccountSelectorHeader
+        konnector={konnector}
+        account={account}
+        accountsAndTriggers={accountsAndTriggers}
+        pushHistory={pushHistory}
+      />
+    )
+
   return (
     <KonnectorModalHeader konnector={konnector}>
       {showAccountSelection && (

--- a/packages/cozy-harvest-lib/src/components/AccountSelectBox/AccountSelectBox.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountSelectBox/AccountSelectBox.jsx
@@ -14,7 +14,8 @@ const AccountSelectBox = ({
   selectedAccount,
   onChange,
   onCreate,
-  loading
+  loading,
+  variant
 }) => {
   if (loading) {
     return <div style={{ height: 20.8 }}>&nbsp;</div>
@@ -39,6 +40,7 @@ const AccountSelectBox = ({
         Control: reactSelectControl(
           <AccountSelectControl
             name={Account.getAccountName(selectedAccount)}
+            variant={variant}
           />
         ),
         Menu: MenuWithFixedComponent

--- a/packages/cozy-harvest-lib/src/components/AccountSelectBox/AccountSelectControl.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountSelectBox/AccountSelectControl.jsx
@@ -5,7 +5,25 @@ import BottomIcon from 'cozy-ui/transpiled/react/Icons/Bottom'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import palette from 'cozy-ui/transpiled/react/palette'
 
-const AccountSelectControl = ({ name }) => {
+const AccountSelectControlBig = ({ name }) => {
+  return (
+    <div className="u-flex u-flex-items-center u-c-pointer">
+      <Typography className="u-dib u-maw-5 u-ellipsis u-lh-1" variant="h3">
+        {name}
+      </Typography>
+      <Icon
+        icon={BottomIcon}
+        size="15"
+        className="u-ml-half"
+        color={"var('--primaryTextColor')"}
+      />
+    </div>
+  )
+}
+
+const AccountSelectControl = ({ name, variant }) => {
+  if (variant === 'big') return <AccountSelectControlBig name={name} />
+
   return (
     <div className="u-flex u-flex-items-center u-c-pointer">
       <Typography className="u-dib u-maw-5 u-ellipsis" variant="body1">

--- a/packages/cozy-harvest-lib/src/components/AccountSelectBox/AccountSelectorHeader.tsx
+++ b/packages/cozy-harvest-lib/src/components/AccountSelectBox/AccountSelectorHeader.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+
+import DialogBackButton from 'cozy-ui/transpiled/react/CozyDialogs/DialogBackButton'
+import DialogTitle from 'cozy-ui/transpiled/react/Dialog/DialogTitle'
+
+import AccountSelectBox from './AccountSelectBox'
+
+interface AccountSelectorHeaderProps {
+  konnector: { slug: string }
+  account: Record<string, unknown>
+  accountsAndTriggers: (object | null | undefined)[]
+  pushHistory: (path: string) => void
+}
+
+export const AccountSelectorHeader = ({
+  konnector,
+  account,
+  accountsAndTriggers,
+  pushHistory
+}: AccountSelectorHeaderProps): JSX.Element => (
+  <>
+    <DialogBackButton
+      onClick={(): void =>
+        pushHistory(`/connected/${konnector.slug}/accounts/:accountId`)
+      }
+    />
+    <DialogTitle
+      className="dialogTitleWithBack dialogTitleWithClose"
+      disableTypography
+    >
+      <AccountSelectBox
+        loading={!account}
+        selectedAccount={account}
+        accountsAndTriggers={accountsAndTriggers}
+        onChange={(option: { account: { _id: string } }): void => {
+          pushHistory(`/accounts/${option.account._id}`)
+        }}
+        onCreate={(): void => {
+          pushHistory('/new')
+        }}
+        variant="big"
+      />
+    </DialogTitle>
+  </>
+)

--- a/packages/cozy-harvest-lib/src/components/AccountSelectBox/MenuWithFixedComponent.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountSelectBox/MenuWithFixedComponent.jsx
@@ -9,7 +9,7 @@ const MenuWithFixedComponent = props => {
   const { createAction, ...selectProps } = props.selectProps
   return (
     <components.Menu {...props} selectProps={selectProps}>
-      {children}
+      <div className="u-text u-fw-normal">{children}</div>
       <CreateAccountButton createAction={createAction} />
     </components.Menu>
   )


### PR DESCRIPTION
- Go Back
- Only show the account name
- Different styles than the default modal

This was painful to implement because I could not use the CozyDialogs API (used in Figma). So I had to create a sort of custom style for that page. Thankfully didn't need to create any CSS so I think it's ok, but ultimately I think Harvest should be refactored to use CozyDialogs everywhere, so this implementation is not necessary.

Before:
![image](https://user-images.githubusercontent.com/12577784/230406461-608a54ba-e00d-4a6e-9493-693738ffad7c.png)


After:
![image](https://user-images.githubusercontent.com/12577784/230405849-51531738-6598-4b15-83d5-ca0fc4fe4e8b.png)
