### PR TITLE
fix: Show accounts paywall for oAuth konnector

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -347,6 +347,16 @@ export class DumbTriggerManager extends Component {
     const showAccountForm = step === 'accountForm'
     const konnectorPolicy = findKonnectorPolicy(konnector)
 
+    if (showPaywall) {
+      return (
+        <AccountsPaywall
+          reason={showPaywall}
+          konnector={konnector}
+          onClose={() => onClose()}
+        />
+      )
+    }
+
     if (oauth || konnectorPolicy.isBIWebView) {
       const Wrapper = OAuthFormWrapperComp
         ? OAuthFormWrapperComp
@@ -407,13 +417,6 @@ export class DumbTriggerManager extends Component {
               fieldOptions={fieldOptions}
             />
           </>
-        )}
-        {showPaywall && (
-          <AccountsPaywall
-            reason={showPaywall}
-            konnector={konnector}
-            onClose={() => onClose()}
-          />
         )}
       </>
     )

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.spec.jsx
@@ -291,24 +291,6 @@ describe('TriggerManager', () => {
         })
       })
     })
-
-    describe('when user has reach limit', () => {
-      afterEach(() => {
-        checkMaxAccounts.mockResolvedValue(null)
-      })
-
-      it('should show a paywall', async () => {
-        checkMaxAccounts.mockResolvedValue('max_accounts')
-        render(
-          <AppLike>
-            <TriggerManager {...props} />
-          </AppLike>
-        )
-        expect(
-          await screen.findByText('Show paywall for this reason : max_accounts')
-        ).toBeDefined()
-      })
-    })
   })
 
   describe('when given an account', () => {
@@ -452,6 +434,58 @@ describe('TriggerManager', () => {
           })
         )
       })
+    })
+  })
+
+  describe('Accounts paywall', () => {
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should show a paywall when given no account', async () => {
+      checkMaxAccounts.mockResolvedValue('max_accounts')
+      render(
+        <AppLike>
+          <TriggerManager {...props} />
+        </AppLike>
+      )
+      expect(
+        await screen.findByText('Show paywall for this reason : max_accounts')
+      ).toBeDefined()
+    })
+
+    it('should show the new account form when checkMaxAccounts return null', async () => {
+      checkMaxAccounts.mockResolvedValue(null)
+      const { findByLabelText } = render(
+        <AppLike>
+          <TriggerManager {...props} />
+        </AppLike>
+      )
+
+      await expect(findByLabelText('username')).resolves.toBeDefined()
+      await expect(findByLabelText('passphrase')).resolves.toBeDefined()
+    })
+
+    it('should show a paywall when given an oauth konnector', async () => {
+      checkMaxAccounts.mockResolvedValue('max_accounts')
+      render(
+        <AppLike>
+          <TriggerManager {...oAuthProps} konnector={oAuthKonnector} />
+        </AppLike>
+      )
+      expect(
+        await screen.findByText('Show paywall for this reason : max_accounts')
+      ).toBeDefined()
+    })
+
+    it('should no check the paywall condition when given an account', async () => {
+      render(
+        <AppLike>
+          <TriggerManager {...propsWithAccount} />
+        </AppLike>
+      )
+
+      expect(checkMaxAccounts).not.toBeCalled()
     })
   })
 })


### PR DESCRIPTION
Stupid error: the check to display the paywall was too early and was bypassed by the oAuth form