### PR TITLE
fix(mespapiers): Copy content on Note wasn't working on iOS Safari

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Actions/Items/copyReminderContent.js
+++ b/packages/cozy-mespapiers-lib/src/components/Actions/Items/copyReminderContent.js
@@ -1,48 +1,43 @@
 import copy from 'copy-text-to-clipboard'
-import React, { forwardRef } from 'react'
+import React, { useRef } from 'react'
 
+import useFetchJSON from 'cozy-client/dist/hooks/useFetchJSON'
 import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import Alerter from 'cozy-ui/transpiled/react/deprecated/Alerter'
+import useEventListener from 'cozy-ui/transpiled/react/hooks/useEventListener'
 
 import withLocales from '../../../locales/withLocales'
 
 export const copyReminderContent = () => {
   return {
     name: 'copyReminderContent',
-    action: async (doc, { client }) => {
-      try {
-        const reminderContent = await client.stackClient.fetchJSON(
-          'GET',
-          `/notes/${doc._id}/text`
-        )
-        const hasCopied = copy(reminderContent)
+    Component: withLocales(({ doc, ...props }) => {
+      const { t } = useI18n()
+      const elRef = useRef()
+      const { data } = useFetchJSON('GET', `/notes/${doc._id}/text`)
+
+      useEventListener(elRef.current, 'click', () => {
+        const hasCopied = copy(data)
+
         if (hasCopied) {
           Alerter.success('action.copyReminderContent.success')
         } else {
           Alerter.error('action.copyReminderContent.error')
         }
-      } catch {
-        Alerter.error('action.copyReminderContent.error')
-      }
-    },
-    Component: withLocales(
-      // eslint-disable-next-line react/display-name
-      forwardRef((props, ref) => {
-        const { t } = useI18n()
-
-        return (
-          <ActionsMenuItem {...props} ref={ref}>
-            <ListItemIcon>
-              <Icon icon="copy" />
-            </ListItemIcon>
-            <ListItemText primary={t('action.copyReminderContent.text')} />
-          </ActionsMenuItem>
-        )
       })
-    )
+
+      return (
+        <ActionsMenuItem {...props} ref={elRef}>
+          <ListItemIcon>
+            <Icon icon="copy" />
+          </ListItemIcon>
+          <ListItemText primary={t('action.copyReminderContent.text')} />
+        </ActionsMenuItem>
+      )
+    })
   }
 }


### PR DESCRIPTION
Sur iOS Safari (desktop et Flagship) uniquement, le copy ne fonctionne pas. Alors qu'on utilise la même méthode ailleurs et ça fonctionne bien...
J'ai copié le code de la lib pour voir quand, c'est simplement https://github.com/sindresorhus/copy-text-to-clipboard/blob/main/index.js#L31 qui retourne `false`.

Comme indiqué dans la doc `Must be called in response to a user gesture event, like click or keyup.` j'ai forcé l'usage d'un event listener.

Mais en fait ce n'est pas tant en rapport avec le useEvent, c'est qu'il manque un render... faire le useFetchJSON provoque un render de plus, et faire ensuite classiquement un onClick sur ActionsMenuItem et dedans un const hasCopied = copy(data) fonctionne bien également 🤷‍♂️ 

Bref ça marche avec le code proposé 👍 