### PR TITLE
feat: Wrap scanner feature behind `mespapiers.features.v3` flag

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanActions/ScanActionsWrapper.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanActions/ScanActionsWrapper.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React, { useState, useEffect } from 'react'
 
 import { isFlagshipApp, isMobile } from 'cozy-device-helper'
+import flag from 'cozy-flags'
 import { useWebviewIntent } from 'cozy-intent'
 
 import ScanDesktopActions from './ScanDesktopActions'
@@ -17,10 +18,14 @@ const ScanActionsWrapper = props => {
       const isAvailable = await webviewIntent.call('isScannerAvailable')
       setIsFlagshipScanAvailable(isAvailable)
     }
-    webviewIntent && checkScanDocument()
+    flag('mespapiers.features.v3') && webviewIntent && checkScanDocument()
   }, [webviewIntent])
 
-  if (isFlagshipApp() && isFlagshipScanAvailable) {
+  if (
+    flag('mespapiers.features.v3') &&
+    isFlagshipApp() &&
+    isFlagshipScanAvailable
+  ) {
     return <ScanFlagshipActions {...props} />
   }
 

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanActions/ScanActionsWrapper.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanActions/ScanActionsWrapper.spec.jsx
@@ -3,6 +3,7 @@ import { render, waitFor } from '@testing-library/react'
 import React from 'react'
 
 import { isMobile, isFlagshipApp } from 'cozy-device-helper'
+import flag from 'cozy-flags'
 import { useWebviewIntent } from 'cozy-intent'
 
 import AppLike from '../../../../../test/components/AppLike'
@@ -21,6 +22,7 @@ const mockFormData = ({ metadata = {}, data = [], contacts = [] } = {}) => ({
   data,
   contacts
 })
+jest.mock('cozy-flags')
 jest.mock('cozy-intent', () => ({
   ...jest.requireActual('cozy-intent'),
   useWebviewIntent: jest.fn()
@@ -57,6 +59,7 @@ const setup = ({
   isFlagshipAppMock = false,
   isScannerAvailable = false
 } = {}) => {
+  flag.mockReturnValue(true)
   isMobile.mockReturnValue(isMobileMock || isFlagshipAppMock)
   isFlagshipApp.mockReturnValue(isFlagshipAppMock)
   useWebviewIntent.mockReturnValue({


### PR DESCRIPTION
This feature must not be effective in the next version of the app (2.2), we must surround it with a flag.