### PR TITLE
fix: Optimize que buildCountTriggersQuery

### DIFF
--- a/packages/cozy-harvest-lib/src/helpers/queries.js
+++ b/packages/cozy-harvest-lib/src/helpers/queries.js
@@ -72,8 +72,13 @@ export const buildAppsByIdQuery = appSlug => ({
 
 export const buildCountTriggersQuery = () => ({
   definition: Q('io.cozy.triggers')
-    .where({ $or: [{ worker: 'client' }, { worker: 'konnector' }] })
-    .indexFields(['worker']),
+    .where({
+      _id: { $gt: null }
+    })
+    .partialIndex({
+      worker: { $in: ['konnector', 'client'] }
+    })
+    .indexFields(['_id']),
   options: {
     as: 'io.cozy.triggers/by_worker_client_konnector',
     fetchPolicy: defaultFetchPolicy


### PR DESCRIPTION
We don't need the current_state of the triggers, so let's call /data/io.cozy.triggers instead of /jobs/triggers. Also use a partialIndex

We had a small "glitch" waiting for the datas to come in before displaying the AccountForm because we need to count the triggers to know if we need to display the AccountForm or the Paywall. 

This is a fix to optimize the query so it should reduce the delay, but a delay should always be there. Maybe we should also display the AccountForm by default and display the paywall only when the check are KO. 

https://github.com/cozy/cozy-libs/assets/1107936/15489559-c06e-4baa-ab4f-e991c5bb1c70

