### PR TITLE
fix: Don't display the KonnectorUpdateButton if maintenance

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorConfiguration/DataTab/index.jsx
@@ -77,12 +77,13 @@ export const DataTab = ({
               <KonnectorMaintenance maintenanceMessages={maintenanceMessages} />
             </div>
           )}
-          {konnectorsModel.hasNewVersionAvailable(konnector) && (
-            <KonnectorUpdateInfos
-              konnector={konnector}
-              isBlocking={hasTermsVersionMismatchError}
-            />
-          )}
+          {!isInMaintenance &&
+            konnectorsModel.hasNewVersionAvailable(konnector) && (
+              <KonnectorUpdateInfos
+                konnector={konnector}
+                isBlocking={hasTermsVersionMismatchError}
+              />
+            )}
           {!flag('harvest.inappconnectors.enabled') && (
             <LaunchTriggerCard flow={flow} disabled={isInMaintenance} />
           )}


### PR DESCRIPTION
Since we can't launch a konnector is maintenance, there is no need to try to update the konnector at this time.

This update button is still needed for manual upgrade (permission changes for instance). Maybe we should only display it in that case because for other case, the konnector will be updated automatically before the launch.