### PR TITLE
fix(mespapiers): Step modal with Radio buttons

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react'
+import React, { Fragment, useEffect, useState } from 'react'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
@@ -15,9 +15,11 @@ const isUserValue = (options, value) => {
 }
 
 const RadioAdapter = ({
-  attrs: { name, options },
+  attrs: { name, options, required },
   defaultValue = '',
-  setValue
+  setValue,
+  setValidInput,
+  idx
 }) => {
   const [optionValue, setOptionValue] = useState(
     isUserValue(options, defaultValue) ? 'other' : defaultValue
@@ -43,6 +45,14 @@ const RadioAdapter = ({
       [name]: currentValue
     }))
   }
+
+  /* Necessary to validate or not the validation button of the current step */
+  useEffect(() => {
+    setValidInput(prev => ({
+      ...prev,
+      [idx]: !required || optionValue || textValue
+    }))
+  }, [idx, setValidInput, optionValue, textValue, required])
 
   return (
     <Paper>

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.spec.jsx
@@ -15,6 +15,7 @@ const setup = ({
       <RadioAdapter
         attrs={attrs}
         defaultValue={defaultValue}
+        setValidInput={jest.fn()}
         setValue={setValue}
       />
     </AppLike>


### PR DESCRIPTION
This `useEffect` had been removed, among other things, during the last evolution of the component.
But it is really necessary for the proper functioning of the functionality (creation/editing).