### PR TITLE
feat: Receive error messages from launcher in clisk konnectors

### DIFF
--- a/packages/cozy-harvest-lib/src/policies/clisk.js
+++ b/packages/cozy-harvest-lib/src/policies/clisk.js
@@ -4,7 +4,7 @@
  */
 
 import logger from '../logger'
-import { LOGIN_SUCCESS_EVENT } from '../models/flowEvents'
+import { ERROR_EVENT, LOGIN_SUCCESS_EVENT } from '../models/flowEvents'
 
 /**
  * Check if the given konnector is a client side konnector
@@ -48,14 +48,19 @@ async function onLaunch({ konnector, account, trigger, flow }) {
     logger.warn('Found no launcher')
   }
   if (launcher === 'react-native') {
-    return startLauncher({ konnector, account, trigger, flow })
+    const result = await startLauncher({ konnector, account, trigger, flow })
+    if (result?.errorMessage) {
+      logger.debug(`Error from launcher ${result.errorMessage}`)
+      flow.triggerEvent(ERROR_EVENT, new Error(result.errorMessage))
+    }
+    return result
   }
   return
 }
 
 /**
  * @typedef StartLauncherResult
- * @property {string} message - startLauncher result message
+ * @property {string} errorMessage - startLauncher errorMessage
  */
 
 /**


### PR DESCRIPTION
Now harvest can receive error messages from the launcher and display it as a non persistent error message like this

![image](https://user-images.githubusercontent.com/228695/230437447-60d73d73-d3df-45c8-8513-6ee0829a0dc8.png)

This PR is related to https://github.com/cozy/cozy-flagship-app/pull/726 to send the error message