### PR TITLE
fix(harvest): Check the flag during React Lifecycle

### DIFF
--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerCard.jsx
@@ -107,10 +107,6 @@ export const DumbLaunchTriggerCard = ({ flow, className, f, t, disabled }) => {
   )
 }
 
-const DumbComponent = flag('harvest.inappconnectors.enabled')
-  ? LaunchTriggerAlert
-  : DumbLaunchTriggerCard
-
 /**
  * Shows the state of the trigger and provides the ability to
  * relaunch a trigger
@@ -118,6 +114,9 @@ const DumbComponent = flag('harvest.inappconnectors.enabled')
  * - Will follow the connection flow and re-render in case of change
  */
 const LaunchTriggerCard = props => {
+  const DumbComponent = flag('harvest.inappconnectors.enabled')
+    ? LaunchTriggerAlert
+    : DumbLaunchTriggerCard
   if (props.flow) {
     return <DumbComponent {...props} />
   }


### PR DESCRIPTION
It seems that sometime we can display the `DumbLaunchTriggerCard` component even if the flag is on. The result is that the user doesn't have, in that case, anything to manage the account because elsewhere the flag is read during the React lifecycle.

I think this is why we can't reproduce it everytime, it's a race condition between the loading of the flags and the read we do here.

In order to read the flag when the flag's store is populated, we need to read if within the React Lifecycle.

It should fix the issue.