### PR TITLE
Categorize and add contact references on reminders

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/useCurrentEditInformations.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/useCurrentEditInformations.jsx
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router-dom'
 import { isQueryLoading, useQuery } from 'cozy-client'
 
 import { getPaperDefinitionByFile, makeCurrentStep } from './helpers'
-import { buildFilesQueryById } from '../../../helpers/queries'
+import { buildFileQueryById } from '../../../helpers/queries'
 import { usePapersDefinitions } from '../../Hooks/usePapersDefinitions'
 
 /**
@@ -16,8 +16,8 @@ export const useCurrentEditInformations = (fileId, model) => {
   const { papersDefinitions } = usePapersDefinitions()
   const metadataName = new URLSearchParams(location.search).get('metadata')
 
-  const buildedFilesQuery = buildFilesQueryById(fileId)
-  const { data: files, ...filesQueryResult } = useQuery(
+  const buildedFilesQuery = buildFileQueryById(fileId)
+  const { data: file, ...filesQueryResult } = useQuery(
     buildedFilesQuery.definition,
     buildedFilesQuery.options
   )
@@ -25,14 +25,13 @@ export const useCurrentEditInformations = (fileId, model) => {
     isQueryLoading(filesQueryResult) || filesQueryResult.hasMore
 
   const paperDef =
-    (!isLoadingFiles &&
-      getPaperDefinitionByFile(papersDefinitions, files[0])) ||
+    (!isLoadingFiles && getPaperDefinitionByFile(papersDefinitions, file)) ||
     null
 
   const currentStep = makeCurrentStep({ paperDef, model, metadataName })
 
   return {
-    file: files?.[0],
+    file,
     paperDef,
     currentStep,
     searchParams: { metadataName },

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/useCurrentEditInformations.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/useCurrentEditInformations.spec.jsx
@@ -3,9 +3,12 @@ import React from 'react'
 import { useLocation } from 'react-router-dom'
 
 import { useQuery, isQueryLoading } from 'cozy-client'
+import I18n from 'cozy-ui/transpiled/react/I18n'
 
 import { useCurrentEditInformations } from './useCurrentEditInformations'
-import AppLike from '../../../../test/components/AppLike'
+import enLocale from '../../../locales/en.json'
+import { PapersDefinitionsProvider } from '../../Contexts/PapersDefinitionsProvider'
+import { ScannerI18nProvider } from '../../Contexts/ScannerI18nProvider'
 
 jest.mock('cozy-client/dist/utils', () => ({
   ...jest.requireActual('cozy-client/dist/utils'),
@@ -18,7 +21,7 @@ jest.mock('react-router-dom', () => ({
 }))
 
 const setup = ({ mockedData, searchParams = '', currentEditModel } = {}) => {
-  const { queryDataResult = [], isLoadingQuery = false } = mockedData || {}
+  const { queryDataResult = {}, isLoadingQuery = false } = mockedData || {}
   useQuery.mockReturnValue({
     data: queryDataResult,
     hasMore: isLoadingQuery
@@ -27,7 +30,13 @@ const setup = ({ mockedData, searchParams = '', currentEditModel } = {}) => {
   useLocation.mockImplementation(() => {
     return { search: searchParams }
   })
-  const wrapper = ({ children }) => <AppLike>{children}</AppLike>
+  const wrapper = ({ children }) => (
+    <I18n dictRequire={() => enLocale} lang="en">
+      <ScannerI18nProvider lang="en">
+        <PapersDefinitionsProvider>{children}</PapersDefinitionsProvider>
+      </ScannerI18nProvider>
+    </I18n>
+  )
 
   return renderHook(
     () => useCurrentEditInformations('fileId', currentEditModel),
@@ -55,8 +64,9 @@ describe('useCurrentEditInformations', () => {
       metadataName: 'issueDate'
     })
   })
+
   it('should return correct data', () => {
-    const queryDataResult = [{ metadata: { qualification: { label: 'caf' } } }]
+    const queryDataResult = { metadata: { qualification: { label: 'caf' } } }
     const searchParams = 'metadata=issueDate'
     const isLoadingQuery = false
 
@@ -76,8 +86,9 @@ describe('useCurrentEditInformations', () => {
       metadataName: 'issueDate'
     })
   })
+
   it('should return currentStep to "null" if has no metadata searchParams', () => {
-    const queryDataResult = [{ metadata: { qualification: { label: 'caf' } } }]
+    const queryDataResult = { metadata: { qualification: { label: 'caf' } } }
     const searchParams = ''
     const isLoadingQuery = false
 
@@ -94,10 +105,10 @@ describe('useCurrentEditInformations', () => {
       metadataName: null
     })
   })
+
   it('should return "paperDef" & "currentStep" to "null" if there is no match in the paperDefinitions file', () => {
-    const queryDataResult = [
-      { metadata: { qualification: { label: 'other' } } }
-    ]
+    const queryDataResult = { metadata: { qualification: { label: 'other' } } }
+
     const searchParams = 'metadata=issueDate'
     const isLoadingQuery = false
 

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/NoteDialog.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/NoteDialog.jsx
@@ -1,10 +1,17 @@
 import React from 'react'
+import { useParams } from 'react-router-dom'
 
 import { useClient } from 'cozy-client'
+import { Qualification } from 'cozy-client/dist/models/document'
+import { saveFileQualification, normalize } from 'cozy-client/dist/models/file'
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import IntentIframe from 'cozy-ui/transpiled/react/IntentIframe'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
+import { FILES_DOCTYPE } from '../../doctypes'
+import { addContactReferenceToFile } from '../../helpers/createPdfAndSave'
+import { buildFileQueryById } from '../../helpers/queries'
+import { useFormData } from '../Hooks/useFormData'
 import { useStepperDialog } from '../Hooks/useStepperDialog'
 import StepperDialogTitle from '../StepperDialog/StepperDialogTitle'
 
@@ -12,6 +19,31 @@ const NoteDialog = ({ onClose, onBack }) => {
   const client = useClient()
   const { isMobile } = useBreakpoints()
   const { currentStepIndex } = useStepperDialog()
+  const { qualificationLabel } = useParams()
+  const { formData } = useFormData()
+
+  const handleTerminate = async ({ document }) => {
+    const qualification = Qualification.getByLabel(qualificationLabel)
+    const fileCollection = client.collection(FILES_DOCTYPE)
+
+    const { data } = await client.fetchQueryAndGetFromState(
+      buildFileQueryById(document.id)
+    )
+    const { data: fileCreated } = await saveFileQualification(
+      client,
+      data,
+      qualification
+    )
+    const normalizedFile = normalize(fileCreated)
+
+    await addContactReferenceToFile({
+      fileCreated: normalizedFile,
+      fileCollection,
+      contacts: formData.contacts
+    })
+
+    onClose()
+  }
 
   return (
     <Dialog
@@ -36,7 +68,7 @@ const NoteDialog = ({ onClose, onBack }) => {
           }}
           create={client.intents.create}
           onCancel={onClose}
-          onTerminate={onClose}
+          onTerminate={handleTerminate}
         />
       }
     />

--- a/packages/cozy-mespapiers-lib/src/helpers/createPdfAndSave.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/createPdfAndSave.js
@@ -44,7 +44,7 @@ const sanitizeFileMetadata = (fileMetadata, isMultipage) => {
 /**
  * @param {AddContactReferenceToFileParam} param
  */
-const addContactReferenceToFile = async ({
+export const addContactReferenceToFile = async ({
   fileCreated,
   fileCollection,
   contacts

--- a/packages/cozy-mespapiers-lib/src/helpers/queries.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/queries.js
@@ -124,11 +124,12 @@ export const buildContactsQuery = (enabled = true) => ({
   }
 })
 
-export const buildFilesQueryById = id => ({
-  definition: () => Q(FILES_DOCTYPE).getById(id),
+export const buildFileQueryById = id => ({
+  definition: Q(FILES_DOCTYPE).getById(id),
   options: {
     as: `${FILES_DOCTYPE}/${id}`,
-    fetchPolicy: defaultFetchPolicy
+    fetchPolicy: defaultFetchPolicy,
+    singleDocData: true
   }
 })
 


### PR DESCRIPTION
Lors de la création d'une aide-mémoire, il faut que celle-ci soit qualifiée et que les contacts de références soient ajoutés. C'est ce qu'on ajoute ici.