### PR TITLE
docs(cozy-intent): Add more info on setFlagshipUi

### DIFF
--- a/packages/cozy-intent/readme.md
+++ b/packages/cozy-intent/readme.md
@@ -103,6 +103,43 @@ const MyComponent = () => {
 
 Will logout the user from the react-native application. Will not touch webview state.
 
-##### `NativeService.call('openWebview', href)`
+#### `NativeService.call('setFlagshipUi')`
 
-Will open a new webview in a Native app with the href provided.
+Example 1: With bottomBackground and topBackground set
+
+```js
+setFlagshipUI({
+  bottomBackground: '#ff0000', // Red background for the Navigation Bar
+  topBackground: '#0000ff' // Blue background for the Status Bar
+})
+```
+
+![{0A71B7E4-3DF7-40F8-AB89-EAB905819E2F}](https://github.com/cozy/cozy-libs/assets/12577784/051b0db7-8f1a-4196-a866-2258a6c4cecd)
+
+Example 2: With all optional parameters set
+
+```js
+setFlagshipUI({
+  bottomBackground: '#008000', // Green background for the Navigation Bar
+  bottomOverlay: 'rgba(0, 0, 0, 0.5)', // Half-transparent black overlay for the Navigation Bar
+  bottomTheme: 'light', // Light-themed icons for the Navigation Bar
+  topBackground: '#ffff00', // Yellow background for the Status Bar
+  topOverlay: 'rgba(0, 0, 0, 0.5)', // Half-transparent black overlay for the Status Bar
+  topTheme: 'dark' // Dark-themed icons for the Status Bar
+})
+```
+
+![{104CBEC0-96CA-4732-AA35-662B115E0C0A}](https://github.com/cozy/cozy-libs/assets/12577784/a056f9d8-e7f0-4551-86d2-98d293ce557b)
+
+Example 3: With themes and overlays set
+
+```js
+setFlagshipUI({
+  bottomOverlay: 'rgba(255, 255, 255, 0.2)', // Light semi-transparent overlay for the Navigation Bar
+  bottomTheme: 'dark', // Dark-themed icons for the Navigation Bar
+  topOverlay: 'rgba(0, 0, 0, 0.3)', // Dark semi-transparent overlay for the Status Bar
+  topTheme: 'light' // Light-themed icons for the Status Bar
+})
+```
+
+![{AA2C98E5-19CA-4658-97B8-CDEAAD3FC5B5}](https://github.com/cozy/cozy-libs/assets/12577784/5e3dbeec-0d0e-4406-bb0a-c2edd2576de5)

--- a/packages/cozy-intent/src/api/models/applications.ts
+++ b/packages/cozy-intent/src/api/models/applications.ts
@@ -27,15 +27,44 @@ export interface CozyBar {
   }
 }
 
+/**
+ * All the different colors are optional
+ */
 export interface FlagshipUI {
-  /** Has to be a <color> CSS data type */
+  /**
+   * It will set the background color of the Navigation Bar (bottom bar with home/back buttons)
+   * Has to be a <color> CSS data type
+   */
   bottomBackground?: string
-  /** Has to be 'rgba(R, G, B[, A])' to enable, 'transparent' to disable */
+  /**
+   * It will set the overlay background color of the Navigation Bar (bottom bar with home/back buttons)
+   * Displayed above the bottomBackground
+   * Has to be 'rgba(R, G, B[, A])' to enable, 'transparent' to disable
+   * It should be the same value as your app overlay color if any
+   */
   bottomOverlay?: string
+  /**
+   * It will set the Navigation bar icon theme (bottom bar with home/back buttons)
+   * Has to be 'dark' or 'light', 'dark' will set the icons to black/dark grey, 'light' will set the icons to white/light grey
+   * Don't use a 'dark' theme with a dark background color, and vice versa
+   */
   bottomTheme?: 'dark' | 'light'
-  /** Has to be a <color> CSS data type */
+  /**
+   * It will set the background color of the Status Bar (top bar in the phone OS with connectivity/time display)
+   * Has to be a <color> CSS data type
+   */
   topBackground?: string
-  /** Has to be 'rgba(R, G, B[, A])' to enable, 'transparent' to disable */
+  /**
+   * It will set the overlay background color of the Status Bar (top bar in the phone OS with connectivity/time display)
+   * Displayed above the topBackground
+   * Has to be 'rgba(R, G, B[, A])' to enable, 'transparent' to disable
+   * It should be the same value as your app overlay color if any
+   */
   topOverlay?: string
+  /**
+   * It will set the Status bar (top bar in the phone OS with connectivity/time display) icon theme
+   * Has to be 'dark' or 'light', 'dark' will set the icons to black/dark grey, 'light' will set the icons to white/light grey
+   * Don't use a 'dark' theme with a dark background color, and vice versa
+   */
   topTheme?: 'dark' | 'light'
 }


### PR DESCRIPTION
Updated readme with:

##### `NativeService.call('openWebview', href)`

Will open a new webview in a Native app with the href provided.

#### `NativeService.call('setFlagshipUi')`

Example 1: With bottomBackground and topBackground set

```js
setFlagshipUI({
  bottomBackground: '#ff0000', // Red background for the Navigation Bar
  topBackground: '#0000ff' // Blue background for the Status Bar
})
```

![{0A71B7E4-3DF7-40F8-AB89-EAB905819E2F}](https://github.com/cozy/cozy-libs/assets/12577784/051b0db7-8f1a-4196-a866-2258a6c4cecd)

Example 2: With all optional parameters set
```js
setFlagshipUI({
  bottomBackground: '#008000', // Green background for the Navigation Bar
  bottomOverlay: 'rgba(0, 0, 0, 0.5)', // Half-transparent black overlay for the Navigation Bar
  bottomTheme: 'light', // Light-themed icons for the Navigation Bar
  topBackground: '#ffff00', // Yellow background for the Status Bar
  topOverlay: 'rgba(0, 0, 0, 0.5)', // Half-transparent black overlay for the Status Bar
  topTheme: 'dark' // Dark-themed icons for the Status Bar
})
```

![{104CBEC0-96CA-4732-AA35-662B115E0C0A}](https://github.com/cozy/cozy-libs/assets/12577784/a056f9d8-e7f0-4551-86d2-98d293ce557b)

Example 3: With themes and overlays set

```js
setFlagshipUI({
  bottomOverlay: 'rgba(255, 255, 255, 0.2)', // Light semi-transparent overlay for the Navigation Bar
  bottomTheme: 'dark', // Dark-themed icons for the Navigation Bar
  topOverlay: 'rgba(0, 0, 0, 0.3)', // Dark semi-transparent overlay for the Status Bar
  topTheme: 'light' // Light-themed icons for the Status Bar
})
```

![{AA2C98E5-19CA-4658-97B8-CDEAAD3FC5B5}](https://github.com/cozy/cozy-libs/assets/12577784/5e3dbeec-0d0e-4406-bb0a-c2edd2576de5)
