### PR TITLE
fix(mespapiers): Wording of EmptyWithHeader

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.spec.js
@@ -70,8 +70,8 @@ describe('MesPapiersLibProviders', () => {
     })
 
     expect(queryByTestId('HarvestBanner')).toBeFalsy()
-    expect(getByText('myLogin'))
-    expect(getByText('myOtherLogin'))
+    expect(getByText('Account %{name} : myLogin'))
+    expect(getByText('Account %{name} : myOtherLogin'))
   })
 
   it('should display logins and harvest banner', () => {
@@ -86,7 +86,7 @@ describe('MesPapiersLibProviders', () => {
     })
 
     expect(queryAllByTestId('HarvestBanner')).toBeTruthy()
-    expect(getByText('myLogin'))
-    expect(getByText('myOtherLogin'))
+    expect(getByText('Account %{name} : myLogin'))
+    expect(getByText('Account %{name} : myOtherLogin'))
   })
 })

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithHeader.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithHeader.jsx
@@ -18,7 +18,12 @@ const EmptyWithHeader = ({ konnector, account }) => {
     <List
       subheader={
         <ListSubheader>
-          <div className="u-ellipsis">{getAccountName(account)}</div>
+          <div className="u-ellipsis">
+            {t('PapersList.accountName', {
+              name: konnector.name,
+              identifier: getAccountName(account)
+            })}
+          </div>
         </ListSubheader>
       }
     >


### PR DESCRIPTION
In the case where there are several accounts on the same konnector, those who do not have papers must have the same wording in their subHeader.