### PR TITLE
fix(mespapiers): Display a fileless account with other files

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.jsx
@@ -7,7 +7,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import EmptyWithKonnector from './EmptyWithKonnector'
 import HomeCloud from '../../../assets/icons/HomeCloud.svg'
 
-const Empty = ({ konnector, accountsByFiles }) => {
+const Empty = ({ konnector, accountsByFiles, hasFiles }) => {
   const { t } = useI18n()
 
   if (!konnector) {
@@ -24,6 +24,7 @@ const Empty = ({ konnector, accountsByFiles }) => {
 
   return (
     <EmptyWithKonnector
+      hasFiles={hasFiles}
       konnector={konnector}
       accountsByFiles={accountsByFiles}
     />
@@ -32,6 +33,7 @@ const Empty = ({ konnector, accountsByFiles }) => {
 
 Empty.propTypes = {
   konnector: PropTypes.object,
+  hasFiles: PropTypes.bool,
   accountsByFiles: PropTypes.shape({
     accountsWithFiles: PropTypes.array,
     accountsWithoutFiles: PropTypes.array

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyNoHeader.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyNoHeader.jsx
@@ -50,6 +50,7 @@ const EmptyNoHeader = ({ konnector, accounts }) => {
         text={t('Empty.konnector.text', {
           konnectorSlug: konnector?.slug?.toUpperCase()
         })}
+        data-testid="EmptyNoHeader"
       >
         <Button label={t('Empty.konnector.button')} onClick={handleClick} />
       </Empty>

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithHeader.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithHeader.jsx
@@ -26,6 +26,7 @@ const EmptyWithHeader = ({ konnector, account }) => {
           </div>
         </ListSubheader>
       }
+      data-testid="EmptyWithHeader"
     >
       {flag('harvest.inappconnectors.enabled') && (
         <HarvestBanner konnector={konnector} account={account} />

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithKonnector.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithKonnector.jsx
@@ -4,9 +4,16 @@ import React from 'react'
 import EmptyNoHeader from './EmptyNoHeader'
 import EmptyWithHeader from './EmptyWithHeader'
 
-const EmptyWithKonnector = ({ konnector, accountsByFiles }) => {
+const EmptyWithKonnector = ({ konnector, accountsByFiles, hasFiles }) => {
   const { accountsWithFiles, accountsWithoutFiles } = accountsByFiles
-  if (accountsWithoutFiles?.length === 1 && accountsWithFiles?.length === 0) {
+  /**
+   * If there is only one account without files and no other files
+   */
+  if (
+    accountsWithoutFiles?.length === 1 &&
+    accountsWithFiles?.length === 0 &&
+    !hasFiles
+  ) {
     return (
       <EmptyNoHeader konnector={konnector} accounts={accountsWithoutFiles} />
     )
@@ -19,6 +26,7 @@ const EmptyWithKonnector = ({ konnector, accountsByFiles }) => {
 
 EmptyWithKonnector.propTypes = {
   konnector: PropTypes.object,
+  hasFiles: PropTypes.bool,
   accountsByFiles: PropTypes.shape({
     accountsWithFiles: PropTypes.array,
     accountsWithoutFiles: PropTypes.array

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithKonnector.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithKonnector.spec.jsx
@@ -1,0 +1,91 @@
+import '@testing-library/jest-dom'
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import EmptyWithKonnector from './EmptyWithKonnector'
+import AppLike from '../../../../test/components/AppLike'
+
+jest.mock('cozy-harvest-lib', () => ({
+  LaunchTriggerCard: () => <div data-testid="LaunchTriggerCard" />
+}))
+
+const setup = ({
+  konnector,
+  accountsWithFiles,
+  accountsWithoutFiles,
+  hasFiles
+} = {}) => {
+  return render(
+    <AppLike>
+      <EmptyWithKonnector
+        konnector={konnector}
+        accountsByFiles={{ accountsWithFiles, accountsWithoutFiles }}
+        hasFiles={hasFiles}
+      />
+    </AppLike>
+  )
+}
+
+describe('EmptyWithKonnector', () => {
+  const konnector = { name: 'Test Konnector' }
+  const accountsWithFiles = [{ id: 'account1' }]
+  const accountsWithoutFiles = [{ id: 'account2' }, { id: 'account3' }]
+
+  it('renders EmptyNoHeader when there is only one account without files and no other files', () => {
+    const { getByTestId } = setup({
+      konnector,
+      accountsWithFiles: [],
+      accountsWithoutFiles: accountsWithoutFiles.slice(0, 1),
+      hasFiles: false
+    })
+
+    expect(getByTestId('EmptyNoHeader')).toBeInTheDocument()
+  })
+
+  it('renders EmptyWithHeader when there is only one account without files and other files exists', () => {
+    const { getByTestId } = setup({
+      konnector,
+      accountsWithFiles: [],
+      accountsWithoutFiles: accountsWithoutFiles.slice(0, 1),
+      hasFiles: true
+    })
+
+    expect(getByTestId('EmptyWithHeader')).toBeInTheDocument()
+  })
+
+  it('renders EmptyWithHeader for each account without files', () => {
+    const { getAllByTestId } = setup({
+      konnector,
+      accountsWithFiles: [],
+      accountsWithoutFiles: accountsWithoutFiles,
+      hasFiles: false
+    })
+    expect(getAllByTestId('EmptyWithHeader')).toHaveLength(
+      accountsWithoutFiles.length
+    )
+  })
+
+  it('renders EmptyWithHeader for each account without files even when there are accounts with files', () => {
+    const { getAllByTestId } = setup({
+      konnector,
+      accountsWithFiles,
+      accountsWithoutFiles,
+      hasFiles: false
+    })
+    expect(getAllByTestId('EmptyWithHeader')).toHaveLength(
+      accountsWithoutFiles.length
+    )
+  })
+
+  it('renders EmptyWithHeader for each account without files even when there are accounts with files and other files exists', () => {
+    const { getAllByTestId } = setup({
+      konnector,
+      accountsWithFiles,
+      accountsWithoutFiles,
+      hasFiles: true
+    })
+    expect(getAllByTestId('EmptyWithHeader')).toHaveLength(
+      accountsWithoutFiles.length
+    )
+  })
+})

--- a/packages/cozy-mespapiers-lib/src/components/Views/PapersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/PapersList.jsx
@@ -111,6 +111,7 @@ const PapersList = () => {
           )}
           {accountsWithoutFiles.length > 0 && (
             <Empty
+              hasFiles={hasFiles}
               konnector={konnectors[0]}
               accountsByFiles={{ accountsWithFiles, accountsWithoutFiles }}
             />


### PR DESCRIPTION
Manually added files must be taken into account when displaying a connector that has no files.