### PR TITLE
feat(cozy-harvest-lib): Reduce the paywall limit by offering accounts

### DIFF
--- a/packages/cozy-harvest-lib/src/helpers/accounts.js
+++ b/packages/cozy-harvest-lib/src/helpers/accounts.js
@@ -275,7 +275,26 @@ export const checkMaxAccounts = async (slug, client) => {
     trigger => !slugInMaintenance.includes(trigger.message.konnector)
   )
 
-  if (hasReachMaxAccounts(activeTrigger.length)) {
+  const accountCountByKonnector = activeTrigger.reduce(
+    (konnectors, current) => {
+      const slug = current.message.konnector
+      const existingKonnector = konnectors.find(
+        konnector => konnector.slug === slug
+      )
+      if (existingKonnector) {
+        existingKonnector.count += 1
+      } else {
+        konnectors.push({
+          slug,
+          count: 1
+        })
+      }
+      return konnectors
+    },
+    []
+  )
+
+  if (hasReachMaxAccounts(accountCountByKonnector)) {
     return 'max_accounts'
   }
 


### PR DESCRIPTION
With the `harvest.accounts.offer` flag, you can list several offers for specific connectors. Each object must include a slug and an offer. You can also specify an expiry date with `expiresAt` in ISO 8601 format