### PR TITLE
feat: Add isAvailable type and remove isOcrAvailable type

### DIFF
--- a/packages/cozy-intent/src/api/models/methods.ts
+++ b/packages/cozy-intent/src/api/models/methods.ts
@@ -26,8 +26,8 @@ interface _NativeMethodsRegister {
   scanDocument: () => Promise<Base64 | undefined>
   isScannerAvailable: () => Promise<boolean>
   ocr: (base64: string) => unknown
-  isOcrAvailable: () => Promise<boolean>
   openAppOSSettings: () => Promise<null>
+  isAvailable: (featureName: string) => Promise<boolean>
 }
 
 export type NativeMethodsRegister = _NativeMethodsRegister & PostMeDefault

--- a/packages/cozy-intent/src/api/services/NativeService.spec.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.spec.ts
@@ -57,7 +57,8 @@ describe('NativeService', () => {
       openSettingBiometry: jest.fn(),
       toggleSetting: jest.fn(),
       isBiometryDenied: jest.fn(),
-      openAppOSSettings: jest.fn()
+      openAppOSSettings: jest.fn(),
+      isAvailable: jest.fn()
     }
   })
 

--- a/packages/cozy-intent/tests/mocks.ts
+++ b/packages/cozy-intent/tests/mocks.ts
@@ -71,5 +71,6 @@ export const mockNativeMethods: NativeMethodsRegister = {
   openSettingBiometry: jest.fn(),
   toggleSetting: jest.fn(),
   isBiometryDenied: jest.fn(),
-  openAppOSSettings: jest.fn()
+  openAppOSSettings: jest.fn(),
+  isAvailable: jest.fn()
 }


### PR DESCRIPTION
Other isXXXAvailable can not be removed for the moment because they are deployed in production.