### PR TITLE
feat(mespapiers): Remove the `stepIndex` property from the config file

### DIFF
--- a/packages/cozy-mespapiers-lib/docs/AddPaperGuidelines.md
+++ b/packages/cozy-mespapiers-lib/docs/AddPaperGuidelines.md
@@ -9,3 +9,5 @@
 - For the `illustration` property in [`acquisitionsteps property`](./papersDefinitions#steps-of-the-acquisitionsteps-property), you must import it and add it to the `images` variable of the [`CompositeHeaderImage`](https://github.com/cozy/cozy-libs/blob/master/packages/cozy-mespapiers-lib/src/components/CompositeHeader/CompositeHeaderImage.jsx#L34) component.
 
 - If adding a `placeholderIndex`, complete this [documentation](https://github.com/cozy/cozy-libs/blob/master/packages/cozy-mespapiers-lib/doc/placeholderIndex.md) accordingly.
+
+- The `Steps` take place in the order defined in the [`acquisitionsteps property`](./papersDefinitions#steps-of-the-acquisitionsteps-property).

--- a/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
+++ b/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
@@ -31,7 +31,6 @@
 ## Steps of the `acquisitionSteps` property:
 
 - ### Step `scan`:
-  - `stepIndex`: {number} Position of the step.
   - `model`: {string} Model used for the step (`scan`).
   - `[tooltip]`: {boolean} Allows to display a tooltip to help the user.
   - `[multipage]`: {boolean} Allows to add as many files as the user wants.
@@ -41,7 +40,6 @@
 <br>
 
 - ### Step `information`:
-  - `stepIndex`: {number} Position of the step.
   - `model`: {string} Model used for the step (`information`).
   - `illustration`: {string} Name of the illustration used on the step (with extension).
   - `[illustrationSize]`: {`small`|`medium`|`large`}(`4rem`|`6rem`|`8rem`) Size of the illustration (default `medium`)
@@ -54,7 +52,6 @@
 <br>
 
 - ### Step `contact`:
-  - `stepIndex`: {number} Position of the step.
   - `model`: {string} Model used for the step (`contact`).
   - `text`: {string} Translation key for the text of the step.
   - `[multiple]`: {boolean} Allows you to add multiple contacts.
@@ -62,7 +59,6 @@
 <br>
 
 - ### Step `note`:
-  - `stepIndex`: {number} Position of the step.
   - `model`: {string} Model used for the step (`note`)
 
 ***

--- a/packages/cozy-mespapiers-lib/src/components/Contexts/StepperDialogProvider.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Contexts/StepperDialogProvider.jsx
@@ -5,14 +5,14 @@ const StepperDialogContext = createContext()
 const StepperDialogProvider = ({ children }) => {
   const [stepperDialogTitle, setStepperDialogTitle] = useState('')
   const [allCurrentSteps, setAllCurrentSteps] = useState([])
-  const [currentStepIndex, setCurrentStepIndex] = useState(1)
+  const [currentStepIndex, setCurrentStepIndex] = useState(0)
   const [currentDefinition, setCurrentDefinition] = useState(null)
 
   const resetStepperDialog = () => {
     setCurrentDefinition(null)
     setStepperDialogTitle('')
     setAllCurrentSteps([])
-    setCurrentStepIndex(1)
+    setCurrentStepIndex(0)
   }
 
   useEffect(() => {
@@ -20,27 +20,24 @@ const StepperDialogProvider = ({ children }) => {
       setStepperDialogTitle(currentDefinition.label)
       const allCurrentStepsDefinitions = currentDefinition.acquisitionSteps
       if (allCurrentStepsDefinitions.length > 0) {
-        const allCurrentStepsDefinitionsSorted =
-          allCurrentStepsDefinitions.sort((a, b) => a.stepIndex - b.stepIndex)
-
-        setAllCurrentSteps(allCurrentStepsDefinitionsSorted)
+        setAllCurrentSteps(allCurrentStepsDefinitions)
       }
     }
   }, [currentDefinition])
 
   const previousStep = () => {
-    if (currentStepIndex > 1) {
+    if (currentStepIndex > 0) {
       setCurrentStepIndex(prev => prev - 1)
     }
   }
 
   const nextStep = () => {
-    allCurrentSteps.length > currentStepIndex &&
+    allCurrentSteps.length > currentStepIndex + 1 &&
       setCurrentStepIndex(prev => prev + 1)
   }
 
   const isLastStep = () => {
-    return currentStepIndex === allCurrentSteps.length
+    return currentStepIndex + 1 === allCurrentSteps.length
   }
 
   const stepperDialog = {

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/ContactDialog.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/ContactDialog.jsx
@@ -37,7 +37,7 @@ const ContactDialog = ({ currentStep, onClose, onBack, onSubmit }) => {
     <>
       <Dialog
         open
-        {...(currentStepIndex > 1 && { transitionDuration: 0, onBack })}
+        {...(currentStepIndex > 0 && { transitionDuration: 0, onBack })}
         onClose={onClose}
         componentsProps={{
           dialogTitle: {

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/helpers.spec.js
@@ -8,7 +8,6 @@ import {
 import { mockPapersDefinitions } from '../../../../test/mockPaperDefinitions'
 
 const informationStep = {
-  stepIndex: 4,
   model: 'information',
   illustration: 'IlluDriverLicenseObtentionDateHelp.png',
   text: 'PaperJSON.driverLicense.obtentionDate.text',

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/InformationDialog.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/InformationDialog.jsx
@@ -75,7 +75,7 @@ const InformationDialog = ({ currentStep, onClose, onBack }) => {
   return (
     <Dialog
       open
-      {...(currentStepIndex > 1 && { transitionDuration: 0 })}
+      {...(currentStepIndex > 0 && { transitionDuration: 0 })}
       onClose={onClose}
       onBack={onBack}
       componentsProps={{

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/NoteDialog.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/NoteDialog.jsx
@@ -48,7 +48,7 @@ const NoteDialog = ({ onClose, onBack }) => {
   return (
     <Dialog
       open
-      {...(currentStepIndex > 1 && { transitionDuration: 0 })}
+      {...(currentStepIndex > 0 && { transitionDuration: 0 })}
       onClose={onClose}
       onBack={onBack}
       componentsProps={{

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanActions/ScanActionsWrapper.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanActions/ScanActionsWrapper.spec.jsx
@@ -12,11 +12,10 @@ import { useFormData } from '../../../Hooks/useFormData'
 import { useStepperDialog } from '../../../Hooks/useStepperDialog'
 import ScanWrapper from '../ScanWrapper'
 
-const mockCurrentStep = ({
-  page = '',
-  multipage = false,
-  stepIndex = 0
-} = {}) => ({ page, multipage, stepIndex })
+const mockCurrentStep = ({ page = '', multipage = false } = {}) => ({
+  page,
+  multipage
+})
 const mockFile = ({ type = '', name = '' } = {}) => ({ type, name })
 const mockFormData = ({ metadata = {}, data = [], contacts = [] } = {}) => ({
   metadata,
@@ -57,6 +56,7 @@ const setup = ({
   setFormData = jest.fn(),
   formData = mockFormData(),
   currentStep = mockCurrentStep(),
+  currentStepIndex = 0,
   isMobileMock = false,
   isFlagshipAppMock = false,
   isScannerAvailable = false
@@ -72,6 +72,7 @@ const setup = ({
     formData
   })
   useStepperDialog.mockReturnValue({
+    currentStepIndex,
     currentDefinition: {},
     allCurrentSteps: []
   })
@@ -137,7 +138,8 @@ describe('Scan component:', () => {
 
   it('CompositeHeader component must be displayed if no file of the current step exists', () => {
     const { queryByTestId } = setup({
-      currentStep: mockCurrentStep({ stepIndex: 1 }),
+      currentStepIndex: 0,
+      currentStep: mockCurrentStep(),
       formData: mockFormData({
         data: [{ stepIndex: 2, file: mockFile({ name: 'test.pdf' }) }]
       })
@@ -148,7 +150,8 @@ describe('Scan component:', () => {
 
   it('ScanResultDialog component must be displayed if a file in the current step exists', () => {
     const { queryByTestId } = setup({
-      currentStep: mockCurrentStep({ stepIndex: 1 }),
+      currentStepIndex: 1,
+      currentStep: mockCurrentStep(),
       formData: mockFormData({
         data: [{ stepIndex: 1, file: mockFile({ name: 'test.pdf' }) }]
       })

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanDialog.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanDialog.jsx
@@ -24,7 +24,7 @@ const ScanDialog = ({
   return (
     <Dialog
       open
-      {...(currentStepIndex > 1 && { transitionDuration: 0, onBack })}
+      {...(currentStepIndex > 0 && { transitionDuration: 0, onBack })}
       onClose={onClose}
       componentsProps={{
         dialogTitle: {

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanWrapper.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanWrapper.jsx
@@ -23,11 +23,11 @@ const { fetchBlobFileById } = models.file
 const ScanWrapper = ({ currentStep, onClose, onBack }) => {
   const client = useClient()
   const [searchParams] = useSearchParams()
-  const { nextStep } = useStepperDialog()
+  const { nextStep, currentStepIndex } = useStepperDialog()
   const { formData, setFormData } = useFormData()
-  const { stepIndex, multipage, page } = currentStep
+  const { multipage, page } = currentStep
   const [currentFile, setCurrentFile] = useState(
-    getLastFormDataFile({ formData: formData, stepIndex })
+    getLastFormDataFile({ formData: formData, currentStepIndex })
   )
   const [isFilePickerModalOpen, setIsFilePickerModalOpen] = useState(false)
   const webviewIntent = useWebviewIntent()
@@ -40,13 +40,16 @@ const ScanWrapper = ({ currentStep, onClose, onBack }) => {
         setFormData(prev => ({
           ...prev,
           data: prev.data.map(data => {
-            if (data.stepIndex === stepIndex && data.file.name === file.name) {
+            if (
+              data.stepIndex === currentStepIndex &&
+              data.file.name === file.name
+            ) {
               return { ...data, file }
             }
             return data
           })
         }))
-      } else if (!isFileAlreadySelected(formData, stepIndex, file)) {
+      } else if (!isFileAlreadySelected(formData, currentStepIndex, file)) {
         setCurrentFile(file)
         setFormData(prev => ({
           ...prev,
@@ -54,7 +57,7 @@ const ScanWrapper = ({ currentStep, onClose, onBack }) => {
             ...prev.data,
             {
               file,
-              stepIndex,
+              stepIndex: currentStepIndex,
               fileMetadata: {
                 page: !multipage ? page : '',
                 multipage

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/ScanResult/ScanResultCard.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/ScanResult/ScanResultCard.jsx
@@ -9,33 +9,25 @@ import Typography from 'cozy-ui/transpiled/react/Typography'
 import styles from './ScanResultCard.styl'
 import ScanResultCardActions from './ScanResultCardActions'
 import { useFormData } from '../../Hooks/useFormData'
+import { useStepperDialog } from '../../Hooks/useStepperDialog'
 import { getLastFormDataFile, isSameFile } from '../helpers'
 import RotateImage from '../widgets/RotateImage'
 
 const isImageType = file => file.type.match(/image\/.*/)
 
 const ScanResultCard = forwardRef(
-  (
-    {
-      currentFile,
-      setCurrentFile,
-      currentStep,
-      setRotationImage,
-      rotationImage
-    },
-    ref
-  ) => {
+  ({ currentFile, setCurrentFile, setRotationImage, rotationImage }, ref) => {
     const { setFormData, formData } = useFormData()
+    const { currentStepIndex } = useStepperDialog()
     const [imgWrapperMinHeight, setImgWrapperMinHeight] = useState(0)
     const [isImageRotating, setIsImageRotating] = useState(false)
-    const { stepIndex } = currentStep
 
     const handleSelectedFile = () => {
       const newData = formData.data.filter(
         data => !isSameFile(currentFile, data.file)
       )
       setCurrentFile(
-        getLastFormDataFile({ formData: { data: newData }, stepIndex })
+        getLastFormDataFile({ formData: { data: newData }, currentStepIndex })
       )
 
       setFormData(prev => ({
@@ -94,7 +86,9 @@ ScanResultCard.displayName = 'ScanResultCard'
 
 ScanResultCard.propTypes = {
   currentFile: PropTypes.object.isRequired,
-  setCurrentFile: PropTypes.func.isRequired
+  setCurrentFile: PropTypes.func.isRequired,
+  setRotationImage: PropTypes.func.isRequired,
+  rotationImage: PropTypes.number.isRequired
 }
 
 export default ScanResultCard

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/ScanResult/ScanResultDialog.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/ScanResult/ScanResultDialog.jsx
@@ -60,7 +60,7 @@ const ScanResultDialog = ({
   return (
     <Dialog
       open
-      {...(currentStepIndex > 1 && { onBack })}
+      {...(currentStepIndex > 0 && { onBack })}
       transitionDuration={0}
       onClose={onClose}
       componentsProps={{
@@ -82,7 +82,6 @@ const ScanResultDialog = ({
           <ScanResultCard
             currentFile={currentFile}
             setCurrentFile={setCurrentFile}
-            currentStep={currentStep}
             rotationImage={rotationImage}
             setRotationImage={setRotationImage}
             ref={imageRef}

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/ScanResult/ScanResultDialog.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/ScanResult/ScanResultDialog.spec.jsx
@@ -7,11 +7,10 @@ import { FormDataProvider } from '../../Contexts/FormDataProvider'
 import { useFormData } from '../../Hooks/useFormData'
 import { useStepperDialog } from '../../Hooks/useStepperDialog'
 
-const mockCurrentStep = ({
-  page = '',
-  multipage = false,
-  stepIndex = 0
-} = {}) => ({ page, multipage, stepIndex })
+const mockCurrentStep = ({ page = '', multipage = false } = {}) => ({
+  page,
+  multipage
+})
 const mockFile = ({ type = '', name = '' } = {}) => ({ type, name })
 const mockFormData = ({ metadata = {}, data = [], contacts = [] } = {}) => ({
   metadata,
@@ -25,11 +24,13 @@ const setup = ({
   nextStep = jest.fn(),
   setFormData = jest.fn(),
   setCurrentFile = jest.fn(),
+  currentStepIndex = 0,
   formData = mockFormData(),
   currentFile = mockFile(),
   currentStep = mockCurrentStep()
 } = {}) => {
   useStepperDialog.mockReturnValue({
+    currentStepIndex,
     nextStep,
     currentDefinition: {},
     allCurrentSteps: []
@@ -158,7 +159,8 @@ describe('AcquisitionResult component:', () => {
       setup({
         setFormData: mockSetFormData,
         currentFile: mockFile({ name: 'test.pdf' }),
-        currentStep: mockCurrentStep({ stepIndex: 1 }),
+        currentStepIndex: 0,
+        currentStep: mockCurrentStep(),
         formData: mockFormData({
           data: [{ stepIndex: 1, file: { name: 'test.pdf' } }]
         })

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/helpers.js
@@ -5,13 +5,17 @@ import { ANDROID_APP_URL, IOS_APP_URL } from '../../constants/const'
 /**
  * Check if a file is already selected in the state of the FormDataProvider
  * @param {object} formData - State of the FormDataProvider
- * @param {number} stepIndex - Used to know if the file is already selected for this step (Some paper have two Scan steps)
+ * @param {number} currentStepIndex - Used to know if the file is already selected for this step (Some paper have two Scan steps)
  * @param {File} currentFile - File object
  * @returns
  */
-export const isFileAlreadySelected = (formData, stepIndex, currentFile) => {
+export const isFileAlreadySelected = (
+  formData,
+  currentStepIndex,
+  currentFile
+) => {
   for (const data of formData.data) {
-    if (data.stepIndex === stepIndex) {
+    if (data.stepIndex === currentStepIndex) {
       if (isSameFile(currentFile, data.file)) {
         return true
       }
@@ -160,11 +164,11 @@ export const makeRotatedImage = (image, rotation) => {
 /**
  * @param {Object} options
  * @param {Array} options.formData - State of the FormDataProvider
- * @param {number} options.stepIndex - Used to know if the file is already selected for this step (Some paper have two Scan steps)
+ * @param {number} options.currentStepIndex - Used to know if the file is already selected for this step (Some paper have two Scan steps)
  * @returns {File} - Last file selected for this step
  */
-export const getLastFormDataFile = ({ formData, stepIndex }) => {
-  const data = formData.data.filter(data => data.stepIndex === stepIndex)
+export const getLastFormDataFile = ({ formData, currentStepIndex }) => {
+  const data = formData.data.filter(data => data.stepIndex === currentStepIndex)
   const { file } = data[data.length - 1] || {}
 
   return file || null

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/FeaturedPlaceholdersList.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/FeaturedPlaceholdersList.spec.jsx
@@ -26,7 +26,6 @@ const fakePlaceholders = [
     maxDisplay: 2,
     acquisitionSteps: [
       {
-        stepIndex: 1,
         model: 'scan',
         page: 'front',
         illustration: 'IlluDriverLicenseFront.png',

--- a/packages/cozy-mespapiers-lib/src/components/Placeholders/Placeholder.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Placeholders/Placeholder.spec.jsx
@@ -25,7 +25,6 @@ const fakePlaceholders = [
     maxDisplay: 2,
     acquisitionSteps: [
       {
-        stepIndex: 1,
         model: 'scan',
         page: 'front',
         illustration: 'IlluDriverLicenseFront.png',

--- a/packages/cozy-mespapiers-lib/src/components/StepperDialog/StepperDialogTitle.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/StepperDialog/StepperDialogTitle.jsx
@@ -20,7 +20,7 @@ const StepperDialogTitle = () => {
         country: currentDefinition.country
       })}
       <Typography variant="h6">
-        {`${currentStepIndex}/${allCurrentSteps.length}`}
+        {`${currentStepIndex + 1}/${allCurrentSteps.length}`}
       </Typography>
     </>
   )

--- a/packages/cozy-mespapiers-lib/src/components/StepperDialog/StepperDialogWrapper.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/StepperDialog/StepperDialogWrapper.jsx
@@ -24,11 +24,11 @@ const StepperDialogWrapper = ({ onClose, onSubmit }) => {
 
   const fromFlagshipUpload = searchParams.get('fromFlagshipUpload')
 
-  return allCurrentSteps.map(currentStep => {
-    if (currentStep.stepIndex === currentStepIndex) {
+  return allCurrentSteps.map((currentStep, idx) => {
+    if (idx === currentStepIndex) {
       const modelPage = currentStep.model.toLowerCase()
 
-      const onBack = () =>
+      const onBack = () => {
         handleBack({
           allCurrentSteps,
           currentStepIndex,
@@ -39,12 +39,13 @@ const StepperDialogWrapper = ({ onClose, onSubmit }) => {
           isMobile,
           onClose
         })
+      }
 
       switch (modelPage) {
         case 'scan':
           return (
             <ScanWrapper
-              key={currentStep.stepIndex}
+              key={idx}
               currentStep={currentStep}
               onClose={onClose}
               onSubmit={onSubmit}
@@ -54,7 +55,7 @@ const StepperDialogWrapper = ({ onClose, onSubmit }) => {
         case 'information':
           return (
             <InformationDialog
-              key={currentStep.stepIndex}
+              key={idx}
               currentStep={currentStep}
               onClose={onClose}
               onSubmit={onSubmit}
@@ -64,7 +65,7 @@ const StepperDialogWrapper = ({ onClose, onSubmit }) => {
         case 'contact':
           return (
             <ContactDialog
-              key={currentStep.stepIndex}
+              key={idx}
               currentStep={currentStep}
               onClose={onClose}
               onSubmit={onSubmit}
@@ -74,7 +75,7 @@ const StepperDialogWrapper = ({ onClose, onSubmit }) => {
         case 'note':
           return (
             <NoteDialog
-              key={currentStep.stepIndex}
+              key={idx}
               currentStep={currentStep}
               onClose={onClose}
               onSubmit={onSubmit}

--- a/packages/cozy-mespapiers-lib/src/components/StepperDialog/StepperDialogWrapper.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/StepperDialog/StepperDialogWrapper.spec.jsx
@@ -20,9 +20,9 @@ jest.mock('../Hooks/useStepperDialog')
 /* eslint-enable react/display-name */
 
 const mockAllCurrentSteps = [
-  { stepIndex: 1, model: 'scan' },
-  { stepIndex: 2, model: 'information' },
-  { stepIndex: 3, model: 'contact' }
+  { model: 'scan' },
+  { model: 'information' },
+  { model: 'contact' }
 ]
 
 describe('StepperDialogWrapper', () => {
@@ -44,7 +44,7 @@ describe('StepperDialogWrapper', () => {
 
   it('should contain only Scan component', () => {
     const { getByTestId, queryByTestId } = setup({
-      currentStepIndex: 1
+      currentStepIndex: 0
     })
 
     expect(getByTestId('ScanWrapper')).toBeInTheDocument()
@@ -54,7 +54,7 @@ describe('StepperDialogWrapper', () => {
 
   it('should contain only InformationDialog component', () => {
     const { getByTestId, queryByTestId } = setup({
-      currentStepIndex: 2
+      currentStepIndex: 1
     })
 
     expect(getByTestId('InformationDialog')).toBeInTheDocument()
@@ -64,7 +64,7 @@ describe('StepperDialogWrapper', () => {
 
   it('should contain only Contact component', () => {
     const { getByTestId, queryByTestId } = setup({
-      currentStepIndex: 3
+      currentStepIndex: 2
     })
 
     expect(getByTestId('ContactDialog')).toBeInTheDocument()

--- a/packages/cozy-mespapiers-lib/src/components/StepperDialog/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/StepperDialog/helpers.js
@@ -8,10 +8,8 @@ export const handleBack = async ({
   isMobile,
   onClose
 }) => {
-  if (currentStepIndex > 1) {
-    const previousDefinition = allCurrentSteps.find(
-      el => el.stepIndex === currentStepIndex - 1
-    )
+  if (currentStepIndex > 0) {
+    const previousDefinition = allCurrentSteps[currentStepIndex - 1]
     const isPreviousScanFront =
       previousDefinition.model === 'scan' &&
       (previousDefinition.page === 'front' ||
@@ -20,7 +18,7 @@ export const handleBack = async ({
     return fromFlagshipUpload
       ? !isPreviousScanFront
         ? previousStep()
-        : currentStepIndex > 2
+        : currentStepIndex > 1
         ? setCurrentStepIndex(currentStepIndex - 2)
         : await webviewIntent?.call('cancelUploadByCozyApp')
       : previousStep()

--- a/packages/cozy-mespapiers-lib/src/components/StepperDialog/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/StepperDialog/helpers.spec.js
@@ -1,9 +1,9 @@
 import { handleBack } from './helpers'
 
 const mockAllCurrentSteps = [
-  { stepIndex: 1, model: 'scan' },
-  { stepIndex: 2, model: 'information' },
-  { stepIndex: 3, model: 'contact' }
+  { model: 'scan' },
+  { model: 'information' },
+  { model: 'contact' }
 ]
 const allCurrentSteps = mockAllCurrentSteps
 const previousStep = jest.fn()
@@ -16,8 +16,8 @@ describe('handleBack', () => {
     jest.resetAllMocks()
   })
 
-  describe('when currentStepIndex <= 1', () => {
-    const currentStepIndex = 1
+  describe('when currentStepIndex == 0', () => {
+    const currentStepIndex = 0
 
     describe('if isMobile is true', () => {
       const isMobile = true
@@ -75,8 +75,8 @@ describe('handleBack', () => {
     })
   })
 
-  describe('when currentStepIndex > 1', () => {
-    const currentStepIndex = 2
+  describe('when currentStepIndex > 0', () => {
+    const currentStepIndex = 1
     const isMobile = undefined
 
     describe('for defined fromFlagshipUpload', () => {
@@ -101,11 +101,11 @@ describe('handleBack', () => {
         it('should go 2 steps back if possible', async () => {
           await handleBack({
             allCurrentSteps: [
-              { stepIndex: 1, model: 'information' },
-              { stepIndex: 2, model: 'scan' },
-              { stepIndex: 3, model: 'contact' }
+              { model: 'information' },
+              { model: 'scan' },
+              { model: 'contact' }
             ],
-            currentStepIndex: 3,
+            currentStepIndex: 2,
             previousStep,
             setCurrentStepIndex,
             fromFlagshipUpload,
@@ -115,7 +115,7 @@ describe('handleBack', () => {
           })
 
           expect(previousStep).not.toBeCalled()
-          expect(setCurrentStepIndex).toBeCalledWith(1)
+          expect(setCurrentStepIndex).toBeCalledWith(0)
           expect(webviewIntent.call).not.toBeCalled()
         })
       })
@@ -124,7 +124,7 @@ describe('handleBack', () => {
         it('should go to the previous step', async () => {
           await handleBack({
             allCurrentSteps,
-            currentStepIndex: 3,
+            currentStepIndex: 2,
             previousStep,
             setCurrentStepIndex,
             fromFlagshipUpload,

--- a/packages/cozy-mespapiers-lib/src/constants/PaperDefinitionsPropTypes.js
+++ b/packages/cozy-mespapiers-lib/src/constants/PaperDefinitionsPropTypes.js
@@ -6,7 +6,6 @@ const PaperDefinitionsStepAttrPropTypes = PropTypes.shape({
 })
 
 export const PaperDefinitionsStepPropTypes = PropTypes.shape({
-  stepIndex: PropTypes.number.isRequired,
   model: PropTypes.string.isRequired,
   multipage: PropTypes.bool,
   page: PropTypes.string,

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -7,14 +7,12 @@
       "maxDisplay": 1,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.issueDate.text",
@@ -27,7 +25,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -41,13 +38,11 @@
       "maxDisplay": 2,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -60,14 +55,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "tooltip": true,
           "illustration": "IlluIBAN.png",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "text": "PaperJSON.bankDetails.number.text",
           "attributes": [
@@ -80,7 +73,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -95,14 +87,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.referencedDate.text",
@@ -115,7 +105,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -130,14 +119,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluCafNumberHelp.png",
           "text": "PaperJSON.caf.number.text",
@@ -150,7 +137,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.issueDate.text",
@@ -163,7 +149,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -180,13 +165,11 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -203,7 +186,6 @@
       "maxDisplay": 2,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "tooltip": true,
           "page": "front",
@@ -211,7 +193,6 @@
           "text": "PaperJSON.generic.front.text"
         },
         {
-          "stepIndex": 2,
           "model": "scan",
           "tooltip": true,
           "page": "back",
@@ -219,7 +200,6 @@
           "text": "PaperJSON.generic.back.text"
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluDriverLicenseNumberHelp.png",
           "text": "PaperJSON.driverLicense.number.text",
@@ -233,7 +213,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "model": "information",
           "illustration": "IlluDriverLicenseObtentionDateHelp.png",
           "text": "PaperJSON.driverLicense.obtentionDate.text",
@@ -261,7 +240,6 @@
           ]
         },
         {
-          "stepIndex": 5,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.driverLicense.expirationDate.text",
@@ -274,7 +252,6 @@
           ]
         },
         {
-          "stepIndex": 6,
           "model": "information",
           "illustration": "IlluGenericAlert.svg",
           "illustrationSize": "small",
@@ -292,7 +269,6 @@
           ]
         },
         {
-          "stepIndex": 7,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -308,14 +284,12 @@
       "maxDisplay": 2,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "Planet.svg",
           "text": "PaperJSON.driverLicense.stranger.country.text",
@@ -328,7 +302,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.driverLicense.stranger.obtentionDate.text",
@@ -341,7 +314,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.driverLicense.expirationDate.text",
@@ -354,7 +326,6 @@
           ]
         },
         {
-          "stepIndex": 5,
           "model": "information",
           "illustration": "IlluGenericAlert.svg",
           "illustrationSize": "small",
@@ -372,7 +343,6 @@
           ]
         },
         {
-          "stepIndex": 6,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -386,7 +356,6 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "tooltip": true,
           "multipage": true,
@@ -394,7 +363,6 @@
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.invoice.referencedDate.text",
@@ -407,7 +375,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -424,14 +391,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -446,13 +411,11 @@
       "maxDisplay": 1,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.shootingDate.text",
@@ -465,7 +428,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -480,14 +442,12 @@
       "maxDisplay": 1,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.referencedDate.text",
@@ -500,7 +460,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "text": "PaperJSON.generic.addressLabel.text",
           "attributes": [
@@ -514,7 +473,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -530,7 +488,6 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "tooltip": true,
           "multipage": true,
@@ -538,7 +495,6 @@
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.invoice.referencedDate.text",
@@ -551,7 +507,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -569,14 +524,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.issueDate.text",
@@ -589,7 +542,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -606,7 +558,6 @@
       "maxDisplay": 2,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "tooltip": true,
           "page": "front",
@@ -614,7 +565,6 @@
           "text": "PaperJSON.card.front.text"
         },
         {
-          "stepIndex": 2,
           "model": "scan",
           "tooltip": true,
           "page": "back",
@@ -622,7 +572,6 @@
           "text": "PaperJSON.card.back.text"
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluIdCardNumberHelp.png",
           "text": "PaperJSON.card.number.text",
@@ -636,7 +585,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "model": "information",
           "illustration": "IlluIdCardExpirationDateHelp.png",
           "text": "PaperJSON.card.expirationDate.text",
@@ -649,7 +597,6 @@
           ]
         },
         {
-          "stepIndex": 5,
           "model": "information",
           "illustration": "IlluGenericAlert.svg",
           "illustrationSize": "small",
@@ -667,7 +614,6 @@
           ]
         },
         {
-          "stepIndex": 6,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -681,14 +627,12 @@
       "maxDisplay": 1,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.referencedDate.text",
@@ -701,7 +645,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -716,14 +659,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "text": "PaperJSON.generic.fileLabel.text",
           "attributes": [
@@ -737,7 +678,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.date.text",
@@ -750,7 +690,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -765,14 +704,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "text": "PaperJSON.generic.fileLabel.text",
           "attributes": [
@@ -786,7 +723,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.date.text",
@@ -799,7 +735,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -815,14 +750,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "text": "PaperJSON.generic.fileLabel.text",
           "attributes": [
@@ -836,7 +769,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.date.text",
@@ -849,7 +781,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -865,14 +796,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "text": "PaperJSON.generic.fileLabel.text",
           "attributes": [
@@ -886,7 +815,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.date.text",
@@ -899,7 +827,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -915,14 +842,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.date.text",
@@ -935,7 +860,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -951,14 +875,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "text": "PaperJSON.generic.fileLabel.text",
           "attributes": [
@@ -972,7 +894,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.date.text",
@@ -985,7 +906,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -1000,14 +920,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "text": "PaperJSON.generic.fileLabel.text",
           "attributes": [
@@ -1021,7 +939,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.date.text",
@@ -1034,7 +951,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -1050,14 +966,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "text": "PaperJSON.generic.fileLabel.text",
           "attributes": [
@@ -1071,7 +985,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.date.text",
@@ -1084,7 +997,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -1100,7 +1012,6 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "tooltip": true,
           "multipage": true,
@@ -1108,7 +1019,6 @@
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "Contract.svg",
           "text": "PaperJSON.work_contract.contract_type.text",
@@ -1122,7 +1032,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.date.text",
@@ -1135,7 +1044,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": false,
@@ -1151,14 +1059,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "text": "PaperJSON.generic.fileLabel.text",
           "attributes": [
@@ -1172,7 +1078,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.referencedDate.text",
@@ -1185,7 +1090,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -1200,14 +1104,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.date.text",
@@ -1220,7 +1122,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -1234,14 +1135,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluCafNumberHelp.png",
           "text": "PaperJSON.payment_proof_family_allowance.number.text",
@@ -1254,7 +1153,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.issueDate.text",
@@ -1267,7 +1165,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -1285,7 +1182,6 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "tooltip": true,
           "multipage": true,
@@ -1293,7 +1189,6 @@
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.invoice.referencedDate.text",
@@ -1306,7 +1201,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -1324,14 +1218,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.referencedDate.text",
@@ -1344,7 +1236,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -1359,7 +1250,6 @@
       "maxDisplay": 2,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "tooltip": true,
           "page": "front",
@@ -1367,7 +1257,6 @@
           "text": "PaperJSON.card.front.text"
         },
         {
-          "stepIndex": 2,
           "model": "scan",
           "tooltip": true,
           "page": "back",
@@ -1375,7 +1264,6 @@
           "text": "PaperJSON.card.back.text"
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluResidencePermitNumberHelp.png",
           "text": "PaperJSON.card.number.text",
@@ -1389,7 +1277,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "model": "information",
           "illustration": "IlluResidencePermitExpirationDateHelp.png",
           "text": "PaperJSON.card.expirationDate.text",
@@ -1402,7 +1289,6 @@
           ]
         },
         {
-          "stepIndex": 5,
           "model": "information",
           "illustration": "IlluGenericAlert.svg",
           "illustrationSize": "small",
@@ -1420,7 +1306,6 @@
           ]
         },
         {
-          "stepIndex": 6,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -1434,14 +1319,12 @@
       "maxDisplay": 1,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.referencedDate.text",
@@ -1454,7 +1337,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -1468,14 +1350,12 @@
       "maxDisplay": 1,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.referencedDate.text",
@@ -1488,7 +1368,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -1503,14 +1382,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputText.svg",
           "text": "PaperJSON.tax_notice.refTaxIncome.text",
@@ -1523,7 +1400,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.referencedDate.text",
@@ -1536,7 +1412,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -1554,14 +1429,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.date.text",
@@ -1574,7 +1447,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -1592,14 +1464,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.referencedDate.text",
@@ -1612,7 +1482,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -1630,14 +1499,12 @@
       "maxDisplay": 1,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.issueDate.text",
@@ -1650,7 +1517,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "text": "PaperJSON.generic.addressLabel.text",
           "attributes": [
@@ -1664,7 +1530,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -1678,14 +1543,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "tooltip": true,
           "illustration": "IlluVehicleRegistration.png",
           "text": "PaperJSON.generic.content.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "text": "PaperJSON.vehicleRegistration.number.text",
           "attributes": [
@@ -1698,7 +1561,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -1713,7 +1575,6 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "tooltip": true,
           "multipage": true,
@@ -1721,7 +1582,6 @@
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.invoice.referencedDate.text",
@@ -1734,7 +1594,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -1750,7 +1609,6 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "tooltip": true,
           "multipage": true,
@@ -1758,7 +1616,6 @@
           "text": "PaperJSON.passport.scan.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "Planet.svg",
           "text": "PaperJSON.passport.information.country.text",
@@ -1771,7 +1628,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluPassportNumber.png",
           "text": "PaperJSON.passport.information.number.text",
@@ -1785,7 +1641,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "model": "information",
           "illustration": "IlluPassportDate.png",
           "text": "PaperJSON.passport.information.expirationDate.text",
@@ -1798,7 +1653,6 @@
           ]
         },
         {
-          "stepIndex": 5,
           "model": "information",
           "illustration": "IlluGenericAlert.svg",
           "illustrationSize": "small",
@@ -1816,7 +1670,6 @@
           ]
         },
         {
-          "stepIndex": 6,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -1832,14 +1685,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "text": "PaperJSON.generic.fileLabel.text",
           "attributes": [
@@ -1853,7 +1704,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.date.text",
@@ -1866,7 +1716,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": false,
@@ -1881,14 +1730,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.date.text",
@@ -1901,7 +1748,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": false,
@@ -1919,7 +1765,6 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "tooltip": true,
           "multipage": true,
@@ -1927,7 +1772,6 @@
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.invoice.referencedDate.text",
@@ -1940,7 +1784,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -1954,13 +1797,11 @@
       "featureDate": "referencedDate",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.referencedDate.text",
@@ -1973,7 +1814,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -1986,14 +1826,12 @@
       "featureDate": "referencedDate",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "tooltip": true,
           "illustration": "IlluInvoice.png",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.referencedDate.text",
@@ -2006,7 +1844,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -2020,13 +1857,11 @@
       "featureDate": "referencedDate",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.referencedDate.text",
@@ -2039,7 +1874,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -2055,13 +1889,11 @@
       "featureDate": "referencedDate",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.referencedDate.text",
@@ -2074,7 +1906,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -2087,21 +1918,18 @@
       "featureDate": "referencedDate",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "page": "front",
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.card.front.text"
         },
         {
-          "stepIndex": 2,
           "model": "scan",
           "page": "back",
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.card.back.text"
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.card.expirationDate.text",
@@ -2114,7 +1942,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "model": "information",
           "illustration": "IlluGenericAlert.svg",
           "illustrationSize": "small",
@@ -2132,7 +1959,6 @@
           ]
         },
         {
-          "stepIndex": 5,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -2145,13 +1971,11 @@
       "featureDate": "referencedDate",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.referencedDate.text",
@@ -2164,7 +1988,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -2178,13 +2001,11 @@
       "featureDate": "referencedDate",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.referencedDate.text",
@@ -2197,7 +2018,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -2211,21 +2031,18 @@
       "featureDate": "referencedDate",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "page": "front",
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.card.front.text"
         },
         {
-          "stepIndex": 2,
           "model": "scan",
           "page": "back",
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.card.back.text"
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.referencedDate.text",
@@ -2238,7 +2055,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -2252,21 +2068,18 @@
       "featureDate": "referencedDate",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "page": "front",
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.card.front.text"
         },
         {
-          "stepIndex": 2,
           "model": "scan",
           "page": "back",
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.card.back.text"
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.referencedDate.text",
@@ -2279,7 +2092,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -2292,13 +2104,11 @@
       "featureDate": "referencedDate",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.singlePage.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.referencedDate.text",
@@ -2311,7 +2121,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "illustration": "Account.svg",
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
@@ -2329,14 +2138,12 @@
       "maxDisplay": 3,
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "model": "scan",
           "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.multiPages.text"
         },
         {
-          "stepIndex": 2,
           "model": "information",
           "text": "PaperJSON.generic.fileLabel.text",
           "attributes": [
@@ -2350,7 +2157,6 @@
           ]
         },
         {
-          "stepIndex": 3,
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
           "text": "PaperJSON.generic.date.text",
@@ -2363,7 +2169,6 @@
           ]
         },
         {
-          "stepIndex": 4,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
@@ -2376,14 +2181,12 @@
       "icon": "file-type-note",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
           "text": "PaperJSON.generic.owner.text"
         },
         {
-          "stepIndex": 2,
           "model": "note"
         }
       ]
@@ -2393,14 +2196,12 @@
       "icon": "file-type-note",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
           "text": "PaperJSON.generic.owner.text"
         },
         {
-          "stepIndex": 2,
           "model": "note"
         }
       ]
@@ -2410,14 +2211,12 @@
       "icon": "file-type-note",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
           "text": "PaperJSON.generic.owner.text"
         },
         {
-          "stepIndex": 2,
           "model": "note"
         }
       ]
@@ -2427,14 +2226,12 @@
       "icon": "file-type-note",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
           "text": "PaperJSON.generic.owner.text"
         },
         {
-          "stepIndex": 2,
           "model": "note"
         }
       ]
@@ -2444,14 +2241,12 @@
       "icon": "file-type-note",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
           "text": "PaperJSON.generic.owner.text"
         },
         {
-          "stepIndex": 2,
           "model": "note"
         }
       ]
@@ -2461,14 +2256,12 @@
       "icon": "file-type-note",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
           "text": "PaperJSON.generic.owner.text"
         },
         {
-          "stepIndex": 2,
           "model": "note"
         }
       ]
@@ -2478,14 +2271,12 @@
       "icon": "file-type-note",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
           "text": "PaperJSON.generic.owner.text"
         },
         {
-          "stepIndex": 2,
           "model": "note"
         }
       ]
@@ -2495,14 +2286,12 @@
       "icon": "file-type-note",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
           "text": "PaperJSON.generic.owner.text"
         },
         {
-          "stepIndex": 2,
           "model": "note"
         }
       ]
@@ -2512,14 +2301,12 @@
       "icon": "file-type-note",
       "acquisitionSteps": [
         {
-          "stepIndex": 1,
           "illustration": "Account.svg",
           "model": "contact",
           "multiple": true,
           "text": "PaperJSON.generic.owner.text"
         },
         {
-          "stepIndex": 2,
           "model": "note"
         }
       ]

--- a/packages/cozy-mespapiers-lib/src/helpers/buildPapersDefinitions.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/buildPapersDefinitions.spec.js
@@ -25,22 +25,14 @@ describe('buildPapersDefinitions', () => {
     },
     {
       label: 'other_three',
-      acquisitionSteps: [
-        {
-          stepIndex: 1
-        }
-      ],
+      acquisitionSteps: [],
       konnectorCriteria: {
         name: 'myKonnector'
       }
     },
     {
       label: 'note_identity_document',
-      acquisitionSteps: [
-        {
-          stepIndex: 1
-        }
-      ]
+      acquisitionSteps: []
     },
     {
       label: 'four',
@@ -48,11 +40,7 @@ describe('buildPapersDefinitions', () => {
     },
     {
       label: 'one',
-      acquisitionSteps: [
-        {
-          stepIndex: 1
-        }
-      ],
+      acquisitionSteps: [],
       konnectorCriteria: {
         name: 'myKonnector'
       }
@@ -62,11 +50,7 @@ describe('buildPapersDefinitions', () => {
   const expectedPapersDef = [
     {
       label: 'one',
-      acquisitionSteps: [
-        {
-          stepIndex: 1
-        }
-      ],
+      acquisitionSteps: [],
       konnectorCriteria: {
         name: 'myKonnector'
       }
@@ -80,22 +64,14 @@ describe('buildPapersDefinitions', () => {
     },
     {
       label: 'other_three',
-      acquisitionSteps: [
-        {
-          stepIndex: 1
-        }
-      ],
+      acquisitionSteps: [],
       konnectorCriteria: {
         name: 'myKonnector'
       }
     },
     {
       label: 'note_identity_document',
-      acquisitionSteps: [
-        {
-          stepIndex: 1
-        }
-      ]
+      acquisitionSteps: []
     },
     {
       label: 'four',

--- a/packages/cozy-mespapiers-lib/src/helpers/filterWithRemaining.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/filterWithRemaining.spec.js
@@ -1,10 +1,9 @@
 import { filterWithRemaining } from './filterWithRemaining'
 
 const mockObjectInArray = [
-  { stepIndex: 1, model: 'scan' },
-  { stepIndex: 2, model: 'information' },
-  { stepIndex: 3, model: 'owner' },
-  { stepIndex: 4 }
+  { model: 'scan' },
+  { model: 'information' },
+  { model: 'owner' }
 ]
 
 describe('filterWithRemaining', () => {
@@ -13,12 +12,8 @@ describe('filterWithRemaining', () => {
     const res = filterWithRemaining(mockObjectInArray, testFunction)
 
     expect(res).toStrictEqual({
-      itemsFound: [{ stepIndex: 3, model: 'owner' }],
-      remainingItems: [
-        { stepIndex: 1, model: 'scan' },
-        { stepIndex: 2, model: 'information' },
-        { stepIndex: 4 }
-      ]
+      itemsFound: [{ model: 'owner' }],
+      remainingItems: [{ model: 'scan' }, { model: 'information' }]
     })
   })
 
@@ -27,11 +22,8 @@ describe('filterWithRemaining', () => {
     const res = filterWithRemaining(mockObjectInArray, testFunction)
 
     expect(res).toStrictEqual({
-      itemsFound: [
-        { stepIndex: 1, model: 'scan' },
-        { stepIndex: 3, model: 'owner' }
-      ],
-      remainingItems: [{ stepIndex: 2, model: 'information' }, { stepIndex: 4 }]
+      itemsFound: [{ model: 'scan' }, { model: 'owner' }],
+      remainingItems: [{ model: 'information' }]
     })
   })
 
@@ -40,12 +32,8 @@ describe('filterWithRemaining', () => {
     const res = filterWithRemaining(mockObjectInArray, testFunction)
 
     expect(res).toStrictEqual({
-      itemsFound: [{ stepIndex: 2, model: 'information' }],
-      remainingItems: [
-        { stepIndex: 1, model: 'scan' },
-        { stepIndex: 3, model: 'owner' },
-        { stepIndex: 4 }
-      ]
+      itemsFound: [{ model: 'information' }],
+      remainingItems: [{ model: 'scan' }, { model: 'owner' }]
     })
   })
 })

--- a/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
@@ -7,7 +7,6 @@ import { hasItemByLabel } from '../components/Home/helpers'
  */
 /**
  * @typedef {Object} AcquisitionSteps
- * @property {number} stepIndex - Position of the step.
  * @property {number} occurrence - Number of occurrence for this step.
  * @property {string} illustration - Name of the illustration.
  * @property {string} text - Text of the step.

--- a/packages/cozy-mespapiers-lib/test/mockPaperDefinitions.js
+++ b/packages/cozy-mespapiers-lib/test/mockPaperDefinitions.js
@@ -7,14 +7,12 @@ export const mockPapersDefinitions = [
     maxDisplay: 6,
     acquisitionSteps: [
       {
-        stepIndex: 1,
         model: 'scan',
         multipage: true,
         illustration: 'IlluInvoice.png',
         text: 'PaperJSON.generic.multiPages.text'
       },
       {
-        stepIndex: 2,
         model: 'information',
         illustration: 'IlluGenericDate.svg',
         text: 'PaperJSON.generic.referencedDate.text',
@@ -27,7 +25,6 @@ export const mockPapersDefinitions = [
         ]
       },
       {
-        stepIndex: 3,
         model: 'owner',
         text: 'PaperJSON.generic.owner.text'
       }
@@ -43,14 +40,12 @@ export const mockPapersDefinitions = [
     maxDisplay: 3,
     acquisitionSteps: [
       {
-        stepIndex: 1,
         model: 'scan',
         multipage: true,
         illustration: 'IlluGenericNewPage.svg',
         text: 'PaperJSON.generic.multiPages.text'
       },
       {
-        stepIndex: 2,
         model: 'information',
         illustration: 'IlluGenericDate.svg',
         text: 'PaperJSON.generic.date.text',
@@ -63,7 +58,6 @@ export const mockPapersDefinitions = [
         ]
       },
       {
-        stepIndex: 3,
         model: 'owner',
         text: 'PaperJSON.generic.owner.text'
       }
@@ -99,14 +93,12 @@ export const mockPapersDefinitions = [
     maxDisplay: 2,
     acquisitionSteps: [
       {
-        stepIndex: 1,
         model: 'scan',
         multipage: true,
         illustration: 'IlluGenericNewPage.svg',
         text: 'PaperJSON.generic.multiPages.text'
       },
       {
-        stepIndex: 2,
         model: 'information',
         illustration: 'IlluDriverLicenseNumberHelp.png',
         text: 'PaperJSON.driverLicense.stranger.country.text',
@@ -119,7 +111,6 @@ export const mockPapersDefinitions = [
         ]
       },
       {
-        stepIndex: 3,
         model: 'information',
         illustration: 'IlluDriverLicenseObtentionDateHelp.png',
         text: 'PaperJSON.driverLicense.stranger.obtentionDate.text',
@@ -133,7 +124,6 @@ export const mockPapersDefinitions = [
         ]
       },
       {
-        stepIndex: 4,
         illustration: 'Account.svg',
         model: 'contact',
         text: 'PaperJSON.generic.owner.text'
@@ -148,14 +138,12 @@ export const mockPapersDefinitions = [
     maxDisplay: 2,
     acquisitionSteps: [
       {
-        stepIndex: 1,
         model: 'scan',
         multipage: true,
         illustration: 'IlluGenericNewPage.svg',
         text: 'PaperJSON.generic.multiPages.text'
       },
       {
-        stepIndex: 2,
         model: 'information',
         illustration: 'IlluDriverLicenseNumberHelp.png',
         text: 'PaperJSON.driverLicense.stranger.country.text',
@@ -168,7 +156,6 @@ export const mockPapersDefinitions = [
         ]
       },
       {
-        stepIndex: 3,
         model: 'information',
         illustration: 'IlluDriverLicenseObtentionDateHelp.png',
         text: 'PaperJSON.driverLicense.stranger.obtentionDate.text',
@@ -182,7 +169,6 @@ export const mockPapersDefinitions = [
         ]
       },
       {
-        stepIndex: 4,
         illustration: 'Account.svg',
         model: 'contact',
         text: 'PaperJSON.generic.owner.text'


### PR DESCRIPTION
This property was added when the project was created.
Its main purpose was to guarantee the order of the steps.
Which is useless in JS because the order of JSON arrays is guaranteed by the language. (https://www.rfc-editor.org/rfc/rfc8259.html#section-1)

This will make it easier to manipulate the steps in addition to making them lighter.