### PR TITLE
fix: Create KonnnectorJobError in clisk policy

### DIFF
--- a/packages/cozy-harvest-lib/src/policies/clisk.js
+++ b/packages/cozy-harvest-lib/src/policies/clisk.js
@@ -3,6 +3,7 @@
  * Clisk specific policy
  */
 
+import { KonnectorJobError } from '../helpers/konnectors'
 import logger from '../logger'
 import { ERROR_EVENT, LOGIN_SUCCESS_EVENT } from '../models/flowEvents'
 
@@ -51,7 +52,7 @@ async function onLaunch({ konnector, account, trigger, flow }) {
     const result = await startLauncher({ konnector, account, trigger, flow })
     if (result?.errorMessage) {
       logger.debug(`Error from launcher ${result.errorMessage}`)
-      flow.triggerEvent(ERROR_EVENT, new Error(result.errorMessage))
+      flow.triggerEvent(ERROR_EVENT, new KonnectorJobError(result.errorMessage))
     }
     return result
   }

--- a/packages/cozy-harvest-lib/src/policies/clisk.spec.js
+++ b/packages/cozy-harvest-lib/src/policies/clisk.spec.js
@@ -1,4 +1,5 @@
 import { getLauncher, konnectorPolicy } from './clisk'
+import { KonnectorJobError } from '../helpers/konnectors'
 
 describe('getLauncher', () => {
   it('should get the current Launcher from the given window object', () => {
@@ -130,7 +131,7 @@ describe('onLaunch', () => {
     ])
     expect(flow.triggerEvent).toHaveBeenCalledWith(
       'error',
-      new Error('test error message')
+      new KonnectorJobError('test error message')
     )
   })
 })


### PR DESCRIPTION
Or else some components won't be able to test this error and will create
error :

```
err.isLoginError is not a fonction
```
