### PR TITLE
fix(harvest): DialogBackButtonon config modal

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/AccountModalHeader.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/AccountModalHeader.jsx
@@ -12,7 +12,8 @@ export const AccountModalHeader = ({
   account,
   accountsAndTriggers,
   showAccountSelection,
-  pushHistory
+  pushHistory,
+  replaceHistory
 }) => {
   const isConfig = useMatch(
     `/connected/${konnector.slug}/accounts/:accountId/config`
@@ -25,6 +26,7 @@ export const AccountModalHeader = ({
         account={account}
         accountsAndTriggers={accountsAndTriggers}
         pushHistory={pushHistory}
+        replaceHistory={replaceHistory}
       />
     )
 

--- a/packages/cozy-harvest-lib/src/components/AccountSelectBox/AccountSelectorHeader.tsx
+++ b/packages/cozy-harvest-lib/src/components/AccountSelectBox/AccountSelectorHeader.tsx
@@ -7,22 +7,21 @@ import AccountSelectBox from './AccountSelectBox'
 
 interface AccountSelectorHeaderProps {
   konnector: { slug: string }
-  account: Record<string, unknown>
+  account: Record<string, unknown> & { _id: string }
   accountsAndTriggers: (object | null | undefined)[]
   pushHistory: (path: string) => void
+  replaceHistory: (path: string) => void
 }
 
 export const AccountSelectorHeader = ({
-  konnector,
   account,
   accountsAndTriggers,
-  pushHistory
+  pushHistory,
+  replaceHistory
 }: AccountSelectorHeaderProps): JSX.Element => (
   <>
     <DialogBackButton
-      onClick={(): void =>
-        pushHistory(`/connected/${konnector.slug}/accounts/:accountId`)
-      }
+      onClick={(): void => replaceHistory(`/accounts/${account._id}`)}
     />
     <DialogTitle
       className="dialogTitleWithBack dialogTitleWithClose"


### PR DESCRIPTION
### Fix Account Modal navigation issue

This pull request addresses an issue with the Account Modal's back button, which previously did not allow the user to navigate back correctly due to using the wrong method (`push` instead of `replace`) and an incorrect redirect path.

#### Changes:

- Replaced `pushHistory` with `replaceHistory` in `AccountModalHeader.jsx` and `AccountSelectorHeader.tsx` to use the correct navigation method.
- Updated the redirect path in the `onClick` callback of the `AccountSelectorHeader` component to correctly navigate back to the account details page.

After considering both the `push` and `replace` methods for navigation, the `replace` method has been chosen in this PR, as it provides a more seamless user experience by not creating an additional history entry when navigating back.
