### PR TITLE
fix: Display reconnection webview for powens konnectors

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/OpenOAuthWindowButton.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/OpenOAuthWindowButton.jsx
@@ -4,14 +4,24 @@ import React, { useCallback } from 'react'
 import { useClient } from 'cozy-client'
 import flag from 'cozy-flags'
 import { useWebviewIntent } from 'cozy-intent'
+import { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import SyncIcon from 'cozy-ui/transpiled/react/Icons/Sync'
 
 import { intentsApiProptype } from '../../helpers/proptypes'
 import { OAUTH_SERVICE_OK, openOAuthWindow } from '../OAuthService'
 import useOAuthExtraParams from '../hooks/useOAuthExtraParams'
 
-const OpenOAuthWindowButton = ({ flow, account, konnector, intentsApi }) => {
+const OpenOAuthWindowButton = ({
+  flow,
+  account,
+  konnector,
+  intentsApi,
+  actionMenuItem = false,
+  onClick
+}) => {
   const { t } = useI18n()
   const client = useClient()
   const webviewIntent = useWebviewIntent()
@@ -24,6 +34,9 @@ const OpenOAuthWindowButton = ({ flow, account, konnector, intentsApi }) => {
   })
 
   const handleClick = useCallback(async () => {
+    if (!extraParams) {
+      return
+    }
     const response = await openOAuthWindow({
       client,
       konnector,
@@ -40,9 +53,19 @@ const OpenOAuthWindowButton = ({ flow, account, konnector, intentsApi }) => {
     ) {
       flow.expectTriggerLaunch()
     }
-  }, [account, client, extraParams, flow, konnector, webviewIntent, intentsApi])
+  }, [account, client, flow, konnector, webviewIntent, intentsApi, extraParams])
 
-  return (
+  return actionMenuItem ? (
+    <ActionMenuItem
+      left={<Icon icon={SyncIcon} />}
+      onClick={() => {
+        handleClick()
+        onClick()
+      }}
+    >
+      {t('card.launchTrigger.button.label')}
+    </ActionMenuItem>
+  ) : (
     <Button
       variant="text"
       color="error"
@@ -59,7 +82,9 @@ OpenOAuthWindowButton.propTypes = {
   flow: PropTypes.object.isRequired,
   account: PropTypes.object.isRequired,
   konnector: PropTypes.object.isRequired,
-  intentsApi: intentsApiProptype
+  intentsApi: intentsApiProptype,
+  actionMenuItem: PropTypes.bool,
+  onClick: PropTypes.func
 }
 
 export default OpenOAuthWindowButton

--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/OpenOAuthWindowButton.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/OpenOAuthWindowButton.jsx
@@ -4,7 +4,7 @@ import React, { useCallback } from 'react'
 import { useClient } from 'cozy-client'
 import flag from 'cozy-flags'
 import { useWebviewIntent } from 'cozy-intent'
-import { Button } from 'cozy-ui/transpiled/react/Button'
+import Button from 'cozy-ui/transpiled/react/Buttons'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import { intentsApiProptype } from '../../helpers/proptypes'
@@ -44,11 +44,12 @@ const OpenOAuthWindowButton = ({ flow, account, konnector, intentsApi }) => {
 
   return (
     <Button
-      className="u-ml-0"
-      variant="secondary"
-      label={t('error.reconnect-via-form')}
-      onClick={handleClick}
+      variant="text"
+      color="error"
+      size="small"
       disabled={!extraParams}
+      label={t('card.launchTrigger.button.label')}
+      onClick={handleClick}
       busy={!extraParams}
     />
   )

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
@@ -16,6 +16,7 @@ import { useTrackPage } from '../../../components/hoc/tracking'
 import useMaintenanceStatus from '../../../components/hooks/useMaintenanceStatus'
 import KonnectorUpdateInfos from '../../../components/infos/KonnectorUpdateInfos'
 import * as konnectorsModel from '../../../helpers/konnectors'
+import { intentsApiProptype } from '../../../helpers/proptypes'
 import getRelatedAppsSlugs from '../../../models/getRelatedAppsSlugs'
 import Datacards from '../../Datacards'
 
@@ -32,6 +33,7 @@ export const DataTab = ({
   trigger,
   client,
   flow,
+  intentsApi,
   account
 }) => {
   const { isMobile } = useBreakpoints()
@@ -61,6 +63,8 @@ export const DataTab = ({
           <LaunchTriggerCard
             konnectorRoot={konnectorRoot}
             flow={flow}
+            intentsApi={intentsApi}
+            account={account}
             withMaintenanceDescription
           />
           {isMobile && <Divider style={styles.divider} />}
@@ -105,6 +109,7 @@ DataTab.propTypes = {
   trigger: PropTypes.object.isRequired,
   client: PropTypes.object.isRequired,
   flow: PropTypes.object,
+  intentsApi: intentsApiProptype,
   account: PropTypes.object
 }
 

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
@@ -69,16 +69,6 @@ export const LaunchTriggerAlert = ({
   const isKonnectorRunnable = konnectorPolicy.isRunnable()
   const isKonnectorDisconnected = isDisconnected(konnector, trigger)
 
-  const shouldDisplayRunningAlert = () => {
-    if (isInError) return false
-    if (isInMaintenance) return false
-    if (!isKonnectorRunnable) return false
-    if (isKonnectorDisconnected) return false
-    if (running && konnector.clientSide) return true
-
-    return false
-  }
-
   useEffect(() => {
     if (status === SUCCESS) {
       setShowSuccessSnackbar(true)
@@ -229,7 +219,9 @@ export const LaunchTriggerAlert = ({
         </div>
       </Alert>
 
-      {shouldDisplayRunningAlert() && <RunningAlert />}
+      {konnectorPolicy.shouldDisplayRunningAlert({ running }) && (
+        <RunningAlert />
+      )}
 
       <Snackbar
         open={showSuccessSnackbar}

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
@@ -16,10 +16,12 @@ import LaunchTriggerAlertMenu from './LaunchTriggerAlertMenu'
 import { RunningAlert } from './RunningAlert'
 import { makeLabel } from './helpers'
 import { isDisconnected } from '../../helpers/konnectors'
+import { intentsApiProptype } from '../../helpers/proptypes'
 import { getAccountId, getKonnectorSlug } from '../../helpers/triggers'
 import { findKonnectorPolicy } from '../../konnector-policies'
 import { SUCCESS } from '../../models/flowEvents'
 import { useFlowState } from '../../models/withConnectionFlow'
+import OpenOAuthWindowButton from '../AccountModalWithoutTabs/OpenOAuthWindowButton'
 import KonnectorIcon from '../KonnectorIcon'
 import withAdaptiveRouter from '../hoc/withRouter'
 import useMaintenanceStatus from '../hooks/useMaintenanceStatus'
@@ -47,6 +49,8 @@ export const LaunchTriggerAlert = ({
   t,
   konnectorRoot,
   historyAction,
+  intentsApi,
+  account,
   withMaintenanceDescription
 }) => {
   const client = useClient()
@@ -129,16 +133,27 @@ export const LaunchTriggerAlert = ({
         action={
           isKonnectorRunnable && (
             <>
-              {!isInMaintenance && !isKonnectorDisconnected && (
-                <Button
-                  variant="text"
-                  color={isInError ? 'error' : undefined}
-                  size="small"
-                  disabled={running}
-                  label={t('card.launchTrigger.button.label')}
-                  onClick={SyncButtonAction}
-                />
-              )}
+              {!isInMaintenance &&
+                !isKonnectorDisconnected &&
+                (konnectorPolicy.isBIWebView &&
+                isInError &&
+                error.isSolvableViaReconnect() ? (
+                  <OpenOAuthWindowButton
+                    flow={flow}
+                    account={account}
+                    intentsApi={intentsApi}
+                    konnector={konnector}
+                  />
+                ) : (
+                  <Button
+                    variant="text"
+                    color={isInError ? 'error' : undefined}
+                    size="small"
+                    disabled={running}
+                    label={t('card.launchTrigger.button.label')}
+                    onClick={SyncButtonAction}
+                  />
+                ))}
               {!block && (
                 <div
                   style={{
@@ -242,7 +257,9 @@ LaunchTriggerAlert.propTypes = {
   t: PropTypes.func,
   konnectorRoot: PropTypes.string,
   historyAction: PropTypes.func,
-  withDescription: PropTypes.bool
+  withDescription: PropTypes.bool,
+  intentsApi: intentsApiProptype,
+  account: PropTypes.object
 }
 
 export default withAdaptiveRouter(LaunchTriggerAlert)

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
@@ -67,10 +67,7 @@ export const LaunchTriggerAlert = ({
   const styles = useStyles({ block })
   const konnectorPolicy = findKonnectorPolicy(konnector)
   const isKonnectorRunnable = konnectorPolicy.isRunnable()
-  const isClisk = konnectorPolicy.name === 'clisk'
   const isKonnectorDisconnected = isDisconnected(konnector, trigger)
-  const shouldTryOauthReconnect =
-    konnectorPolicy.isBIWebView && isInError && error.isSolvableViaReconnect()
 
   const shouldDisplayRunningAlert = () => {
     if (isInError) return false
@@ -88,19 +85,15 @@ export const LaunchTriggerAlert = ({
     }
   }, [status])
 
-  const SyncButtonAction =
-    isInError &&
-    error.isSolvableViaReconnect() &&
-    !isClisk &&
-    !konnectorPolicy.isBIWebView
-      ? () =>
-          historyAction(
-            konnectorRoot
-              ? `${konnectorRoot}/accounts/${getAccountId(trigger)}/edit`
-              : '/edit',
-            'push'
-          )
-      : () => launch({ autoSuccessTimer: false })
+  const SyncButtonAction = konnectorPolicy.shouldLaunchRedirectToEdit(error)
+    ? () =>
+        historyAction(
+          konnectorRoot
+            ? `${konnectorRoot}/accounts/${getAccountId(trigger)}/edit`
+            : '/edit',
+          'push'
+        )
+    : () => launch({ autoSuccessTimer: false })
   const alertColor = () => {
     if (isInError) return undefined
     if (isInMaintenance) return 'var(--grey50)'
@@ -140,7 +133,7 @@ export const LaunchTriggerAlert = ({
             <>
               {!isInMaintenance &&
                 !isKonnectorDisconnected &&
-                (shouldTryOauthReconnect ? (
+                (konnectorPolicy.shouldLaunchDisplayOAuthWindow(error) ? (
                   <OpenOAuthWindowButton
                     flow={flow}
                     account={account}

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
@@ -69,6 +69,8 @@ export const LaunchTriggerAlert = ({
   const isKonnectorRunnable = konnectorPolicy.isRunnable()
   const isClisk = konnectorPolicy.name === 'clisk'
   const isKonnectorDisconnected = isDisconnected(konnector, trigger)
+  const shouldTryOauthReconnect =
+    konnectorPolicy.isBIWebView && isInError && error.isSolvableViaReconnect()
 
   const shouldDisplayRunningAlert = () => {
     if (isInError) return false
@@ -87,7 +89,10 @@ export const LaunchTriggerAlert = ({
   }, [status])
 
   const SyncButtonAction =
-    isInError && !isClisk
+    isInError &&
+    error.isSolvableViaReconnect() &&
+    !isClisk &&
+    !konnectorPolicy.isBIWebView
       ? () =>
           historyAction(
             konnectorRoot
@@ -135,9 +140,7 @@ export const LaunchTriggerAlert = ({
             <>
               {!isInMaintenance &&
                 !isKonnectorDisconnected &&
-                (konnectorPolicy.isBIWebView &&
-                isInError &&
-                error.isSolvableViaReconnect() ? (
+                (shouldTryOauthReconnect ? (
                   <OpenOAuthWindowButton
                     flow={flow}
                     account={account}
@@ -165,6 +168,8 @@ export const LaunchTriggerAlert = ({
                     t={t}
                     konnectorRoot={konnectorRoot}
                     historyAction={historyAction}
+                    account={account}
+                    intentsApi={intentsApi}
                   />
                 </div>
               )}
@@ -210,6 +215,8 @@ export const LaunchTriggerAlert = ({
                   t={t}
                   konnectorRoot={konnectorRoot}
                   historyAction={historyAction}
+                  account={account}
+                  intentsApi={intentsApi}
                 />
               </div>
             )}

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.spec.jsx
@@ -1,0 +1,177 @@
+import { render, waitFor, fireEvent } from '@testing-library/react'
+import React from 'react'
+
+import flag from 'cozy-flags'
+
+import { LaunchTriggerAlert } from './LaunchTriggerAlert'
+import AppLike from '../../../test/AppLike'
+import ConnectionFlow from '../../models/ConnectionFlow'
+import OpenOAuthWindowButton from '../AccountModalWithoutTabs/OpenOAuthWindowButton'
+
+jest.mock('../AccountModalWithoutTabs/OpenOAuthWindowButton')
+
+jest.mock('../../models/ConnectionFlow', () => {
+  // Require the original module to not be mocked...
+  const { default: mockConnectionFlow } = jest.requireActual(
+    '../../models/ConnectionFlow'
+  )
+
+  mockConnectionFlow.prototype.watchJob = jest.fn()
+
+  return mockConnectionFlow
+})
+
+jest.mock('cozy-flags')
+
+const triggerFixture = {
+  _id: 'd861818b62204988bf0bb78c182a9149',
+  arguments: '0 0 0 * * 0'
+}
+
+const konnectorFixture = {
+  slug: 'testslug'
+}
+
+const cliskKonnectorFixture = {
+  slug: 'testslug',
+  clientSide: true
+}
+
+const powensKonnectorFixture = {
+  slug: 'powenstestslug',
+  partnership: {
+    domain: 'budget-insight.com'
+  }
+}
+
+const erroredTriggerFixture = {
+  id: 'errored-trigger-id',
+  current_state: {
+    status: 'errored',
+    last_error: 'random error message'
+  },
+  arguments: '0 0 0 * * 0'
+}
+
+const reconnectErrorTriggerFixture = {
+  id: 'reconnect-errored-trigger-id',
+  current_state: {
+    status: 'errored',
+    last_error: 'LOGIN_FAILED'
+  },
+  arguments: '0 0 0 * * 0'
+}
+
+describe('LaunchTriggerAlert', () => {
+  const setup = ({ trigger, konnector }) => {
+    const client = {
+      collection: () => {
+        return {
+          get: jest.fn().mockResolvedValue({ data: trigger })
+        }
+      },
+      plugins: {
+        realtime: {
+          sendNotification: jest.fn(),
+          subscribe: jest.fn()
+        }
+      }
+    }
+
+    const flow = new ConnectionFlow(client, trigger, konnector)
+    flow.launch = jest.fn()
+    const historyAction = jest.fn()
+    const root = render(
+      <AppLike client={client}>
+        <LaunchTriggerAlert
+          t={key => key}
+          flow={flow}
+          historyAction={historyAction}
+          account={{}}
+        />
+      </AppLike>
+    )
+    return { root, flow, historyAction, client }
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.resetAllMocks()
+  })
+
+  it('should just launch konnector when there is no error', async () => {
+    const { root, flow } = setup({
+      trigger: triggerFixture,
+      konnector: konnectorFixture
+    })
+    await waitFor(() => root.getByTestId('alert-menu-button'))
+    fireEvent.click(root.getByTestId('alert-menu-button'))
+    const buttons = root.getAllByText('card.launchTrigger.button.label')
+    expect(buttons.length).toBe(2)
+    for (const button of buttons) {
+      fireEvent.click(button)
+    }
+    expect(flow.launch).toHaveBeenCalledTimes(2)
+  })
+
+  it('should launch konnector when there is an error which is not solvable via reconnect', async () => {
+    const { root, flow } = setup({
+      trigger: erroredTriggerFixture,
+      konnector: konnectorFixture
+    })
+    await waitFor(() => root.getByTestId('alert-menu-button'))
+    fireEvent.click(root.getByTestId('alert-menu-button'))
+    const buttons = root.getAllByText('card.launchTrigger.button.label')
+    expect(buttons.length).toBe(2)
+    for (const button of buttons) {
+      fireEvent.click(button)
+    }
+    expect(flow.launch).toHaveBeenCalledTimes(2)
+  })
+
+  it('should redirect when there is an error which is solvable via reconnect', async () => {
+    const { root, flow, historyAction } = setup({
+      trigger: reconnectErrorTriggerFixture,
+      konnector: konnectorFixture
+    })
+    await waitFor(() => root.getByText('card.launchTrigger.button.label'))
+    fireEvent.click(root.getByText('card.launchTrigger.button.label'))
+    expect(historyAction).toHaveBeenCalledWith('/edit', 'push')
+    expect(flow.launch).not.toHaveBeenCalled()
+  })
+
+  it('should show OpenOAuthWindowButton when there is an error which is solvable via reconnect with a powens konnector', async () => {
+    flag.mockImplementation(key =>
+      key === 'harvest.bi.webview' ? true : false
+    )
+    OpenOAuthWindowButton.mockImplementation(() => (
+      <>
+        <div>OpenOAuthWindowButton</div>
+      </>
+    ))
+    const { root } = setup({
+      trigger: reconnectErrorTriggerFixture,
+      konnector: powensKonnectorFixture
+    })
+    await waitFor(() => root.getByTestId('alert-menu-button'))
+    expect(OpenOAuthWindowButton).toHaveBeenCalled()
+  })
+
+  it('should launch when there is an error which is solvable via reconnect but with a clisk konnector', async () => {
+    window.cozy = {
+      ClientKonnectorLauncher: 'react-native'
+    }
+    const { root, flow } = setup({
+      trigger: reconnectErrorTriggerFixture,
+      konnector: cliskKonnectorFixture
+    })
+    await waitFor(() => root.getByTestId('alert-menu-button'))
+    fireEvent.click(root.getByTestId('alert-menu-button'))
+    const buttons = root.getAllByText('card.launchTrigger.button.label')
+    expect(buttons.length).toBe(2)
+    for (const button of buttons) {
+      fireEvent.click(button)
+    }
+    expect(flow.launch).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlertMenu.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlertMenu.jsx
@@ -40,22 +40,15 @@ const LaunchTriggerAlertMenu = ({
   const anchorRef = useRef()
   const [showOptions, setShowOptions] = useState(false)
 
-  const isInError = !!error
-  const shouldTryOauthReconnect =
-    konnectorPolicy.isBIWebView && isInError && error.isSolvableViaReconnect()
-  const SyncButtonAction =
-    isInError &&
-    error.isSolvableViaReconnect() &&
-    !isClisk &&
-    !konnectorPolicy.isBIWebView
-      ? () =>
-          historyAction(
-            konnectorRoot
-              ? `${konnectorRoot}/accounts/${getAccountId(trigger)}/edit`
-              : '/edit',
-            'push'
-          )
-      : () => launch({ autoSuccessTimer: false })
+  const SyncButtonAction = konnectorPolicy.shouldLaunchRedirectToEdit(error)
+    ? () =>
+        historyAction(
+          konnectorRoot
+            ? `${konnectorRoot}/accounts/${getAccountId(trigger)}/edit`
+            : '/edit',
+          'push'
+        )
+    : () => launch({ autoSuccessTimer: false })
 
   return (
     <>
@@ -72,7 +65,7 @@ const LaunchTriggerAlertMenu = ({
             !running &&
             !isInMaintenance &&
             !isKonnectorDisconnected &&
-            (shouldTryOauthReconnect ? (
+            (konnectorPolicy.shouldLaunchDisplayOAuthWindow(error) ? (
               <OpenOAuthWindowButton
                 flow={flow}
                 account={account}

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlertMenu.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlertMenu.jsx
@@ -52,7 +52,11 @@ const LaunchTriggerAlertMenu = ({
 
   return (
     <>
-      <IconButton ref={anchorRef} onClick={() => setShowOptions(true)}>
+      <IconButton
+        ref={anchorRef}
+        onClick={() => setShowOptions(true)}
+        data-testid="alert-menu-button"
+      >
         <Icon icon={DotsIcon} />
       </IconButton>
       {showOptions && (

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
@@ -12,6 +12,7 @@ import { Media, Img, Bd } from 'cozy-ui/transpiled/react/Media'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
 import LaunchTriggerAlert from './LaunchTriggerAlert'
+import { intentsApiProptype } from '../../helpers/proptypes'
 import * as triggers from '../../helpers/triggers'
 import { findKonnectorPolicy } from '../../konnector-policies'
 import { useFlowState } from '../../models/withConnectionFlow'
@@ -151,7 +152,9 @@ LaunchTriggerCard.propTypes = {
   /**
    * Disables the "run trigger" button
    */
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  intentsApi: intentsApiProptype,
+  account: PropTypes.object
 }
 
 export default translate()(LaunchTriggerCard)

--- a/packages/cozy-harvest-lib/src/konnector-policies.js
+++ b/packages/cozy-harvest-lib/src/konnector-policies.js
@@ -24,7 +24,8 @@ const defaultKonnectorPolicy = {
   shouldLaunchRedirectToEdit: error => {
     return error && error.isSolvableViaReconnect()
   },
-  shouldLaunchDisplayOAuthWindow: () => false
+  shouldLaunchDisplayOAuthWindow: () => false,
+  shouldDisplayRunningAlert: () => false
 }
 
 const policies = [

--- a/packages/cozy-harvest-lib/src/konnector-policies.js
+++ b/packages/cozy-harvest-lib/src/konnector-policies.js
@@ -15,7 +15,16 @@ const defaultKonnectorPolicy = {
   needsTriggerLaunch: true,
   needsAccountAndTriggerCreation: true,
   onLaunch: null,
-  isRunnable: () => true
+  isRunnable: () => true,
+  // ConnectionFlow redirects to the edit form page only when there is an error and if this error is solvable with a configuration change. Ex LOGIN_FAILED
+  /**
+   * @param {import('./helpers/konnectors').KonnectorJobError} error - current error in ConnectionFlow
+   * @returns
+   */
+  shouldLaunchRedirectToEdit: error => {
+    return error && error.isSolvableViaReconnect()
+  },
+  shouldLaunchDisplayOAuthWindow: () => false
 }
 
 const policies = [

--- a/packages/cozy-harvest-lib/src/policies/biWebView.js
+++ b/packages/cozy-harvest-lib/src/policies/biWebView.js
@@ -515,5 +515,6 @@ export const konnectorPolicy = {
    */
   shouldLaunchDisplayOAuthWindow: error => {
     return error && error.isSolvableViaReconnect()
-  }
+  },
+  shouldDisplayRunningAlert: () => false
 }

--- a/packages/cozy-harvest-lib/src/policies/biWebView.js
+++ b/packages/cozy-harvest-lib/src/policies/biWebView.js
@@ -506,5 +506,14 @@ export const konnectorPolicy = {
   onAccountCreation: onBIAccountCreation,
   fetchExtraOAuthUrlParams: fetchExtraOAuthUrlParams,
   handleOAuthAccount,
-  refreshContracts
+  refreshContracts,
+  // ConnectionFlow display OAuthWindow only when there is an error and when this error is solvable with it
+  shouldLaunchRedirectToEdit: () => false,
+  /**
+   * @param {import('./../helpers/konnectors').KonnectorJobError} error - current error in ConnectionFlow
+   * @returns
+   */
+  shouldLaunchDisplayOAuthWindow: error => {
+    return error && error.isSolvableViaReconnect()
+  }
 }

--- a/packages/cozy-harvest-lib/src/policies/clisk.js
+++ b/packages/cozy-harvest-lib/src/policies/clisk.js
@@ -146,5 +146,13 @@ export const konnectorPolicy = {
   isRunnable,
   // ConnectionFlow always launches the konnector which will handle the error itself if any
   shouldLaunchRedirectToEdit: () => false,
-  shouldLaunchDisplayOAuthWindow: () => false
+  shouldLaunchDisplayOAuthWindow: () => false,
+  /**
+   * Will tell if an alert indicating the need to keep the flagship app in front for the time of the konnector execution should be displayed
+   *
+   * @param {Object} options - options object
+   * @param {boolean} options.running - true if the current konnector is running
+   * @returns {boolean}
+   */
+  shouldDisplayRunningAlert: ({ running }) => running
 }

--- a/packages/cozy-harvest-lib/src/policies/clisk.js
+++ b/packages/cozy-harvest-lib/src/policies/clisk.js
@@ -143,5 +143,8 @@ export const konnectorPolicy = {
   onAccountCreation: null,
   fetchExtraOAuthUrlParams: null,
   refreshContracts: null,
-  isRunnable
+  isRunnable,
+  // ConnectionFlow always launches the konnector which will handle the error itself if any
+  shouldLaunchRedirectToEdit: () => false,
+  shouldLaunchDisplayOAuthWindow: () => false
 }


### PR DESCRIPTION
Even with harvest.inappconnectors.enabled flag activated.

The difference with previous interface is that the "reconnect" button
and the synchronize button have merge.

When the konnector is a powens one and when the error is solvable via
reconnection, the reconnection action (display the powens webview) is
done instead of just launching the konnector.

The reconnection button has exactly the same style as the
synchronization button.
