### PR TITLE
feat: Ignore onboarding from flagshipUpload

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/OnboardedGuardedRoute.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/OnboardedGuardedRoute.jsx
@@ -20,6 +20,7 @@ const OnboardedGuardedRoute = () => {
   const { OnboardingComponent } = useOnboarding()
   const client = useClient()
 
+  const fromFlagshipUpload = searchParams.get('fromFlagshipUpload') !== null
   const skipOnboarding = searchParams.get('skipOnboarding') !== null
   const isOnboardingPage = location.pathname === '/paper/onboarding'
 
@@ -76,7 +77,7 @@ const OnboardedGuardedRoute = () => {
     return <Navigate to="/paper" replace />
   }
 
-  if (isNotOnboarded) {
+  if (!fromFlagshipUpload && isNotOnboarded) {
     return <Navigate to="onboarding" replace />
   }
 

--- a/packages/cozy-mespapiers-lib/src/components/Views/CreatePaperModal.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/CreatePaperModal.jsx
@@ -52,7 +52,11 @@ const CreatePaperModal = () => {
   }, [fromFlagshipUpload, navigate, webviewIntent])
 
   const onSubmit = () => {
-    navigate(`/paper/files/${qualificationLabel}`)
+    navigate(
+      `/paper/files/${qualificationLabel}${
+        fromFlagshipUpload ? '?skipOnboarding=true' : ''
+      }`
+    )
   }
 
   useEffect(() => {


### PR DESCRIPTION
If we come from the flagship upload,
we don't want to interact with the onboarding
Do not display the onboarding
Set the onboarding to true
Let the app handle the routing to the suited page
![image](https://github.com/cozy/cozy-libs/assets/12577784/3970e6e4-c120-4323-972d-456ea27710e7)
