### PR TITLE
feat: Add max accounts by konnector paywall

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -54,7 +54,7 @@
     "babel-jest": "26.6.3",
     "babel-plugin-inline-react-svg": "1.1.2",
     "babel-preset-cozy-app": "^2.1.0",
-    "cozy-client": "^37.1.0",
+    "cozy-client": "^38.6.0",
     "cozy-device-helper": "^2.7.0",
     "cozy-flags": "^3.0.1",
     "cozy-intent": "^2.13.1",

--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -61,7 +61,7 @@
     "cozy-keys-lib": "^4.1.9",
     "cozy-realtime": "^4.6.0",
     "cozy-tsconfig": "^1.0.0",
-    "cozy-ui": "^80.1.1",
+    "cozy-ui": "^85.8.1",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.6",
     "form-data": "4.0.0",
@@ -87,7 +87,7 @@
     "cozy-intent": ">=1.14.1",
     "cozy-keys-lib": ">=4.1.9",
     "cozy-realtime": ">=4.2.8",
-    "cozy-ui": ">=80.1.1",
+    "cozy-ui": ">=85.8.0",
     "leaflet": "^1.7.1",
     "react-router": "3.2.6",
     "react-router-dom": ">=4.3.1"

--- a/packages/cozy-harvest-lib/src/components/AccountsPaywall/AccountsPaywall.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountsPaywall/AccountsPaywall.jsx
@@ -1,0 +1,34 @@
+// @ts-check
+import React from 'react'
+
+import {
+  MaxAccountsByKonnectorPaywall,
+  MaxAccountsPaywall
+} from 'cozy-ui/transpiled/react/Paywall'
+
+import { computeMaxAccountsByKonnector, computeMaxAccounts } from './helpers'
+
+/**
+ *
+ * @param {Object} props
+ * @param {string} props.reason
+ * @param {import('cozy-client/types/types').IOCozyKonnector} props.konnector
+ * @param {Function} props.onClose
+ */
+const AccountsPaywall = ({ reason, konnector, onClose }) => {
+  if (reason === 'max_accounts_by_konnector') {
+    const max = computeMaxAccountsByKonnector(konnector.slug)
+    return (
+      <MaxAccountsByKonnectorPaywall
+        max={max}
+        konnectorName={konnector.name}
+        onClose={onClose}
+      />
+    )
+  } else if (reason === 'max_accounts') {
+    const max = computeMaxAccounts()
+    return <MaxAccountsPaywall max={max} onClose={onClose} />
+  }
+}
+
+export default AccountsPaywall

--- a/packages/cozy-harvest-lib/src/components/AccountsPaywall/helpers.js
+++ b/packages/cozy-harvest-lib/src/components/AccountsPaywall/helpers.js
@@ -1,0 +1,59 @@
+// @ts-check
+// @ts-ignore
+import flag from 'cozy-flags'
+
+/**
+ * @param {string} slug the slug of the konnector to check
+ * @returns {number} the maximum accounts allowed for given konnector
+ */
+export function computeMaxAccountsByKonnector(slug) {
+  const maxAccountsByKonnector = flag(`harvest.accounts.maxByKonnector.${slug}`)
+  if (maxAccountsByKonnector !== null) {
+    return maxAccountsByKonnector === -1 ? Infinity : maxAccountsByKonnector
+  }
+  const maxAccountsDefault = flag('harvest.accounts.maxByKonnector.default')
+  if (maxAccountsDefault !== null) {
+    return maxAccountsDefault === -1 ? Infinity : maxAccountsDefault
+  }
+  return Infinity
+}
+
+/**
+ *
+ * @param {string} slug the slug of the konnector to check
+ * @param {number} nbAccounts the current number of account for the konnector to check
+ * @returns {boolean} whether the number of accounts allowed for a given connector has been reached
+ */
+export function hasReachMaxAccountsByKonnector(slug, nbAccounts) {
+  const maxAccounts = computeMaxAccountsByKonnector(slug)
+  if (isFinite(maxAccounts) && nbAccounts >= maxAccounts) {
+    return true
+  }
+
+  return false
+}
+
+/**
+ * @returns {number} the maximum accounts allowed for all konnectors
+ */
+export function computeMaxAccounts() {
+  const maxAccounts = flag('harvest.accounts.max')
+  if (maxAccounts !== null) {
+    return maxAccounts === -1 ? Infinity : maxAccounts
+  }
+  return Infinity
+}
+
+/**
+ *
+ * @param {number} nbAccounts the current number of account for the konnector to check
+ * @returns {boolean} whether the number of accounts allowed for all konnectors has been reached
+ */
+export function hasReachMaxAccounts(nbAccounts) {
+  const maxAccounts = computeMaxAccounts()
+  if (isFinite(maxAccounts) && nbAccounts >= maxAccounts) {
+    return true
+  }
+
+  return false
+}

