### PR TITLE
feat(cozy-mespapiers-lib): Add ThumbnailStack component

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Papers/CategoryItemByPaper.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/CategoryItemByPaper.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import { useClient } from 'cozy-client'
+import flag from 'cozy-flags'
 import MuiCardMedia from 'cozy-ui/transpiled/react/CardMedia'
 import { FileImageLoader } from 'cozy-ui/transpiled/react/FileImageLoader'
 import Icon from 'cozy-ui/transpiled/react/Icon'
@@ -10,6 +11,7 @@ import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
 
+import StackedThumbnail from './StackedThumbnail'
 import { useScannerI18n } from '../Hooks/useScannerI18n'
 
 const CategoryItemByPaper = ({ papers, category, isLast, onClick }) => {
@@ -24,14 +26,18 @@ const CategoryItemByPaper = ({ papers, category, isLast, onClick }) => {
             client={client}
             file={papers[0]}
             linkType="tiny"
-            render={src => (
-              <MuiCardMedia
-                component="img"
-                width={32}
-                height={32}
-                image={src}
-              />
-            )}
+            render={src => {
+              return flag('mespapiers.v2-1-0.enabled') ? (
+                <StackedThumbnail image={src} isStacked={papers.length > 1} />
+              ) : (
+                <MuiCardMedia
+                  component="img"
+                  width={32}
+                  height={32}
+                  image={src}
+                />
+              )
+            }}
             renderFallback={() => <Icon icon="file-type-image" size={32} />}
           />
         </ListItemIcon>

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperItem.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperItem.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 
 import { models, useClient } from 'cozy-client'
+import flag from 'cozy-flags'
 import CardMedia from 'cozy-ui/transpiled/react/CardMedia'
 import Checkbox from 'cozy-ui/transpiled/react/Checkbox'
 import FileImageLoader from 'cozy-ui/transpiled/react/FileImageLoader'
@@ -18,6 +19,7 @@ import { makeStyles } from 'cozy-ui/transpiled/react/styles'
 
 import ExpirationAnnotation from './ExpirationAnnotation'
 import RenameInput from './Renaming/RenameInput'
+import StackedThumbnail from './StackedThumbnail'
 import { useMultiSelection } from '../Hooks/useMultiSelection'
 
 const { isExpired, isExpiringSoon } = models.paper
@@ -126,7 +128,9 @@ const PaperItem = ({
             file={paper}
             linkType="tiny"
             render={src => {
-              return (
+              return flag('mespapiers.v2-1-0.enabled') ? (
+                <StackedThumbnail image={src} />
+              ) : (
                 <CardMedia component="img" width={32} height={32} image={src} />
               )
             }}

--- a/packages/cozy-mespapiers-lib/src/components/Papers/StackedThumbnail.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/StackedThumbnail.jsx
@@ -1,0 +1,59 @@
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import styles from './Thumbnail.styl'
+
+/**
+ * StackedThumbnail component
+ * @param {Object} props
+ * @param {string} props.image - Image url
+ * @param {boolean} props.isStacked - Is the image stacked
+ * @example
+ * <StackedThumbnail image="https://example.com/image.jpg" isStacked={<condition>} />
+ */
+const StackedThumbnail = ({ image, isStacked }) => {
+  return (
+    <div className={styles['container']} aria-hidden="true">
+      <div
+        className={cx(styles['image__wrapper'], {
+          [styles['image__wrapper__multiple']]: isStacked
+        })}
+        data-testid="ThumbnailContainer"
+      >
+        <img
+          src={image}
+          className={cx(styles['image'], {
+            [styles['image__multiple']]: isStacked
+          })}
+        />
+      </div>
+      {isStacked && (
+        <div
+          className={cx(
+            styles['image__wrapper'],
+            styles['image__wrapper__background'],
+            styles['image__wrapper__multiple']
+          )}
+          data-testid="ThumbnailBackgroundContainer"
+        >
+          <img
+            src={image}
+            className={cx(
+              styles['image'],
+              styles['image__background'],
+              styles['image__multiple']
+            )}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+StackedThumbnail.propTypes = {
+  image: PropTypes.string,
+  isStacked: PropTypes.bool
+}
+
+export default StackedThumbnail

--- a/packages/cozy-mespapiers-lib/src/components/Papers/StackedThumbnail.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/StackedThumbnail.spec.jsx
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom'
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import StackedThumbnail from './StackedThumbnail'
+
+const setup = isStacked => {
+  return render(
+    <StackedThumbnail image="/fakeImagePath" isStacked={isStacked} />
+  )
+}
+
+describe('StackedThumbnail components:', () => {
+  it('should display only one Thumbnail', () => {
+    const { getByTestId, queryByTestId } = setup()
+
+    expect(getByTestId('ThumbnailContainer')).toBeInTheDocument()
+    expect(queryByTestId('ThumbnailBackgroundContainer')).toBeNull()
+  })
+
+  it('should display Thumbnail stacked', () => {
+    const { getByTestId } = setup(true)
+
+    expect(getByTestId('ThumbnailContainer')).toBeInTheDocument()
+    expect(getByTestId('ThumbnailBackgroundContainer')).toBeInTheDocument()
+  })
+})

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Thumbnail.styl
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Thumbnail.styl
@@ -1,0 +1,39 @@
+.container
+  align-items center
+  box-sizing border-box
+  display flex
+  height 32px
+  justify-content center
+  position relative
+  width 32px
+
+.image__wrapper
+  border 3px solid var(--paperBackgroundColor)
+  border-radius 3px
+  box-shadow 0px 0px 0px 1px rgba(29, 33, 42, 0.24), 0px 2px 4px rgba(29, 33, 42, 0.08), 0px 4px 16px rgba(29, 33, 42, 0.06)
+  display inline-block
+  max-height 32px
+  max-width 32px
+  z-index 1
+
+
+  &.image__wrapper__background
+    position absolute
+    transform translate(3px, -3px)
+    z-index 0
+
+  &.image__wrapper__multiple
+    max-height: 29px
+    max-width: 29px
+
+.image
+  display block
+  max-height 26px
+  max-width 26px
+
+  &.image__background
+    opacity 0
+
+  &.image__multiple
+    max-height: 23px
+    max-width: 23px


### PR DESCRIPTION
It replaces the CardMedia component, to display the thumbnails of the papers on the homepage and the paper lists.

Before:
![Capture d’écran 2023-04-18 à 11 33 19](https://user-images.githubusercontent.com/14182143/232737328-e0a92447-919c-4c89-9dbd-e7d23d9f787a.png)

After:
![Capture d’écran 2023-04-18 à 11 39 34](https://user-images.githubusercontent.com/14182143/232737804-3cfe0d18-34cd-4524-a38d-80bd7c9c118c.png)
