### PR TITLE
fix(harvest): Wrap SuggestionModal with theme

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorSuggestionModal/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorSuggestionModal/index.jsx
@@ -5,8 +5,8 @@ import { generateWebLink, useClient } from 'cozy-client'
 import AppLinker from 'cozy-ui/transpiled/react/AppLinker'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import { IllustrationDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
-import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 import Typography from 'cozy-ui/transpiled/react/Typography'
+import CozyTheme from 'cozy-ui/transpiled/react/providers/CozyTheme'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import DataTypes from './DataTypes'
@@ -44,7 +44,7 @@ const KonnectorSuggestionModal = ({
   }
 
   return (
-    <MuiCozyTheme>
+    <CozyTheme variant="normal">
       <IllustrationDialog
         open
         onClose={onClose}
@@ -104,7 +104,7 @@ const KonnectorSuggestionModal = ({
           </>
         }
       />
-    </MuiCozyTheme>
+    </CozyTheme>
   )
 }
 


### PR DESCRIPTION
The MuiCozyTheme didn't seem to apply the correct theme
variables. Using the CozyTheme provider instead

![image](https://github.com/cozy/cozy-libs/assets/12577784/2fdb4a46-fee6-4b9b-8da2-7d80fb58b836)
