### PR TITLE
fix(mespapiers): Scan rotation doesn't work at the last rotation before its original position

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Hooks/useRotatedImage.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Hooks/useRotatedImage.jsx
@@ -28,7 +28,7 @@ export const useRotatedImage = (imageSrc, rotation) => {
       }
     }
 
-    if (typeof rotation === 'number' && rotation % 360 !== 0) {
+    if (typeof rotation === 'number' && rotation !== 0) {
       rotateImage()
     }
   }, [imageSrc, rotation])


### PR DESCRIPTION
Following the changes made by this commit 9c8efb3