### PR TITLE
Unlink the form submission from the Contact step

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Contexts/StepperDialogProvider.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Contexts/StepperDialogProvider.jsx
@@ -39,11 +39,16 @@ const StepperDialogProvider = ({ children }) => {
       setCurrentStepIndex(prev => prev + 1)
   }
 
+  const isLastStep = () => {
+    return currentStepIndex === allCurrentSteps.length
+  }
+
   const stepperDialog = {
     allCurrentSteps,
     currentStepIndex,
     stepperDialogTitle,
     currentDefinition,
+    isLastStep,
     setCurrentDefinition,
     previousStep,
     nextStep,

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/ContactDialog.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/ContactDialog.jsx
@@ -29,7 +29,7 @@ const ContactDialog = ({ currentStep, onClose, onBack }) => {
   const [contactModalOpened, setContactModalOpened] = useState(false)
   const { illustration, text, multiple } = currentStep
 
-  const cozyFiles = formData.data.filter(d => d.file.constructor === Blob)
+  const cozyFiles = formData.data.filter(d => d.file.from === 'cozy')
   const saveButtonDisabled =
     onLoad || contactIdsSelected.length === 0 || contactModalOpened
 

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanWrapper.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanWrapper.jsx
@@ -63,7 +63,8 @@ const ScanWrapper = ({ currentStep, onClose, onBack }) => {
   const onChangeFilePicker = async cozyFileId => {
     const blobFile = await fetchBlobFileById(client, cozyFileId)
     const file = makeFileFromBlob(blobFile, {
-      name: cozyFileId
+      name: cozyFileId,
+      from: 'cozy'
     })
     onChangeFile(file)
   }

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/ScanResult/ScanResultDialog.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/ScanResult/ScanResultDialog.jsx
@@ -92,9 +92,8 @@ const ScanResultDialog = ({
       actions={
         <>
           <Button
-            className="u-db"
             data-testid="next-button"
-            extension="full"
+            fullWidth
             label={t('common.next')}
             onClick={handleNextStep}
           />

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/ConfirmReplaceFile.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/ConfirmReplaceFile.jsx
@@ -57,9 +57,9 @@ const ConfirmReplaceFile = ({ onReplace, onClose, cozyFilesCount }) => {
 }
 
 ConfirmReplaceFile.propTypes = {
-  onReplace: PropTypes.object.isRequired,
+  onReplace: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
-  nbOfCozyFiles: PropTypes.number.isRequired
+  cozyFilesCount: PropTypes.number.isRequired
 }
 
 export default memo(ConfirmReplaceFile)

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/SubmitButton.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/SubmitButton.jsx
@@ -1,0 +1,80 @@
+import PropTypes from 'prop-types'
+import React, { useState } from 'react'
+
+import { useClient } from 'cozy-client'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import useEventListener from 'cozy-ui/transpiled/react/hooks/useEventListener'
+
+import ConfirmReplaceFile from './ConfirmReplaceFile'
+import { KEYS } from '../../../constants/const'
+import { FILES_DOCTYPE } from '../../../doctypes'
+import { useFormData } from '../../Hooks/useFormData'
+
+const SubmitButton = ({ onClose, disabled }) => {
+  const [isBusy, setIsBusy] = useState(false)
+  const [confirmReplaceFileModal, setConfirmReplaceFileModal] = useState(false)
+  const { formSubmit, formData } = useFormData()
+  const client = useClient()
+  const { t } = useI18n()
+
+  const cozyFiles = formData.data.filter(d => d.file.from === 'cozy')
+  const isDisabled = disabled || isBusy
+
+  const submit = async () => {
+    setIsBusy(true)
+    await formSubmit()
+    onClose()
+  }
+
+  const handleReplace = async isFileReplaced => {
+    if (isFileReplaced) {
+      for (const { file } of cozyFiles) {
+        await client.destroy({ _id: file.id, _type: FILES_DOCTYPE })
+      }
+    }
+    submit()
+  }
+
+  const handleClick = () => {
+    if (cozyFiles.length > 0) {
+      setConfirmReplaceFileModal(true)
+    } else {
+      submit()
+    }
+  }
+
+  const handleKeyDown = ({ key }) => {
+    if (isDisabled) return
+    if (key === KEYS.ENTER) handleClick()
+  }
+
+  useEventListener(window, 'keydown', handleKeyDown)
+
+  return (
+    <>
+      <Button
+        fullWidth
+        label={t(!isBusy ? 'ContactStep.save' : 'ContactStep.onLoad')}
+        onClick={handleClick}
+        disabled={isDisabled}
+        busy={isBusy}
+        data-testid="ButtonSave"
+      />
+      {confirmReplaceFileModal && (
+        <ConfirmReplaceFile
+          onClose={() => setConfirmReplaceFileModal(false)}
+          onReplace={handleReplace}
+          cozyFilesCount={cozyFiles.length}
+        />
+      )}
+    </>
+  )
+}
+
+SubmitButton.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  disabled: PropTypes.bool
+}
+
+export default SubmitButton

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/SubmitButton.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/SubmitButton.spec.jsx
@@ -1,0 +1,89 @@
+/* eslint-disable jest/no-focused-tests */
+import '@testing-library/jest-dom'
+import { fireEvent, render } from '@testing-library/react'
+import React from 'react'
+
+import SubmitButton from './SubmitButton'
+import AppLike from '../../../../test/components/AppLike'
+import { useFormData } from '../../Hooks/useFormData'
+
+const mockFormData = ({ metadata = {}, data = [], contacts = [] } = {}) => ({
+  metadata,
+  data,
+  contacts
+})
+
+jest.mock('../../Hooks/useFormData')
+/* eslint-disable react/display-name */
+jest.mock('./ConfirmReplaceFile', () => () => (
+  <div data-testid="ConfirmReplaceFile" />
+))
+/* eslint-enable react/display-name */
+
+const setup = ({
+  formData = mockFormData(),
+  formSubmit = jest.fn(),
+  onClose = jest.fn(),
+  disabled = false
+} = {}) => {
+  useFormData.mockReturnValue({
+    formData,
+    setFormData: jest.fn(),
+    formSubmit
+  })
+  return render(
+    <AppLike>
+      <SubmitButton onClose={onClose} disabled={disabled} />
+    </AppLike>
+  )
+}
+
+describe('ContactDialog', () => {
+  it('should submit when save button is clicked, if the file is from user device', async () => {
+    const mockFormSubmit = jest.fn()
+    const mockFetchCurrentUser = jest.fn(() => ({ _id: '1234' }))
+    const userDeviceFile = new File([{}], 'userDeviceFile')
+    const { findByTestId } = setup({
+      formData: mockFormData({ data: [{ file: userDeviceFile }] }),
+      formSubmit: mockFormSubmit,
+      mockFetchCurrentUser
+    })
+
+    const btn = await findByTestId('ButtonSave')
+    fireEvent.click(btn)
+
+    expect(mockFormSubmit).toBeCalledTimes(1)
+  })
+
+  it('should not diplay ConfirmReplaceFile modal when save button is clicked, if the file is from User Device', () => {
+    const mockFetchCurrentUser = jest.fn(() => ({ _id: '1234' }))
+    const userDeviceFile = new File([{}], 'userDeviceFile')
+    const { getByTestId, queryByTestId } = setup({
+      formData: mockFormData({ data: [{ file: userDeviceFile }] }),
+      mockFetchCurrentUser
+    })
+
+    const btn = getByTestId('ButtonSave')
+    fireEvent.click(btn)
+
+    expect(queryByTestId('ConfirmReplaceFile')).toBeNull()
+  })
+
+  it('should diplay ConfirmReplaceFile modal when save button is clicked, if the file is from Cozy Drive', async () => {
+    const mockFormSubmit = jest.fn()
+    const mockFetchCurrentUser = jest.fn(() => ({ _id: '1234' }))
+    const cozyFile = new File([{}], 'cozyFile')
+    cozyFile.from = 'cozy'
+    const { getByTestId } = setup({
+      formData: mockFormData({ data: [{ file: cozyFile }] }),
+      mockFetchCurrentUser,
+      formSubmit: mockFormSubmit
+    })
+
+    const btn = getByTestId('ButtonSave')
+    fireEvent.click(btn)
+    expect(mockFormSubmit).toBeCalledTimes(0)
+
+    expect(getByTestId('ConfirmReplaceFile')).toBeInTheDocument()
+  })
+})

--- a/packages/cozy-mespapiers-lib/src/components/StepperDialog/StepperDialogWrapper.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/StepperDialog/StepperDialogWrapper.spec.jsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom'
 import { render } from '@testing-library/react'
 import React from 'react'
 
@@ -25,7 +26,15 @@ const mockAllCurrentSteps = [
 ]
 
 describe('StepperDialogWrapper', () => {
-  const setup = () => {
+  const setup = ({
+    allCurrentSteps = mockAllCurrentSteps,
+    currentStepIndex
+  }) => {
+    useStepperDialog.mockReturnValue({
+      allCurrentSteps,
+      currentStepIndex
+    })
+
     return render(
       <AppLike>
         <StepperDialogWrapper />
@@ -34,37 +43,31 @@ describe('StepperDialogWrapper', () => {
   }
 
   it('should contain only Scan component', () => {
-    useStepperDialog.mockReturnValue({
-      allCurrentSteps: mockAllCurrentSteps,
+    const { getByTestId, queryByTestId } = setup({
       currentStepIndex: 1
     })
-    const { queryByTestId } = setup()
 
-    expect(queryByTestId('ScanWrapper')).toBeTruthy()
+    expect(getByTestId('ScanWrapper')).toBeInTheDocument()
     expect(queryByTestId('InformationDialog')).toBeNull()
     expect(queryByTestId('ContactDialog')).toBeNull()
   })
 
   it('should contain only InformationDialog component', () => {
-    useStepperDialog.mockReturnValue({
-      allCurrentSteps: mockAllCurrentSteps,
+    const { getByTestId, queryByTestId } = setup({
       currentStepIndex: 2
     })
-    const { queryByTestId } = setup()
 
-    expect(queryByTestId('InformationDialog')).toBeTruthy()
+    expect(getByTestId('InformationDialog')).toBeInTheDocument()
     expect(queryByTestId('ScanWrapper')).toBeNull()
     expect(queryByTestId('ContactDialog')).toBeNull()
   })
 
   it('should contain only Contact component', () => {
-    useStepperDialog.mockReturnValue({
-      allCurrentSteps: mockAllCurrentSteps,
+    const { getByTestId, queryByTestId } = setup({
       currentStepIndex: 3
     })
-    const { queryByTestId } = setup()
 
-    expect(queryByTestId('ContactDialog')).toBeTruthy()
+    expect(getByTestId('ContactDialog')).toBeInTheDocument()
     expect(queryByTestId('ScanWrapper')).toBeNull()
     expect(queryByTestId('InformationDialog')).toBeNull()
   })

--- a/packages/cozy-mespapiers-lib/src/helpers/buildPapersDefinitions.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/buildPapersDefinitions.js
@@ -9,28 +9,36 @@
  * @returns {Object[]} - Array of Papers sorted
  */
 export const buildPapersDefinitions = (papersDefList, scannerT) => {
-  const papersDefListSorted = [...papersDefList].sort((w, x) =>
-    scannerT(`items.${w.label}`) > scannerT(`items.${x.label}`)
+  const papersDefListSorted = [...papersDefList].sort((w, x) => {
+    return scannerT(`items.${w.label}`) > scannerT(`items.${x.label}`)
       ? 1
       : scannerT(`items.${x.label}`) > scannerT(`items.${w.label}`)
       ? -1
       : 0
-  )
+  })
 
-  const [papersUsedList, papersUnUsedList, otherPaperList] =
+  const [papersUsedList, papersUnUsedList, otherPaperList, noteList] =
     papersDefListSorted.reduce(
-      ([used, unUsed, other], currentPaperDef) => {
+      ([used, unUsed, other, note], currentPaperDef) => {
         if (/other_/i.test(currentPaperDef.label)) {
-          return [used, unUsed, [...other, currentPaperDef]]
+          return [used, unUsed, [...other, currentPaperDef], note]
+        }
+        if (/note_/i.test(currentPaperDef.label)) {
+          return [used, unUsed, other, [...note, currentPaperDef]]
         }
 
         return currentPaperDef.acquisitionSteps.length > 0 ||
           currentPaperDef.konnectorCriteria
-          ? [[...used, currentPaperDef], unUsed, other]
-          : [used, [...unUsed, currentPaperDef], other]
+          ? [[...used, currentPaperDef], unUsed, other, note]
+          : [used, [...unUsed, currentPaperDef], other, note]
       },
-      [[], [], []]
+      [[], [], [], []]
     )
 
-  return [...papersUsedList, ...otherPaperList, ...papersUnUsedList]
+  return [
+    ...papersUsedList,
+    ...otherPaperList,
+    ...noteList,
+    ...papersUnUsedList
+  ]
 }

--- a/packages/cozy-mespapiers-lib/src/helpers/buildPapersDefinitions.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/buildPapersDefinitions.spec.js
@@ -9,8 +9,10 @@ describe('buildPapersDefinitions', () => {
         return 'b'
       case 'items.other_three':
         return 'c'
-      case 'items.four':
+      case 'items.note_identity_document':
         return 'd'
+      case 'items.four':
+        return 'e'
     }
   })
   const mockPapersDef = [
@@ -32,7 +34,14 @@ describe('buildPapersDefinitions', () => {
         name: 'myKonnector'
       }
     },
-
+    {
+      label: 'note_identity_document',
+      acquisitionSteps: [
+        {
+          stepIndex: 1
+        }
+      ]
+    },
     {
       label: 'four',
       acquisitionSteps: []
@@ -79,6 +88,14 @@ describe('buildPapersDefinitions', () => {
       konnectorCriteria: {
         name: 'myKonnector'
       }
+    },
+    {
+      label: 'note_identity_document',
+      acquisitionSteps: [
+        {
+          stepIndex: 1
+        }
+      ]
     },
     {
       label: 'four',

--- a/packages/cozy-mespapiers-lib/src/helpers/makeFileFromBlob.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/makeFileFromBlob.js
@@ -4,9 +4,14 @@
  * @param {string} attrs.name - File name
  * @returns {File}
  */
-export const makeFileFromBlob = (blobFile, { name } = {}) => {
+export const makeFileFromBlob = (blobFile, attributes = {}) => {
+  const { name, ...rest } = attributes
   const defaultName = `${name || 'temp'}.${blobFile.type.split('/')[1]}`
   const newFile = new File([blobFile], defaultName, { type: blobFile.type })
+
+  for (const [key, val] of Object.entries(rest)) {
+    newFile[key] = val
+  }
 
   return newFile
 }

--- a/packages/cozy-mespapiers-lib/src/helpers/makeFileFromBlob.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/makeFileFromBlob.spec.js
@@ -22,4 +22,9 @@ describe('makeFileFromBlob', () => {
     const res = makeFileFromBlob(blob, {})
     expect(res.type).toBe('image/png')
   })
+
+  it('should return File with attributes passed', () => {
+    const res = makeFileFromBlob(blob, { from: 'cozy' })
+    expect(res.from).toBe('cozy')
+  })
 })


### PR DESCRIPTION
Cette PR permet de délier l'étape "contact" de la soumission du formulaire, ainsi nous pourrons mettre cette étape avant la création d'une note/aide-mémoire.