### PR TITLE
fix: Wrong export for DumbTriggerManager

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.jsx
@@ -9,7 +9,7 @@ import {
 } from 'cozy-keys-lib'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 
-import DumbTriggerManager from './DumbTriggerManager'
+import { DumbTriggerManager } from './DumbTriggerManager'
 import FlowProvider from './FlowProvider'
 import HarvestWrapper from './HarvestWrapper'
 import withConnectionFlow from '../models/withConnectionFlow'


### PR DESCRIPTION
DumbTriggerManager (cf: [code](https://github.com/cozy/cozy-libs/blob/ed9e18998c30701d07292c44cea46534525df182/packages/cozy-harvest-lib/src/components/DumbTriggerManager.jsx#L28)) imported as default in TriggerManager (cf: [code](https://github.com/cozy/cozy-libs/blob/ed9e18998c30701d07292c44cea46534525df182/packages/cozy-harvest-lib/src/components/TriggerManager.jsx#L12)) but just export which lead to white screen in cozy-home