### PR TITLE
fix: Discard errors when closing the websocket

### DIFF
--- a/packages/cozy-realtime/src/CozyRealtime.js
+++ b/packages/cozy-realtime/src/CozyRealtime.js
@@ -135,7 +135,12 @@ class CozyRealtime {
     if (this.hasWebSocket()) {
       logger.info('trashing the previous websocket…')
       this.websocket.onmessage = null
-      this.websocket.onerror = null
+      this.websocket.onerror = err => {
+        // XXX: discard errors
+        logger.error(
+          `Error while trying to close the websocket: ${err.message}`
+        )
+      }
       this.websocket.onopen = null
       this.websocket.onclose = null
       try {


### PR DESCRIPTION
The `WebSocket` API is not implemented in NodeJS so apps such as
Cozy Desktop need to use the `ws` library.

Unfortunately, this library's implementation differs from the
browsers' native ones in some ways such as the behavior when closing
the WebSocket.

In `ws`'s implementation, if the WebSocket is open but not connected
yet, an error event will be emitted causing an unhandled error since
`cozy-realtime` removes the `onerror` listener before attempting to
close the WebSocket.

Since we don't care about such errors anyway, we can use a different
listener that will simply log these errors rather than completely
removing the listener.