### PR TITLE
fix: Refetch current trigger when it is running

### DIFF
--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -799,8 +799,10 @@ export class ConnectionFlow {
    */
   watchTriggerJobs() {
     if (this.trigger) {
-      // When the trigger comes from realtime, cozy-stack does not add the current_state to the object. So we need to request the stack to get it
-      if (!this.trigger?.current_state) {
+      if (
+        !this.trigger?.current_state || // When the trigger comes from realtime, cozy-stack does not add the current_state to the object. So we need to request the stack to get it
+        this.trigger.current_state.status === 'running' // ConnectionFlow could miss end of trigger job execution while reloading. We force refetch in this case
+      ) {
         this.refetchTrigger()
       }
       this.realtime.subscribe(


### PR DESCRIPTION
When creating a new account/trigger couple, when the given trigger has
started running, the FlowProvider is reloaded, which means it
unsubscribes from realtime events until it is reloaded.

If the konnector execution is really fast (example: dummy-> 1s), its
execution could end during the FlowProvider reload (which is a little
less than 1s on my development environment).

To fix this issue, I force the ConnectionFlow to refetch the current
trigger if this trigger is in the state "running", in case we missed the
konnector execution end.
