### PR TITLE
fix: Display of the last Divider

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
@@ -48,7 +48,7 @@ const PaperGroup = ({ papersByCategories, konnectors, selectedTheme }) => {
             key={category}
             category={category}
             papers={papers}
-            isLast={index === papersByCategories.length - 1}
+            isLast={index === Object.entries(papersByCategories).length - 1}
             onClick={goPapersList}
           />
         ))}


### PR DESCRIPTION
Suite au changement de `papersByCategories` dernièrement (https://github.com/cozy/cozy-libs/pull/2110), nous avons manqué de mettre à jour une partie