### PR TITLE
feat: Expose native intent service

### DIFF
--- a/packages/cozy-intent/src/view/components/NativeIntentProvider.tsx
+++ b/packages/cozy-intent/src/view/components/NativeIntentProvider.tsx
@@ -8,11 +8,27 @@ interface Props {
   localMethods: NativeMethodsRegister
 }
 
+let nativeIntentService: NativeService | undefined
+
+export const getNativeIntentService = (): NativeService => {
+  if (!nativeIntentService) {
+    throw new Error(
+      'nativeIntentService has not been instantiated in a NativeIntentProvider'
+    )
+  }
+
+  return nativeIntentService
+}
+
 export const NativeIntentProvider = ({
   children,
   localMethods
-}: Props): ReactElement => (
-  <NativeContext.Provider value={new NativeService(localMethods)}>
-    {children}
-  </NativeContext.Provider>
-)
+}: Props): ReactElement => {
+  nativeIntentService = new NativeService(localMethods)
+
+  return (
+    <NativeContext.Provider value={nativeIntentService}>
+      {children}
+    </NativeContext.Provider>
+  )
+}


### PR DESCRIPTION
On flagship app, we need to call a intent from a webview inside an intent in the flagship app. To do so, we need to access the native intent service. We can not use useNativeIntent webhook, because in the flagship app we are not in a React component, and we are at the same level of the provider definition.