### PR TITLE
feat(cozy-intent): Avoid localMethods rerender

### DIFF
--- a/packages/cozy-intent/src/api/services/NativeService.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.ts
@@ -19,7 +19,7 @@ const log = debug('NativeService')
 export class NativeService {
   private readonly messengerService: typeof NativeMessenger
 
-  private readonly localMethods: NativeMethodsRegister
+  private localMethods: NativeMethodsRegister
   private messengerRegister = {} as MessengerRegister
 
   constructor(
@@ -30,8 +30,12 @@ export class NativeService {
     this.localMethods = localMethods
   }
 
+  public updateLocalMethods = (localMethods: NativeMethodsRegister): void => {
+    this.localMethods = localMethods
+  }
+
   private isNativeEvent(object: unknown): object is NativeEvent {
-    return (object as NativeEvent).nativeEvent?.data !== undefined
+    return (object as NativeEvent).nativeEvent.data !== undefined
   }
 
   private getUri = (source: NativeEvent): string =>

--- a/packages/cozy-intent/src/view/components/NativeIntentProvider.spec.tsx
+++ b/packages/cozy-intent/src/view/components/NativeIntentProvider.spec.tsx
@@ -2,13 +2,40 @@ import 'mutationobserver-shim'
 import React from 'react'
 import { render } from '@testing-library/react'
 
-import { NativeIntentProvider } from '../../view'
 import { mockNativeMethods } from '../../../tests'
+import { NativeIntentProvider } from '../../view'
+
+import { NativeMethodsRegister } from 'api'
 
 describe('NativeIntentProvider', () => {
   it('Should mount', async () => {
     const { findByText } = render(
       <NativeIntentProvider localMethods={mockNativeMethods}>
+        Hello
+      </NativeIntentProvider>
+    )
+
+    expect(await findByText('Hello')).toBeDefined()
+  })
+
+  it('Should update localMethods', async () => {
+    const { findByText, rerender } = render(
+      <NativeIntentProvider localMethods={mockNativeMethods}>
+        Hello
+      </NativeIntentProvider>
+    )
+
+    expect(await findByText('Hello')).toBeDefined()
+
+    rerender(
+      <NativeIntentProvider
+        localMethods={
+          {
+            ...mockNativeMethods,
+            foo: 'bar'
+          } as unknown as NativeMethodsRegister
+        }
+      >
         Hello
       </NativeIntentProvider>
     )

--- a/packages/cozy-intent/src/view/components/NativeIntentProvider.tsx
+++ b/packages/cozy-intent/src/view/components/NativeIntentProvider.tsx
@@ -1,7 +1,7 @@
-import React, { ReactElement } from 'react'
+import React, { ReactElement, useEffect, useRef } from 'react'
 
-import { NativeContext } from '../../view'
 import { NativeMethodsRegister, NativeService } from '../../api'
+import { NativeContext } from '../../view'
 
 interface Props {
   children: React.ReactChild
@@ -20,11 +20,23 @@ export const getNativeIntentService = (): NativeService => {
   return nativeIntentService
 }
 
+/**
+ * `localMethods` can be updated at any time, it will not trigger a re-render of the context provider
+ */
 export const NativeIntentProvider = ({
   children,
   localMethods
 }: Props): ReactElement => {
-  nativeIntentService = new NativeService(localMethods)
+  const hasRendered = useRef(false)
+
+  useEffect(() => {
+    if (!hasRendered.current) {
+      nativeIntentService = new NativeService(localMethods)
+      hasRendered.current = true
+    }
+
+    nativeIntentService?.updateLocalMethods(localMethods)
+  }, [localMethods])
 
   return (
     <NativeContext.Provider value={nativeIntentService}>


### PR DESCRIPTION
Previously, the context was recreated each time the localMethods
reference changed.
Now, if this object change, we will just update the existing
context instance with this new localMethods object.
This will optimize the behaviour of the provider because it avoids
destructive rerenders that are not necessary for the intents
to still work and use the updated localMethods with the existing service