### PR TITLE
fix(cozy-interapp): The document wasn't returned in onExposeFrameRemoval

### DIFF
--- a/packages/cozy-interapp/src/client.js
+++ b/packages/cozy-interapp/src/client.js
@@ -1,5 +1,5 @@
-import { errorSerializer, pickService } from './helpers'
 import * as dom from './dom'
+import { errorSerializer, pickService } from './helpers'
 import IntentListener from './listener'
 
 /**
@@ -78,7 +78,7 @@ export function start(createIntent, intent, element, data, options = {}) {
 
       onExposeFrameRemoval: event => {
         resolve({
-          document: event.document,
+          document: event.data.document,
           removeIntentIframe: () => dom.remove(iframe)
         })
       },


### PR DESCRIPTION
Bug détecté lors de l'utilisation des intent via IntentIfram de cozy-ui, qui fait que `result` ici https://github.com/cozy/cozy-ui/blob/master/react/IntentIframe/IntentIframe.jsx#L50 contient un object `{ document: undefined, removeIntentIframe: ... }`

On se base sur l'approche de onDone https://github.com/cozy/cozy-libs/blob/2a162e4d4547c506ec6cceb91bc9fabc6e4637d5/packages/cozy-interapp/src/client.js#L53C17-L53C17

Ceci dans le cadre de l'app Notes chargée via intent dans MesPapiers, on souhaite récupérer la note créée dans MesPapiers après création de celle-ci via intent dans Notes, afin d'appliquer la qualification dessus et l'ajout de contact de référence. Feature sur laquelle nous sommes déjà très limite en terme de timing, ajouté à ça la méconnaissance de cozy-interapp, le bugfix ne comporte donc pas de test.