### PR TITLE
fix: Optimize the request

### DIFF
--- a/packages/cozy-harvest-lib/src/connections/accounts.spec.js
+++ b/packages/cozy-harvest-lib/src/connections/accounts.spec.js
@@ -417,19 +417,14 @@ describe('Account mutations', () => {
 describe('fetchReusableAccount', () => {
   const setup = ({ accounts, triggers }) => {
     const client = new CozyClient({})
-    client.collection = jest.fn(doctype => {
-      if (doctype === 'io.cozy.triggers') {
-        return {
-          all: jest.fn().mockResolvedValue({ data: triggers })
-        }
-      } else {
-        throw new Error(`client.collection for ${doctype} is not mocked`)
-      }
-    })
     client.query = jest.fn().mockImplementation(() => {
       return {
         data: accounts
       }
+    })
+
+    client.queryAll = jest.fn().mockImplementation(() => {
+      return triggers
     })
     return { client }
   }


### PR DESCRIPTION
No need to get the current_state (of mapping all the jobs) for the triggers here. So let's make a call to /data/io.cozy.triggers instead