### PR TITLE
feat: Allow to skip maintenance for konnector with a flag

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -72,7 +72,7 @@
     "babel-jest": "26.6.3",
     "babel-plugin-inline-react-svg": "1.1.2",
     "babel-preset-cozy-app": "^2.1.0",
-    "cozy-client": "^41.9.0",
+    "cozy-client": "^43.1.0",
     "cozy-device-helper": "^3.0.0",
     "cozy-flags": "^3.1.0",
     "cozy-intent": "^2.18.0",

--- a/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/TriggerError.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountModalWithoutTabs/TriggerError.jsx
@@ -1,21 +1,18 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import { useClient } from 'cozy-client'
-
 import TriggerErrorAction from './TriggerErrorAction'
 import { intentsApiProptype } from '../../helpers/proptypes'
 import useMaintenanceStatus from '../hooks/useMaintenanceStatus'
 import TriggerErrorInfo from '../infos/TriggerErrorInfo'
 
 const TriggerError = ({ flow, konnector, account, trigger, intentsApi }) => {
-  const client = useClient()
   const flowState = flow.getState()
   const { error } = flowState
 
   const {
     data: { isInMaintenance }
-  } = useMaintenanceStatus(client, konnector)
+  } = useMaintenanceStatus(konnector.slug)
 
   if (!error || isInMaintenance) return null
 

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
@@ -54,7 +54,7 @@ export const DataTab = ({
 
   const {
     data: { isInMaintenance, messages: maintenanceMessages }
-  } = useMaintenanceStatus(client, konnector)
+  } = useMaintenanceStatus(konnector.slug)
 
   return (
     <div>

--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/KonnectorAccountTabs.jsx
@@ -80,7 +80,7 @@ const KonnectorAccountTabs = props => {
   )
   const {
     data: { isInMaintenance }
-  } = useMaintenanceStatus(client, konnector)
+  } = useMaintenanceStatus(konnector.slug)
 
   const webviewIntent = useWebviewIntent()
 

--- a/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/NewAccountModal.jsx
@@ -2,7 +2,6 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useContext } from 'react'
 
-import { useClient } from 'cozy-client'
 import { triggers as triggersModel } from 'cozy-client/dist/models/trigger'
 import flag from 'cozy-flags'
 import { DialogTitle } from 'cozy-ui/transpiled/react/Dialog'
@@ -28,12 +27,11 @@ import useMaintenanceStatus from './hooks/useMaintenanceStatus'
  */
 const NewAccountModal = ({ konnector, onSuccess, onDismiss }) => {
   const { t } = useI18n()
-  const client = useClient()
   const { replaceHistory } = useContext(MountPointContext)
   const {
     fetchStatus,
     data: { isInMaintenance, messages: maintenanceMessages }
-  } = useMaintenanceStatus(client, konnector)
+  } = useMaintenanceStatus(konnector.slug)
   const isMaintenanceLoaded =
     fetchStatus === 'loaded' || fetchStatus === 'failed'
   const serverSideKonnector = !(konnector.oauth || konnector.clientSide)

--- a/packages/cozy-harvest-lib/src/components/NewAccountModal.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/NewAccountModal.spec.jsx
@@ -13,6 +13,10 @@ jest.mock('./TriggerManager', () => ({ onLoginSuccess, onSuccess }) => {
   onSuccessFn = onSuccess
   return null
 })
