### PR TITLE
fix(mespapiers): Redirect to the correct store

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/InstallAppModal.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/InstallAppModal.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import { getPlatform } from 'cozy-device-helper'
 import Box from 'cozy-ui/transpiled/react/Box'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
@@ -9,12 +8,11 @@ import Empty from 'cozy-ui/transpiled/react/Empty'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import IlluCozyCloud from '../../../assets/icons/IlluCozyCloud.svg'
-import { getLinkByPlatform } from '../helpers'
+import { getLink } from '../helpers'
 
 const InstallAppModal = ({ onBack }) => {
   const { t } = useI18n()
-  const platform = getPlatform()
-  const link = getLinkByPlatform(platform)
+  const { url, name } = getLink()
 
   return (
     <Dialog
@@ -38,9 +36,9 @@ const InstallAppModal = ({ onBack }) => {
                 <span className="u-db">{t('InstallAppModal.text')}</span>
                 <Button
                   className="u-mt-1-half"
-                  label={t(`InstallAppModal.action.${platform}`)}
+                  label={t(`InstallAppModal.action.${name}`)}
                   component="a"
-                  href={link}
+                  href={url}
                   target="_blank"
                   rel="noopener"
                 />

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/helpers.js
@@ -1,3 +1,5 @@
+import { isAndroid, isIOS } from 'cozy-device-helper'
+
 import { ANDROID_APP_URL, IOS_APP_URL } from '../../constants/const'
 
 /**
@@ -168,13 +170,13 @@ export const getLastFormDataFile = ({ formData, stepIndex }) => {
   return file || null
 }
 
-export const getLinkByPlatform = platform => {
-  switch (platform) {
-    case 'ios':
-      return IOS_APP_URL
-    case 'android':
-      return ANDROID_APP_URL
-    case 'web': // Case that should only exist in development, as this component is used in ScanMobileActions
-      return IOS_APP_URL
+export const getLink = () => {
+  if (isIOS()) {
+    return { url: IOS_APP_URL, name: 'ios' }
   }
+  if (isAndroid()) {
+    return { url: ANDROID_APP_URL, name: 'android' }
+  }
+  // Case that should only exist in development, as this component is used in ScanMobileActions
+  return { url: IOS_APP_URL, name: 'ios' }
 }

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -446,8 +446,7 @@
     "text": "Install the Cozy Cloud app on your mobile to take photos of your papers directly.",
     "action": {
       "android": "Install on Google Play",
-      "ios": "Install on App Store",
-      "web": "Install on App Store"
+      "ios": "Install on App Store"
     }
   }
 }

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -446,8 +446,7 @@
     "text": "Installer l'application Cozy Cloud sur votre mobile pour prendre directement vos papiers en photo.",
     "action": {
       "android": "Installer sur Google Play",
-      "ios": "Installer sur l'App Store",
-      "web": "Installer sur l'App Store"
+      "ios": "Installer sur l'App Store"
     }
   }
 }


### PR DESCRIPTION
`getPlatform` returns the `android` or `ios` device only under Cordova, so it is completely useless to use this helper here.