### PR TITLE
fix(scanner): Displaying qualifications

### DIFF
--- a/packages/cozy-scanner/src/DocumentCategory.jsx
+++ b/packages/cozy-scanner/src/DocumentCategory.jsx
@@ -66,7 +66,7 @@ class DocumentCategory extends Component {
           <ActionMenu
             onClose={this.closeMenu}
             autoclose
-            popperOptions={{ strategy: 'fixed' }}
+            popperOptions={{ strategy: 'fixed', placement: 'right' }}
           >
             <ActionMenuHeader>
               <Media>


### PR DESCRIPTION
On Desktop, when selecting a theme, a popper listing the qualifications appears below the theme button. With the recent addition of new qualifications, not all of them are accessible.
In order to have access to all qualifications, we display them on the right side of the theme button instead.