### PR TITLE
fix: Change flag name to always show the clisk worker

### DIFF
--- a/packages/cozy-harvest-lib/src/policies/clisk.js
+++ b/packages/cozy-harvest-lib/src/policies/clisk.js
@@ -109,7 +109,7 @@ function startLauncher({ konnector, account, trigger, flow }) {
           konnector,
           account,
           trigger,
-          DEBUG: flag('debug') ? true : false
+          DEBUG: flag('clisk.always-show-worker') ? true : false
         }
       })
     )


### PR DESCRIPTION
It was easier at first to be plugged on debug, but this is not ideal anymore since we can have a debug true on a cozy but we don't want to display the worker.