### PR TITLE
feat: Allow passing a custom logger to realtime

### DIFF
--- a/packages/cozy-realtime/src/RealtimePlugin.js
+++ b/packages/cozy-realtime/src/RealtimePlugin.js
@@ -20,11 +20,13 @@ class RealtimePlugin {
    * @constructor
    * @param {CozyClient} client A cozy-client instance
    * @param {object} options
-   * @param {Function} options.createWebSocket The function used to create WebSocket instances
+   * @param {Function} [options.createWebSocket] The function used to create WebSocket instances
+   * @param {object} [options.logger] A custom logger for CozyRealtime
    */
   constructor(client, options = {}) {
     this.client = client
     this.createWebSocket = options.createWebSocket
+    this.logger = options.logger
     this.realtime = null
     this.handleLogin = this.handleLogin.bind(this)
     this.handleLogout = this.handleLogout.bind(this)
@@ -37,7 +39,8 @@ class RealtimePlugin {
   handleLogin() {
     this.realtime = new CozyRealtime({
       client: this.client,
-      createWebSocket: this.createWebSocket
+      createWebSocket: this.createWebSocket,
+      logger: this.logger
     })
     this.client.emit('plugin:realtime:login')
   }

--- a/packages/cozy-realtime/src/RetryManager.js
+++ b/packages/cozy-realtime/src/RetryManager.js
@@ -1,13 +1,12 @@
 import MicroEE from 'microee'
 
-import logger from './logger'
-
 import {
   maxWaitBetweenRetries as defaultMaxWaitBetweenRetries,
   baseWaitAfterFirstFailure as defaultBaseWaitAfterFirstFailure,
   timeBeforeSuccessful as defaultTimeBeforeSuccessful,
   raiseErrorAfterAttempts as defaultRaiseErrorAfterAttempts
 } from './config'
+import defaultLogger from './logger'
 
 /**
  * This class creates an helper for processes that need
@@ -21,13 +20,16 @@ class RetryManager {
    * @param {number} baseWaitAfterFirstFailure - how much time in ms should we wait after the first failure?
    * @param {number} timeBeforeSuccessful - how much time should  we wait without error to acknowledge a success?
    * @param {number} raiseErrorAfterAttempts - after how many failed attempts should we raise an error?
+   * @param {object} logger A custom logger
    */
   constructor({
     maxWaitBetweenRetries = defaultMaxWaitBetweenRetries,
     baseWaitAfterFirstFailure = defaultBaseWaitAfterFirstFailure,
     timeBeforeSuccessful = defaultTimeBeforeSuccessful,
-    raiseErrorAfterAttempts = defaultRaiseErrorAfterAttempts
+    raiseErrorAfterAttempts = defaultRaiseErrorAfterAttempts,
+    logger = defaultLogger
   } = {}) {
+    this.logger = logger
     this.reset()
     this.onSuccess = this.onSuccess.bind(this)
     this.onFailure = this.onFailure.bind(this)
@@ -111,7 +113,9 @@ class RetryManager {
    * @param {object} error
    */
   onFailure(error) {
-    logger.debug('failure, increase the failure counter of the retry manager')
+    this.logger.debug(
+      'failure, increase the failure counter of the retry manager'
+    )
     this.clearSuccessTimer()
     this.increaseFailureCounter()
     this.emit('failure', error)
@@ -131,7 +135,7 @@ class RetryManager {
    * Reset failures counters (do not wait before trying to connect next time)
    */
   reset() {
-    logger.debug('reset the retry manager')
+    this.logger.debug('reset the retry manager')
     this.clearSuccessTimer()
     this.retries = 0
     this.wait = 0
@@ -159,7 +163,7 @@ class RetryManager {
    * Wait an amount of time before the next attempt (if needed)
    */
   async waitBeforeNextAttempt() {
-    logger.debug('waitBeforeNextAttempt', this.wait)
+    this.logger.debug('waitBeforeNextAttempt', this.wait)
     if (this.wait) {
       if (!this.waiting) {
         let stop

--- a/packages/cozy-realtime/src/SubscriptionList.js
+++ b/packages/cozy-realtime/src/SubscriptionList.js
@@ -1,8 +1,8 @@
 import isEqual from 'lodash/isEqual'
-import uniqWith from 'lodash/uniqWith'
 import pick from 'lodash/pick'
-import remove from 'lodash/remove'
 import pullAt from 'lodash/pullAt'
+import remove from 'lodash/remove'
+import uniqWith from 'lodash/uniqWith'
 
 import {
   allowDoubleSubscriptions,
@@ -10,7 +10,7 @@ import {
   onDoubleSubscriptions,
   eventNames
 } from './config'
-import logger from './logger'
+import defaultLogger from './logger'
 
 /**
  * @typedef {object} SubscriptionRequest
@@ -29,8 +29,9 @@ import logger from './logger'
  * Manage event subscriptions
  */
 export default class SubscriptionList {
-  constructor() {
+  constructor(options = {}) {
     this.subscriptions = []
+    this.logger = options.logger || defaultLogger
   }
 
   /**
@@ -43,7 +44,8 @@ export default class SubscriptionList {
     const subscription = this.normalize(request)
     const found = this.subscriptions.find(s => isEqual(s, subscription))
     if (found) {
-      onDoubleSubscriptions && onDoubleSubscriptions(subscription)
+      onDoubleSubscriptions &&
+        onDoubleSubscriptions(subscription, { logger: this.logger })
       if (!allowDoubleSubscriptions) return
     }
     this.subscriptions.push(subscription)
@@ -68,7 +70,7 @@ export default class SubscriptionList {
       const removed = remove(this.subscriptions, s => isEqual(s, subscription))
       if (removed && removed.length > 0) return
     }
-    logger.warn(
+    this.logger.warn(
       'Trying to unsubscribe to an unknown subscription',
       subscription
     )
@@ -155,7 +157,7 @@ export default class SubscriptionList {
    */
   normalize(sub) {
     function error(msg) {
-      logger.error(msg)
+      this.logger.error(msg)
       throw new Error(msg)
     }
 

--- a/packages/cozy-realtime/src/config.js
+++ b/packages/cozy-realtime/src/config.js
@@ -1,4 +1,4 @@
-import logger from './logger'
+import defaultLogger from './logger'
 
 const ms = 1
 const sec = 1000
@@ -79,7 +79,10 @@ export const requireDoubleUnsubscriptions = true
  * @type {Function}
  * @private
  */
-export const onDoubleSubscriptions = subscription => {
+export const onDoubleSubscriptions = (
+  subscription,
+  { logger = defaultLogger } = {}
+) => {
   logger.warn('Double subscription for ', subscription)
   if (allowDoubleSubscriptions) {
     logger.info('The handler may be called twice for the same event!')

--- a/packages/cozy-realtime/src/utils.js
+++ b/packages/cozy-realtime/src/utils.js
@@ -1,6 +1,6 @@
 import has from 'lodash/has'
 
-import logger from './logger'
+import defaultLogger from './logger'
 
 /**
  * If the current context is a browser context
@@ -80,7 +80,11 @@ export function getToken(client) {
  * @param {CozyClient} cozyClient - deprecated, a cozy client instance
  * @returns {CozyClient}
  */
-export function getCozyClientFromOptions({ cozyClient, client }) {
+export function getCozyClientFromOptions({
+  cozyClient,
+  client,
+  logger = defaultLogger
+}) {
   if (cozyClient) {
     logger.warn(
       'Passing a `cozyClient` parameter is deprecated, please use `client` instead'


### PR DESCRIPTION
The way `cozy-realtime`'s logger is defined and used does not allow
a user of the library to configure the logger as they see fit.
For example, Cozy Desktop cannot get these logs into its own log
files.

With these changes, we can pass a logger object with the same
interface as `@cozy/minilog` when creating a `CozyRealtime` instance
(either directly or via a `RealtimePlugin` registration).
If this option is not passed, we'll fallback to `cozy-realtime`'s
logger.