### PR TITLE
feat(mespapiers): Replace ellipsis by midellipsis for document name

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperItem.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperItem.jsx
@@ -8,6 +8,7 @@ import Checkbox from 'cozy-ui/transpiled/react/Checkbox'
 import FileImageLoader from 'cozy-ui/transpiled/react/FileImageLoader'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import MidEllipsis from 'cozy-ui/transpiled/react/MidEllipsis'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
@@ -86,6 +87,10 @@ const PaperItem = ({
     )
   }
 
+  const primaryText = validPageName(paperLabel)
+    ? t(`PapersList.label.${paperLabel}`)
+    : paper.name
+
   const secondaryText = (
     <>
       {contactNames ? contactNames : ''}
@@ -136,9 +141,9 @@ const PaperItem = ({
           <ListItemText
             className="u-mr-1"
             primary={
-              validPageName(paperLabel)
-                ? t(`PapersList.label.${paperLabel}`)
-                : paper.name
+              <span data-testid={primaryText}>
+                <MidEllipsis text={primaryText} />
+              </span>
             }
             secondary={secondaryText}
           />

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperLine.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperLine.spec.jsx
@@ -37,15 +37,15 @@ describe('PaperLine components:', () => {
 
   it('should display "ID card"', () => {
     getBoundT.mockReturnValueOnce(() => 'ID card')
-    const { getByText } = setup(mockPapers[0])
+    const { getByTestId } = setup(mockPapers[0])
 
-    expect(getByText('ID card'))
+    expect(getByTestId('ID card'))
   })
 
   it('should display "Passport"', () => {
     getBoundT.mockReturnValueOnce(() => 'Passport')
-    const { getByText } = setup(mockPapers[1])
+    const { getByTestId } = setup(mockPapers[1])
 
-    expect(getByText('Passport'))
+    expect(getByTestId('Passport'))
   })
 })

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PapersList.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PapersList.spec.jsx
@@ -38,6 +38,13 @@ describe('PapersList components:', () => {
     data
     ${'File01'}
     ${'File02'}
+  `(`should display "$data"`, ({ data }) => {
+    const { getByTestId } = setup()
+    expect(getByTestId(data))
+  })
+
+  it.each`
+    data
     ${'See more (2)'}
   `(`should display "$data"`, ({ data }) => {
     const { getByText } = setup()

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PapersListByContact.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PapersListByContact.spec.jsx
@@ -71,12 +71,19 @@ describe('PapersList components:', () => {
     it.each`
       data
       ${'Alice'}
+    `(`should display "$data"`, ({ data }) => {
+      const { getByText } = setup()
+      expect(getByText(data))
+    })
+
+    it.each`
+      data
       ${'File05'}
       ${'File06'}
       ${'File07'}
     `(`should display "$data"`, ({ data }) => {
-      const { getByText } = setup()
-      expect(getByText(data))
+      const { getByTestId } = setup()
+      expect(getByTestId(data))
     })
   })
 
@@ -84,12 +91,19 @@ describe('PapersList components:', () => {
     it.each`
       data
       ${'Bob'}
-      ${'File01'}
-      ${'File02'}
       ${'See more (2)'}
     `(`should display "$data"`, ({ data }) => {
       const { getByText } = setup()
       expect(getByText(data))
+    })
+
+    it.each`
+      data
+      ${'File01'}
+      ${'File02'}
+    `(`should display "$data"`, ({ data }) => {
+      const { getByTestId } = setup()
+      expect(getByTestId(data))
     })
   })
 })


### PR DESCRIPTION
MidEllipsis doesn't support props spreading (I'll fix it) so we can't
use data-testid on it. That's why the span.