### PR TITLE
feat(mespapiers): Add bypass to the SelectPaperVersion modal

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/ScanResult/SelectPaperVersion.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/ScanResult/SelectPaperVersion.jsx
@@ -11,23 +11,15 @@ import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import Radio from 'cozy-ui/transpiled/react/Radios'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
-import { findPaperVersion } from '../../../helpers/findAttributes'
-import { makeReferenceRulesByOcrAttributes } from '../../../helpers/makeReferenceRulesByOcrAttributes'
 import CompositeHeader from '../../CompositeHeader/CompositeHeader'
 import CompositeHeaderImage from '../../CompositeHeader/CompositeHeaderImage'
 import { useFormData } from '../../Hooks/useFormData'
 import { useStepperDialog } from '../../Hooks/useStepperDialog'
-import { getAttributesFromOcr, makeMetadataFromOcr } from '../helpers'
-
-const getDefaultSelectedVersion = ({ ocrFromFlagship, ocrAttributes }) => {
-  const allReferenceRules = ocrAttributes.map(attrs => ({
-    version: attrs.version,
-    referenceRules: makeReferenceRulesByOcrAttributes(attrs)
-  }))
-
-  const { version } = findPaperVersion(ocrFromFlagship, allReferenceRules)
-  return version
-}
+import {
+  getAttributesFromOcr,
+  getDefaultSelectedVersion,
+  makeMetadataFromOcr
+} from '../helpers'
 
 const SelectPaperVersion = ({ onBack, ocrFromFlagship }) => {
   const { t } = useI18n()

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/helpers.js
@@ -5,7 +5,8 @@ import log from 'cozy-logger'
 import { knownDateMetadataNames } from 'cozy-ui/transpiled/react/Viewer/helpers'
 
 import { ANDROID_APP_URL, IOS_APP_URL } from '../../constants/const'
-import { findAttributes } from '../../helpers/findAttributes'
+import { findAttributes, findPaperVersion } from '../../helpers/findAttributes'
+import { makeReferenceRulesByOcrAttributes } from '../../helpers/makeReferenceRulesByOcrAttributes'
 
 /**
  * Check if a file is already selected in the state of the FormDataProvider
@@ -358,4 +359,17 @@ export const makeMetadataFromOcr = ocrAttributes => {
         : value
     }
   }, {})
+}
+
+export const getDefaultSelectedVersion = ({
+  ocrFromFlagship,
+  ocrAttributes
+}) => {
+  const allReferenceRules = ocrAttributes.map(attrs => ({
+    version: attrs.version,
+    referenceRules: makeReferenceRulesByOcrAttributes(attrs)
+  }))
+
+  const { version } = findPaperVersion(ocrFromFlagship, allReferenceRules)
+  return version
 }


### PR DESCRIPTION
To improve, the general idea is that for papers with several versions, there is not systematically the SelectPaperVersion modal which appears to ask the user to confirm the version.
But to be able to activate it only for certain papers.
(_no time left_)
The code in place remains useful in the near future, plan for a more dynamic approach when adding future papers with versions.