### PR TITLE
fix(mespapiers): Restrict mime type images for paper creation

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanActions/ScanDesktopActions.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanActions/ScanDesktopActions.jsx
@@ -84,7 +84,7 @@ const ScanDesktopActions = ({ onOpenFilePickerModal, onChangeFile }) => {
         onChange={evt => handleEvent(evt, onChangeFile)}
         className="u-w-100 u-ml-0"
         onClick={e => e.stopPropagation()}
-        accept={'image/*,.pdf'}
+        accept="application/pdf,image/jpeg,image/png"
         data-testid="importPicFromDesktop-btn"
       >
         <Button

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanActions/ScanFlagshipActions.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanActions/ScanFlagshipActions.jsx
@@ -45,7 +45,7 @@ const ScanFlagshipActions = ({
           onChange={evt => handleEvent(evt, onChangeFile)}
           className="u-w-100 u-ml-0"
           onClick={e => e.stopPropagation()}
-          accept={'image/*,.pdf'}
+          accept="application/pdf,image/jpeg,image/png"
           data-testid="importPicFromMobile-btn"
         >
           <Button

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanActions/ScanMobileActions.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanActions/ScanMobileActions.jsx
@@ -44,7 +44,7 @@ const ScanMobileActions = ({ onOpenFilePickerModal, onChangeFile }) => {
           onChange={evt => handleEvent(evt, onChangeFile)}
           className="u-w-100 u-ml-0"
           onClick={e => e.stopPropagation()}
-          accept={'image/*,.pdf'}
+          accept="application/pdf,image/jpeg,image/png"
           data-testid="importPicFromMobile-btn"
         >
           <Button
@@ -64,7 +64,7 @@ const ScanMobileActions = ({ onOpenFilePickerModal, onChangeFile }) => {
           className="u-w-100 u-ta-center u-ml-0"
           onClick={e => e.stopPropagation()}
           capture="environment"
-          accept={'image/*'}
+          accept="image/jpeg,image/png"
           data-testid="takePic-btn"
         >
           <Button


### PR DESCRIPTION
Restrict mime type images, because the process of creating a paper does not accept mime types like `image/svg+xml`, `image/webp`, etc