### PR TITLE
feat(cozy-intent): Add `componentId` parameter to `tryEmit`

### DIFF
--- a/packages/cozy-intent/src/api/models/applications.ts
+++ b/packages/cozy-intent/src/api/models/applications.ts
@@ -68,3 +68,16 @@ export interface FlagshipUI {
    */
   topTheme?: 'dark' | 'light'
 }
+
+export const isFlagshipUI = (item: unknown): item is FlagshipUI => {
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    ('bottomBackground' in item ||
+      'bottomOverlay' in item ||
+      'bottomTheme' in item ||
+      'topBackground' in item ||
+      'topOverlay' in item ||
+      'topTheme' in item)
+  )
+}

--- a/packages/cozy-intent/src/api/models/events.ts
+++ b/packages/cozy-intent/src/api/models/events.ts
@@ -12,7 +12,7 @@ export type NativeEvent = {
 
 export type PostMeMessage = {
   action: string
-  args: string
+  args: unknown[]
   message?: string
   methodName: string
   requestId: number

--- a/packages/cozy-intent/src/api/services/NativeService.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.ts
@@ -12,7 +12,13 @@ import {
   numbers,
   WebviewMethods
 } from '../../api'
-import { getErrorMessage, interpolate, isNativeDevMode } from '../../utils'
+import {
+  getErrorMessage,
+  interpolate,
+  isFlagshipUiArgsArray,
+  isNativeDevMode,
+  isThemeArg
+} from '../../utils'
 
 const log = debug('NativeService')
 
@@ -94,13 +100,18 @@ export class NativeService {
 
     const parsedEvent = this.parseNativeEvent(event)
 
-    if (parsedEvent.methodName === 'setFlagshipUI' && parsedEvent.args) {
-      // @ts-expect-error we know that `setFlagshipUI` args are in an array
+    if (
+      parsedEvent.methodName === 'setFlagshipUI' &&
+      isFlagshipUiArgsArray(parsedEvent.args)
+    ) {
       parsedEvent.args[0].componentId = componentId
     }
 
-    if (parsedEvent.methodName === 'setTheme' && parsedEvent.args) {
-      // @ts-expect-error we know that `setTheme` args is a string and we want to convert it to an object
+    if (
+      parsedEvent.methodName === 'setTheme' &&
+      Array.isArray(parsedEvent.args) &&
+      isThemeArg(parsedEvent.args[0])
+    ) {
       parsedEvent.args[0] = {
         homeTheme: parsedEvent.args[0],
         componentId: componentId

--- a/packages/cozy-intent/src/api/services/NativeService.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.ts
@@ -86,10 +86,26 @@ export class NativeService {
   ): Promise<Connection> =>
     await ParentHandshake(messenger, this.localMethods, numbers.maxAttempts)
 
-  public tryEmit = async (event: NativeEvent): Promise<void> => {
+  public tryEmit = async (
+    event: NativeEvent,
+    componentId: string
+  ): Promise<void> => {
     if (!this.isNativeEvent(event)) return
 
     const parsedEvent = this.parseNativeEvent(event)
+
+    if (parsedEvent.methodName === 'setFlagshipUI' && parsedEvent.args) {
+      // @ts-expect-error we know that `setFlagshipUI` args are in an array
+      parsedEvent.args[0].componentId = componentId
+    }
+
+    if (parsedEvent.methodName === 'setTheme' && parsedEvent.args) {
+      // @ts-expect-error we know that `setTheme` args is a string and we want to convert it to an object
+      parsedEvent.args[0] = {
+        homeTheme: parsedEvent.args[0],
+        componentId: componentId
+      }
+    }
 
     if (this.isInitMessage(parsedEvent)) return await this.tryInit(event)
 

--- a/packages/cozy-intent/src/utils/index.ts
+++ b/packages/cozy-intent/src/utils/index.ts
@@ -1,3 +1,5 @@
+import { isFlagshipUI } from '../api'
+
 export const interpolate = (
   str: string,
   params: Record<string, string>
@@ -40,4 +42,18 @@ export const isWebDevMode = (): boolean => {
 export const getErrorMessage = (error: unknown): string => {
   if (error instanceof Error) return error.message
   return String(error)
+}
+
+interface WithComponentId {
+  componentId: string
+}
+
+export const isFlagshipUiArgsArray = (
+  item: unknown
+): item is WithComponentId[] => {
+  return Array.isArray(item) && isFlagshipUI(item[0])
+}
+
+export const isThemeArg = (item: unknown): item is string => {
+  return typeof item === 'string'
 }


### PR DESCRIPTION
In the Flagship app we want to implement a new API for FlagshipUI

This new API requires all calls to contains a `componentId` parameter and so we want the CozyWebViews to pass this parameter

To allow this, we want the `tryEmit` to require this parameter. Then it will pass this parameter to `setFlagshipUI` and `setTheme` calls that would trigger the new FlagshipUI on native side