### PR TITLE
fix: Skip the document not found during indexing after a realtime update

### DIFF
--- a/packages/cozy-sharing/src/SharingProvider.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.jsx
@@ -27,7 +27,7 @@ import reducer, {
   getOwner,
   getRecipients,
   getSharingById,
-  getSharingDocIds,
+  getExternalSharingIds,
   getSharingForSelf,
   getSharingType,
   getSharingLink,
@@ -155,7 +155,10 @@ export class SharingProvider extends Component {
     if (internalSharing) {
       updateSharingInStore(this.dispatch, newSharing)
     } else {
-      const docsId = getSharingDocIds(newSharing)
+      const docsId = getExternalSharingIds(
+        newSharing,
+        client.getStackClient().uri
+      )
       this.synchronousJobQueue.push({
         function: createSharingInStore,
         arguments: {

--- a/packages/cozy-sharing/src/helpers/sharings.js
+++ b/packages/cozy-sharing/src/helpers/sharings.js
@@ -5,6 +5,7 @@ import {
   updateInternalObjectFromRealtime,
   normalizeDocFromRealtime
 } from './realtime'
+import logger from '../logger'
 import { addSharing, updateSharing } from '../state'
 
 export const getSharingObject = (internalSharing, sharing) => {
@@ -25,17 +26,21 @@ export const createSharingInStore = async ({
   // TODO Check if we can getByIds to avoid query in map
   await Promise.all(
     docsId.map(async id => {
-      const file =
-        doctype === 'io.cozy.files'
-          ? await client.query(Q(doctype).getById(id))
-          : undefined
+      try {
+        const file =
+          doctype === 'io.cozy.files'
+            ? await client.query(Q(doctype).getById(id))
+            : undefined
 
-      const path =
-        file &&
-        (file.data.path ||
-          (await fetchFilesPaths(client, doctype, [file.data])))
+        const path =
+          file &&
+          (file.data.path ||
+            (await fetchFilesPaths(client, doctype, [file.data])))
 
-      dispatch(addSharing(sharing, path))
+        dispatch(addSharing(sharing, path))
+      } catch (e) {
+        logger.log(e)
+      }
     })
   )
 }

--- a/packages/cozy-sharing/src/state.js
+++ b/packages/cozy-sharing/src/state.js
@@ -395,6 +395,31 @@ export const getSharingDocIds = sharing => {
   return docs
 }
 
+/**
+ * Get ids of shared documents, but only if sharing is ready so files exist
+ * @param {object} sharing
+ * @param {string} instanceUri
+ * @returns {string[]} List of document ids of a sharing
+ */
+export const getExternalSharingIds = (sharing, instanceUri) => {
+  const member = sharing.attributes.members.find(
+    member => member.instance === instanceUri
+  )
+
+  let docs = []
+  if (member?.status === 'ready') {
+    docs = sharing.attributes.rules
+      .map(r => r.values)
+      .reduce((acc, val) => acc.concat(val), [])
+  }
+
+  if (sharing.attributes.shortcut_id) {
+    docs.push(sharing.attributes.shortcut_id)
+  }
+
+  return docs
+}
+
 // Some permissions can not have values since they can
 // be on a global doctype. In that case, we can't sort
 // them by id

--- a/packages/cozy-sharing/src/state.spec.js
+++ b/packages/cozy-sharing/src/state.spec.js
@@ -15,7 +15,8 @@ import reducer, {
   getSharingType,
   getPermissionDocIds,
   getDocumentSharingType,
-  getSharedParentPath
+  getSharedParentPath,
+  getExternalSharingIds
 } from './state'
 import {
   SHARING_1,
@@ -641,5 +642,76 @@ describe('getSharedParentPath', () => {
     expect(
       getSharedParentPath(state, '/folder-3/sub-folder-4/sub-folder-5/file-4')
     ).toBe('/folder-3/sub-folder-4')
+  })
+})
+
+/* eslint-disable jest/no-focused-tests */
+fdescribe('getExternalSharingIds', () => {
+  const getAttributes = (memberStatus = 'mail-not-sent') => ({
+    rules: [
+      {
+        title: 'Photos',
+        doctype: 'io.cozy.files',
+        values: ['5f8c1090afad686a8f7f56cce07e8098'],
+        add: 'sync',
+        update: 'sync',
+        remove: 'sync'
+      }
+    ],
+    members: [
+      {
+        status: 'owner',
+        name: 'Jane Doe',
+        email: 'jane@doe.com',
+        instance: 'http://cozy.tools:8080'
+      },
+      {
+        status: memberStatus,
+        name: 'John Doe',
+        email: 'john@doe.com',
+        instance: 'http://cozy.local:8080'
+      }
+    ]
+  })
+
+  it('should add shorcut ', () => {
+    const res = getExternalSharingIds(
+      {
+        attributes: {
+          ...getAttributes('ready')
+        }
+      },
+      'http://cozy.local:8080'
+    )
+    expect(res).toStrictEqual(['5f8c1090afad686a8f7f56cce07e8098'])
+  })
+
+  it('should get only shorcut if share is not ready', () => {
+    const res = getExternalSharingIds(
+      {
+        attributes: {
+          ...getAttributes(),
+          shortcut_id: 'c63de58b2c898e457fbdfdc11a24a986'
+        }
+      },
+      'http://cozy.local:8080'
+    )
+    expect(res).toStrictEqual(['c63de58b2c898e457fbdfdc11a24a986'])
+  })
+
+  it('should add shorcut ', () => {
+    const res = getExternalSharingIds(
+      {
+        attributes: {
+          ...getAttributes('ready'),
+          shortcut_id: 'c63de58b2c898e457fbdfdc11a24a986'
+        }
+      },
+      'http://cozy.local:8080'
+    )
+    expect(res).toStrictEqual([
+      '5f8c1090afad686a8f7f56cce07e8098',
+      'c63de58b2c898e457fbdfdc11a24a986'
+    ])
   })
 })


### PR DESCRIPTION
When a new share is made, realtime trigger the indexation of all documents in the new sharing as well as the shortcut. If the recipient has not synchronised the sharing, the document does not exist, leading to errors in the indexing script. This is why we only index files if the share is ready, so that the files exist