### PR TITLE
fix(sharing): Use `.fetchQueryAndGetFromState` instead `.query`

### DIFF
--- a/packages/cozy-sharing/src/SharingProvider.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.jsx
@@ -171,7 +171,7 @@ export class SharingProvider extends Component {
     const [sharings, permissions, apps] = await Promise.all([
       this.sharingCol.findByDoctype(doctype),
       this.permissionCol.findLinksByDoctype(doctype),
-      client.query(fetchApps().definition, fetchApps().options)
+      client.fetchQueryAndGetFromState(fetchApps())
     ])
     this.dispatch(
       receiveSharings({


### PR DESCRIPTION
When using `fetchPolicy`, the `client.query` method does not work correctly,
use `client.fetchQueryAndGetFromState` instead.

Known issue: cozy/cozy-client#931