### PR TITLE
fix(harvest): Update AccountsListModal title

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountsListModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountsListModal.jsx
@@ -1,9 +1,10 @@
 import PropTypes from 'prop-types'
 import React, { useContext } from 'react'
 
+import DialogTitle from 'cozy-ui/transpiled/react/Dialog/DialogTitle'
 import DialogContent from 'cozy-ui/transpiled/react/DialogContent'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
-import Stack from 'cozy-ui/transpiled/react/Stack'
+import Typography from 'cozy-ui/transpiled/react/Typography'
 
 import AccountsList from './AccountsList/AccountsList'
 import KonnectorIcon from './KonnectorIcon'
@@ -13,15 +14,16 @@ const AccountsListModal = ({ konnector, accounts, t }) => {
   const { pushHistory, replaceHistory } = useContext(MountPointContext)
   return (
     <>
+      <DialogTitle disableTypography className="u-pt-3 u-pt-2-s">
+        <div className="u-w-3 u-h-3 u-mh-auto">
+          <KonnectorIcon konnector={konnector} />
+        </div>
+        <Typography variant="h5" className="u-title-h3 u-ta-center">
+          {t('modal.accounts.title', { name: konnector.name })}
+        </Typography>
+      </DialogTitle>
+
       <DialogContent>
-        <Stack className="u-mb-3">
-          <div className="u-w-3 u-h-3 u-mh-auto">
-            <KonnectorIcon konnector={konnector} />
-          </div>
-          <h3 className="u-title-h3 u-ta-center">
-            {t('modal.accounts.title', { name: konnector.name })}
-          </h3>
-        </Stack>
         <AccountsList
           accounts={accounts}
           konnector={konnector}


### PR DESCRIPTION
### Update AccountsListModal styles and components

This pull request updates the `AccountsListModal` component to use the `<DialogTitle>` component from Cozy UI, replacing the outdated `<Stack>` component. This change addresses styling issues on desktop, mobile, and mobile native platforms.

#### Changes:

- Replaced `<Stack>` with `<DialogTitle>` for improved consistency in header styling
- Updated the component to use `<Typography>` for better text display
- Removed unnecessary styles and classNames

While this PR fixes the immediate styling issues in `AccountsListModal`, it has been noted that there is a lack of consistency in the header styling throughout the Harvest library. Further work may be needed to ensure a more robust and consistent styling solution.

#### Screenshots: 

![{EDC06993-C704-4DEF-BCEC-9E4E7B0EA05A}](https://user-images.githubusercontent.com/12577784/233095626-b3b3eb6d-a487-4975-96fc-4a183dd13b9b.png)

![{3E719EAA-2E5D-4D40-9FEA-C2836AA14F5C}](https://user-images.githubusercontent.com/12577784/233095639-03ffd495-895d-48dd-bab6-d3abf591f426.png)

![{41DD139D-DAAA-4BE3-BF00-BCBA019ADAE8}](https://user-images.githubusercontent.com/12577784/233095650-c8efeb92-e1b8-45a8-bffa-3a7f21bc6e13.png)

![{9ACEA756-41D3-45CC-9300-D02392072AC1}](https://user-images.githubusercontent.com/12577784/233096045-63d3977c-31ed-4d7a-96ad-dc1248a8dcf1.png)
![{FA0770F0-B7C1-444C-AFE3-89EC5A929C5B}](https://user-images.githubusercontent.com/12577784/233096060-5be17525-68ea-4d2a-98f3-fd65e6e46cca.png)
![{4FA20824-BD9A-4341-BFDD-A7E24617FD0E}](https://user-images.githubusercontent.com/12577784/233096440-524308ae-936c-4f7f-bbe5-934d25ba053b.png)
