### PR TITLE
feat: Allow using non-native `WebSocket`

### DIFF
--- a/packages/cozy-realtime/README.md
+++ b/packages/cozy-realtime/README.md
@@ -59,6 +59,25 @@ import { RealTimeQueries } from 'cozy-client'
 
 Simple, isn't it?
 
+You can also provide your own method to instantiate Websockets. This can be useful when using `cozy-realtime` from a Node application for example.
+
+```js
+// main.node.js
+import { Agent } from 'http'
+import { WebSocket } from 'ws'
+
+import CozyClient from 'cozy-client'
+import { RealtimePlugin } from 'cozy-realtime'
+
+const agent = new Agent({ keepAlive: true })
+const createWebSocket = (uri, doctype) => {
+  return new WebSocket(uri, doctype, { agent })
+}
+
+const client = new CozyClient({})
+client.registerPlugin(RealtimePlugin, { createWebSocket })
+```
+
 ### Manual subscribe
 
 If your app needs to handle specific events on the data, you need to subscribe/unsubscribe like this:
@@ -131,7 +150,16 @@ Here we subscribe to
 
 import CozyRealtime from 'cozy-realtime'
 
+/**
+ * In Node applications, provide a function to instantiate Websockets:
+ *
+ * const createWebSocket = (uri, doctype) => { ... }
+ *
+ * const realtime = new CozyRealtime({ client: cozyClient, createWebSocket })
+ *
+ */
 const realtime = new CozyRealtime({ client: cozyClient })
+
 const type = 'io.cozy.accounts'
 const id = 'document_id'
 

--- a/packages/cozy-realtime/src/CozyRealtime.js
+++ b/packages/cozy-realtime/src/CozyRealtime.js
@@ -12,6 +12,7 @@ import {
 } from './config'
 import logger from './logger'
 import {
+  createWebSocket,
   getUrl,
   getToken,
   doctype,
@@ -21,16 +22,23 @@ import {
 } from './utils'
 
 /**
+ * A cozy-client instance.
+ * @typedef {import("cozy-client/dist/index").CozyClient} CozyClient
+ */
+
+/**
  * Manage the realtime interactions with a cozy stack
  */
 class CozyRealtime {
   /**
    * @constructor
    * @param {object} options
-   * @param {CozyClient}  options.client
+   * @param {CozyClient}  options.client A cozy-client instance
+   * @param {Function} options.createWebSocket The function used to create WebSocket instances
    */
   constructor(options) {
     this.client = getCozyClientFromOptions(options)
+    this.createWebSocket = options.createWebSocket || createWebSocket
     this.subscriptions = new SubscriptionList()
     this.retryManager = new RetryManager({
       raiseErrorAfterAttempts,
@@ -83,7 +91,7 @@ class CozyRealtime {
     logger.info('creating a new websocket…')
     const url = getUrl(this.client)
     try {
-      this.websocket = new WebSocket(url, doctype)
+      this.websocket = this.createWebSocket(url, doctype)
       this.websocket.authenticated = false
       this.websocket.onmessage = this.onWebSocketMessage
       this.websocket.onerror = this.onWebSocketError

--- a/packages/cozy-realtime/src/RealtimePlugin.js
+++ b/packages/cozy-realtime/src/RealtimePlugin.js
@@ -1,6 +1,11 @@
 import CozyRealtime from './CozyRealtime'
 
 /**
+ * A cozy-client instance.
+ * @typedef {import("cozy-client/dist/index").CozyClient} CozyClient
+ */
+
+/**
  * Realtime plugin for cozy-client
  *
  * - Handles login/logout
@@ -14,9 +19,12 @@ class RealtimePlugin {
    *
    * @constructor
    * @param {CozyClient} client A cozy-client instance
+   * @param {object} options
+   * @param {Function} options.createWebSocket The function used to create WebSocket instances
    */
-  constructor(client) {
+  constructor(client, options = {}) {
     this.client = client
+    this.createWebSocket = options.createWebSocket
     this.realtime = null
     this.handleLogin = this.handleLogin.bind(this)
     this.handleLogout = this.handleLogout.bind(this)
@@ -28,7 +36,8 @@ class RealtimePlugin {
 
   handleLogin() {
     this.realtime = new CozyRealtime({
-      client: this.client
+      client: this.client,
+      createWebSocket: this.createWebSocket
     })
     this.client.emit('plugin:realtime:login')
   }

--- a/packages/cozy-realtime/src/RealtimePlugin.spec.js
+++ b/packages/cozy-realtime/src/RealtimePlugin.spec.js
@@ -1,5 +1,6 @@
-import RealtimePlugin from './RealtimePlugin'
 import CozyClient from 'cozy-client'
+
+import RealtimePlugin from './RealtimePlugin'
 
 let client
 
@@ -44,6 +45,20 @@ it('should login/logout correctly', async () => {
   expect(client.plugins.realtime.realtime).toBeNull()
   expect(onLogin).toHaveBeenCalledTimes(1)
   expect(onLogout).toHaveBeenCalledTimes(1)
+})
+
+it('should pass the given createWebSocket function on login', async () => {
+  const createWebSocket = jest.fn()
+
+  client = new CozyClient({})
+  client.registerPlugin(RealtimePlugin, { createWebSocket })
+
+  await client.login({
+    uri: 'http://cozy.tools:8080',
+    token: 'fake-token'
+  })
+  expect(client.plugins.realtime.realtime).not.toBeNull()
+  expect(client.plugins.realtime.createWebSocket).toBe(createWebSocket)
 })
 
 it('throws user friendly errors when trying to use the realtime while logged out', async () => {

--- a/packages/cozy-realtime/src/utils.js
+++ b/packages/cozy-realtime/src/utils.js
@@ -92,3 +92,7 @@ export function getCozyClientFromOptions({ cozyClient, client }) {
   }
   return client || cozyClient
 }
+
+export function createWebSocket(url, doctype) {
+  return new WebSocket(url, doctype)
+}


### PR DESCRIPTION
Node core does not offer a `WebSocket` implementation. Node
applications have to use a third-party package, most likely `ws`, to
create `WebSocket` instances.

Although `ws` defines a global `WebSocket`, its constructor's
signature is different from the native one used in browsers as it
accepts a third, `options`, argument.
Since Node applications might want to pass options to their websockets
(to provide a different `http.Agent` for example), we'll add the
ability to pass a `createWebSocket` function in both `CozyRealtime`
and `RealtimePlugin` options. This function will be used to create
`WebSocket` instances.

A default `createWebSocket` using the globally defined `WebSocket`
without the third argument is used when this option is not provided.