### PR TITLE
fix(cozy-intent): Use service as ref, not props

### DIFF
--- a/packages/cozy-intent/src/view/components/NativeIntentProvider.spec.tsx
+++ b/packages/cozy-intent/src/view/components/NativeIntentProvider.spec.tsx
@@ -1,11 +1,10 @@
+import { render, act } from '@testing-library/react'
+import { NativeMethodsRegister } from 'api'
 import 'mutationobserver-shim'
-import React from 'react'
-import { render } from '@testing-library/react'
+import React, { useEffect } from 'react'
 
 import { mockNativeMethods } from '../../../tests'
-import { NativeIntentProvider } from '../../view'
-
-import { NativeMethodsRegister } from 'api'
+import { NativeIntentProvider, useNativeIntent } from '../../view'
 
 describe('NativeIntentProvider', () => {
   it('Should mount', async () => {
@@ -41,5 +40,28 @@ describe('NativeIntentProvider', () => {
     )
 
     expect(await findByText('Hello')).toBeDefined()
+  })
+
+  it('Should be available to child on first render without rejecting promises', () => {
+    const TestChildComponent = (): JSX.Element => {
+      const nativeService = useNativeIntent()
+
+      useEffect(() => {
+        const callMethodAsync = async (): Promise<void> => {
+          await nativeService?.call('any', 'thing')
+        }
+        void callMethodAsync()
+      }, [nativeService])
+
+      return <div>Child Component</div>
+    }
+
+    act(() => {
+      render(
+        <NativeIntentProvider localMethods={mockNativeMethods}>
+          <TestChildComponent />
+        </NativeIntentProvider>
+      )
+    })
   })
 })


### PR DESCRIPTION
This PR introduces a refactor in the `NativeIntentProvider` component to manage the instance of `NativeService` more efficiently, ensuring that it is created only once and preserved across re-renders, while also updating its `localMethods` smoothly upon prop changes.

#### Changes:

- **`NativeIntentProvider` Component**
  - Introduced a `useRef` to preserve the `NativeService` instance across re-renders.
  - Ensured `NativeService` is instantiated once, and then preserved.
  - Updated `localMethods` in the `NativeService` instance using a `useEffect`.

#### Reasoning:

These changes provide a more reliable and performance-efficient way of managing the `nativeIntentService`:
- **Stable Instance**: Prevents multiple re-instantiations of the `NativeService`, ensuring better performance and preventing unexpected behaviors.
- **Updated Methods**: Ensures that updated `localMethods` are efficiently reflected in the `nativeIntentService`.