### PR TITLE
Fix: Being able to connect to an already installed konnector

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/InstallKonnectorFromIntent/InstallKonnectorFromIntent.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/InstallKonnectorFromIntent/InstallKonnectorFromIntent.jsx
@@ -33,6 +33,7 @@ const InstallKonnectorFromIntent = () => {
       doctype={APPS_DOCTYPE}
       mobileFullscreen
       options={{
+        terminateIfInstalled: true,
         slug: konnectorSlug,
         pageToDisplay: 'details',
         category: konnectorCategory,

--- a/packages/cozy-mespapiers-lib/src/components/Views/PlaceholdersSelector.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/PlaceholdersSelector.jsx
@@ -177,6 +177,10 @@ const PlaceholdersSelector = () => {
       : navigate('..')
   }
 
+  // The "NestedSelect" component does not manage asynchronous options.
+  // See https://github.com/cozy/cozy-ui/issues/2555
+  if (isKonnectorsLoading) return null
+
   return (
     <>
       <NestedSelectResponsive


### PR DESCRIPTION
When the connector is installed but not connected and there are no papers, when clicking on the "Auto retrieve" button, we must be redirected to the connection modal.
![image](https://github.com/cozy/cozy-libs/assets/14182143/071b4da3-447e-4001-8166-b77d9efc940d)

See https://github.com/cozy/cozy-store/pull/884