### PR TITLE
feat(cozy-intent): Add `ocr` and `isOcrAvailable` on API methods

### DIFF
--- a/packages/cozy-intent/src/api/models/methods.ts
+++ b/packages/cozy-intent/src/api/models/methods.ts
@@ -25,6 +25,8 @@ interface _NativeMethodsRegister {
   isNativePassInstalledOnDevice: () => Promise<boolean>
   scanDocument: () => Promise<Base64 | undefined>
   isScannerAvailable: () => Promise<boolean>
+  ocr: (base64: string) => unknown
+  isOcrAvailable: () => Promise<boolean>
   openAppOSSettings: () => Promise<null>
 }
 


### PR DESCRIPTION
Add API method signatures for new OCR feature

`ocr` method's return type is `unknown` to avoid redeclaring the entire `MlkitOcrResult` type from `react-native-mlkit-ocr` module

This should not be a problem for now as this new API should be consumed from JS code

Related PR: cozy/cozy-flagship-app#959