### PR TITLE
feat(mespapiers): Add `tooltip` property to scan step

### DIFF
--- a/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
+++ b/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
@@ -32,6 +32,7 @@
 - ### Step `scan`:
   - `stepIndex`: {number} Position of the step.
   - `model`: {string} Model used for the step (`scan`).
+  - `[tooltip]`: {boolean} Allows to display a tooltip to help the user.
   - `[multipage]`: {boolean} Allows to add as many files as the user wants.
   - `illustration`: {string} Name of the illustration used on the step (with extension).
   - `text`: {string} Translation key for the text of the step.

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/ScanResult/ScanResultDialog.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/ScanResult/ScanResultDialog.jsx
@@ -23,7 +23,7 @@ const ScanResultDialog = ({
   currentFile,
   setCurrentFile
 }) => {
-  const { illustration, multipage, page = 'default' } = currentStep
+  const { illustration, multipage, page = 'default', tooltip } = currentStep
   const { t } = useI18n()
   const { currentStepIndex } = useStepperDialog()
 
@@ -72,11 +72,13 @@ const ScanResultDialog = ({
       content={
         <div className={cx('u-flex u-flex-column u-flex-justify-center')}>
           <ScanResultTitle />
-          <ScanResultInfo
-            icon={illustration}
-            text={t(`Acquisition.tooltip.${page}`)}
-            className="u-mb-1"
-          />
+          {tooltip && (
+            <ScanResultInfo
+              icon={illustration}
+              text={t(`Acquisition.tooltip.${page}`)}
+              className="u-mb-1"
+            />
+          )}
           <ScanResultCard
             currentFile={currentFile}
             setCurrentFile={setCurrentFile}

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -62,6 +62,7 @@
         {
           "stepIndex": 1,
           "model": "scan",
+          "tooltip": true,
           "illustration": "IlluIBAN.png",
           "text": "PaperJSON.generic.singlePage.text"
         },
@@ -204,6 +205,7 @@
         {
           "stepIndex": 1,
           "model": "scan",
+          "tooltip": true,
           "page": "front",
           "illustration": "IlluDriverLicenseFront.png",
           "text": "PaperJSON.generic.front.text"
@@ -211,6 +213,7 @@
         {
           "stepIndex": 2,
           "model": "scan",
+          "tooltip": true,
           "page": "back",
           "illustration": "IlluDriverLicenseBack.png",
           "text": "PaperJSON.generic.back.text"
@@ -385,6 +388,7 @@
         {
           "stepIndex": 1,
           "model": "scan",
+          "tooltip": true,
           "multipage": true,
           "illustration": "IlluInvoice.png",
           "text": "PaperJSON.generic.multiPages.text"
@@ -528,6 +532,7 @@
         {
           "stepIndex": 1,
           "model": "scan",
+          "tooltip": true,
           "multipage": true,
           "illustration": "IlluInvoice.png",
           "text": "PaperJSON.generic.multiPages.text"
@@ -603,6 +608,7 @@
         {
           "stepIndex": 1,
           "model": "scan",
+          "tooltip": true,
           "page": "front",
           "illustration": "IlluIdCardFront.png",
           "text": "PaperJSON.card.front.text"
@@ -610,6 +616,7 @@
         {
           "stepIndex": 2,
           "model": "scan",
+          "tooltip": true,
           "page": "back",
           "illustration": "IlluIdCardBack.png",
           "text": "PaperJSON.card.back.text"
@@ -1095,6 +1102,7 @@
         {
           "stepIndex": 1,
           "model": "scan",
+          "tooltip": true,
           "multipage": true,
           "illustration": "IlluWorkContract.png",
           "text": "PaperJSON.generic.singlePage.text"
@@ -1280,6 +1288,7 @@
         {
           "stepIndex": 1,
           "model": "scan",
+          "tooltip": true,
           "multipage": true,
           "illustration": "IlluInvoice.png",
           "text": "PaperJSON.generic.multiPages.text"
@@ -1353,6 +1362,7 @@
         {
           "stepIndex": 1,
           "model": "scan",
+          "tooltip": true,
           "page": "front",
           "illustration": "IlluResidencePermitFront.png",
           "text": "PaperJSON.card.front.text"
@@ -1360,6 +1370,7 @@
         {
           "stepIndex": 2,
           "model": "scan",
+          "tooltip": true,
           "page": "back",
           "illustration": "IlluResidencePermitBack.png",
           "text": "PaperJSON.card.back.text"
@@ -1670,6 +1681,7 @@
         {
           "stepIndex": 1,
           "model": "scan",
+          "tooltip": true,
           "illustration": "IlluVehicleRegistration.png",
           "text": "PaperJSON.generic.content.text"
         },
@@ -1704,6 +1716,7 @@
         {
           "stepIndex": 1,
           "model": "scan",
+          "tooltip": true,
           "multipage": true,
           "illustration": "IlluInvoice.png",
           "text": "PaperJSON.generic.multiPages.text"
@@ -1740,6 +1753,7 @@
         {
           "stepIndex": 1,
           "model": "scan",
+          "tooltip": true,
           "multipage": true,
           "illustration": "IlluPassport.png",
           "text": "PaperJSON.passport.scan.text"
@@ -1908,6 +1922,7 @@
         {
           "stepIndex": 1,
           "model": "scan",
+          "tooltip": true,
           "multipage": true,
           "illustration": "IlluInvoice.png",
           "text": "PaperJSON.generic.multiPages.text"
@@ -1974,6 +1989,7 @@
         {
           "stepIndex": 1,
           "model": "scan",
+          "tooltip": true,
           "illustration": "IlluInvoice.png",
           "text": "PaperJSON.generic.singlePage.text"
         },

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -430,7 +430,7 @@
   },
   "ScanDesktopActionsAlert": {
     "title": "Scan with the Cozy Cloud app",
-    "text": "Install the Cozy Cloud application on your mobile to take a photo of your papers directly and extract the information automatically.",
+    "text": "Install the Cozy Cloud application on your mobile to take a photo of your papers directly and extract the information.",
     "actions": {
       "hide": "No, thanks",
       "install": "Install the app"

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -430,7 +430,7 @@
   },
   "ScanDesktopActionsAlert": {
     "title": "Scanner avec l’app Cozy Cloud",
-    "text": "Installer l’application Cozy Cloud sur votre mobile pour prendre directement vos papiers en photo et en extraire les informations automatiquement.",
+    "text": "Installer l’application Cozy Cloud sur votre mobile pour prendre directement vos papiers en photo et en extraire les informations.",
     "actions": {
       "hide": "Non, merci",
       "install": "Installer l'app"


### PR DESCRIPTION
This option allows to display or not the tooltip present in the second part of the Scan.

Because we don't want a tooltip in all cases where we have a "generic" illustration.