### PR TITLE
feat: First step to manage OCR result

### DIFF
--- a/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
+++ b/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
@@ -36,6 +36,7 @@
   - `[multipage]`: {boolean} Allows to add as many files as the user wants.
   - `illustration`: {string} Name of the illustration used on the step (with extension).
   - `text`: {string} Translation key for the text of the step.
+  - `[ocr]`: {`only`|`both`} Determine if the step should be shown when OCR is activated.
 
 <br>
 
@@ -49,6 +50,7 @@
     - [`date`](#information-field-attributes): {object} Fields used to enter a date (reference, expiration date, etc).
     - [`radio`](#information-field-attributes): {object} Fields used to enter a radio list.
     - [`contact`](#information-field-attributes): {object} Fields used to select a contact.
+  - `[ocr]`: {`only`|`both`} Determine if the step should be shown when OCR is activated.
 
 <br>
 
@@ -56,13 +58,23 @@
   - `model`: {string} Model used for the step (`contact`).
   - `text`: {string} Translation key for the text of the step.
   - `[multiple]`: {boolean} Allows you to add multiple contacts.
+  - `[ocr]`: {`only`|`both`} Determine if the step should be shown when OCR is activated.
 
 <br>
 
 - ### Step `note`:
   - `model`: {string} Model used for the step (`note`)
+  - `[ocr]`: {`only`|`both`} Determine if the step should be shown when OCR is activated.
 
 ***
+
+## Manage OCR information
+
+The `ocr` property manages the display of steps according to OCR activation. Its different values display the step according to the context:
+
+- `only` displayes the step when OCR is activated
+- `undefined` displayes the step when OCR is disabled
+- `both` displayes the step in any case
 
 ## Information field attributes:
 

--- a/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
+++ b/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
@@ -42,7 +42,7 @@
 
 - ### Step `information`:
   - `model`: {string} Model used for the step (`information`).
-  - `illustration`: {string} Name of the illustration used on the step (with extension).
+  - `illustration`: {string|boolean} Name of the illustration used on the step (with extension). If false, no illustration will be displayed even the fallback
   - `[illustrationSize]`: {`small`|`medium`|`large`}(`4rem`|`6rem`|`8rem`) Size of the illustration (default `medium`)
   - `text`: {string} Translation key for the text of the step.
   - `attributes`: {object} Type of fields.

--- a/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
+++ b/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
@@ -106,3 +106,11 @@ The `ocr` property manages the display of steps according to OCR activation. Its
 
 - Properties of the object to define a field of type `radio`:
   - `options`: {string\[]} Option values
+
+## List of compatible paper with OCR :
+
+- `bank_details`
+- `national_id_card` with `country: "fr"`
+- `driver_license` with `country: "fr"`
+- `residence_permit`
+- `passport`

--- a/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
+++ b/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
@@ -48,6 +48,7 @@
     - [`text|number`](#information-field-attributes) : {object} Fields used to fill in more information about the paper.
     - [`date`](#information-field-attributes): {object} Fields used to enter a date (reference, expiration date, etc).
     - [`radio`](#information-field-attributes): {object} Fields used to enter a radio list.
+    - [`contact`](#information-field-attributes): {object} Fields used to select a contact.
 
 <br>
 
@@ -68,7 +69,7 @@
 - Properties of the object to define a field of type `text|number`:
   - `name`: {string} Used for `filenameModel` attributes
   - `inputLabel`: {string} Translation key for the label
-  - `[type]`: {`text`|`number`} Type of field (if no mask)
+  - `[type]`: {`text`|`number`|`contact`} Type of field (if no mask)
   - `[withAdornment]`: {`start`|`end`} Add a text as a prefix or suffix
     - `[start]`: {string} Add a text as a prefix
     - `[end]`: {string} Add a text as a suffix

--- a/packages/cozy-mespapiers-lib/src/components/CompositeHeader/CompositeHeader.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/CompositeHeader/CompositeHeader.jsx
@@ -5,7 +5,6 @@ import React, { isValidElement } from 'react'
 
 import { iconPropType } from 'cozy-ui/transpiled/react/Icon'
 import Typography from 'cozy-ui/transpiled/react/Typography'
-import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import { makeStyles } from 'cozy-ui/transpiled/react/styles'
 
 import CompositeHeaderImage from './CompositeHeaderImage'
@@ -16,7 +15,7 @@ const useStyles = makeStyles(() => ({
     flexDirection: 'column',
     justifyContent: 'center',
     textAlign: 'center',
-    height: '100%',
+    minHeight: '100%',
     maxWidth: '100%',
     '&.is-focused': {
       height: '100vh'
@@ -36,7 +35,6 @@ const CompositeHeader = ({
   className,
   ...restProps
 }) => {
-  const { isMobile } = useBreakpoints()
   const styles = useStyles()
 
   return (
@@ -56,15 +54,7 @@ const CompositeHeader = ({
         ))}
       {Text &&
         (isValidElement(Text) || isArray(Text) ? (
-          <div
-            className={cx({
-              ['u-mt-1']: !isMobile || (isArray(Text) && Text.length <= 1),
-              ['u-mt-1 u-mah-5 u-pv-1 u-ov-scroll']:
-                isMobile && isArray(Text) && Text.length > 1
-            })}
-          >
-            {Text}
-          </div>
+          <div className="u-mt-1">{Text}</div>
         ) : (
           <Typography className="u-mt-1">{Text}</Typography>
         ))}

--- a/packages/cozy-mespapiers-lib/src/components/Contexts/FormDataProvider.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Contexts/FormDataProvider.jsx
@@ -1,58 +1,15 @@
 import React, { createContext, useState } from 'react'
-
-import { models, useClient } from 'cozy-client'
-import log from 'cozy-logger'
-import { useI18n } from 'cozy-ui/transpiled/react/I18n'
-import Alerter from 'cozy-ui/transpiled/react/deprecated/Alerter'
-
-import { createPdfAndSave } from '../../helpers/createPdfAndSave'
-import getOrCreateAppFolderWithReference from '../../helpers/getFolderWithReference'
-import { useScannerI18n } from '../Hooks/useScannerI18n'
-import { useStepperDialog } from '../Hooks/useStepperDialog'
-
-const {
-  document: { Qualification }
-} = models
-
 const FormDataContext = createContext()
 
 const FormDataProvider = ({ children }) => {
-  const client = useClient()
-  const { f, t } = useI18n()
-  const scannerT = useScannerI18n()
-  const { currentDefinition, stepperDialogTitle } = useStepperDialog()
   const [formData, setFormData] = useState({
     metadata: {},
     data: [],
     contacts: []
   })
 
-  const formSubmit = async () => {
-    try {
-      const qualification = Qualification.getByLabel(stepperDialogTitle)
-      const { _id: appFolderID } = await getOrCreateAppFolderWithReference(
-        client,
-        t
-      )
-
-      await createPdfAndSave({
-        formData,
-        qualification,
-        currentDefinition,
-        appFolderID,
-        client,
-        i18n: { t, f, scannerT }
-      })
-
-      Alerter.success('common.saveFile.success', { duration: 4000 })
-    } catch (error) {
-      log('error', error)
-      Alerter.error('common.saveFile.error', { duration: 4000 })
-    }
-  }
-
   return (
-    <FormDataContext.Provider value={{ formData, setFormData, formSubmit }}>
+    <FormDataContext.Provider value={{ formData, setFormData }}>
       {children}
     </FormDataContext.Provider>
   )

--- a/packages/cozy-mespapiers-lib/src/components/Contexts/StepperDialogProvider.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Contexts/StepperDialogProvider.jsx
@@ -1,5 +1,7 @@
 import React, { createContext, useEffect, useState } from 'react'
 
+import { filterSteps } from '../../helpers/filterSteps'
+
 const StepperDialogContext = createContext()
 
 const StepperDialogProvider = ({ children }) => {
@@ -20,7 +22,8 @@ const StepperDialogProvider = ({ children }) => {
       setStepperDialogTitle(currentDefinition.label)
       const allCurrentStepsDefinitions = currentDefinition.acquisitionSteps
       if (allCurrentStepsDefinitions.length > 0) {
-        setAllCurrentSteps(allCurrentStepsDefinitions)
+        const filteredSteps = filterSteps(allCurrentStepsDefinitions)
+        setAllCurrentSteps(filteredSteps)
       }
     }
   }, [currentDefinition])

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Contact.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Contact.jsx
@@ -17,36 +17,11 @@ const styleAvatar = {
   backgroundColor: 'var(--primaryColorLightest)'
 }
 
-const Contact = ({
-  contact,
-  multiple,
-  contactIdsSelected,
-  setContactIdsSelected
-}) => {
+const Contact = ({ contact, multiple, selected, onSelection }) => {
   const { t } = useI18n()
 
-  const onClickContactLine = val => {
-    const newValue = val?.target?.value || val
-
-    if (multiple) {
-      const newContactIdSelected = [...contactIdsSelected]
-      const find = newContactIdSelected.indexOf(newValue)
-
-      if (find > -1) newContactIdSelected.splice(find, 1)
-      else newContactIdSelected.push(newValue)
-
-      setContactIdsSelected(newContactIdSelected)
-    } else {
-      setContactIdsSelected([newValue])
-    }
-  }
-
   return (
-    <ListItem
-      button
-      key={contact._id}
-      onClick={() => onClickContactLine(contact._id)}
-    >
+    <ListItem button key={contact._id} onClick={() => onSelection(contact._id)}>
       <ListItemIcon>
         <Avatar size="small" style={styleAvatar} />
       </ListItemIcon>
@@ -58,15 +33,15 @@ const Contact = ({
       <ListItemSecondaryAction className="u-mr-half">
         {multiple ? (
           <Checkbox
-            checked={contactIdsSelected.includes(contact._id)}
-            onChange={onClickContactLine}
+            checked={selected}
+            onChange={onSelection}
             value={contact._id}
             name="checkbox-contactsList"
           />
         ) : (
           <Radio
-            checked={contactIdsSelected.includes(contact._id)}
-            onChange={onClickContactLine}
+            checked={selected}
+            onChange={onSelection}
             value={contact._id}
             name="radio-contactsList"
           />

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/ContactDialog.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/ContactDialog.jsx
@@ -18,7 +18,7 @@ import StepperDialogTitle from '../StepperDialog/StepperDialogTitle'
 const ContactDialog = ({ currentStep, onClose, onBack, onSubmit }) => {
   const { t } = useI18n()
   const client = useClient()
-  const { setFormData } = useFormData()
+  const { formData, setFormData } = useFormData()
   const { currentStepIndex, nextStep, isLastStep } = useStepperDialog()
   const [currentUser, setCurrentUser] = useState(null)
   const [contactsSelected, setContactsSelected] = useState([])
@@ -86,6 +86,7 @@ const ContactDialog = ({ currentStep, onClose, onBack, onSubmit }) => {
         actions={
           SubmitButtonComponent ? (
             <SubmitButtonComponent
+              formData={formData}
               onSubmit={onSubmit}
               disabled={buttonDisabled}
             />

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/ContactDialog.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/ContactDialog.jsx
@@ -5,33 +5,49 @@ import { useClient } from 'cozy-client'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Paper from 'cozy-ui/transpiled/react/Paper'
 
 import ContactList from './ContactList'
 import SubmitButton from './widgets/SubmitButton'
 import { fetchCurrentUser } from '../../helpers/fetchCurrentUser'
 import CompositeHeader from '../CompositeHeader/CompositeHeader'
+import { useFormData } from '../Hooks/useFormData'
 import { useStepperDialog } from '../Hooks/useStepperDialog'
 import StepperDialogTitle from '../StepperDialog/StepperDialogTitle'
 
 const ContactDialog = ({ currentStep, onClose, onBack, onSubmit }) => {
   const { t } = useI18n()
   const client = useClient()
+  const { setFormData } = useFormData()
   const { currentStepIndex, nextStep, isLastStep } = useStepperDialog()
   const [currentUser, setCurrentUser] = useState(null)
-  const [contactIdsSelected, setContactIdsSelected] = useState([])
+  const [contactsSelected, setContactsSelected] = useState([])
   const [contactModalOpened, setContactModalOpened] = useState(false)
   const { illustration, text, multiple } = currentStep
 
   const SubmitButtonComponent = isLastStep() ? SubmitButton : null
-  const buttonDisabled = contactIdsSelected.length === 0 || contactModalOpened
+  const buttonDisabled = contactsSelected.length === 0 || contactModalOpened
 
   useEffect(() => {
     const init = async () => {
       const myself = await fetchCurrentUser(client)
       setCurrentUser(myself)
+      setFormData(prev => ({
+        ...prev,
+        contacts: [myself]
+      }))
+      setContactsSelected([myself])
     }
     init()
-  }, [client])
+  }, [client, setFormData])
+
+  const handleContactSelection = contacts => {
+    setContactsSelected(contacts)
+    setFormData(prev => ({
+      ...prev,
+      contacts: contacts
+    }))
+  }
 
   return (
     <>
@@ -52,14 +68,17 @@ const ContactDialog = ({ currentStep, onClose, onBack, onSubmit }) => {
             title={t(text)}
             text={
               currentUser && (
-                <ContactList
-                  multiple={multiple}
-                  currentUser={currentUser}
-                  contactIdsSelected={contactIdsSelected}
-                  setContactIdsSelected={setContactIdsSelected}
-                  contactModalOpened={contactModalOpened}
-                  setContactModalOpened={setContactModalOpened}
-                />
+                <Paper elevation={2} className="u-mt-1 u-mh-half">
+                  <ContactList
+                    className="u-pv-0"
+                    multiple={multiple}
+                    selected={contactsSelected}
+                    currentUser={currentUser}
+                    onSelection={handleContactSelection}
+                    contactModalOpened={contactModalOpened}
+                    setContactModalOpened={setContactModalOpened}
+                  />
+                </Paper>
               )
             }
           />

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/InformationDialog.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/InformationDialog.jsx
@@ -9,6 +9,7 @@ import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import useEventListener from 'cozy-ui/transpiled/react/hooks/useEventListener'
 
+import SubmitButton from './widgets/SubmitButton'
 import IlluGenericInputDate from '../../assets/icons/IlluGenericInputDate.svg'
 import IlluGenericInputText from '../../assets/icons/IlluGenericInputText.svg'
 import { KEYS } from '../../constants/const'
@@ -19,7 +20,7 @@ import { useFormData } from '../Hooks/useFormData'
 import { useStepperDialog } from '../Hooks/useStepperDialog'
 import StepperDialogTitle from '../StepperDialog/StepperDialogTitle'
 
-const InformationDialog = ({ currentStep, onClose, onBack }) => {
+const InformationDialog = ({ currentStep, onClose, onBack, onSubmit }) => {
   const {
     illustration,
     illustrationSize = 'medium',
@@ -27,9 +28,8 @@ const InformationDialog = ({ currentStep, onClose, onBack }) => {
     attributes
   } = currentStep
   const { t } = useI18n()
-  const { currentStepIndex } = useStepperDialog()
+  const { currentStepIndex, nextStep, isLastStep } = useStepperDialog()
   const { formData, setFormData } = useFormData()
-  const { nextStep } = useStepperDialog()
   const [value, setValue] = useState({})
   const [validInput, setValidInput] = useState({})
   const [isFocus, setIsFocus] = useState(false)
@@ -54,6 +54,17 @@ const InformationDialog = ({ currentStep, onClose, onBack }) => {
     [submit]
   )
 
+  const newFormData = useMemo(
+    () => ({
+      ...formData,
+      metadata: {
+        ...formData.metadata,
+        ...value
+      }
+    }),
+    [formData, value]
+  )
+
   useEventListener(window, 'keydown', handleKeyDown)
 
   const inputs = makeInputsInformationStep(attributes)
@@ -71,6 +82,9 @@ const InformationDialog = ({ currentStep, onClose, onBack }) => {
     attributes?.[0]?.type === 'date'
       ? IlluGenericInputDate
       : IlluGenericInputText
+
+  const showSubmitButton = isLastStep()
+  const isActionButtonDisabled = !allInputsValid
 
   return (
     <Dialog
@@ -111,16 +125,24 @@ const InformationDialog = ({ currentStep, onClose, onBack }) => {
         />
       }
       actions={
-        <Button
-          label={t('common.next')}
-          onClick={submit}
-          fullWidth
-          onTouchEnd={evt => {
-            evt.preventDefault()
-            submit()
-          }}
-          disabled={!allInputsValid}
-        />
+        showSubmitButton ? (
+          <SubmitButton
+            onSubmit={onSubmit}
+            disabled={isActionButtonDisabled}
+            formData={newFormData}
+          />
+        ) : (
+          <Button
+            label={t('common.next')}
+            onClick={submit}
+            fullWidth
+            onTouchEnd={evt => {
+              evt.preventDefault()
+              submit()
+            }}
+            disabled={isActionButtonDisabled}
+          />
+        )
       }
     />
   )

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/InformationDialog.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/InformationDialog.jsx
@@ -100,10 +100,10 @@ const InformationDialog = ({ currentStep, onClose, onBack, onSubmit }) => {
       title={<StepperDialogTitle />}
       content={
         <CompositeHeader
-          icon={illustration}
+          icon={illustration ? illustration : null}
           iconSize={illustrationSize}
           className={isFocus && isIOS() ? 'is-focused' : ''}
-          fallbackIcon={fallbackIcon}
+          fallbackIcon={illustration !== false ? fallbackIcon : null}
           title={t(text)}
           text={inputs.map(({ Component, attrs }, idx) => (
             <div
@@ -150,7 +150,7 @@ const InformationDialog = ({ currentStep, onClose, onBack, onSubmit }) => {
 
 InformationDialog.propTypes = {
   currentStep: PropTypes.shape({
-    illustration: PropTypes.string,
+    illustration: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     illustrationSize: PropTypes.string,
     text: PropTypes.string,
     attributes: PropTypes.arrayOf(PropTypes.object)

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanWrapper.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanWrapper.jsx
@@ -35,6 +35,7 @@ const ScanWrapper = ({ currentStep, onClose, onBack }) => {
   const fromFlagshipUpload = searchParams.get('fromFlagshipUpload')
 
   const onChangeFile = (file, { replace = false } = {}) => {
+    // TODO : Integrate the values recovered by the OCR
     if (file) {
       if (replace) {
         setFormData(prev => ({
@@ -81,6 +82,7 @@ const ScanWrapper = ({ currentStep, onClose, onBack }) => {
   const onOpenFlagshipScan = async () => {
     try {
       const base64 = await webviewIntent.call('scanDocument')
+      // TODO : Launch ocr after scanning the document
       const file = makeFileFromBase64({
         source: base64,
         name: 'flagshipScanTemp.png',

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/ContactAdapter/ContactAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/ContactAdapter/ContactAdapter.jsx
@@ -1,0 +1,109 @@
+import PropTypes from 'prop-types'
+import React, { useState, useEffect } from 'react'
+
+import { useClient } from 'cozy-client'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import BottomIcon from 'cozy-ui/transpiled/react/Icons/Bottom'
+import InputAdornment from 'cozy-ui/transpiled/react/InputAdornment'
+import TextField from 'cozy-ui/transpiled/react/TextField'
+
+import { SingleContactPicker } from './SingleContactPicker'
+import { makeDisplayName } from './helpers'
+import { fetchCurrentUser } from '../../../../helpers/fetchCurrentUser'
+import { useFormData } from '../../../Hooks/useFormData'
+
+const ContactAdapter = ({ attrs: { inputLabel }, setValidInput, idx }) => {
+  const { t } = useI18n()
+  const client = useClient()
+  const { setFormData } = useFormData()
+
+  const [contactModalOpened, setContactModalOpened] = useState(false)
+  const [contactPickerOpened, setContactPickerOpened] = useState(false)
+  const [contactSelected, setContactSelected] = useState(null)
+  const [currentUser, setCurrentUser] = useState()
+
+  useEffect(() => {
+    const init = async () => {
+      const myself = await fetchCurrentUser(client)
+      setCurrentUser(myself)
+      setContactSelected(myself)
+      setFormData(prev => ({
+        ...prev,
+        contacts: [myself]
+      }))
+    }
+    init()
+  }, [client, setContactSelected, setFormData])
+
+  const showContactPicker = () => {
+    setContactPickerOpened(true)
+  }
+  const hideContactPicker = () => {
+    setContactPickerOpened(false)
+  }
+
+  const isValidInputValue = contactSelected !== null
+
+  useEffect(() => {
+    setValidInput(prev => ({
+      ...prev,
+      [idx]: isValidInputValue
+    }))
+  }, [idx, isValidInputValue, setValidInput])
+
+  const label = inputLabel ? t(inputLabel) : ''
+
+  const handleContactSelection = contact => {
+    setContactSelected(contact)
+    setFormData(prev => ({
+      ...prev,
+      contacts: [contact]
+    }))
+  }
+
+  return (
+    <>
+      <TextField
+        name="contacts"
+        value={makeDisplayName(contactSelected, t)}
+        type="button"
+        onClick={showContactPicker}
+        variant="outlined"
+        label={label}
+        fullWidth
+        inputProps={{
+          className: 'u-ta-left'
+        }}
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              <Icon icon={BottomIcon} />
+            </InputAdornment>
+          )
+        }}
+      />
+      {contactPickerOpened && currentUser ? (
+        <SingleContactPicker
+          label={label}
+          selected={contactSelected}
+          onSelection={handleContactSelection}
+          currentUser={currentUser}
+          onClose={hideContactPicker}
+          contactModalOpened={contactModalOpened}
+          setContactModalOpened={setContactModalOpened}
+        />
+      ) : null}
+    </>
+  )
+}
+
+ContactAdapter.propTypes = {
+  attrs: PropTypes.shape({
+    inputLabel: PropTypes.string
+  }),
+  setValidInput: PropTypes.func.isRequired,
+  idx: PropTypes.number
+}
+
+export { ContactAdapter }

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/ContactAdapter/SingleContactPicker.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/ContactAdapter/SingleContactPicker.jsx
@@ -1,0 +1,77 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import BottomSheet, {
+  BottomSheetItem,
+  BottomSheetTitle
+} from 'cozy-ui/transpiled/react/BottomSheet'
+import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import Divider from 'cozy-ui/transpiled/react/Divider'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+import ContactList from '../../ContactList'
+
+const SingleContactPicker = ({
+  label,
+  selected,
+  contactModalOpened,
+  setContactModalOpened,
+  currentUser,
+  onSelection,
+  onClose
+}) => {
+  const { isMobile } = useBreakpoints()
+
+  const handleSelection = contacts => {
+    onSelection(contacts[0])
+    onClose()
+  }
+
+  const contactListProps = {
+    currentUser,
+    multiple: false,
+    withoutDivider: true,
+    contactModalOpened,
+    setContactModalOpened,
+    selected: selected ? [selected] : [],
+    onSelection: handleSelection
+  }
+
+  if (isMobile) {
+    return (
+      <BottomSheet open backdrop onClose={onClose}>
+        <BottomSheetItem disableGutters>
+          <BottomSheetTitle label={label} />
+          <Divider />
+          <ContactList {...contactListProps} />
+        </BottomSheetItem>
+      </BottomSheet>
+    )
+  }
+  return (
+    <ConfirmDialog
+      title={label}
+      open
+      onClose={onClose}
+      disableGutters
+      componentsProps={{
+        dialogTitle: {
+          className: 'u-mt-1-half'
+        }
+      }}
+      content={<ContactList {...contactListProps} />}
+    />
+  )
+}
+
+SingleContactPicker.propTypes = {
+  label: PropTypes.string.isRequired,
+  selected: PropTypes.object.isRequired,
+  onSelection: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+  contactModalOpened: PropTypes.bool.isRequired,
+  setContactModalOpened: PropTypes.func.isRequired,
+  currentUser: PropTypes.object.isRequired
+}
+
+export { SingleContactPicker }

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/ContactAdapter/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/ContactAdapter/helpers.js
@@ -1,0 +1,16 @@
+import { getDisplayName } from 'cozy-client/dist/models/contact'
+
+/**
+ * Make the display name and adds me mention if its the current user
+ * @param {object} contact
+ * @param {Function} t function to translate a key
+ * @returns {string} display name
+ */
+export const makeDisplayName = (contact, t) => {
+  if (contact) {
+    return `${getDisplayName(contact)} ${
+      contact.me ? `(${t('ContactStep.me')})` : ''
+    }`
+  }
+  return ''
+}

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/SubmitButton.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/SubmitButton.spec.jsx
@@ -5,7 +5,6 @@ import React from 'react'
 
 import SubmitButton from './SubmitButton'
 import AppLike from '../../../../test/components/AppLike'
-import { useFormData } from '../../Hooks/useFormData'
 
 const mockFormData = ({ metadata = {}, data = [], contacts = [] } = {}) => ({
   metadata,
@@ -13,7 +12,6 @@ const mockFormData = ({ metadata = {}, data = [], contacts = [] } = {}) => ({
   contacts
 })
 
-jest.mock('../../Hooks/useFormData')
 /* eslint-disable react/display-name */
 jest.mock('./ConfirmReplaceFile', () => () => (
   <div data-testid="ConfirmReplaceFile" />
@@ -22,37 +20,35 @@ jest.mock('./ConfirmReplaceFile', () => () => (
 
 const setup = ({
   formData = mockFormData(),
-  formSubmit = jest.fn(),
   onSubmit = jest.fn(),
   disabled = false
 } = {}) => {
-  useFormData.mockReturnValue({
-    formData,
-    setFormData: jest.fn(),
-    formSubmit
-  })
   return render(
     <AppLike>
-      <SubmitButton onSubmit={onSubmit} disabled={disabled} />
+      <SubmitButton
+        formData={formData}
+        onSubmit={onSubmit}
+        disabled={disabled}
+      />
     </AppLike>
   )
 }
 
 describe('ContactDialog', () => {
   it('should submit when save button is clicked, if the file is from user device', async () => {
-    const mockFormSubmit = jest.fn()
+    const submitSpy = jest.fn()
     const mockFetchCurrentUser = jest.fn(() => ({ _id: '1234' }))
     const userDeviceFile = new File([{}], 'userDeviceFile')
     const { findByTestId } = setup({
       formData: mockFormData({ data: [{ file: userDeviceFile }] }),
-      formSubmit: mockFormSubmit,
+      onSubmit: submitSpy,
       mockFetchCurrentUser
     })
 
     const btn = await findByTestId('ButtonSave')
     fireEvent.click(btn)
 
-    expect(mockFormSubmit).toBeCalledTimes(1)
+    expect(submitSpy).toBeCalledTimes(1)
   })
 
   it('should not diplay ConfirmReplaceFile modal when save button is clicked, if the file is from User Device', () => {

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -63,6 +63,7 @@
         },
         {
           "model": "information",
+          "illustration": false,
           "text": "PaperJSON.generic.ocrResult.text",
           "attributes": [
             {
@@ -239,6 +240,7 @@
         },
         {
           "model": "information",
+          "illustration": false,
           "text": "PaperJSON.generic.ocrResult.text",
           "attributes": [
             {
@@ -645,6 +647,7 @@
         },
         {
           "model": "information",
+          "illustration": false,
           "text": "PaperJSON.generic.ocrResult.text",
           "attributes": [
             {
@@ -1370,6 +1373,7 @@
         },
         {
           "model": "information",
+          "illustration": false,
           "text": "PaperJSON.generic.ocrResult.text",
           "attributes": [
             {
@@ -1766,6 +1770,7 @@
         },
         {
           "model": "information",
+          "illustration": false,
           "text": "PaperJSON.generic.ocrResult.text",
           "attributes": [
             {

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -58,7 +58,31 @@
           "model": "scan",
           "tooltip": true,
           "illustration": "IlluIBAN.png",
-          "text": "PaperJSON.generic.singlePage.text"
+          "text": "PaperJSON.generic.singlePage.text",
+          "ocr": "both"
+        },
+        {
+          "model": "information",
+          "text": "PaperJSON.generic.ocrResult.text",
+          "attributes": [
+            {
+              "name": "number",
+              "type": "text",
+              "mask": "aa** 9999 9999 99** **** **** *99",
+              "inputLabel": "PaperJSON.bankDetails.number.inputLabel"
+            },
+            {
+              "name": "bicNumber",
+              "type": "text",
+              "maxLength": 11,
+              "inputLabel": "PaperJSON.bankDetails.bicNumber.inputLabel"
+            },
+            {
+              "type": "contact",
+              "inputLabel": "PaperJSON.generic.owner.inputLabel"
+            }
+          ],
+          "ocr": "only"
         },
         {
           "model": "information",
@@ -202,14 +226,47 @@
           "tooltip": true,
           "page": "front",
           "illustration": "IlluDriverLicenseFront.png",
-          "text": "PaperJSON.generic.front.text"
+          "text": "PaperJSON.generic.front.text",
+          "ocr": "both"
         },
         {
           "model": "scan",
           "tooltip": true,
           "page": "back",
           "illustration": "IlluDriverLicenseBack.png",
-          "text": "PaperJSON.generic.back.text"
+          "text": "PaperJSON.generic.back.text",
+          "ocr": "both"
+        },
+        {
+          "model": "information",
+          "text": "PaperJSON.generic.ocrResult.text",
+          "attributes": [
+            {
+              "name": "number",
+              "type": "text",
+              "maxLength": 12,
+              "inputLabel": "PaperJSON.driverLicense.number.inputLabel"
+            },
+            {
+              "name": "expirationDate",
+              "type": "date",
+              "inputLabel": "PaperJSON.generic.expirationDate.inputLabel"
+            },
+            {
+              "name": "noticePeriod",
+              "type": "number",
+              "withAdornment": {
+                "end": "PaperJSON.generic.noticePeriod.endAdornment"
+              },
+              "maxLength": 3,
+              "inputLabel": "PaperJSON.generic.noticePeriod.inputLabel"
+            },
+            {
+              "type": "contact",
+              "inputLabel": "PaperJSON.generic.owner.inputLabel"
+            }
+          ],
+          "ocr": "only"
         },
         {
           "model": "information",
@@ -249,7 +306,8 @@
               "type": "date",
               "inputLabel": "PaperJSON.driverLicense.DObtentionDate.inputLabel"
             }
-          ]
+          ],
+          "ocr": "both"
         },
         {
           "model": "information",
@@ -574,14 +632,47 @@
           "tooltip": true,
           "page": "front",
           "illustration": "IlluIdCardFront.png",
-          "text": "PaperJSON.card.front.text"
+          "text": "PaperJSON.card.front.text",
+          "ocr": "both"
         },
         {
           "model": "scan",
           "tooltip": true,
           "page": "back",
           "illustration": "IlluIdCardBack.png",
-          "text": "PaperJSON.card.back.text"
+          "text": "PaperJSON.card.back.text",
+          "ocr": "both"
+        },
+        {
+          "model": "information",
+          "text": "PaperJSON.generic.ocrResult.text",
+          "attributes": [
+            {
+              "name": "number",
+              "type": "text",
+              "maxLength": 12,
+              "inputLabel": "PaperJSON.card.number.inputLabel"
+            },
+            {
+              "name": "expirationDate",
+              "type": "date",
+              "inputLabel": "PaperJSON.card.expirationDate.inputLabel"
+            },
+            {
+              "name": "noticePeriod",
+              "type": "number",
+              "withAdornment": {
+                "end": "PaperJSON.generic.noticePeriod.endAdornment"
+              },
+              "maxLength": 3,
+              "inputLabel": "PaperJSON.generic.noticePeriod.inputLabel"
+            },
+            {
+              "type": "contact",
+              "inputLabel": "PaperJSON.generic.owner.inputLabel"
+            }
+          ],
+          "ocr": "only"
         },
         {
           "model": "information",
@@ -1266,14 +1357,47 @@
           "tooltip": true,
           "page": "front",
           "illustration": "IlluResidencePermitFront.png",
-          "text": "PaperJSON.card.front.text"
+          "text": "PaperJSON.card.front.text",
+          "ocr": "both"
         },
         {
           "model": "scan",
           "tooltip": true,
           "page": "back",
           "illustration": "IlluResidencePermitBack.png",
-          "text": "PaperJSON.card.back.text"
+          "text": "PaperJSON.card.back.text",
+          "ocr": "both"
+        },
+        {
+          "model": "information",
+          "text": "PaperJSON.generic.ocrResult.text",
+          "attributes": [
+            {
+              "name": "number",
+              "type": "number",
+              "maxLength": 12,
+              "inputLabel": "PaperJSON.card.number.inputLabel"
+            },
+            {
+              "name": "expirationDate",
+              "type": "date",
+              "inputLabel": "PaperJSON.card.expirationDate.inputLabel"
+            },
+            {
+              "name": "noticePeriod",
+              "type": "number",
+              "withAdornment": {
+                "end": "PaperJSON.generic.noticePeriod.endAdornment"
+              },
+              "maxLength": 3,
+              "inputLabel": "PaperJSON.generic.noticePeriod.inputLabel"
+            },
+            {
+              "type": "contact",
+              "inputLabel": "PaperJSON.generic.owner.inputLabel"
+            }
+          ],
+          "ocr": "only"
         },
         {
           "model": "information",
@@ -1637,7 +1761,44 @@
           "tooltip": true,
           "multipage": true,
           "illustration": "IlluPassport.png",
-          "text": "PaperJSON.passport.scan.text"
+          "text": "PaperJSON.passport.scan.text",
+          "ocr": "both"
+        },
+        {
+          "model": "information",
+          "text": "PaperJSON.generic.ocrResult.text",
+          "attributes": [
+            {
+              "name": "country",
+              "type": "text",
+              "inputLabel": "PaperJSON.passport.information.country.inputLabel"
+            },
+            {
+              "name": "number",
+              "type": "text",
+              "maxLength": 12,
+              "inputLabel": "PaperJSON.passport.information.number.inputLabel"
+            },
+            {
+              "name": "expirationDate",
+              "type": "date",
+              "inputLabel": "PaperJSON.passport.information.expirationDate.inputLabel"
+            },
+            {
+              "name": "noticePeriod",
+              "type": "number",
+              "withAdornment": {
+                "end": "PaperJSON.generic.noticePeriod.endAdornment"
+              },
+              "maxLength": 3,
+              "inputLabel": "PaperJSON.generic.noticePeriod.inputLabel"
+            },
+            {
+              "type": "contact",
+              "inputLabel": "PaperJSON.generic.owner.inputLabel"
+            }
+          ],
+          "ocr": "only"
         },
         {
           "model": "information",

--- a/packages/cozy-mespapiers-lib/src/helpers/filterSteps.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/filterSteps.js
@@ -1,0 +1,19 @@
+import { isOCRActivated } from './isOCRActivated'
+
+/**
+ * Filter a list of step with OCR contraint
+ * @param {object[]} steps list of step
+ * @returns list of step filtered
+ */
+const filterSteps = steps => {
+  const isOCR = isOCRActivated(steps)
+  return steps.filter(step => {
+    if (isOCR) {
+      return step.ocr === 'both' || step.ocr === 'only'
+    } else {
+      return step?.ocr !== 'only'
+    }
+  })
+}
+
+export { filterSteps }

--- a/packages/cozy-mespapiers-lib/src/helpers/filterSteps.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/filterSteps.spec.js
@@ -1,0 +1,38 @@
+import { filterSteps } from './filterSteps'
+import { isOCRActivated } from './isOCRActivated'
+
+jest.mock('./isOCRActivated', () => ({
+  isOCRActivated: jest.fn()
+}))
+
+describe('filterSteps', () => {
+  const steps = [
+    { model: 'scan', ocr: 'both' },
+    {
+      model: 'information',
+      ocr: 'only'
+    },
+    { model: 'information', ocr: 'randomValue' },
+    { model: 'contact' }
+  ]
+
+  it('should return step with ocr as only or both when OCR is activated', () => {
+    isOCRActivated.mockReturnValue(true)
+    expect(filterSteps(steps)).toStrictEqual([
+      { model: 'scan', ocr: 'both' },
+      {
+        model: 'information',
+        ocr: 'only'
+      }
+    ])
+  })
+
+  it('should return step with ocr as undefined or both when OCR is desactivated', () => {
+    isOCRActivated.mockReturnValue(false)
+    expect(filterSteps(steps)).toStrictEqual([
+      { model: 'scan', ocr: 'both' },
+      { model: 'information', ocr: 'randomValue' },
+      { model: 'contact' }
+    ])
+  })
+})

--- a/packages/cozy-mespapiers-lib/src/helpers/isOCRActivated.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/isOCRActivated.js
@@ -1,0 +1,17 @@
+import { isFlagshipApp } from 'cozy-device-helper'
+import flag from 'cozy-flags'
+
+import { isOCRCompliant } from './isOCRCompliant'
+
+const isOCRActivated = steps => {
+  // TODO : Check whether the Flagship application has OCR capability
+  if (
+    isFlagshipApp() &&
+    isOCRCompliant(steps) &&
+    flag('mespapiers.ocr.enabled')
+  )
+    return true
+  return false
+}
+
+export { isOCRActivated }

--- a/packages/cozy-mespapiers-lib/src/helpers/isOCRActivated.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/isOCRActivated.spec.js
@@ -1,0 +1,82 @@
+import { isFlagshipApp } from 'cozy-device-helper'
+import flag from 'cozy-flags'
+
+import { isOCRActivated } from './isOCRActivated'
+
+jest.mock('cozy-device-helper', () => ({
+  ...jest.requireActual('cozy-device-helper'),
+  isFlagshipApp: jest.fn()
+}))
+jest.mock('cozy-flags')
+
+describe('isOCRActivated', () => {
+  const stepsWithOCR = [
+    { model: 'scan', text: 'PaperJSON.generic.singlePage.text', ocr: 'both' },
+    {
+      model: 'information',
+      text: 'PaperJSON.card.number.inputLabel',
+      ocr: 'only'
+    },
+    { model: 'contact', text: 'PaperJSON.generic.owner.text' }
+  ]
+
+  const stepsWithoutOCR = [
+    { model: 'scan', text: 'PaperJSON.generic.singlePage.text' },
+    {
+      model: 'information',
+      text: 'PaperJSON.card.number.inputLabel'
+    },
+    { model: 'contact', text: 'PaperJSON.generic.owner.text' }
+  ]
+
+  const setup = ({
+    flagship = false,
+    enabled = false,
+    compatible = false
+  } = {}) => {
+    flag.mockReturnValue(enabled)
+    isFlagshipApp.mockReturnValue(flagship)
+    return isOCRActivated(compatible ? stepsWithOCR : stepsWithoutOCR)
+  }
+
+  it('should return false if any criteria is missing (flagship, compatible, enabled)', () => {
+    const res = setup()
+    expect(res).toBe(false)
+  })
+
+  it('should return true if meet all criteria (flagship, compatible, enabled)', () => {
+    const res = setup({
+      flagship: true,
+      enabled: true,
+      compatible: true
+    })
+    expect(res).toBe(true)
+  })
+
+  it('should return false if it is not on the flagship app', () => {
+    const res = setup({
+      flagship: false,
+      enabled: true,
+      compatible: true
+    })
+    expect(res).toBe(false)
+  })
+
+  it('should return false if mespapiers.ocr.enabled is not true', () => {
+    const res = setup({
+      flagship: true,
+      enabled: false,
+      compatible: true
+    })
+    expect(res).toBe(false)
+  })
+
+  it('should return false if any step is compatible with ocr', () => {
+    const res = setup({
+      flagship: true,
+      enabled: true,
+      compatible: false
+    })
+    expect(res).toBe(false)
+  })
+})

--- a/packages/cozy-mespapiers-lib/src/helpers/isOCRCompliant.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/isOCRCompliant.js
@@ -1,0 +1,5 @@
+const isOCRCompliant = steps => {
+  return steps.some(step => 'ocr' in step)
+}
+
+export { isOCRCompliant }

--- a/packages/cozy-mespapiers-lib/src/helpers/isOCRCompliant.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/isOCRCompliant.spec.js
@@ -1,0 +1,27 @@
+import { isOCRCompliant } from './isOCRCompliant'
+
+describe('isOCRCompliant', () => {
+  it('should return true if the ocr attribute exist in some step', () => {
+    const steps = [
+      { model: 'scan', text: 'PaperJSON.generic.singlePage.text', ocr: 'both' },
+      {
+        model: 'information',
+        text: 'PaperJSON.card.number.inputLabel',
+        ocr: 'only'
+      },
+      { model: 'contact', text: 'PaperJSON.generic.owner.text' }
+    ]
+    expect(isOCRCompliant(steps)).toBe(true)
+  })
+  it('should return false if the ocr attribute does not exist in any step', () => {
+    const steps = [
+      { model: 'scan', text: 'PaperJSON.generic.singlePage.text' },
+      {
+        model: 'information',
+        text: 'PaperJSON.card.number.inputLabel'
+      },
+      { model: 'contact', text: 'PaperJSON.generic.owner.text' }
+    ]
+    expect(isOCRCompliant(steps)).toBe(false)
+  })
+})

--- a/packages/cozy-mespapiers-lib/src/helpers/makeInputsInformationStep.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/makeInputsInformationStep.js
@@ -1,3 +1,4 @@
+import { ContactAdapter } from '../components/ModelSteps/widgets/ContactAdapter/ContactAdapter'
 import InputDateAdapter from '../components/ModelSteps/widgets/InputDateAdapter'
 import InputTextAdapter from '../components/ModelSteps/widgets/InputTextAdapter'
 import RadioAdapter from '../components/ModelSteps/widgets/RadioAdapter'
@@ -10,6 +11,9 @@ const hasInputText = ({ attrs }) => {
 }
 const hasRadio = ({ attrs }) => {
   return attrs.type === 'radio'
+}
+const hasContact = ({ attrs }) => {
+  return attrs.type === 'contact'
 }
 
 const inputInformationSpecs = {
@@ -24,6 +28,10 @@ const inputInformationSpecs = {
   radio: {
     condition: hasRadio,
     component: RadioAdapter
+  },
+  contact: {
+    condition: hasContact,
+    component: ContactAdapter
   }
 }
 

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -199,6 +199,9 @@
         "inputLabel": "Expiration alert",
         "text": "Be alerted before the document expires",
         "endAdornment": "day before |||| days before"
+      },
+      "ocrResult": {
+        "text": "Check the following information"
       }
     },
     "invoice": {

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -199,6 +199,9 @@
         "inputLabel": "Alerte d'expiration",
         "text": "Être alerté avant l'expiration du document",
         "endAdornment": "jour avant |||| jours avant"
+      },
+      "ocrResult": {
+        "text": "Vérifier les informations suivantes"
       }
     },
     "invoice": {


### PR DESCRIPTION
This first step is to manage the user interface. The next step will be to launch and retrieve the data proposed by OCR. I've put TODOs in places that will need additional code to complete the functionality. The feature is behind a flag called `mespapiers.ocr.enabled`