### PR TITLE
feat(mespapiers): Add more permissive encoder for flexsearch

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Search/search.js
+++ b/packages/cozy-mespapiers-lib/src/components/Search/search.js
@@ -1,4 +1,5 @@
 import { Document } from 'flexsearch'
+import { encode } from 'flexsearch/dist/module/lang/latin/balance'
 
 import { isFile, hasQualifications } from 'cozy-client/dist/models/file'
 import flag from 'cozy-flags'
@@ -66,6 +67,7 @@ if (!flag('mespapiers.migrated.metadata')) {
  */
 export const index = new Document({
   tokenize: 'full',
+  encode,
   document: {
     id: '_id',
     tag: 'flexsearchProps:tag',

--- a/packages/cozy-mespapiers-lib/test/jestLib/setup.js
+++ b/packages/cozy-mespapiers-lib/test/jestLib/setup.js
@@ -14,6 +14,11 @@ jest.mock('cozy-ui/transpiled/react/utils/color', () => ({
   getInvertedCssVariableValue: () => '#000'
 }))
 
+// Fix error "Cannot use import statement outside a module"
+jest.mock('flexsearch/dist/module/lang/latin/balance', () => ({
+  encode: jest.fn()
+}))
+
 window.cozy = {
   bar: {
     BarLeft: () => null,


### PR DESCRIPTION
see https://github.com/nextapps-de/flexsearch#encoders

On souhaite notamment couvrir le cas des mots accentués. Il n'est plus 
nécessaire d'avoir les accents pour avoir un résultat