+jest.mock('./hooks/useMaintenanceStatus', () => () => ({
+  fetchStatus: 'loaded',
+  data: { isInMaintenance: false, messages: {} }
+}))
 
 describe('NewAccountModal', () => {
   const replaceHistory = jest.fn()

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { useState, useEffect } from 'react'
 
-import { useClient } from 'cozy-client'
 import { triggers as triggersModel } from 'cozy-client/dist/models/trigger'
 import Alert from 'cozy-ui/transpiled/react/Alert'
 import Button from 'cozy-ui/transpiled/react/Buttons'
@@ -54,14 +53,13 @@ export const LaunchTriggerAlert = ({
   account,
   withMaintenanceDescription
 }) => {
-  const client = useClient()
   const [showSuccessSnackbar, setShowSuccessSnackbar] = useState(false)
   const { error, trigger, running, expectingTriggerLaunch, status } =
     useFlowState(flow)
   const { launch, konnector } = flow
   const {
     data: { isInMaintenance, messages: maintenanceMessages }
-  } = useMaintenanceStatus(client, konnector)
+  } = useMaintenanceStatus(konnector.slug)
 
   const isInError = !!error
   const block = isInError || (!!withMaintenanceDescription && isInMaintenance)

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlert.spec.jsx
@@ -21,6 +21,11 @@ jest.mock('../../models/ConnectionFlow', () => {
 
 jest.mock('cozy-flags')
 
+jest.mock('../hooks/useMaintenanceStatus', () => () => ({
+  fetchStatus: 'loaded',
+  data: { isInMaintenance: false, messages: {} }
+}))
+
 const triggerFixture = {
   _id: 'd861818b62204988bf0bb78c182a9149',
   arguments: '0 0 0 * * 0'

--- a/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlertMenu.jsx
+++ b/packages/cozy-harvest-lib/src/components/cards/LaunchTriggerAlertMenu.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { useRef, useState } from 'react'
 
-import { useClient } from 'cozy-client'
 import { triggers as triggersModel } from 'cozy-client/dist/models/trigger'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
@@ -28,12 +27,11 @@ const LaunchTriggerAlertMenu = ({
   account,
   intentsApi
 }) => {
-  const client = useClient()
   const { running, trigger, error } = useFlowState(flow)
   const { launch, konnector } = flow
   const {
     data: { isInMaintenance }
-  } = useMaintenanceStatus(client, konnector)
+  } = useMaintenanceStatus(konnector.slug)
   const isKonnectorDisconnected = isDisconnected(konnector, trigger)
   const konnectorPolicy = findKonnectorPolicy(konnector)
   const isKonnectorRunnable = konnectorPolicy.isRunnable()

--- a/packages/cozy-harvest-lib/src/components/hooks/useMaintenanceStatus.jsx
+++ b/packages/cozy-harvest-lib/src/components/hooks/useMaintenanceStatus.jsx
@@ -1,13 +1,28 @@
 import { useQuery } from 'cozy-client'
+import flag from 'cozy-flags'
 
 import { buildAppsRegistryBySlug } from '../../helpers/queries'
 
 const useMaintenanceStatus = slug => {
+  const skipMaintenanceList = flag('harvest.skip-maintenance-for.list') ?? []
+  const skipMaintenance = skipMaintenanceList.includes(slug)
+
   const registryQuery = buildAppsRegistryBySlug(slug)
-  const registryResult = useQuery(
-    registryQuery.definition,
-    registryQuery.options
-  )
+  const registryResult = useQuery(registryQuery.definition, {
+    ...registryQuery.options,
+    enabled: !skipMaintenance
+  })
+
+  if (skipMaintenance) {
+    return {
+      data: {
+        isInMaintenance: false,
+        messages: {}
+      },
+      fetchStatus: 'loaded',
+      lastError: null
+    }
+  }
 
   return {
     data: {

--- a/packages/cozy-harvest-lib/src/components/hooks/useMaintenanceStatus.jsx
+++ b/packages/cozy-harvest-lib/src/components/hooks/useMaintenanceStatus.jsx
@@ -1,58 +1,21 @@
-import get from 'lodash/get'
-import memoize from 'lodash/memoize'
-import { useState, useEffect } from 'react'
+import { useQuery } from 'cozy-client'
 
-import { Registry } from 'cozy-client'
+import { buildAppsRegistryBySlug } from '../../helpers/queries'
 
-const memoizedFetchApp = memoize(
-  (registry, slug) => {
-    return registry.fetchApp(slug)
-  },
-  (registry, slug) => slug
-)
-
-const useMaintenanceStatus = (client, konnector) => {
-  const { slug, source } = konnector
-
-  const [isInMaintenance, setIsInMaintenance] = useState(false)
-  const [messages, setMessages] = useState({})
-  const [fetchStatus, setFetchStatus] = useState('idle')
-  const [lastError, setLastError] = useState(null)
-
-  useEffect(() => {
-    const registry = new Registry({
-      client
-    })
-
-    const fetchData = async () => {
-      if (/^registry:\/\//i.test(source) === false) {
-        // Only konnectors from the registry have a maintenance status, manually installed once are always considered OK
-        setFetchStatus('loaded')
-        return
-      }
-      try {
-        setFetchStatus('loading')
-        const appStatus = await memoizedFetchApp(registry, slug)
-        const isInMaintenance = get(appStatus, 'maintenance_activated', false)
-        const messages = get(appStatus, 'maintenance_options.messages', {})
-        setFetchStatus('loaded')
-        setIsInMaintenance(isInMaintenance)
-        setMessages(messages)
-      } catch (error) {
-        setFetchStatus('failed')
-        setLastError(error)
-      }
-    }
-    fetchData()
-  }, [client, slug, source])
+const useMaintenanceStatus = slug => {
+  const registryQuery = buildAppsRegistryBySlug(slug)
+  const registryResult = useQuery(
+    registryQuery.definition,
+    registryQuery.options
+  )
 
   return {
     data: {
-      isInMaintenance,
-      messages
+      isInMaintenance: registryResult.data?.maintenance_activated ?? false,
+      messages: registryResult.data?.maintenance_options?.messages ?? {}
     },
-    fetchStatus,
-    lastError
+    fetchStatus: registryResult.fetchStatus,
+    lastError: registryResult.lastError
   }
 }
 

--- a/packages/cozy-harvest-lib/src/components/hooks/useMaintenanceStatus.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/hooks/useMaintenanceStatus.spec.jsx
@@ -2,8 +2,11 @@ import { renderHook } from '@testing-library/react-hooks'
 import React from 'react'
 
 import { CozyProvider, createMockClient } from 'cozy-client'
+import flag from 'cozy-flags'
 
 import useMaintenanceStatus from './useMaintenanceStatus'
+
+jest.mock('cozy-flags')
 
 describe('useMaintenanceStatus', () => {
   const setup = (slug = 'test') => {
@@ -64,5 +67,16 @@ describe('useMaintenanceStatus', () => {
     expect(result.current.lastError).toEqual(
       new Error('Failed to found konnector')
     )
+  })
+
+  it('should not be consider under maintenance if the slug is declared in the skip flag', async () => {
+    flag.mockReturnValue(['test'])
+
+    const { result } = setup()
+
+    expect(result.current.fetchStatus).toBe('loaded')
+    expect(result.current.data.isInMaintenance).toBe(false)
+    expect(result.current.data.messages).toEqual({})
+    expect(result.current.lastError).toBe(null)
   })
 })

--- a/packages/cozy-harvest-lib/src/components/hooks/useMaintenanceStatus.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/hooks/useMaintenanceStatus.spec.jsx
@@ -1,0 +1,68 @@
+import { renderHook } from '@testing-library/react-hooks'
+import React from 'react'
+
+import { CozyProvider, createMockClient } from 'cozy-client'
+
+import useMaintenanceStatus from './useMaintenanceStatus'
+
+describe('useMaintenanceStatus', () => {
+  const setup = (slug = 'test') => {
+    const mockClient = createMockClient({
+      queries: {
+        'io.cozy.apps_registry/test': {
+          doctype: 'io.cozy.apps_registry',
+          definition: {
+            doctype: 'io.cozy.apps_registry',
+            id: 'io.cozy.apps_registry/test'
+          },
+          data: [
+            {
+              id: 'test',
+              slug: 'test',
+              maintenance_activated: true,
+              maintenance_options: {
+                messages: {
+                  en: 'Maintenance in progress'
+                }
+              }
+            }
+          ]
+        },
+        'io.cozy.apps_registry/not-found': {
+          doctype: 'io.cozy.apps_registry',
+          queryError: new Error('Failed to found konnector')
+        }
+      }
+    })
+    const wrapper = ({ children }) => (
+      <CozyProvider client={mockClient}>{children}</CozyProvider>
+    )
+    return renderHook(() => useMaintenanceStatus(slug), { wrapper })
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return maintenance status of registry konnector', async () => {
+    const { result } = setup()
+
+    expect(result.current.fetchStatus).toBe('loaded')
+    expect(result.current.data.isInMaintenance).toBe(true)
+    expect(result.current.data.messages).toEqual({
+      en: 'Maintenance in progress'
+    })
+    expect(result.current.lastError).toBe(null)
+  })
+
+  it('should not be consider under maintenance if the slug is not found', async () => {
+    const { result } = setup('not-found')
+
+    expect(result.current.fetchStatus).toBe('failed')
+    expect(result.current.data.isInMaintenance).toBe(false)
+    expect(result.current.data.messages).toEqual({})
+    expect(result.current.lastError).toEqual(
+      new Error('Failed to found konnector')
+    )
+  })
+})

--- a/packages/cozy-harvest-lib/src/helpers/queries.js
+++ b/packages/cozy-harvest-lib/src/helpers/queries.js
@@ -92,3 +92,12 @@ export const buildAppsRegistryMaintenance = () => ({
     fetchPolicy: defaultFetchPolicy
   }
 })
+
+export const buildAppsRegistryBySlug = slug => ({
+  definition: Q('io.cozy.apps_registry').getById(slug),
+  options: {
+    as: `io.cozy.apps_registry/${slug}`,
+    fetchPolicy: defaultFetchPolicy,
+    singleDocData: true
+  }
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -10141,16 +10141,16 @@ cozy-client@^40.3.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^41.9.0:
-  version "41.9.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-41.9.0.tgz#909b8c678a88f6fdb1c7ff0dffb757d0cd59dd22"
-  integrity sha512-nmEF/4dAlTcklZ0vTFBZDdTqvQIBnqAjA6zkusgN5lrCaQ+VGe/WQSQ2+3EdIC/xryo0Qa4/kk6RG1AzTsntZg==
+cozy-client@^43.1.0:
+  version "43.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-43.1.0.tgz#1c7b19c0be3b8e56fd7b2f4a1ed98468bb3149fc"
+  integrity sha512-DEsb16KV4eg4tHJZhTT/gpS4RbaRv4N/zCjo+Y/ND4s25d27IGDy3UJcE1gnX7v/5crxRJERRnloIc4j9PAdSg==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^41.9.0"
+    cozy-stack-client "^43.0.0"
     date-fns "2.29.3"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
@@ -10298,10 +10298,10 @@ cozy-stack-client@^40.2.1:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^41.9.0:
-  version "41.9.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-41.9.0.tgz#1d21fa2a4b09b545f8ddd9468e3771761e86b455"
-  integrity sha512-dc048YfX8n+JRvlZP3bgM7v/qKkj/C9/yvEigwdU+FtKUNTBZVbPGLbJN9KZ9nNU0mjs1o1DMHjFvjHzgr9wHg==
+cozy-stack-client@^43.0.0:
+  version "43.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-43.0.0.tgz#05ef0dc9f6fe4db70d06c17962d44e05c6e593fb"
+  integrity sha512-ZxVYc4OGhWWPKMxUjmVBiLNzzQ162x6X9EzcDnwvtIHpJRDHlN3aBFaMdfPh/uO8zJv8FbATrHFADQCWAXP0lg==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
This PR adds the `harvest.skip-maintenance-for` flag to avoid maintenance for a given konnector.  This is useful for test periods before returning to normal mode.

**Example of flag content :**
```
{ "list": ["slug_konnector1", "slug_konnector2"] }
```

The array is wrap into an object because our tool to manage feature flag only support array for its internal usage.

**Related PRs:**
- https://github.com/cozy/cozy-client/pull/1417