### PR TITLE
fix: Reset flow.accountError on launch for clisk konnectors

### DIFF
--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -729,7 +729,10 @@ export class ConnectionFlow {
 
     // @ts-ignore
     logger.info('ConnectionFlow: Launching job...')
-    this.setState({ status: PENDING })
+    this.setState({
+      status: PENDING,
+      accountError: null
+    })
 
     if (this.trigger) {
       this.account = await prepareTriggerAccount(this.client, this.trigger)

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.spec.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.spec.js
@@ -434,7 +434,7 @@ describe('ConnectionFlow', () => {
       delete window.ReactNativeWebView
     })
 
-    it('should set the flow status to idle if the launcher aborts', async () => {
+    it('should reset the flow state on konnector execution end', async () => {
       prepareTriggerAccount.mockImplementation(
         async () => fixtures.existingAccount
       )
@@ -451,6 +451,7 @@ describe('ConnectionFlow', () => {
         postMessage: jest.fn()
       }
 
+      await flow.setState({ accountError: new Error('old account error') })
       await flow.launch()
       await waitFor(() =>
         expect(flow.getState().status).toStrictEqual('PENDING')
@@ -465,6 +466,7 @@ describe('ConnectionFlow', () => {
         '*'
       )
       await waitFor(() => expect(flow.getState().status).toStrictEqual('IDLE'))
+      expect(flow.getState().accountError).toStrictEqual(null)
 
       delete window.cozy
       delete window.ReactNativeWebView


### PR DESCRIPTION
In the case of clisk konnectors, only ConnectionFlow.launch is called,
without calling handleFormSubmit.

Now the accountError state is reset in launch which is also always
called by handleFormSubmit also.
