### PR TITLE
fix(mespapiers): Behavior of information step on mobile device

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/CompositeHeader/CompositeHeader.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/CompositeHeader/CompositeHeader.jsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles(() => ({
     height: '100%',
     maxWidth: '100%',
     '&.is-focused': {
-      height: 'initial'
+      height: '100vh'
     },
     '& img': {
       margin: '0 auto'


### PR DESCRIPTION
when input is focused.

This fix prevents the content of the information step modal from being off-center when you focus the input.