### PR TITLE
fix(cozy-flags): Add declaration dir in options

### DIFF
--- a/packages/cozy-flags/tsconfig.json
+++ b/packages/cozy-flags/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "cozy-tsconfig",
   "include": ["./src/**/*"],
-  "exclude": ["node_modules", "dist", "bin"]
+  "exclude": ["node_modules", "dist", "bin"],
+  "compilerOptions": {
+    "declarationDir": "./dist",
+  }
 }


### PR DESCRIPTION
The default cozy-tsconfig doesn't have a declarationDir
or can't share it.
We're adding it explicitly in cozy-flags so types are properly created