### PR TITLE
fix: Don't display this link for Clisk

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -304,16 +304,17 @@ export class AccountForm extends PureComponent {
                   inputRefByName={this.inputRefByName}
                   t={t}
                 />
-                {flag('harvest.inappconnectors.enabled') && (
-                  <Link
-                    className="u-mt-1"
-                    variant="body1"
-                    component="button"
-                    onClick={this.showCannotConnectModal}
-                  >
-                    {t('accountForm.cannotConnectLink')}
-                  </Link>
-                )}
+                {flag('harvest.inappconnectors.enabled') &&
+                  !konnector.clientSide && (
+                    <Link
+                      className="u-mt-1"
+                      variant="body1"
+                      component="button"
+                      onClick={this.showCannotConnectModal}
+                    >
+                      {t('accountForm.cannotConnectLink')}
+                    </Link>
+                  )}
                 {konnector.clientSide ? (
                   <ConnectCard
                     title={t('accountForm.clientSide.title')}


### PR DESCRIPTION
This link is particularly useful for server side konnectors, for Clisk it is not useful? Might as well hide it? In any case, it was displayed badly so I prefer to hide it for now. 