### PR TITLE
fix(mespapiers): Flashing of the title when arriving on the list of a type of paper

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Papers/PapersListToolbar.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PapersListToolbar.jsx
@@ -12,7 +12,7 @@ import { getCurrentFileTheme } from './helpers'
 import { useMultiSelection } from '../Hooks/useMultiSelection'
 import { useScannerI18n } from '../Hooks/useScannerI18n'
 
-const PapersListToolbar = ({ selectedThemeLabel, fileCount }) => {
+const PapersListToolbar = ({ selectedThemeLabel }) => {
   const { BarLeft, BarCenter } = cozy.bar
   const params = useParams()
   const navigate = useNavigate()
@@ -21,7 +21,7 @@ const PapersListToolbar = ({ selectedThemeLabel, fileCount }) => {
 
   const currentFileTheme = getCurrentFileTheme(params, selectedThemeLabel)
   const themeLabel = scannerT(`items.${currentFileTheme}`, {
-    smart_count: fileCount
+    smart_count: 2 // We always want to have the plural here, unlike other places
   })
   const onBack = () => navigate('..')
 

--- a/packages/cozy-mespapiers-lib/src/components/Views/PapersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/PapersList.jsx
@@ -86,10 +86,7 @@ const PapersList = () => {
 
   return (
     <>
-      <PapersListToolbar
-        selectedThemeLabel={selectedThemeLabel}
-        fileCount={fileQueryResult.count}
-      />
+      <PapersListToolbar selectedThemeLabel={selectedThemeLabel} />
       {isLoading && (
         <Spinner
           className="u-flex u-flex-justify-center u-mt-2 u-h-5"


### PR DESCRIPTION
This flashing is due to the fact that the title is displayed before knowing the number of existing files.
It makes sense to always keep the plural here, because we are on the page of papers of the same type, even if there is only one.