### PR TITLE
feat(mespapiers): Increase the maximum size of images before integrating them into PDF

### DIFF
--- a/packages/cozy-mespapiers-lib/src/utils/addFileToPdf.js
+++ b/packages/cozy-mespapiers-lib/src/utils/addFileToPdf.js
@@ -3,6 +3,9 @@ import { PDFDocument } from 'pdf-lib'
 import { resizeImage, fileToDataUri } from '../utils/image'
 import { fileToArrayBuffer } from '../utils/pdf'
 
+// Should guarantee good resolution for different uses (printing, downloading, etc.)
+const MAX_RESIZE_IMAGE_SIZE = 3840
+
 /**
  * @param {PDFDocument} pdfDoc
  * @param {File} file
@@ -10,7 +13,11 @@ import { fileToArrayBuffer } from '../utils/pdf'
  */
 const addImageToPdf = async (pdfDoc, file) => {
   const fileDataUri = await fileToDataUri(file)
-  const resizedImage = await resizeImage(fileDataUri, file.type)
+  const resizedImage = await resizeImage({
+    base64: fileDataUri,
+    type: file.type,
+    maxSize: MAX_RESIZE_IMAGE_SIZE
+  })
 
   let img
   if (file.type === 'image/png') img = await pdfDoc.embedPng(resizedImage)

--- a/packages/cozy-mespapiers-lib/src/utils/image.js
+++ b/packages/cozy-mespapiers-lib/src/utils/image.js
@@ -1,9 +1,9 @@
 /**
  * @param {HTMLImageElement} image
- * @param {number} [maxSizeInPixel=900] - Max size in pixel
+ * @param {number} [maxSizeInPixel] - Maximum size before being resized
  * @returns {number}
  */
-export const getImageScaleRatio = (image, maxSize = 900) => {
+export const getImageScaleRatio = (image, maxSize) => {
   const longerSideSizeInPixel = Math.max(image.height, image.width)
   let scaleRatio = 1
   if (maxSize < longerSideSizeInPixel) {
@@ -14,18 +14,24 @@ export const getImageScaleRatio = (image, maxSize = 900) => {
 }
 
 /**
- * @param {string} fileDataUri
- * @param {string} fileType
+ * @param {object} opts
+ * @param {string} opts.base64 - Base64 of image
+ * @param {string} opts.type - Type of image
+ * @param {number} opts.maxSize - Maximum size before being resized
  * @returns {Promise<string>}
  */
-export const resizeImage = async (fileDataUri, fileType) => {
+export const resizeImage = async ({
+  base64: fileDataUri,
+  type: fileType,
+  maxSize
+}) => {
   return new Promise((resolve, reject) => {
     const newImage = new Image()
     newImage.src = fileDataUri
     newImage.onerror = reject
     newImage.onload = () => {
       const canvas = document.createElement('canvas')
-      const scaleRatio = getImageScaleRatio(newImage)
+      const scaleRatio = getImageScaleRatio(newImage, maxSize)
       const scaledWidth = scaleRatio * newImage.width
       const scaledHeight = scaleRatio * newImage.height
 


### PR DESCRIPTION
Today we are resizing uploaded images to 900px, for optimization reasons.
It turns out that this resolution is too low, resulting in poor quality PDFs.
We have chosen to push the limit quite high, which should guarantee better quality PDFs.