### PR TITLE
feat(mespapiers): Use CozyDevTools instead FlagSwitcher

### DIFF
--- a/packages/cozy-mespapiers-lib/package.json
+++ b/packages/cozy-mespapiers-lib/package.json
@@ -35,6 +35,7 @@
     "lodash": "4.17.21",
     "mockdate": "3.0.5",
     "prop-types": "15.8.1",
+    "react-inspector": "5.1.1",
     "react-router-dom": "6.4.5",
     "stylus": "0.59.0"
   },
@@ -63,6 +64,7 @@
     "lodash": ">=4.17.21",
     "react": ">=17.0.2",
     "react-dom": ">=17.0.2",
+    "react-inspector": "5.1.1",
     "react-router-dom": ">=6.4.5"
   }
 }

--- a/packages/cozy-mespapiers-lib/src/components/MesPapiersLibLayout.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/MesPapiersLibLayout.jsx
@@ -2,8 +2,8 @@ import React from 'react'
 import { Outlet } from 'react-router-dom'
 
 import { RealTimeQueries } from 'cozy-client'
+import CozyDevTools from 'cozy-client/dist/devtools'
 import flag from 'cozy-flags'
-import FlagSwitcher from 'cozy-flags/dist/FlagSwitcher'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import Alerter from 'cozy-ui/transpiled/react/deprecated/Alerter'
@@ -31,7 +31,7 @@ export const MesPapiersLibLayout = () => {
 
   return (
     <>
-      {flag('switcher') && <FlagSwitcher />}
+      {flag('debug') && <CozyDevTools />}
 
       {customPapersDefinitions.isLoaded && (
         <Typography variant="subtitle2" align="center" color="error">

--- a/packages/cozy-mespapiers-lib/src/components/MesPapiersLibLayout.test.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/MesPapiersLibLayout.test.jsx
@@ -41,12 +41,6 @@ const setup = ({
 }
 
 describe('MesPapiersLibLayout', () => {
-  it('should contain FlagSwitcher when flag "switcher" is activate', () => {
-    const { queryByTestId } = setup({ isFlag: true })
-
-    expect(queryByTestId('FlagSwitcher')).toBeTruthy()
-  })
-
   it('should contain "custom name" text if custom papersDefinitions file is used', () => {
     const { queryByText } = setup({
       customPapersDefinitions: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16215,6 +16215,14 @@ is-docker@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
+is-dom@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-dom/-/is-dom-1.1.0.tgz#af1fced292742443bb59ca3f76ab5e80907b4e8a"
+  integrity sha512-u82f6mvhYxRPKpw8V1N0W8ce1xXwOrQtgGcxl6UCL5zBmZu3is/18K0rR7uFCnMDuAsS/3W54mGL4vsaFUQlEQ==
+  dependencies:
+    is-object "^1.0.1"
+    is-window "^1.0.2"
+
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -16387,6 +16395,11 @@ is-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
   integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
+
+is-object@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.2.tgz#a56552e1c665c9e950b4a025461da87e72f86fcf"
+  integrity sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==
 
 is-path-cwd@^2.0.0, is-path-cwd@^2.2.0:
   version "2.2.0"
@@ -16618,6 +16631,11 @@ is-whitespace-character@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz#b3ad9546d916d7d3ffa78204bca0c26b56257fac"
   integrity sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ==
+
+is-window@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-window/-/is-window-1.0.2.tgz#2c896ca53db97de45d3c33133a65d8c9f563480d"
+  integrity sha512-uj00kdXyZb9t9RcAUAwMZAnkBUwdYGhYlt7djMXhfyhUCzwNba50tIiBKR7q0l7tdoBtFVw/3JmLY6fI3rmZmg==
 
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
@@ -20144,17 +20162,6 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
-  version "1.0.8"
-  uid "3dc4c2a245ab39079bc2f73546bccf80847be14c"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
-  dependencies:
-    "@juggle/resize-observer" "^3.1.3"
-    jest-environment-jsdom-sixteen "^1.0.3"
-    react-spring "9.0.0-rc.3"
-    react-use-gesture "^7.0.8"
-    react-use-measure "^2.0.0"
-
 "mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
   resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
@@ -22751,7 +22758,7 @@ prop-types@15.7.2:
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
-prop-types@15.8.1, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@15.8.1, prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -23261,6 +23268,15 @@ react-input-mask@3.0.0-alpha.2:
     invariant "^2.2.4"
     prop-types "^15.7.2"
     warning "^4.0.3"
+
+react-inspector@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.1.tgz#58476c78fde05d5055646ed8ec02030af42953c8"
+  integrity sha512-GURDaYzoLbW8pMGXwYPDBIv6nqei4kK7LPRZ9q9HCZF54wqXz/dnylBp/kfE9XmekBhHvLDdcYeyIwSrvtOiWg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    is-dom "^1.0.0"
+    prop-types "^15.0.0"
 
 react-is@18.1.0:
   version "18.1.0"


### PR DESCRIPTION
`CozyDevTools` offers better management of flags, it provides other useful tools in development (visualization of requests, version number of dependencies).

The “switcher” flag is replaced by “debug” to display the `CozyDevTools` component.