--- a/packages/cozy-harvest-lib/src/components/AccountsPaywall/helpers.spec.js
+++ b/packages/cozy-harvest-lib/src/components/AccountsPaywall/helpers.spec.js
@@ -1,0 +1,116 @@
+// @ts-check
+// @ts-ignore
+import flag from 'cozy-flags'
+
+import {
+  computeMaxAccountsByKonnector,
+  hasReachMaxAccountsByKonnector,
+  computeMaxAccounts,
+  hasReachMaxAccounts
+} from './helpers'
+
+jest.mock('cozy-flags')
+
+/**
+ * @param {Object} params
+ * @param {number} [params.defaultValue] value return by default in maxByKonnector flag
+ * @param {number} [params.idValue] value return for a specific konnector in maxByKonnector flag
+ * @param {number} [params.maxValue] value return max flag
+ * @returns { (flag:string) => number|null } return a function which take a flag name and returns its link number or null
+ */
+function getCurrentFlag({ defaultValue, idValue, maxValue } = {}) {
+  return flag => {
+    if (defaultValue && flag === 'harvest.accounts.maxByKonnector.default') {
+      return defaultValue
+    }
+
+    if (idValue && flag === 'harvest.accounts.maxByKonnector.ameli') {
+      return idValue
+    }
+
+    if (maxValue && flag === 'harvest.accounts.max') {
+      return maxValue
+    }
+    return null
+  }
+}
+
+describe('AccountsPaywall helpers', () => {
+  describe('computeMaxAccountsByKonnector', () => {
+    it('should return nothing or infinity when there no flag set', () => {
+      flag.mockImplementation(() => null)
+      expect(computeMaxAccountsByKonnector('ameli')).toBe(Infinity)
+    })
+
+    it('should return default case if flag set', () => {
+      flag.mockImplementation(getCurrentFlag({ defaultValue: 5 }))
+      expect(computeMaxAccountsByKonnector('ameli')).toBe(5)
+    })
+
+    it('should return default case if flag infinity', () => {
+      flag.mockImplementation(getCurrentFlag({ defaultValue: -1 }))
+      expect(computeMaxAccountsByKonnector('ameli')).toBe(Infinity)
+    })
+
+    it('should return konnector specific case if flag set', () => {
+      flag.mockImplementation(getCurrentFlag({ defaultValue: 5, idValue: 6 }))
+      expect(computeMaxAccountsByKonnector('ameli')).toBe(6)
+    })
+
+    it('should return konnector specific case if flag set infinity', () => {
+      flag.mockImplementation(getCurrentFlag({ defaultValue: 5, idValue: -1 }))
+      expect(computeMaxAccountsByKonnector('ameli')).toBe(Infinity)
+    })
+  })
+
+  describe('hasReachMaxAccountsByKonnector', () => {
+    it('should be true when current account number is equal or upper maximum', () => {
+      flag.mockImplementation(getCurrentFlag({ defaultValue: 5 }))
+      expect(hasReachMaxAccountsByKonnector('ameli', 5)).toBe(true)
+    })
+
+    it('should be false when current account number is below maximum', () => {
+      flag.mockImplementation(getCurrentFlag({ defaultValue: 5 }))
+      expect(hasReachMaxAccountsByKonnector('ameli', 4)).toBe(false)
+    })
+
+    it('should be false when there is no maximum', () => {
+      flag.mockImplementation(getCurrentFlag({ defaultValue: -1 }))
+      expect(hasReachMaxAccountsByKonnector('ameli', 5)).toBe(false)
+    })
+  })
+
+  describe('computeMaxAccounts', () => {
+    it('should return nothing or infinity when there no flag set', () => {
+      flag.mockImplementation(() => null)
+      expect(computeMaxAccounts()).toBe(Infinity)
+    })
+
+    it('should return a number if harvest.accounts.max flag set', () => {
+      flag.mockImplementation(getCurrentFlag({ maxValue: 5 }))
+      expect(computeMaxAccounts()).toBe(5)
+    })
+
+    it('should return infinity if harvest.accounts.max flag is -1', () => {
+      flag.mockImplementation(getCurrentFlag({ maxValue: -1 }))
+      expect(computeMaxAccounts()).toBe(Infinity)
+    })
+  })
+
+  describe('hasReachMaxAccounts', () => {
+    it('should be true when current account number is equal or upper maximum', () => {
+      flag.mockImplementation(getCurrentFlag({ maxValue: 5 }))
+      expect(hasReachMaxAccounts(5)).toBe(true)
+    })
+
+    it('should be false when current account number is below maximum', () => {
+      flag.mockImplementation(getCurrentFlag({ maxValue: 5 }))
+      expect(hasReachMaxAccounts(4)).toBe(false)
+    })
+
+    it('should be false when there is no maximum', () => {
+      flag.mockImplementation(getCurrentFlag({ maxValue: -1 }))
+      expect(hasReachMaxAccounts(5)).toBe(false)
+    })
+  })
+})

