### PR TITLE
fix: Display success dialog on powens account creation success

### DIFF
--- a/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.jsx
@@ -1,12 +1,13 @@
 import compose from 'lodash/flowRight'
 import isEqual from 'lodash/isEqual'
 import PropTypes from 'prop-types'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useContext, useEffect, useState } from 'react'
 
 import { useClient } from 'cozy-client'
 import flag from 'cozy-flags'
 import { useWebviewIntent } from 'cozy-intent'
 
+import { MountPointContext } from './MountPointContext'
 import {
   OAUTH_SERVICE_ERROR,
   OAUTH_SERVICE_OK,
@@ -32,6 +33,7 @@ export const OAuthForm = props => {
   const client = useClient()
   const flowState = useFlowState(flow)
   const webviewIntent = useWebviewIntent()
+  const { replaceHistory } = useContext(MountPointContext)
   const { extraParams, needsExtraParams } = useOAuthExtraParams({
     account,
     client,
@@ -73,7 +75,7 @@ export const OAuthForm = props => {
     if (response.result === OAUTH_SERVICE_OK) {
       const konnectorPolicy = findKonnectorPolicy(konnector)
       if (konnectorPolicy.isBIWebView && flag('harvest.bi.fullwebhooks')) {
-        flow.expectTriggerLaunch()
+        replaceHistory(`/accounts/bi/success`)
       }
       const accountId = response.key
       if (typeof onSuccess === 'function') onSuccess(accountId)
@@ -89,6 +91,7 @@ export const OAuthForm = props => {
     konnector,
     onSuccess,
     reconnect,
+    replaceHistory,
     webviewIntent
   ])
 

--- a/packages/cozy-harvest-lib/src/components/OAuthForm.spec.js
+++ b/packages/cozy-harvest-lib/src/components/OAuthForm.spec.js
@@ -5,6 +5,7 @@ import React from 'react'
 
 import CozyClient from 'cozy-client'
 
+import { MountPointContext } from './MountPointContext'
 import AppLike from '../../test/AppLike'
 import { KonnectorJobError } from '../helpers/konnectors'
 import { findKonnectorPolicy } from '../konnector-policies'
@@ -50,15 +51,21 @@ describe('OAuthForm', () => {
     const flow = new ConnectionFlow(client, null, konnector)
     flow.getState = jest.fn().mockReturnValue(flowState)
 
+    const mountPointContextValue = {
+      replaceHistory: jest.fn()
+    }
+
     const root = await render(
       <AppLike client={client}>
-        <OAuthForm
-          account={account}
-          flow={flow}
-          konnector={fixtures.konnector}
-          reconnect={reconnect}
-          t={t}
-        />
+        <MountPointContext.Provider value={mountPointContextValue}>
+          <OAuthForm
+            account={account}
+            flow={flow}
+            konnector={fixtures.konnector}
+            reconnect={reconnect}
+            t={t}
+          />
+        </MountPointContext.Provider>
       </AppLike>
     )
     // Wait for next tick so the effects of useOAuthExtraParams are done

--- a/packages/cozy-harvest-lib/src/components/Routes/RoutesV6.jsx
+++ b/packages/cozy-harvest-lib/src/components/Routes/RoutesV6.jsx
@@ -119,23 +119,21 @@ const RoutesV6 = ({
           </HarvestParamsWrapper>
         }
       />
-      {!flag('harvest.inappconnectors.enabled') && (
-        <Route
-          path="accounts/:accountId/success"
-          element={
-            <HarvestParamsWrapper>
-              {params => (
-                <KonnectorSuccess
-                  konnector={konnectorWithTriggers}
-                  accountId={params.accountId}
-                  accounts={accountsAndTriggers}
-                  onDismiss={onDismiss}
-                />
-              )}
-            </HarvestParamsWrapper>
-          }
-        />
-      )}
+      <Route
+        path="accounts/:accountId/success"
+        element={
+          <HarvestParamsWrapper>
+            {params => (
+              <KonnectorSuccess
+                konnector={konnectorWithTriggers}
+                accountId={params.accountId}
+                accounts={accountsAndTriggers}
+                onDismiss={onDismiss}
+              />
+            )}
+          </HarvestParamsWrapper>
+        }
+      />
 
       <Route
         path="viewer/:accountId/:folderToSaveId/:fileIndex"

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.spec.jsx
@@ -6,6 +6,7 @@ import React from 'react'
 
 import CozyClient from 'cozy-client'
 
+import { MountPointContext } from './MountPointContext'
 import ConnectionFlow from '../../src/models/ConnectionFlow'
 import AppLike from '../../test/AppLike'
 import fixtures from '../../test/fixtures'
@@ -153,11 +154,16 @@ describe('TriggerManager', () => {
   })
 
   describe('when given an oauth konnector', () => {
-    it('should should not show a form but only a button to connect with oauth', async () => {
+    it('should not show a form but only a button to connect with oauth', async () => {
       mockVaultClient.getAll.mockResolvedValue([])
+      const mountPointContextValue = {
+        replaceHistory: jest.fn()
+      }
       const root = render(
         <AppLike>
-          <TriggerManager {...oAuthProps} konnector={oAuthKonnector} />
+          <MountPointContext.Provider value={mountPointContextValue}>
+            <TriggerManager {...oAuthProps} konnector={oAuthKonnector} />
+          </MountPointContext.Provider>
         </AppLike>
       )
       await expect(root.findByText('Connect')).resolves.toBeDefined()
@@ -165,11 +171,16 @@ describe('TriggerManager', () => {
       expect(root.queryByLabelText('passphrase')).toBeFalsy()
     })
 
-    it('should should not show a form but only a button to connect with a banking konnector', async () => {
+    it('should not show a form but only a button to connect with a banking konnector', async () => {
       mockVaultClient.getAll.mockResolvedValue([])
+      const mountPointContextValue = {
+        replaceHistory: jest.fn()
+      }
       const root = render(
         <AppLike>
-          <TriggerManager {...oAuthProps} konnector={bankingKonnector} />
+          <MountPointContext.Provider value={mountPointContextValue}>
+            <TriggerManager {...oAuthProps} konnector={bankingKonnector} />
+          </MountPointContext.Provider>
         </AppLike>
       )
       await expect(root.findByText('Add your bank')).resolves.toBeDefined()
@@ -468,9 +479,14 @@ describe('TriggerManager', () => {
 
     it('should show a paywall when given an oauth konnector', async () => {
       checkMaxAccounts.mockResolvedValue('max_accounts')
+      const mountPointContextValue = {
+        replaceHistory: jest.fn()
+      }
       render(
         <AppLike>
-          <TriggerManager {...oAuthProps} konnector={oAuthKonnector} />
+          <MountPointContext.Provider value={mountPointContextValue}>
+            <TriggerManager {...oAuthProps} konnector={oAuthKonnector} />
+          </MountPointContext.Provider>
         </AppLike>
       )
       expect(


### PR DESCRIPTION
This is a quick fix to avoid having an error after powens account
creation.

We may find a better way to display the powens account creation result
later.
