### PR TITLE
feat: Add a `hideCross` method

### DIFF
--- a/packages/cozy-interapp/src/client.js
+++ b/packages/cozy-interapp/src/client.js
@@ -98,6 +98,16 @@ export function start(createIntent, intent, element, data, options = {}) {
         } finally {
           dom.show(iframe)
         }
+      },
+      onHideCross: () => {
+        if (options.onHideCross) {
+          options.onHideCross()
+        }
+      },
+      onShowCross: () => {
+        if (options.onShowCross) {
+          options.onShowCross()
+        }
       }
     })
 

--- a/packages/cozy-interapp/src/intents.js
+++ b/packages/cozy-interapp/src/intents.js
@@ -1,7 +1,7 @@
 import * as client from './client'
-import * as service from './service'
-import Request from './request'
 import { pickService, buildRedirectionURL, removeQueryString } from './helpers'
+import Request from './request'
+import * as service from './service'
 
 class Intents {
   constructor({ client } = {}) {
@@ -17,10 +17,17 @@ class Intents {
 
     const createPromise = this.request.post(action, type, data, permissions)
 
-    createPromise.start = (element, onReadyCallback) => {
+    createPromise.start = (
+      element,
+      onReadyCallback,
+      onHideCross,
+      onShowCross
+    ) => {
       const options = {
         filteredServices: data.filteredServices,
-        onReadyCallback: onReadyCallback
+        onReadyCallback: onReadyCallback,
+        onHideCross: onHideCross,
+        onShowCross: onShowCross
       }
 
       delete data.filteredServices

--- a/packages/cozy-interapp/src/service.js
+++ b/packages/cozy-interapp/src/service.js
@@ -92,6 +92,18 @@ export const start = request => (intentIdArg, serviceWindowArg) => {
       })
     }
 
+    const hideCross = () => {
+      sendMessage({
+        type: `intent-${intent._id}:hideCross`
+      })
+    }
+
+    const showCross = () => {
+      sendMessage({
+        type: `intent-${intent._id}:showCross`
+      })
+    }
+
     const cancel = () => {
       terminate({ type: `intent-${intent._id}:cancel` })
     }
@@ -123,7 +135,9 @@ export const start = request => (intentIdArg, serviceWindowArg) => {
             error: errorSerializer.serialize(error)
           }),
         resizeClient: resizeClient,
-        cancel: cancel
+        cancel: cancel,
+        hideCross: hideCross,
+        showCross: showCross
       }
     })
   })


### PR DESCRIPTION
Some services can handle by themself the display of the cross to close the intent modale. So in order to let them do that, we can now pass an `onHideCross` method to the intent.

```
hideCross(){
    this.setState({
      closable: false
    })
  }

<Modal
        {...modalProps}
        key="modal"
        className={styles.intentModal}
        closeBtnClassName={styles.intentModal__cross}
        dismissAction={this.dismiss}
        overflowHidden
        closable={this.state.closable}
      >
        <IntentIframe
          action={action}
          create={create}
          data={options}
          onCancel={this.dismiss}
          onError={onError}
          onTerminate={onComplete}
          type={doctype}
          onHideCross={this.hideCross}
        />
      </Modal>
```

Also add showCross