### PR TITLE
feat: Add information button redirecting to the store

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
@@ -94,9 +94,7 @@ export const DataTab = ({
             trigger={trigger}
             konnector={konnector}
           />
-          {konnector.vendor_link && (
-            <InformationsCard link={konnector.vendor_link} />
-          )}
+          <InformationsCard konnector={konnector} />
         </Stack>
       </div>
     </div>

--- a/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
@@ -102,7 +102,7 @@ const NewAccountModal = ({ konnector, onSuccess, onDismiss }) => {
           />
 
           {!serverSideKonnector && (
-            <InformationsCard className="u-mt-1" link={konnector.vendor_link} />
+            <InformationsCard className="u-mt-1" konnector={konnector} />
           )}
 
           {/*

--- a/packages/cozy-harvest-lib/src/components/cards/InformationsCard.tsx
+++ b/packages/cozy-harvest-lib/src/components/cards/InformationsCard.tsx
@@ -1,26 +1,48 @@
-import { ListItemText } from '@material-ui/core'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import cx from 'classnames'
 import React from 'react'
 
+import { useClient, generateWebLink } from 'cozy-client'
 import Card from 'cozy-ui/transpiled/react/Card'
 import Divider from 'cozy-ui/transpiled/react/Divider'
-import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import GlobeIcon from 'cozy-ui/transpiled/react/Icons/Globe'
+import StoreIcon from 'cozy-ui/transpiled/react/Icons/Store'
 import List from 'cozy-ui/transpiled/react/List'
 import ListItem from 'cozy-ui/transpiled/react/ListItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import Typography from 'cozy-ui/transpiled/react/Typography'
+import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import { getErrorMessage } from '../../helpers/getErrorMessage'
 import logger from '../../logger'
 
+interface Konnector {
+  vendor_link: string
+  slug: string
+}
 interface InformationsCardProps {
   className?: string
-  link: string
+  konnector: Konnector
 }
 
-const getLabel = (link?: string): string | null => {
+interface StoreButtonProps {
+  appSlug: string
+}
+interface VendorLinkButtonProps {
+  vendorLink: string
+}
+interface ExternalLinkButtonProps {
+  url: string
+  primaryText: string
+  secondaryText: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  icon: any
+}
+
+const getHost = (link?: string): string | null => {
   if (!link) return null
 
   try {
@@ -32,14 +54,87 @@ const getLabel = (link?: string): string | null => {
   }
 }
 
+const ExternalLinkButton = ({
+  url,
+  primaryText,
+  secondaryText,
+  icon
+}: ExternalLinkButtonProps): JSX.Element | null => {
+  return (
+    <ListItem
+      button
+      className="u-mb-half"
+      component="a"
+      href={url}
+      target="_blank"
+    >
+      <ListItemIcon>
+        <Icon icon={icon} size={16} color="textPrimary" />
+      </ListItemIcon>
+
+      <ListItemText primary={primaryText} secondary={secondaryText} />
+    </ListItem>
+  )
+}
+
+const StoreButton = ({ appSlug }: StoreButtonProps): JSX.Element | null => {
+  const client = useClient()
+  const { t } = useI18n()
+  if (!client) {
+    return null
+  }
+  if (!appSlug) {
+    return null
+  }
+  const { cozySubdomainType: subDomainType }: any = client.getInstanceOptions()
+
+  const storeAppName = 'store'
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+  const cozyURL = new URL(client.getStackClient().uri)
+  const nativePath = `/myapps/${appSlug}`
+  const url = generateWebLink({
+    cozyUrl: cozyURL.origin,
+    searchParams: [],
+    pathname: '/',
+    hash: nativePath,
+    slug: storeAppName,
+    subDomainType
+  })
+  return (
+    <ExternalLinkButton
+      url={url}
+      primaryText={t('card.information.store')}
+      secondaryText={t('card.information.storeDescription')}
+      icon={StoreIcon}
+    />
+  )
+}
+
+const VendorLinkButton = ({
+  vendorLink
+}: VendorLinkButtonProps): JSX.Element | null => {
+  const { t } = useI18n()
+  const host = getHost(vendorLink)
+
+  if (!host) {
+    return null
+  }
+
+  return (
+    <ExternalLinkButton
+      url={vendorLink}
+      primaryText={t('card.information.websiteLink')}
+      secondaryText={host}
+      icon={GlobeIcon}
+    />
+  )
+}
+
 export const InformationsCard = ({
   className,
-  link
+  konnector
 }: InformationsCardProps): JSX.Element | null => {
   const { t } = useI18n()
-  const label = getLabel(link)
-
-  if (!label) return null
 
   return (
     <Card className={cx('u-p-0', className)}>
@@ -47,28 +142,14 @@ export const InformationsCard = ({
         className="u-ph-1 u-flex u-flex-items-center"
         style={{ minHeight: '64px' }}
       >
-        <Typography variant="h5">{t('card.websiteLink.title')}</Typography>
+        <Typography variant="h5">{t('card.information.title')}</Typography>
       </div>
 
       <Divider className="u-ml-0 u-maw-100 u-mb-half" />
 
       <List className="u-p-0">
-        <ListItem
-          button
-          className="u-mb-half"
-          component="a"
-          href={link}
-          target="_blank"
-        >
-          <ListItemIcon>
-            <Icon icon={GlobeIcon} size={16} color="textPrimary" />
-          </ListItemIcon>
-
-          <ListItemText
-            primary={t('card.websiteLink.description')}
-            secondary={label}
-          />
-        </ListItem>
+        <StoreButton appSlug={konnector.slug} />
+        <VendorLinkButton vendorLink={konnector.vendor_link} />
       </List>
     </Card>
   )

--- a/packages/cozy-harvest-lib/src/components/cards/RunningAlert.tsx
+++ b/packages/cozy-harvest-lib/src/components/cards/RunningAlert.tsx
@@ -4,9 +4,9 @@ import { isFlagshipApp } from 'cozy-device-helper'
 import Alert from 'cozy-ui/transpiled/react/Alert'
 import AlertTitle from 'cozy-ui/transpiled/react/AlertTitle'
 import Button from 'cozy-ui/transpiled/react/Buttons'
-import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import ArrowUp from 'cozy-ui/transpiled/react/Icons/ArrowUp'
+import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 export const RunningAlert = (): JSX.Element | null => {
   const { t } = useI18n()

--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -136,9 +136,11 @@
         "install": "Discover CoachCO2"
       }
     },
-    "websiteLink": {
+    "information": {
       "title": "Useful information",
-      "description": "Service website"
+      "websiteLink": "Open the website",
+      "store": "See in Cozy Cloud Store",
+      "storeDescription": "Access the description of this konnector app"
     }
   },
   "default": {

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -136,9 +136,11 @@
         "install": "Découvrir Coach CO2"
       }
     },
-    "websiteLink": {
+    "information": {
       "title": "Informations utiles",
-      "description": "Site du service"
+      "websiteLink": "Ouvrir le site",
+      "store": "Voir dans le Store Cozy Cloud",
+      "storeDescription": "Accès la fiche descriptive de cette application connecteur"
     }
   },
   "default": {

--- a/packages/cozy-harvest-lib/src/locales/nl_NL.json
+++ b/packages/cozy-harvest-lib/src/locales/nl_NL.json
@@ -136,9 +136,11 @@
         "install": "Ontdek CoachCO2"
       }
     },
-    "websiteLink": {
+    "information": {
       "title": "Nuttige informatie",
-      "description": "Website van dienst"
+      "websiteLink": "De website openen",
+      "store": "Zie in de Cozy Cloud Store",
+      "storeDescription": "Ga naar de beschrijving van deze konnector app"
     }
   },
   "default": {


### PR DESCRIPTION
When a opening a konnector, we used to only display the vendor link into the 'Information' section.
We now add a button that redirects to the store, so the user can access the description there.

Here what it looks like: 
![image](https://github.com/cozy/cozy-libs/assets/7010087/915e0e3f-92db-4079-9b33-5c932b3b287e)

Note we mention a "Cozy Cloud Store" but this might eventually change to a dynamic name the day we need to support different names  