### PR TITLE
fix(mespapiers): `makeContactFlexsearchProps` must handle string emails

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Search/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Search/helpers.js
@@ -196,8 +196,16 @@ export const makeFileFlexsearchProps = ({ doc, scannerT, t }) => ({
   }
 })
 
+/**
+ * @param {object} doc - A contact
+ * @param {object} t - The translation function
+ * @returns {object} - The flexsearch props for a contact
+ */
 export const makeContactFlexsearchProps = (doc, t) => {
-  const flexsearchEmailAddresses = doc.email
+  // TODO On the connector side, the `email` field of the `Contact` object could be a string instead of an object array. Issue fixed here: https://github.com/konnectors/libs/pull/987. Pending the propagation of the fix, it is relevant to predict the case here
+  const normalizeEmail =
+    typeof doc.email === 'string' ? [{ address: doc.email }] : doc.email
+  const flexsearchEmailAddresses = normalizeEmail
     ?.map(email => email.address)
     .reduce((acc, val, idx) => ({ ...acc, [`email[${idx}].address`]: val }), {})
 

--- a/packages/cozy-mespapiers-lib/src/components/Search/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Search/helpers.spec.js
@@ -5,7 +5,8 @@ import {
   makeFileTags,
   makeContactTags,
   makeFileFlexsearchProps,
-  makeMultipleSearchResultIds
+  makeMultipleSearchResultIds,
+  makeContactFlexsearchProps
 } from './helpers'
 import { index } from './search'
 
@@ -17,6 +18,48 @@ jest.mock('./search', () => ({
 }))
 
 const mockT = x => x
+
+describe('makeContactFlexsearchProps', () => {
+  const expectedResult = {
+    'address[0].formattedAddress': '2 place Victor Hugo',
+    'email[0].address': 'victor@hugo.cc',
+    'phone[0].number': '0123456789',
+    tag: ['identity', 'home', 'work_study'],
+    translated: {
+      address: 'Search.attributeLabel.address',
+      email: 'Search.attributeLabel.email',
+      phone: 'Search.attributeLabel.phone'
+    }
+  }
+  it('should return correct formatted contact for flexsearch', () => {
+    const res = makeContactFlexsearchProps(
+      {
+        name: { givenName: 'Victor', familyName: 'Hugo' },
+        email: [{ address: 'victor@hugo.cc' }],
+        phone: [{ number: '0123456789' }],
+        company: 'Cozy',
+        address: [{ formattedAddress: '2 place Victor Hugo' }]
+      },
+      mockT
+    )
+
+    expect(res).toStrictEqual(expectedResult)
+  })
+  it('should return correct formatted contact for flexsearch when email is a String', () => {
+    const res = makeContactFlexsearchProps(
+      {
+        name: { givenName: 'Victor', familyName: 'Hugo' },
+        email: 'victor@hugo.cc',
+        phone: [{ number: '0123456789' }],
+        company: 'Cozy',
+        address: [{ formattedAddress: '2 place Victor Hugo' }]
+      },
+      mockT
+    )
+
+    expect(res).toStrictEqual(expectedResult)
+  })
+})
 
 describe('makeRealtimeConnection', () => {
   it('should return a well structured object', () => {


### PR DESCRIPTION
On the connector side, the `email` field of the `Contact` object could be a string instead of an object array.
Issue fixed here: konnectors/libs#987
Pending the propagation of the fix, it is relevant to predict the case here.