--- a/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/EditAccountModal.jsx
@@ -68,6 +68,7 @@ const DumbEditAccountModal = withMountPointProps(
               fieldOptions={fieldOptions}
               reconnect={fromReconnect}
               intentsApi={intentsApi}
+              onClose={redirectToAccount}
             />
           )
         }

--- a/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorModal.jsx
@@ -130,6 +130,7 @@ const DumbKonnectorDialogContent = props => {
           konnector={konnector}
           onLoginSuccess={endAccountCreation}
           onSuccess={endAccountCreation}
+          onClose={onClose}
         />
       </div>
     )

--- a/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
@@ -98,6 +98,7 @@ const NewAccountModal = ({ konnector, onSuccess, onDismiss }) => {
             onSuccess={handleSuccess}
             onVaultDismiss={onDismiss}
             fieldOptions={fieldOptions}
+            onClose={onDismiss}
           />
 
           {!serverSideKonnector && (

--- a/packages/cozy-harvest-lib/src/helpers/queries.js
+++ b/packages/cozy-harvest-lib/src/helpers/queries.js
@@ -61,3 +61,13 @@ export const buildAppsByIdQuery = appSlug => ({
     singleDocData: true
   }
 })
+
+export const buildCountTriggersQuery = () => ({
+  definition: Q('io.cozy.triggers')
+    .where({ $or: [{ worker: 'client' }, { worker: 'konnector' }] })
+    .indexFields(['worker']),
+  options: {
+    as: 'io.cozy.triggers/by_worker_client_konnector',
+    fetchPolicy: defaultFetchPolicy
+  }
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -7362,31 +7362,6 @@ cozy-client@^27.14.4:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^37.1.0:
-  version "37.1.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-37.1.0.tgz#d8d583dd79a58c88de811649304763909799ee76"
-  integrity sha512-4HxFdnyIMR/Q1f34LsGmBKwMwF7IaMGDRQ4d1wiwqSyliwb16uhAecEYmhjAE4tyebmIm/dvZz68zlb+eFyyFg==
-  dependencies:
-    "@cozy/minilog" "1.0.0"
-    "@types/jest" "^26.0.20"
-    "@types/lodash" "^4.14.170"
-    btoa "^1.2.1"
-    cozy-stack-client "^37.0.0"
-    date-fns "2.29.3"
-    json-stable-stringify "^1.0.1"
-    lodash "^4.17.13"
-    microee "^0.0.6"
-    node-fetch "^2.6.1"
-    node-polyglot "2.4.2"
-    open "7.4.2"
-    prop-types "^15.6.2"
-    react-redux "^7.2.0"
-    redux "3 || 4"
-    redux-thunk "^2.3.0"
-    server-destroy "^1.0.1"
-    sift "^6.0.0"
-    url-search-params-polyfill "^8.0.0"
-
 cozy-client@^37.2.0:
   version "37.2.0"
   resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-37.2.0.tgz#0e2070e1a0dd229ac044c68213dfe41cc1afd10b"
@@ -7416,6 +7391,31 @@ cozy-client@^38.5.1:
   version "38.5.1"
   resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-38.5.1.tgz#9b27ef8c3dec956247fbe5921fac5559e2d13669"
   integrity sha512-A4eosfgNxQ7CJBmM5TCHq9+Wg1o496Uqok258WhfUkjrEXHVh0aeZSmwHOURzYyZYDDILhIvQzD7lHON+tLlMQ==
+  dependencies:
+    "@cozy/minilog" "1.0.0"
+    "@types/jest" "^26.0.20"
+    "@types/lodash" "^4.14.170"
+    btoa "^1.2.1"
+    cozy-stack-client "^38.0.2"
+    date-fns "2.29.3"
+    json-stable-stringify "^1.0.1"
+    lodash "^4.17.13"
+    microee "^0.0.6"
+    node-fetch "^2.6.1"
+    node-polyglot "2.4.2"
+    open "7.4.2"
+    prop-types "^15.6.2"
+    react-redux "^7.2.0"
+    redux "3 || 4"
+    redux-thunk "^2.3.0"
+    server-destroy "^1.0.1"
+    sift "^6.0.0"
+    url-search-params-polyfill "^8.0.0"
+
+cozy-client@^38.6.0:
+  version "38.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-38.6.0.tgz#7cc29bede36d685c54478a597c94defc1fd78ae1"
+  integrity sha512-mYKe0iluvA0S/sronxfIgD+KKxHoVTAkIOVlEzneW2XVFfqs5/Dmoa3oKGRnij8PvNrn6CZeiQlt6ZUktBJ+vA==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7652,10 +7652,10 @@ cozy-ui@82.2.0:
     react-swipeable-views "^0.13.3"
     rooks "^5.11.2"
 
-cozy-ui@^80.1.1:
-  version "80.1.1"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-80.1.1.tgz#c9be72fb103c9f3ee9cd89ed1d88b528acccf27e"
-  integrity sha512-d2DrLMvUT4Yn1ce6W7ALkIqYdmF3fv1dBGpKx2moSmsPUX0Z/8ft9kVgAUoSrnjyh4+RCpG04RaqBiEcm/1SUQ==
+cozy-ui@^85.8.1:
+  version "85.8.1"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-85.8.1.tgz#2c3951f215de770101f4719d7dcb01caa38af70d"
+  integrity sha512-iy83ub/R9HXGqL5kNdvh+kwbQAYjivZZLAacZ90T8FiCmLT8putDfpl0B73ZaNSZWfu/y/pGSiMxM7+P4MR2QA==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"
@@ -7676,7 +7676,7 @@ cozy-ui@^80.1.1:
     piwik-react-router "0.12.1"
     react-chartjs-2 "4.1.0"
     react-markdown "^4.0.8"
-    react-pdf "^4.0.5"
+    react-pdf "^5.7.2"
     react-popper "^2.2.3"
     react-remove-scroll "^2.4.0"
     react-select "^4.3.0"
@@ -15623,17 +15623,6 @@ msgpack5@^4.0.2:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
-
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
-  version "1.0.8"
-  uid "3dc4c2a245ab39079bc2f73546bccf80847be14c"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
-  dependencies:
-    "@juggle/resize-observer" "^3.1.3"
-    jest-environment-jsdom-sixteen "^1.0.3"
-    react-spring "9.0.0-rc.3"
-    react-use-gesture "^7.0.8"
-    react-use-measure "^2.0.0"
 
 "mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"


### PR DESCRIPTION
I've found two places that ask you to create an account either with the '/new' route and with an intent that uses TriggerManager from cozy-home. Verification is carried out in both places to limit the opening and closing of successive modals as quickly as possible.

I'll try to optimise the request to retrieve the triggers

**Related PRs:**
- https://github.com/cozy/cozy-client/pull/1356
- https://github.com/cozy/cozy-ui/pull/2452