### PR TITLE
fix: Do not display reconnection webview for USER_ACTION_NEEDED state

### DIFF
--- a/packages/cozy-harvest-lib/src/helpers/konnectors.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectors.js
@@ -111,7 +111,6 @@ export class KonnectorJobError extends Error {
       // since we do not currently *need* to display a 2fa modal
       // for the flow to work. There will be no modal displayed
       // but the user will be able to do the 2fa on its mobile phone.
-      this.code === 'USER_ACTION_NEEDED' ||
       this.code === 'USER_ACTION_NEEDED.SCA_REQUIRED' ||
       this.code === 'USER_ACTION_NEEDED.WEBAUTH_REQUIRED' ||
       this.code === 'USER_ACTION_NEEDED.OAUTH_OUTDATED' ||


### PR DESCRIPTION
USER_ACTION_NEEDED state corresponds to 'actionNeeded' state for Powens
and this state states that :

```
Synchronization failed because the user needs to perform an action
directly on the bank website or app (usually, accept new CGUs or
similar one-time actions).
```
source: https://docs.budget-insight.com/guides/handle-scas-connection-states


Then this error cannot be solved with reconnection webview. We should just try to launch again the konnector.
