### PR TITLE
fix(mespapiers): All accounts must appear in the file lists

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.jsx
@@ -7,7 +7,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import EmptyWithKonnector from './EmptyWithKonnector'
 import HomeCloud from '../../../assets/icons/HomeCloud.svg'
 
-const Empty = ({ konnector, accounts }) => {
+const Empty = ({ konnector, accountsByFiles }) => {
   const { t } = useI18n()
 
   if (!konnector) {
@@ -22,12 +22,20 @@ const Empty = ({ konnector, accounts }) => {
     )
   }
 
-  return <EmptyWithKonnector konnector={konnector} accounts={accounts} />
+  return (
+    <EmptyWithKonnector
+      konnector={konnector}
+      accountsByFiles={accountsByFiles}
+    />
+  )
 }
 
 Empty.propTypes = {
   konnector: PropTypes.object,
-  accounts: PropTypes.array
+  accountsByFiles: PropTypes.shape({
+    accountsWithFiles: PropTypes.array,
+    accountsWithoutFiles: PropTypes.array
+  })
 }
 
 export default Empty

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.spec.js
@@ -9,10 +9,13 @@ import AppLike from '../../../../test/components/AppLike'
 jest.mock('cozy-flags')
 jest.mock('../HarvestBanner', () => () => <div data-testid="HarvestBanner" />)
 
-const setup = ({ konnector, accounts } = {}) => {
+const setup = ({ konnector, accountsWithFiles, accountsWithoutFiles } = {}) => {
   return render(
     <AppLike>
-      <Empty konnector={konnector} accounts={accounts} />
+      <Empty
+        konnector={konnector}
+        accountsByFiles={{ accountsWithFiles, accountsWithoutFiles }}
+      />
     </AppLike>
   )
 }
@@ -25,7 +28,8 @@ describe('MesPapiersLibProviders', () => {
   it('should display basic text without harvest banner', () => {
     const { queryByTestId, getByText } = setup({
       konnector: undefined,
-      accounts: undefined
+      accountsWithFiles: undefined,
+      accountsWithoutFiles: undefined
     })
 
     expect(queryByTestId('HarvestBanner')).toBeFalsy()
@@ -35,7 +39,8 @@ describe('MesPapiersLibProviders', () => {
   it('should display specific text', () => {
     const { queryByTestId, getByText } = setup({
       konnector: {},
-      accounts: [{}]
+      accountsWithFiles: [],
+      accountsWithoutFiles: [{}]
     })
 
     expect(queryByTestId('HarvestBanner')).toBeFalsy()
@@ -47,7 +52,8 @@ describe('MesPapiersLibProviders', () => {
 
     const { queryByTestId, getByText } = setup({
       konnector: {},
-      accounts: [{}]
+      accountsWithFiles: [],
+      accountsWithoutFiles: [{}]
     })
 
     expect(queryByTestId('HarvestBanner')).toBeTruthy()
@@ -57,7 +63,7 @@ describe('MesPapiersLibProviders', () => {
   it('should display logins', () => {
     const { queryByTestId, getByText } = setup({
       konnector: {},
-      accounts: [
+      accountsWithoutFiles: [
         { auth: { login: 'myLogin' } },
         { auth: { login: 'myOtherLogin' } }
       ]
@@ -73,7 +79,7 @@ describe('MesPapiersLibProviders', () => {
 
     const { queryAllByTestId, getByText } = setup({
       konnector: {},
-      accounts: [
+      accountsWithoutFiles: [
         { auth: { login: 'myLogin' } },
         { auth: { login: 'myOtherLogin' } }
       ]

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithKonnector.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithKonnector.jsx
@@ -4,19 +4,25 @@ import React from 'react'
 import EmptyNoHeader from './EmptyNoHeader'
 import EmptyWithHeader from './EmptyWithHeader'
 
-const EmptyWithKonnector = ({ konnector, accounts }) => {
-  if (accounts?.length > 1) {
-    return accounts.map((account, index) => (
-      <EmptyWithHeader key={index} konnector={konnector} account={account} />
-    ))
+const EmptyWithKonnector = ({ konnector, accountsByFiles }) => {
+  const { accountsWithFiles, accountsWithoutFiles } = accountsByFiles
+  if (accountsWithoutFiles?.length === 1 && accountsWithFiles?.length === 0) {
+    return (
+      <EmptyNoHeader konnector={konnector} accounts={accountsWithoutFiles} />
+    )
   }
 
-  return <EmptyNoHeader konnector={konnector} accounts={accounts} />
+  return accountsWithoutFiles.map((account, index) => (
+    <EmptyWithHeader key={index} konnector={konnector} account={account} />
+  ))
 }
 
 EmptyWithKonnector.propTypes = {
   konnector: PropTypes.object,
-  accounts: PropTypes.array
+  accountsByFiles: PropTypes.shape({
+    accountsWithFiles: PropTypes.array,
+    accountsWithoutFiles: PropTypes.array
+  })
 }
 
 export default EmptyWithKonnector

--- a/packages/cozy-mespapiers-lib/src/components/Views/PapersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/PapersList.jsx
@@ -6,6 +6,7 @@ import { getThemeByItem } from 'cozy-client/dist/models/document/documentTypeDat
 import flag from 'cozy-flags'
 import { Spinner } from 'cozy-ui/transpiled/react/Spinner'
 
+import { makeAccountsByFiles } from './helpers'
 import {
   buildContactsQueryByIds,
   buildFilesQueryByLabel,
@@ -78,6 +79,11 @@ const PapersList = () => {
   )
   const isAccountsLoading = hasKonnector && isQueryLoading(accountsQueryLeft)
 
+  const { accountsWithFiles, accountsWithoutFiles } = makeAccountsByFiles(
+    accounts,
+    files
+  )
+
   const isLoading =
     isLoadingFiles ||
     isLoadingContacts ||
@@ -87,13 +93,12 @@ const PapersList = () => {
   return (
     <>
       <PapersListToolbar selectedThemeLabel={selectedThemeLabel} />
-      {isLoading && (
+      {isLoading ? (
         <Spinner
           className="u-flex u-flex-justify-center u-mt-2 u-h-5"
           size="xxlarge"
         />
-      )}
-      {!isLoading && (
+      ) : (
         <>
           {hasFiles && (
             <PapersListByContact
@@ -101,10 +106,15 @@ const PapersList = () => {
               files={files}
               contacts={contacts}
               konnectors={konnectors}
-              accounts={accounts}
+              accounts={accountsWithFiles}
             />
           )}
-          {!hasFiles && <Empty konnector={konnectors[0]} accounts={accounts} />}
+          {accountsWithoutFiles.length > 0 && (
+            <Empty
+              konnector={konnectors[0]}
+              accountsByFiles={{ accountsWithFiles, accountsWithoutFiles }}
+            />
+          )}
         </>
       )}
     </>

--- a/packages/cozy-mespapiers-lib/src/components/Views/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Views/helpers.js
@@ -1,3 +1,7 @@
+import { getAccountName } from 'cozy-client/dist/models/account'
+
+import { filterWithRemaining } from '../../helpers/filterWithRemaining'
+
 export const makePapers = (
   papersDefinitionsLabels,
   filesWithQualificationLabel
@@ -28,3 +32,27 @@ export const makeKonnectorsAndQualificationLabelWithoutFiles = (
         qualificationLabelWithoutFiles.includes(qualificationLabel)
       ) || []
   }))
+
+/**
+ * Groups together accounts that have files and those that don't
+ * @param {import('cozy-client/types/types').AccountsDocument[]} accounts - Array of accounts
+ * @param {import('cozy-client/types/types').IOCozyFile[]} files - Array of IOCozyFile
+ * @returns {{ accountsWithFiles: import('cozy-client/types/types').AccountsDocument[], accountsWithoutFiles: import('cozy-client/types/types').AccountsDocument[] }} - Accounts with files and accounts without files
+ */
+export const makeAccountsByFiles = (accounts, files) => {
+  const hasFile = account => {
+    return files?.some(
+      file =>
+        file.cozyMetadata.sourceAccountIdentifier === getAccountName(account)
+    )
+  }
+
+  // if (!accounts) return { accountsWithFiles: [], accountsWithoutFiles: [] }
+
+  const {
+    itemsFound: accountsWithFiles,
+    remainingItems: accountsWithoutFiles
+  } = filterWithRemaining(accounts, hasFile)
+
+  return { accountsWithFiles, accountsWithoutFiles }
+}

--- a/packages/cozy-mespapiers-lib/src/components/Views/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Views/helpers.spec.js
@@ -1,7 +1,8 @@
 import {
   makePapers,
   makeQualificationLabelWithoutFiles,
-  makeKonnectorsAndQualificationLabelWithoutFiles
+  makeKonnectorsAndQualificationLabelWithoutFiles,
+  makeAccountsByFiles
 } from './helpers'
 
 const papersDefinitionsLabels = ['caf', 'isp_invoice', 'resume']
@@ -103,5 +104,29 @@ describe('makeKonnectorsAndQualificationLabelWithoutFiles', () => {
         konnectorQualifLabelsWithoutFile: []
       }
     ])
+  })
+})
+
+describe('makeAccountsByFiles', () => {
+  it('should return accounts with files and accounts without files', () => {
+    const accounts = [
+      { auth: { login: 'account1' } },
+      { auth: { login: 'account2' } },
+      { auth: { login: 'account3' } }
+    ]
+    const files = [
+      { cozyMetadata: { sourceAccountIdentifier: 'account1' } },
+      { cozyMetadata: { sourceAccountIdentifier: 'account3' } }
+    ]
+
+    const res = makeAccountsByFiles(accounts, files)
+
+    expect(res).toStrictEqual({
+      accountsWithFiles: [
+        { auth: { login: 'account1' } },
+        { auth: { login: 'account3' } }
+      ],
+      accountsWithoutFiles: [{ auth: { login: 'account2' } }]
+    })
   })
 })

--- a/packages/cozy-mespapiers-lib/src/helpers/filterWithRemaining.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/filterWithRemaining.js
@@ -17,7 +17,7 @@
 export const filterWithRemaining = (array, callback) => {
   const [itemsFound, remainingItems] = [[], []]
 
-  array.forEach((arr, index) => {
+  array?.forEach((arr, index) => {
     const currentItem = arr?.model ?? arr
 
     if (callback(currentItem, index)) itemsFound.push(arr)


### PR DESCRIPTION
On a list of files with konnector, accounts without files disappear if other accounts with files exist.