### PR TITLE
fix(harvest): Remove SuggestionContainer from flow

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorSuggestionModal/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorSuggestionModal/index.jsx
@@ -44,7 +44,7 @@ const KonnectorSuggestionModal = ({
   }
 
   return (
-    <CozyTheme variant="normal">
+    <CozyTheme variant="normal" className="u-pos-absolute">
       <IllustrationDialog
         open
         onClose={onClose}


### PR DESCRIPTION
As the CozyTheme was in a flex container, it was attributed width and
height. We don't want the container to appear visually
cf commit [c4773585a747866a06e719e7b9ebf3062c753609](https://github.com/cozy/cozy-home/commit/c4773585a747866a06e719e7b9ebf3062c753609)