### PR TITLE
[SCR-22] fix: No more disabled submit button on 2nd 2FA

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
@@ -47,7 +47,7 @@ export class TwoFAModal extends PureComponent {
     const flowState = this.props.flow.getState()
     this.setState({
       hasErrored: flowState.twoFARetry,
-      isJobRunning: flowState.twoFARunning || flowState.konnectorRunning
+      isJobRunning: flowState.twoFARunning
     })
   }
 

--- a/packages/cozy-harvest-lib/src/components/TwoFAModal.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/TwoFAModal.spec.jsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
 import React from 'react'
 
 import TwoFAModal from './TwoFAModal'
@@ -82,7 +82,7 @@ describe('TwoFAModal', () => {
     )
   })
 
-  it('should work for several two fa requests', () => {
+  it('should work for several two fa requests', async () => {
     const opts = {
       account: {
         state: 'TWO_FA_NEEDED.SMS'
@@ -103,6 +103,9 @@ describe('TwoFAModal', () => {
     expect(root.getByText('code')).toBeTruthy()
 
     fireEvent.change(input, { target: { value: 'abcd' } })
+    const button = root.getByText('Validate').closest('button')
+    expect(button.getAttribute('aria-disabled')).toBe(null)
+    fireEvent.click(button)
 
     // 2nd 2FA request
     flow.emit('twoFARequest')
@@ -115,12 +118,32 @@ describe('TwoFAModal', () => {
     ).toBeTruthy()
 
     expect(root.getByText('Second code')).toBeTruthy()
+    const input2 = root.getByPlaceholderText('')
+    fireEvent.change(input2, { target: { value: 'abcd' } })
+    await waitFor(() =>
+      expect(
+        root
+          .getByText('Validate')
+          .closest('button')
+          .getAttribute('aria-disabled')
+      ).toBe(null)
+    )
     flow.emit('twoFARequest')
 
     // 3rd 2FA (should not happen, hypothetical case)
     flow.emit('twoFARequest')
 
     expect(getInputValue(root)).toBe('')
+    const input3 = root.getByPlaceholderText('')
+    fireEvent.change(input3, { target: { value: 'abcd' } })
+    await waitFor(() =>
+      expect(
+        root
+          .getByText('Validate')
+          .closest('button')
+          .getAttribute('aria-disabled')
+      ).toBe(null)
+    )
     // First attempt translations are re-used
     expect(
       root.getByText('This code enables you to finish your connexion.')


### PR DESCRIPTION
When the konnector was asking 2FA code multiple times, the user could
not submit the 2nd code since the submit button was forefever disabled.

This bug was due to the dependency on "konnectorRunning" in the flow
state. I don't know why this dependency was needed and neither the git
history or unit tests would help me.

But with this condition removed, every 2FA code are asked properly.
I also changed the related unit test to have more tests on this case
(which failed silently before).