### PR TITLE
fix: Saving the upload file in the state of the paper creation process

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Views/CreatePaperModal.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/CreatePaperModal.jsx
@@ -82,7 +82,7 @@ const CreatePaperModal = () => {
               ...prev.data,
               {
                 file,
-                stepIndex: 1,
+                stepIndex: 0,
                 fileMetadata: {
                   page: 'front'
                 }


### PR DESCRIPTION
`stepIndex` no longer starts at 1 but at 0.
As a result, we did not arrive at the right step or it created inconsistencies on the double-sided papers (identity card, etc.)