### PR TITLE
fix(mespapiers): The text field must not be hidden by the keyboard

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/CompositeHeader/CompositeHeader.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/CompositeHeader/CompositeHeader.jsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles(() => ({
     height: '100%',
     maxWidth: '100%',
     '&.is-focused': {
-      height: 'initial'
+      height: '100vh'
     },
     '& img': {
       margin: '0 auto'


### PR DESCRIPTION
On mobile, when focusing the text field, the keyboard passes in front and we lose the visual of the field.