### PR TITLE
fix: Load icon from stack first

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorIcon.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorIcon.jsx
@@ -6,18 +6,9 @@ import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
 
 // TODO move this to cozy-ui
 class KonnectorIcon extends PureComponent {
-  fetchIcon() {
-    const { konnector, konnectorSlug, client } = this.props
-    return client.getStackClient().getIconURL({
-      type: 'konnector',
-      slug: konnectorSlug || konnector.slug
-    })
-  }
-
   render() {
-    // eslint-disable-next-line no-unused-vars
-    const { client, konnector, ...restProps } = this.props
-    return <AppIcon fetchIcon={this.fetchIcon.bind(this)} {...restProps} />
+    const { konnector, ...restProps } = this.props
+    return <AppIcon type="konnector" app={konnector} {...restProps} />
   }
 }
 


### PR DESCRIPTION
By using the previous custom method, we were calling the registry by default.

We should let the AppIcon component do the work because it'll first ask the stack and if this request failled, then it'll fallback to the registry.