### PR TITLE
fix: Override `maxWidth` of SearchInput

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/SearchInput/SearchInput.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/SearchInput/SearchInput.jsx
@@ -20,7 +20,8 @@ const useStyles = makeStyles(theme => ({
     },
     '& input': {
       borderRadius: '25px',
-      height: '38px'
+      height: '38px',
+      maxWidth: '100%'
     }
   }
 }))


### PR DESCRIPTION
When the InputSearch is of large size, the focus is not possible beyond 512px, which is a rule imposed by the Input component but that we do not want here.