### PR TITLE
fix: Do not overwrite onDeleteAccount in KonnectorAccountWrapper

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountWrapper.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountWrapper.jsx
@@ -26,7 +26,6 @@ export const KonnectorAccountWrapper = props => {
             <Component
               {...rest}
               trigger={rest.initialTrigger}
-              onAccountDeleted={rest.onDismiss}
               addAccount={() => navigate('new', { replace: true })}
               flow={flow}
             />


### PR DESCRIPTION
This property is already defined in components using this componenent
I checked other overwritten properties and it looks OK.

This fixes an error when trying to delete an account with `harvest.inappconnectors.enabled` flag enabled
