### PR TITLE
fix: An error when file doesn't have a createdByApp cozyMetadata

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
@@ -128,14 +128,14 @@ export const buildFilesByContacts = ({
     const filesByKonnectors = groupBy(
       filesCreatedByKonnectors,
       file =>
-        `${file.cozyMetadata.uploadedBy.slug}-${file.cozyMetadata.sourceAccountIdentifier}`
+        `${file.cozyMetadata.createdByApp}-${file.cozyMetadata.sourceAccountIdentifier}`
     )
 
     const unsortedlistByKonnector = Object.values(filesByKonnectors).map(
       value => ({
         withHeader: true,
         konnector: konnectors?.find(
-          konnector => konnector.slug === value[0].cozyMetadata.uploadedBy.slug
+          konnector => konnector.slug === value[0].cozyMetadata.createdByApp
         ),
         contact: t('PapersList.accountName', {
           name: value[0].cozyMetadata.createdByApp,

--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.spec.js
@@ -83,9 +83,7 @@ const mockFilesWithSourceAccount = [
     cozyMetadata: {
       sourceAccount: 'KonnectorAccountId01',
       sourceAccountIdentifier: 'Account 1',
-      uploadedBy: {
-        slug: 'KonnectorOne'
-      }
+      createdByApp: 'KonnectorOne'
     }
   },
   {
@@ -94,9 +92,7 @@ const mockFilesWithSourceAccount = [
     cozyMetadata: {
       sourceAccount: 'KonnectorAccountId01',
       sourceAccountIdentifier: 'Account 1',
-      uploadedBy: {
-        slug: 'KonnectorOne'
-      }
+      createdByApp: 'KonnectorOne'
     }
   },
   {
@@ -105,9 +101,7 @@ const mockFilesWithSourceAccount = [
     cozyMetadata: {
       sourceAccount: 'KonnectorAccountId02',
       sourceAccountIdentifier: 'Account 2',
-      uploadedBy: {
-        slug: 'KonnectorTwo'
-      }
+      createdByApp: 'KonnectorTwo'
     }
   }
 ]
@@ -119,9 +113,7 @@ const mockFilesWithContactsAndSourceAccount = [
     cozyMetadata: {
       sourceAccount: 'KonnectorAccountId02',
       sourceAccountIdentifier: 'Account 2',
-      uploadedBy: {
-        slug: 'KonnectorTwo'
-      }
+      createdByApp: 'KonnectorTwo'
     },
     relationships: {
       referenced_by: {


### PR DESCRIPTION
In https://github.com/cozy/cozy-libs/commit/72e5f5f073d6ddc575cae4cef26b4ca9624efa54 we replaced the mango query to only check the existence of `createdByApp`

But we were using `uploadedBy` later in the code. For old files, we can have a `createdByApp` without a `uploadedBy` attribute.

Since we check the existence of `createdByApp` let's use this field later on the code, like that we are sure that this field exists.