### PR TITLE
Fix(harvest): konnectorBlock query

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -72,7 +72,7 @@
     "babel-jest": "26.6.3",
     "babel-plugin-inline-react-svg": "1.1.2",
     "babel-preset-cozy-app": "^2.1.0",
-    "cozy-client": "^38.6.0",
+    "cozy-client": "^40.2.0",
     "cozy-device-helper": "^2.7.0",
     "cozy-flags": "^3.0.1",
     "cozy-intent": "^2.15.0",
@@ -100,7 +100,7 @@
   },
   "peerDependencies": {
     "@babel/runtime": ">=7.12.5",
-    "cozy-client": ">=34.10.1",
+    "cozy-client": ">=40.2.0",
     "cozy-device-helper": ">=2.6.0",
     "cozy-flags": ">=2.3.5",
     "cozy-intent": ">=1.14.1",

--- a/packages/cozy-harvest-lib/src/helpers/konnectorBlock.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectorBlock.js
@@ -9,7 +9,8 @@ import {
   buildKonnectorQuery,
   buildAccountQuery,
   buildTriggersQuery,
-  buildTriggersByIdQuery
+  buildTriggersByIdQuery,
+  buildAppsRegistryQueryBySlug
 } from './queries'
 import logger from '../logger'
 import sentryHub from '../sentry'
@@ -67,7 +68,7 @@ const isAccountConnected = async (client, sourceAccount) => {
 const isInMaintenance = async (client, slug) => {
   const konnector = await konnectorBlock.fetchKonnector(
     client,
-    buildKonnectorQuery(slug, 'registry')
+    buildAppsRegistryQueryBySlug(slug)
   )
   return get(konnector, 'maintenance_activated', false)
 }
@@ -246,7 +247,7 @@ const fetchKonnectorStatus = async ({ client, slug, sourceAccount }) => {
       try {
         const konnector = await konnectorBlock.fetchKonnector(
           client,
-          buildKonnectorQuery(slug, 'registry')
+          buildAppsRegistryQueryBySlug(slug)
         )
         return { konnector, status: 'stackNotFound' }
       } catch (error) {

--- a/packages/cozy-harvest-lib/src/helpers/konnectorBlock.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectorBlock.js
@@ -6,7 +6,7 @@ import { generateUniversalLink } from 'cozy-ui/transpiled/react/AppLinker'
 import { getErrorLocale } from './konnectors'
 import { hasNewVersionAvailable } from './konnectors'
 import {
-  buildKonnectorQuery,
+  buildKonnectorQueryBySlug,
   buildAccountQuery,
   buildTriggersQuery,
   buildTriggersByIdQuery,
@@ -211,7 +211,7 @@ const fetchKonnectorStatus = async ({ client, slug, sourceAccount }) => {
   try {
     const konnector = await konnectorBlock.fetchKonnector(
       client,
-      buildKonnectorQuery(slug, 'stack')
+      buildKonnectorQueryBySlug(slug)
     )
 
     const accountConnected = await konnectorBlock.isAccountConnected(

--- a/packages/cozy-harvest-lib/src/helpers/konnectorBlock.spec.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectorBlock.spec.js
@@ -94,10 +94,6 @@ describe('fetchKonnectorData', () => {
     spy.mockRejectedValueOnce(error).mockResolvedValue(konnector)
 
     const res = await setup()
-    const firstResponseArg = spy.mock.calls[0][1]
-    expect(firstResponseArg.definition.sources).toStrictEqual(['stack'])
-    const secondResponseArg = spy.mock.calls[1][1]
-    expect(secondResponseArg.definition.sources).toStrictEqual(['registry'])
     expect(res).toMatchObject({
       name: 'Pajemploi',
       link: 'https://links.mycozy.cloud/store/discover/pajemploi?fallback=http%3A%2F%2Fcozy-store.tools%3A8080%2F%23%2Fdiscover%2Fpajemploi',

--- a/packages/cozy-harvest-lib/src/helpers/queries.js
+++ b/packages/cozy-harvest-lib/src/helpers/queries.js
@@ -20,6 +20,17 @@ export const buildKonnectorQuery = (slug, source) => {
   return { definition: queryDef, options: query.options }
 }
 
+export const buildAppsRegistryQueryBySlug = slug => {
+  const query = {
+    definition: () => Q('io.cozy.apps_registry').getById(`${slug}`),
+    options: {
+      as: `io.cozy.apps_registry/${slug}`,
+      fetchPolicy: defaultFetchPolicy
+    }
+  }
+  return { definition: query.definition(), options: query.options }
+}
+
 export const buildAccountQuery = accountId => ({
   definition: Q('io.cozy.accounts').getById(accountId),
   options: {

--- a/packages/cozy-harvest-lib/src/helpers/queries.js
+++ b/packages/cozy-harvest-lib/src/helpers/queries.js
@@ -5,19 +5,16 @@ const defaultFetchPolicy = CozyClient.fetchPolicies.olderThan(
   DEFAULT_CACHE_TIMEOUT_QUERIES
 )
 
-export const buildKonnectorQuery = (slug, source) => {
+export const buildKonnectorQueryBySlug = slug => {
   const query = {
     definition: () =>
       Q('io.cozy.konnectors').getById(`io.cozy.konnectors/${slug}`),
     options: {
-      as: `io.cozy.konnectors/${slug}-${source}`,
+      as: `io.cozy.konnectors/${slug}`,
       fetchPolicy: defaultFetchPolicy
     }
   }
-  const queryDef = query.definition()
-  queryDef.sources = [source]
-
-  return { definition: queryDef, options: query.options }
+  return { definition: query.definition(), options: query.options }
 }
 
 export const buildAppsRegistryQueryBySlug = slug => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10141,16 +10141,16 @@ cozy-client@^37.2.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^38.6.0:
-  version "38.6.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-38.6.0.tgz#7cc29bede36d685c54478a597c94defc1fd78ae1"
-  integrity sha512-mYKe0iluvA0S/sronxfIgD+KKxHoVTAkIOVlEzneW2XVFfqs5/Dmoa3oKGRnij8PvNrn6CZeiQlt6ZUktBJ+vA==
+cozy-client@^40.1.0:
+  version "40.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-40.1.0.tgz#f87556627dd7611163c5eda98380667ab999b311"
+  integrity sha512-iGIOMZDCx2495Uy1gFfHxRZJ3njunmHnXxHi8qVZB0Mjjfib9dV2DvVzKZZqYo5WNjmXVtru00eKaJYlzt/3EA==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^38.0.2"
+    cozy-stack-client "^40.0.1"
     date-fns "2.29.3"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
@@ -10308,19 +10308,19 @@ cozy-stack-client@^37.2.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^38.0.2:
-  version "38.0.2"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-38.0.2.tgz#d6534510b11e15a4f353b075348a130d7e4af184"
-  integrity sha512-GOOsyfugChHA+fiyr/6h6ARoUFYn/dVV3t2VWFfzQr/jpiXpOCaPr+jW+9D1HAfi2RTZJ6S7Zt8GXguEU/dthg==
+cozy-stack-client@^38.9.2:
+  version "38.9.2"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-38.9.2.tgz#f6762292ff8ea5fbb2d474aad154765d1cf62b79"
+  integrity sha512-HGzdumaObPUJP0kDu6X+cFZTK8kj7sGQ4I6cKSofLuRu69TxOZEYgrvomcpOAARi4vZuR1OmoBPnmOKBGbSChA==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^38.9.2:
-  version "38.9.2"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-38.9.2.tgz#f6762292ff8ea5fbb2d474aad154765d1cf62b79"
-  integrity sha512-HGzdumaObPUJP0kDu6X+cFZTK8kj7sGQ4I6cKSofLuRu69TxOZEYgrvomcpOAARi4vZuR1OmoBPnmOKBGbSChA==
+cozy-stack-client@^40.2.0:
+  version "40.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-40.2.0.tgz#e1b1845dd0360efc1774dfeda3ee57b134484a01"
+  integrity sha512-vhLnEoRlsdvrtAVjM3gKX6VPUprtu8b0Uu7mlZwjL0gyPgBVCTaqUF4w2I1kH+xvvZuuLTp//vJFfZhXuF1vkg==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
Ce problème est apparu suite à l'utilisation du Viewer sur un fichier provenant d'un connecteur.
A son ouverture, plusieurs requêtes partent du composant `KonnectorBlock`.

Plus précisément, une des requêtes exécuté regarde si le connecteur est en maintenance https://github.com/cozy/cozy-libs/blob/26c25008cf0b145e16e9b971a8c550c7b31e99a6/packages/cozy-harvest-lib/src/helpers/konnectorBlock.js#L224 qui mène à
https://github.com/cozy/cozy-libs/blob/26c25008cf0b145e16e9b971a8c550c7b31e99a6/packages/cozy-harvest-lib/src/helpers/queries.js#L8

A ce moment nous retombons dans le même problème rencontré avec le doctype io.cozy.apps, solutionné ici
https://github.com/cozy/cozy-client/commit/9d010a9943d295b4eeb789bd188d4b4988164382
