### PR TITLE
fix: EnsureTriggerAndLaunch in oauth context

### DIFF
--- a/packages/cozy-harvest-lib/src/components/FlowProvider.jsx
+++ b/packages/cozy-harvest-lib/src/components/FlowProvider.jsx
@@ -5,9 +5,9 @@ import { createPortal } from 'react-dom'
 import { withClient } from 'cozy-client'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 
-import assert from '../assert'
 import ConnectionBackdrop from './AccountForm/ConnectionBackdrop'
 import TwoFAModal from './TwoFAModal'
+import assert from '../assert'
 import logger from '../logger'
 import ConnectionFlow from '../models/ConnectionFlow'
 import {

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -524,9 +524,10 @@ export class ConnectionFlow {
           konnector,
           t
         })
+      } else {
+        await this.launch()
       }
 
-      await this.launch()
       this.setState({ accountError: null })
     } catch (e) {
       // @ts-ignore
@@ -574,6 +575,7 @@ export class ConnectionFlow {
 
     // @ts-ignore
     this.emit(UPDATE_EVENT)
+    await this.launch()
   }
 
   handleTriggerCreated(trigger) {

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.spec.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.spec.js
@@ -655,6 +655,7 @@ describe('ConnectionFlow', () => {
           }
         })
       )
+      expect(ensureTrigger).not.toHaveBeenCalled()
       expect(launchTrigger).not.toHaveBeenCalled()
 
       delete window.cozy
@@ -827,6 +828,28 @@ describe('ConnectionFlow', () => {
         flow.konnector,
         onAccountCreationResult
       )
+    })
+    it('should should call launch when the policy does not need account and trigger creation', async () => {
+      const { flow } = setup({ konnector: fixtures.clientKonnector })
+      jest.spyOn(flow, 'launch')
+      await setupSubmit(flow, {
+        konnector: fixtures.clientKonnector
+      })
+      expect(flow.launch).toHaveBeenCalledTimes(1)
+      expect(ensureTrigger).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('ensureTriggerAndLaunch', () => {
+    it('should call ensureTrigger and launch', async () => {
+      const { flow, client } = setup()
+      await flow.ensureTriggerAndLaunch(client, {
+        account: fixtures.createdAccount,
+        trigger: fixtures.createdTrigger,
+        konnector: fixtures.konnector
+      })
+      expect(ensureTrigger).toHaveBeenCalled()
+      expect(launchTrigger).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
Now ConnectionFlow ensureTriggerAndLaunch really launches
the job and ConnectionFlow.launch is called alone in clisk context.
