### PR TITLE
feat: Allow to offer account with flag harvest.accounts.offers

### DIFF
--- a/packages/cozy-harvest-lib/src/helpers/accounts.js
+++ b/packages/cozy-harvest-lib/src/helpers/accounts.js
@@ -275,7 +275,26 @@ export const checkMaxAccounts = async (slug, client) => {
     trigger => !slugInMaintenance.includes(trigger.message.konnector)
   )
 
-  if (hasReachMaxAccounts(activeTrigger.length)) {
+  const accountCountByKonnector = activeTrigger.reduce(
+    (konnectors, current) => {
+      const slug = current.message.konnector
+      const existingKonnector = konnectors.find(
+        konnector => konnector.slug === slug
+      )
+      if (existingKonnector) {
+        existingKonnector.count += 1
+      } else {
+        konnectors.push({
+          slug,
+          count: 1
+        })
+      }
+      return konnectors
+    },
+    []
+  )
+
+  if (hasReachMaxAccounts(accountCountByKonnector)) {
     return 'max_accounts'
   }
 


### PR DESCRIPTION
The main idea behind this flag is to offer user accounts for a given period and a given konnector. This will also be used for migration to CCC so that users have the same number of connectors at the end