### PR TITLE
fix: Store wording

### DIFF
--- a/packages/cozy-harvest-lib/src/locales/en.json
+++ b/packages/cozy-harvest-lib/src/locales/en.json
@@ -140,7 +140,7 @@
       "title": "Useful information",
       "websiteLink": "Open the website",
       "store": "See in Cozy Cloud Store",
-      "storeDescription": "Access the description of this konnector app"
+      "storeDescription": "Access the description of this app"
     }
   },
   "default": {

--- a/packages/cozy-harvest-lib/src/locales/fr.json
+++ b/packages/cozy-harvest-lib/src/locales/fr.json
@@ -140,7 +140,7 @@
       "title": "Informations utiles",
       "websiteLink": "Ouvrir le site",
       "store": "Voir dans le Store Cozy Cloud",
-      "storeDescription": "Accès la fiche descriptive de cette application connecteur"
+      "storeDescription": "Accès à la fiche descriptive de cette application"
     }
   },
   "default": {

--- a/packages/cozy-harvest-lib/src/locales/nl_NL.json
+++ b/packages/cozy-harvest-lib/src/locales/nl_NL.json
@@ -140,7 +140,7 @@
       "title": "Nuttige informatie",
       "websiteLink": "De website openen",
       "store": "Zie in de Cozy Cloud Store",
-      "storeDescription": "Ga naar de beschrijving van deze konnector app"
+      "storeDescription": "Ga naar de beschrijving van deze app"
     }
   },
   "default": {


### PR DESCRIPTION
'konnector app' is not very understandable, so we restrict it to 'app'