### PR TITLE
fix(mespapiers): Flattened image on some browsers

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/CompositeHeader/CompositeHeader.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/CompositeHeader/CompositeHeader.jsx
@@ -22,7 +22,6 @@ const useStyles = makeStyles(() => ({
       height: 'initial'
     },
     '& img': {
-      width: 'fit-content',
       margin: '0 auto'
     }
   }


### PR DESCRIPTION
Removed the `width: fit-content` CSS rule on the `img` tags in `CompositeHeader` component, this rule is no longer useful and even causes problems on Firefox & Safari browsers