### PR TITLE
Feat(mespapiers): Add `InstallAppFromIntent` component

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/InstallAppFromIntent/InstallAppFromIntent.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/InstallAppFromIntent/InstallAppFromIntent.jsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+
+import { useClient } from 'cozy-client'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import { IllustrationDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import IntentModal from 'cozy-ui/transpiled/react/deprecated/IntentModal'
+
+import { APPS_DOCTYPE } from '../../doctypes'
+
+const InstallAppFromIntent = () => {
+  const [showIntent, setShowIntent] = useState(false)
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const client = useClient()
+  const { t } = useI18n()
+
+  const handleTerminate = () => {
+    return navigate(`${searchParams.get('redirect')}`, {
+      replace: true
+    })
+  }
+
+  const handleClose = () => {
+    return navigate('..')
+  }
+
+  if (showIntent) {
+    return (
+      <IntentModal
+        action="INSTALL"
+        doctype={APPS_DOCTYPE}
+        mobileFullscreen
+        options={{ slug: 'notes' }}
+        create={client.intents.create}
+        onComplete={handleTerminate}
+        dismissAction={handleClose}
+      />
+    )
+  }
+
+  return (
+    <IllustrationDialog
+      open
+      size="small"
+      onClose={handleClose}
+      title={
+        <div className="u-flex u-flex-column u-flex-items-center">
+          <div className="u-mv-1">
+            <Icon icon="file-type-note" size={96} />
+          </div>
+          <Typography variant="h3" className="u-ta-center">
+            {t('InstallAppFromIntent.title')}
+          </Typography>
+        </div>
+      }
+      content={
+        <Typography className="u-ta-center">
+          {t('InstallAppFromIntent.text')}
+        </Typography>
+      }
+      actions={
+        <Button
+          fullWidth
+          label={t('InstallAppFromIntent.action')}
+          endIcon={<Icon icon="openwith" aria-hidden />}
+          onClick={() => setShowIntent(true)}
+        />
+      }
+    />
+  )
+}
+
+export default InstallAppFromIntent

--- a/packages/cozy-mespapiers-lib/src/components/MesPapiersLibRoutes.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/MesPapiersLibRoutes.jsx
@@ -9,6 +9,7 @@ import {
   Outlet
 } from 'react-router-dom'
 
+import InstallAppFromIntent from './InstallAppFromIntent/InstallAppFromIntent'
 import { MesPapiersLibProviders } from './MesPapiersLibProviders'
 import OnboardedGuardedRoute from './OnboardedGuardedRoute'
 import ContactEdit from './Views/ContactEdit'
@@ -49,6 +50,7 @@ const MesPapiersLibRoutes = ({ lang, components }) => {
         <Route element={<OnboardedGuardedRoute />}>
           <Route path="/" element={<OutletWrapper Component={Home} />}>
             <Route path="editcontact/:fileId" element={<ContactEdit />} />
+            <Route path="installAppIntent" element={<InstallAppFromIntent />} />
             <Route path="create" element={<PlaceholderListModal />} />
             <Route
               path="create/:qualificationLabel"
@@ -61,6 +63,7 @@ const MesPapiersLibRoutes = ({ lang, components }) => {
             element={<OutletWrapper Component={PapersList} />}
           >
             <Route path="editcontact/:fileId" element={<ContactEdit />} />
+            <Route path="installAppIntent" element={<InstallAppFromIntent />} />
             <Route path="create" element={<PlaceholderListModal />} />
             <Route
               path="create/:qualificationLabel"

--- a/packages/cozy-mespapiers-lib/src/components/PapersFab/PapersFabWrapper.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/PapersFab/PapersFabWrapper.spec.jsx
@@ -8,6 +8,9 @@ import flag from 'cozy-flags'
 import PapersFabWrapper from './PapersFabWrapper'
 import AppLike from '../../../test/components/AppLike'
 
+jest.mock('cozy-client/dist/models/applications', () => ({
+  isInstalled: jest.fn()
+}))
 jest.mock('cozy-flags')
 jest.mock('react-router-dom', () => {
   return {

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/PlaceholderListModal/PlaceholdersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/PlaceholderListModal/PlaceholdersList.jsx
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types'
 import React, { useState, useMemo, useRef, Fragment } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 
+import { useQuery } from 'cozy-client'
+import { isInstalled } from 'cozy-client/dist/models/applications'
 import ActionsMenu from 'cozy-ui/transpiled/react/ActionsMenu'
 import Divider from 'cozy-ui/transpiled/react/Divider'
 import Icon from 'cozy-ui/transpiled/react/Icon'
@@ -12,6 +14,7 @@ import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import Radio from 'cozy-ui/transpiled/react/Radios'
 
 import { findPlaceholdersByQualification } from '../../../helpers/findPlaceholders'
+import { buildAppsQuery } from '../../../helpers/queries'
 import { usePapersDefinitions } from '../../Hooks/usePapersDefinitions'
 import { useScannerI18n } from '../../Hooks/useScannerI18n'
 import FileIcon from '../../Icons/FileIcon'
@@ -29,6 +32,9 @@ const PlaceholdersList = ({ currentQualifItems }) => {
   const anchorRefs = useRef([])
   const anchorRef = useRef()
 
+  const appsQuery = buildAppsQuery()
+  const { data: apps } = useQuery(appsQuery.definition, appsQuery.options)
+
   const allPlaceholders = useMemo(
     () =>
       findPlaceholdersByQualification(papersDefinitions, currentQualifItems),
@@ -45,9 +51,18 @@ const PlaceholdersList = ({ currentQualifItems }) => {
     const countrySearchParam = `${
       placeholder.country ? `country=${placeholder.country}` : ''
     }`
+
+    const isNoteAppInstalled = !!isInstalled(apps, { slug: 'notes' })
+    if (isReminder(placeholder) && !isNoteAppInstalled) {
+      return navigate({
+        pathname: '../installAppIntent',
+        search: `redirect=${pathname}/${placeholder.label}`
+      })
+    }
+
     return navigate({
       pathname: `${pathname}/${placeholder.label}`,
-      search: `${countrySearchParam}`
+      search: countrySearchParam
     })
   }
 

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/PlaceholderListModal/PlaceholdersList.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/PlaceholderListModal/PlaceholdersList.spec.jsx
@@ -13,6 +13,9 @@ const fakeQualificationItems = [
   }
 ]
 
+jest.mock('cozy-client/dist/models/applications', () => ({
+  isInstalled: jest.fn()
+}))
 jest.mock('cozy-client', () => ({
   ...jest.requireActual('cozy-client'),
   generateWebLink: () => ''

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -2420,22 +2420,6 @@
       ]
     },
     {
-      "label": "note_identity_document",
-      "icon": "file-type-note",
-      "acquisitionSteps": [
-        {
-          "stepIndex": 1,
-          "illustration": "Account.svg",
-          "model": "contact",
-          "text": "PaperJSON.generic.owner.text"
-        },
-        {
-          "stepIndex": 2,
-          "model": "note"
-        }
-      ]
-    },
-    {
       "label": "note_health_document",
       "icon": "file-type-note",
       "acquisitionSteps": [

--- a/packages/cozy-mespapiers-lib/src/helpers/queries.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/queries.js
@@ -6,7 +6,8 @@ import {
   SETTINGS_DOCTYPE,
   TRIGGERS_DOCTYPE,
   KONNECTORS_DOCTYPE,
-  ACCOUNTS_DOCTYPE
+  ACCOUNTS_DOCTYPE,
+  APPS_DOCTYPE
 } from '../doctypes'
 
 const defaultFetchPolicy = fetchPolicies.olderThan(86_400_000) // 24 hours
@@ -203,3 +204,11 @@ export const queryAccounts = {
     fetchPolicy: defaultFetchPolicy
   }
 }
+
+export const buildAppsQuery = () => ({
+  definition: () => Q(APPS_DOCTYPE),
+  options: {
+    as: APPS_DOCTYPE,
+    fetchPolicy: defaultFetchPolicy
+  }
+})

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -443,5 +443,10 @@
       "android": "Install on Google Play",
       "ios": "Install on App Store"
     }
+  },
+  "InstallAppFromIntent": {
+    "title": "Would you like to add a note?",
+    "text": "Install the Note application in your Cozy to use this feature from My Papers!",
+    "action": "Install"
   }
 }

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -443,5 +443,10 @@
       "android": "Installer sur Google Play",
       "ios": "Installer sur l'App Store"
     }
+  },
+  "InstallAppFromIntent": {
+    "title": "Vous souhaitez ajouter une note ?",
+    "text": "Installer l’application Note dans votre Cozy pour utiliser cette fonctionnalité depuis Mes Papiers !",
+    "action": "Installer"
   }
 }


### PR DESCRIPTION
Ici on ajoute le contrôle que l'application Notes soit bien installée sur le Cozy avant d'entamer le processus de création d'un aide-mémoire.
Le cas échant, nous proposons de l'installer via Intent.