### PR TITLE
feat(minilog): Recognize ReactNative as modern env

### DIFF
--- a/packages/cozy-minilog/src/web/index.js
+++ b/packages/cozy-minilog/src/web/index.js
@@ -1,13 +1,14 @@
 var Minilog = require('../common/minilog.js')
-
 var oldEnable = Minilog.enable,
   oldDisable = Minilog.disable,
   isChrome =
     typeof navigator != 'undefined' && /chrome/i.test(navigator.userAgent),
+  isReactNative =
+    typeof navigator != 'undefined' && navigator.product === 'ReactNative',
   console = require('./console.js')
 
 // Use a more capable logging backend if on Chrome
-Minilog.defaultBackend = isChrome ? console.minilog : console
+Minilog.defaultBackend = isChrome || isReactNative ? console.minilog : console
 
 // apply enable inputs from localStorage and from the URL
 if (typeof window != 'undefined') {


### PR DESCRIPTION
By modifying the library code in this way,
we're ensuring that the more capable
logging backend console.minilog is used
not only when the code is running in a Chrome browser, but also when it's running in a React Native environment. This ensures better compatibility with different running environments without the need for users to modify their global objects (like navigator), resulting in cleaner and more maintainable code.