### PR TITLE
fix: Wrap offers into json flag instead an array

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountsPaywall/helpers.js
+++ b/packages/cozy-harvest-lib/src/components/AccountsPaywall/helpers.js
@@ -96,7 +96,7 @@ export function computeNbAccounts(accounts, offers = []) {
  * @returns {boolean} whether the number of accounts allowed for all konnectors has been reached
  */
 export function hasReachMaxAccounts(accounts) {
-  const offers = flag('harvest.accounts.offers') || []
+  const offers = flag('harvest.accounts.offers.list') || []
 
   const nbAccounts = computeNbAccounts(accounts, offers)
 


### PR DESCRIPTION
Our internal tool to manage feature flag use json array only for its own use which is why I'm wrapping the list of offers into a json object. 

Old : 
```json
[
  {"slug": "*", "offer": 4}
]
```

New : 
```json
{
  "list": [
    {"slug": "*", "offer": 4}
  ]
}
``` 
