### PR TITLE
fix: Display the right konnector

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.jsx
@@ -4,13 +4,12 @@ import React from 'react'
 import UiEmpty from 'cozy-ui/transpiled/react/Empty'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
-import EmptyWithKonnector from './EmptyWithKonnector'
+import EmptyWithKonnectors from './EmptyWithKonnectors'
 import HomeCloud from '../../../assets/icons/HomeCloud.svg'
 
-const Empty = ({ konnector, accountsByFiles, hasFiles }) => {
+const Empty = ({ konnectors, accountsByFiles, hasFiles }) => {
   const { t } = useI18n()
-
-  if (!konnector) {
+  if (!konnectors || konnectors.length === 0) {
     return (
       <UiEmpty
         className="u-ph-1"
@@ -23,16 +22,16 @@ const Empty = ({ konnector, accountsByFiles, hasFiles }) => {
   }
 
   return (
-    <EmptyWithKonnector
+    <EmptyWithKonnectors
       hasFiles={hasFiles}
-      konnector={konnector}
+      konnectors={konnectors}
       accountsByFiles={accountsByFiles}
     />
   )
 }
 
 Empty.propTypes = {
-  konnector: PropTypes.object,
+  konnectors: PropTypes.array.isRequired,
   hasFiles: PropTypes.bool,
   accountsByFiles: PropTypes.shape({
     accountsWithFiles: PropTypes.array,

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/Empty.spec.js
@@ -7,11 +7,15 @@ import AppLike from '../../../../test/components/AppLike'
 jest.mock('cozy-flags')
 jest.mock('../HarvestBanner', () => () => <div data-testid="HarvestBanner" />)
 
-const setup = ({ konnector, accountsWithFiles, accountsWithoutFiles } = {}) => {
+const setup = ({
+  konnectors,
+  accountsWithFiles,
+  accountsWithoutFiles
+} = {}) => {
   return render(
     <AppLike>
       <Empty
-        konnector={konnector}
+        konnectors={konnectors}
         accountsByFiles={{ accountsWithFiles, accountsWithoutFiles }}
       />
     </AppLike>
@@ -25,20 +29,25 @@ describe('MesPapiersLibProviders', () => {
 
   it('should display basic text without harvest banner', () => {
     const { queryByTestId, getByText } = setup({
-      konnector: undefined,
-      accountsWithFiles: undefined,
-      accountsWithoutFiles: undefined
+      konnectors: [],
+      accountsWithFiles: [],
+      accountsWithoutFiles: []
     })
 
     expect(queryByTestId('HarvestBanner')).toBeFalsy()
     expect(getByText('Add your personal documents'))
   })
 
-  it('should display specific text', () => {
+  it('should display specific text if there is at least one konnector, one account without files but no with files ', () => {
     const { getByText } = setup({
-      konnector: {},
+      konnectors: [{ slug: 'slug_1', name: 'Slug 1' }],
       accountsWithFiles: [],
-      accountsWithoutFiles: [{}]
+      accountsWithoutFiles: [
+        {
+          auth: { login: 'myLogin' },
+          account_type: 'slug_1'
+        }
+      ]
     })
 
     expect(getByText('Add manually'))
@@ -46,14 +55,23 @@ describe('MesPapiersLibProviders', () => {
 
   it('should display logins', () => {
     const { getByText } = setup({
-      konnector: {},
+      konnectors: [
+        {
+          slug: 'slug_1',
+          name: 'Slug 1'
+        },
+        {
+          slug: 'slug_2',
+          name: 'Slug 2'
+        }
+      ],
       accountsWithoutFiles: [
-        { auth: { login: 'myLogin' } },
-        { auth: { login: 'myOtherLogin' } }
+        { auth: { login: 'myLogin' }, account_type: 'slug_1' },
+        { auth: { login: 'myOtherLogin' }, account_type: 'slug_2' }
       ]
     })
 
-    expect(getByText('Account %{name} : myLogin'))
-    expect(getByText('Account %{name} : myOtherLogin'))
+    expect(getByText('Account Slug 1 : myLogin'))
+    expect(getByText('Account Slug 2 : myOtherLogin'))
   })
 })

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithKonnector.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithKonnector.spec.jsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom'
 import { render } from '@testing-library/react'
 import React from 'react'
 
-import EmptyWithKonnector from './EmptyWithKonnector'
+import EmptyWithKonnectors from './EmptyWithKonnectors'
 import AppLike from '../../../../test/components/AppLike'
 
 jest.mock('cozy-harvest-lib', () => ({
@@ -10,15 +10,15 @@ jest.mock('cozy-harvest-lib', () => ({
 }))
 
 const setup = ({
-  konnector,
+  konnectors,
   accountsWithFiles,
   accountsWithoutFiles,
   hasFiles
 } = {}) => {
   return render(
     <AppLike>
-      <EmptyWithKonnector
-        konnector={konnector}
+      <EmptyWithKonnectors
+        konnectors={konnectors}
         accountsByFiles={{ accountsWithFiles, accountsWithoutFiles }}
         hasFiles={hasFiles}
       />
@@ -26,14 +26,23 @@ const setup = ({
   )
 }
 
-describe('EmptyWithKonnector', () => {
-  const konnector = { name: 'Test Konnector' }
-  const accountsWithFiles = [{ id: 'account1' }]
-  const accountsWithoutFiles = [{ id: 'account2' }, { id: 'account3' }]
+describe('EmptyWithKonnectors', () => {
+  const konnectors = [
+    { name: 'Test Konnector 1', slug: 'konnector_test_1' },
+    { name: 'Test Konnector 2', slug: 'konnector_test_2' },
+    { name: 'Test Konnector 3', slug: 'konnector_test_3' }
+  ]
+  const accountsWithFiles = [
+    { id: 'account1', account_type: 'konnector_test_1' }
+  ]
+  const accountsWithoutFiles = [
+    { id: 'account2', account_type: 'konnector_test_2' },
+    { id: 'account3', account_type: 'konnector_test_3' }
+  ]
 
   it('renders EmptyNoHeader when there is only one account without files and no other files', () => {
     const { getByTestId } = setup({
-      konnector,
+      konnectors,
       accountsWithFiles: [],
       accountsWithoutFiles: accountsWithoutFiles.slice(0, 1),
       hasFiles: false
@@ -44,7 +53,7 @@ describe('EmptyWithKonnector', () => {
 
   it('renders EmptyWithHeader when there is only one account without files and other files exists', () => {
     const { getByTestId } = setup({
-      konnector,
+      konnectors,
       accountsWithFiles: [],
       accountsWithoutFiles: accountsWithoutFiles.slice(0, 1),
       hasFiles: true
@@ -55,7 +64,7 @@ describe('EmptyWithKonnector', () => {
 
   it('renders EmptyWithHeader for each account without files', () => {
     const { getAllByTestId } = setup({
-      konnector,
+      konnectors,
       accountsWithFiles: [],
       accountsWithoutFiles: accountsWithoutFiles,
       hasFiles: false
@@ -67,7 +76,7 @@ describe('EmptyWithKonnector', () => {
 
   it('renders EmptyWithHeader for each account without files even when there are accounts with files', () => {
     const { getAllByTestId } = setup({
-      konnector,
+      konnectors,
       accountsWithFiles,
       accountsWithoutFiles,
       hasFiles: false
@@ -79,7 +88,7 @@ describe('EmptyWithKonnector', () => {
 
   it('renders EmptyWithHeader for each account without files even when there are accounts with files and other files exists', () => {
     const { getAllByTestId } = setup({
-      konnector,
+      konnectors,
       accountsWithFiles,
       accountsWithoutFiles,
       hasFiles: true

--- a/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithKonnectors.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/Empty/EmptyWithKonnectors.jsx
@@ -4,28 +4,36 @@ import React from 'react'
 import EmptyNoHeader from './EmptyNoHeader'
 import EmptyWithHeader from './EmptyWithHeader'
 
-const EmptyWithKonnector = ({ konnector, accountsByFiles, hasFiles }) => {
+const getKonnectorByAccount = (konnectors, account) => {
+  return konnectors.find(konnector => konnector.slug === account.account_type)
+}
+const EmptyWithKonnectors = ({ konnectors, accountsByFiles, hasFiles }) => {
   const { accountsWithFiles, accountsWithoutFiles } = accountsByFiles
   /**
    * If there is only one account without files and no other files
    */
+
   if (
     accountsWithoutFiles?.length === 1 &&
     accountsWithFiles?.length === 0 &&
     !hasFiles
   ) {
+    const konnector = getKonnectorByAccount(konnectors, accountsWithoutFiles[0])
     return (
       <EmptyNoHeader konnector={konnector} accounts={accountsWithoutFiles} />
     )
   }
 
-  return accountsWithoutFiles.map((account, index) => (
-    <EmptyWithHeader key={index} konnector={konnector} account={account} />
-  ))
+  return accountsWithoutFiles.map((account, index) => {
+    const konnector = getKonnectorByAccount(konnectors, account)
+    return (
+      <EmptyWithHeader key={index} konnector={konnector} account={account} />
+    )
+  })
 }
 
-EmptyWithKonnector.propTypes = {
-  konnector: PropTypes.object,
+EmptyWithKonnectors.propTypes = {
+  konnectors: PropTypes.array,
   hasFiles: PropTypes.bool,
   accountsByFiles: PropTypes.shape({
     accountsWithFiles: PropTypes.array,
@@ -33,4 +41,4 @@ EmptyWithKonnector.propTypes = {
   })
 }
 
-export default EmptyWithKonnector
+export default EmptyWithKonnectors

--- a/packages/cozy-mespapiers-lib/src/components/Views/PapersList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/PapersList.jsx
@@ -115,7 +115,7 @@ const PapersList = () => {
           {accountsWithoutFiles.length > 0 && (
             <Empty
               hasFiles={hasFiles}
-              konnector={konnectors[0]}
+              konnectors={konnectors}
               accountsByFiles={{ accountsWithFiles, accountsWithoutFiles }}
             />
           )}


### PR DESCRIPTION
We can have several konnectors for a paper but we always passed the first on the array resulting we displayed something wrong to the user.

Let's pass all the konnectors & slugs and find the right one.