### PR TITLE
Fix search result when filtering with no keywords

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Home/HomeLayout.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/HomeLayout.jsx
@@ -26,7 +26,7 @@ const HomeLayout = ({ contacts, papers, konnectors }) => {
 
   useEffect(() => {
     if (flag('mespapiers.flexsearch.enabled')) {
-      addAllOnce([...contacts, ...papers])
+      addAllOnce(papers.concat(contacts))
     }
   }, [addAllOnce, contacts, papers])
 

--- a/packages/cozy-mespapiers-lib/src/components/Search/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Search/helpers.js
@@ -26,7 +26,7 @@ export const makeReducedResultIds = flexsearchResult =>
     return acc
   }, [])
 
-export const makeFirstSearchResultMatchingAttributes = (results, id) =>
+const makeFirstSearchResultMatchingAttributes = (results, id) =>
   results.map(x => (x.result.includes(id) ? x.field : undefined)).filter(x => x)
 
 export const search = async ({ docs, value, tag }) => {
@@ -35,7 +35,7 @@ export const search = async ({ docs, value, tag }) => {
 
   return isMultipleSearch
     ? await computeResultForMultipleSearch({ docs, tokens, tag })
-    : computeResultForSearch({ docs, tokens, tag })
+    : computeResultForSearch({ docs, token: tokens[0], tag })
 }
 
 export const makeMultipleSearchResultIds = resultsPerTokens => {
@@ -46,7 +46,7 @@ export const makeMultipleSearchResultIds = resultsPerTokens => {
   return intersection(...resultsIdsPerTokens)
 }
 
-export const computeResultForMultipleSearch = async ({ docs, tokens, tag }) => {
+const computeResultForMultipleSearch = async ({ docs, tokens, tag }) => {
   const promises = tokens.map(token => index.searchAsync(token, { tag }))
   const resultsPerTokens = await Promise.all(promises)
 
@@ -63,8 +63,8 @@ export const computeResultForMultipleSearch = async ({ docs, tokens, tag }) => {
   return { filteredDocs, firstSearchResultMatchingAttributes }
 }
 
-export const computeResultForSearch = ({ docs, tokens, tag }) => {
-  const results = index.search(tokens[0], { tag })
+const computeResultForSearch = ({ docs, token, tag }) => {
+  const results = index.search(token, { tag })
 
   const resultIds = makeReducedResultIds(results)
 

--- a/packages/cozy-mespapiers-lib/src/components/Search/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Search/helpers.js
@@ -47,7 +47,9 @@ export const makeMultipleSearchResultIds = resultsPerTokens => {
 }
 
 const computeResultForMultipleSearch = async ({ docs, tokens, tag }) => {
-  const promises = tokens.map(token => index.searchAsync(token, { tag }))
+  const promises = tokens.map(token =>
+    index.searchAsync(token, { tag, limit: 9999 })
+  )
   const resultsPerTokens = await Promise.all(promises)
 
   const resultIds = makeMultipleSearchResultIds(resultsPerTokens)
@@ -64,7 +66,7 @@ const computeResultForMultipleSearch = async ({ docs, tokens, tag }) => {
 }
 
 const computeResultForSearch = ({ docs, token, tag }) => {
-  const results = index.search(token, { tag })
+  const results = index.search(token, { tag, limit: 9999 })
 
   const resultIds = makeReducedResultIds(results)
 


### PR DESCRIPTION
Sur des cozy avec beaucoup de documents, dans certains cas de filtrage par catégorie sans mot clé dans la barre de recherche, il n'y a aucun document retourné alors que ça devrait.

La cause étant que flexsearch retourne bien des résultats, mais est limité à 100 résultats par défaut https://github.com/nextapps-de/flexsearch#limit--offset . Comme on lui injectait d'abord les `contacts` puis ensuite les `papers`, et qu'un filtrage comme `identité` retourne tous les contacts, si on a plus de 100 contacts dans le cozy cela vient remplir tous les résultats, ne laissant plus de place pour les papers.

Le correctif est double : injecter d'abord les papers (pour retourner plus prioritairement des papers), augmenter la limite de résultat à `9999` (ce qui ne semble pas être un souci, cf la doc linké plus haut).