### PR TITLE
feat(mespapiers): Add `qualificationLabel` option to `konnectorCriteria`

### DIFF
--- a/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
+++ b/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
@@ -20,6 +20,7 @@
     - - *Only one of the following properties is accepted:*
       - `name`: {string} Name of the konnector.
       - `category`: {string} Konnector category.
+      - `qualificationLabel`: {string} Label of the konnector qualification
   - [`acquisitionSteps`](#steps-of-the-acquisitionsteps-property): {object\[]} Contains the steps of the creation process.
     - [`scan`](#step-scan) {object} Step to select a file (image/pdf).
     - [`[information]`](#step-information) {object} Step to get more informations about this file.

--- a/packages/cozy-mespapiers-lib/src/components/Actions/Items/importAuto.js
+++ b/packages/cozy-mespapiers-lib/src/components/Actions/Items/importAuto.js
@@ -14,6 +14,7 @@ import {
   buildKonnectorsQueryBySlug
 } from '../../../helpers/queries'
 import withLocales from '../../../locales/withLocales'
+import { buildURLSearchParamsForInstallKonnectorFromIntent } from '../../Views/helpers'
 
 export const importAuto = ({ paperDefinition, importAutoOnclick }) => {
   return {
@@ -26,13 +27,8 @@ export const importAuto = ({ paperDefinition, importAutoOnclick }) => {
         const { pathname } = useLocation()
         const normalizePathname = pathname.split('/create')[0]
 
-        const {
-          konnectorCriteria: {
-            name: konnectorName,
-            category: konnectorCategory
-          } = {},
-          label
-        } = paperDefinition
+        const { konnectorCriteria, label } = paperDefinition
+        const { name: konnectorName } = konnectorCriteria || {}
 
         const queryKonnector = buildKonnectorsQueryBySlug(konnectorName)
         const { data: konnectors, ...konnectorsQueryLeft } = useQuery(
@@ -60,9 +56,10 @@ export const importAuto = ({ paperDefinition, importAutoOnclick }) => {
           )
         )
 
-        const redirectPathSearchParam = `redirectAfterInstall=/paper/files/${label}/harvest/${
-          konnectorName ? `&slug=${konnectorName}` : ''
-        }${konnectorCategory ? `&category=${konnectorCategory}` : ''}`
+        const searchParams = buildURLSearchParamsForInstallKonnectorFromIntent(
+          konnectorCriteria,
+          label
+        )
 
         const handleClick = () => {
           if (konnectors?.length > 0 && isKonnectorsConnected) {
@@ -70,7 +67,7 @@ export const importAuto = ({ paperDefinition, importAutoOnclick }) => {
           } else {
             navigate({
               pathname: `${normalizePathname}/installKonnectorIntent`,
-              search: `${redirectPathSearchParam}`
+              search: `${searchParams}`
             })
           }
           importAutoOnclick()

--- a/packages/cozy-mespapiers-lib/src/components/InstallKonnectorFromIntent/InstallKonnectorFromIntent.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/InstallKonnectorFromIntent/InstallKonnectorFromIntent.jsx
@@ -12,6 +12,7 @@ const InstallKonnectorFromIntent = () => {
   const client = useClient()
   const konnectorSlug = searchParams.get('slug')
   const konnectorCategory = searchParams.get('category')
+  const qualificationLabel = searchParams.get('qualificationLabel')
 
   const handleTerminate = ({ document }) => {
     const redirectLink = `${searchParams.get('redirectAfterInstall')}${
@@ -37,6 +38,7 @@ const InstallKonnectorFromIntent = () => {
         slug: konnectorSlug,
         pageToDisplay: 'details',
         category: konnectorCategory,
+        qualificationLabels: qualificationLabel,
         configure: false
       }}
       create={client.intents.create}

--- a/packages/cozy-mespapiers-lib/src/components/Views/PlaceholdersSelector.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/PlaceholdersSelector.jsx
@@ -9,6 +9,7 @@ import NestedSelectResponsive from 'cozy-ui/transpiled/react/NestedSelect/Nested
 import PointerAlert from 'cozy-ui/transpiled/react/PointerAlert'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
+import { buildURLSearchParamsForInstallKonnectorFromIntent } from './helpers'
 import Konnector from '../../assets/icons/Konnectors.svg'
 import { APPS_DOCTYPE } from '../../doctypes'
 import { findPlaceholdersByQualification } from '../../helpers/findPlaceholders'
@@ -156,8 +157,6 @@ const PlaceholdersSelector = () => {
     isDisabled
   }) => {
     if (!isDisabled && isKonnectorAutoImport) {
-      const konnectorName = placeholder.konnectorCriteria.name
-      const konnectorCategory = placeholder.konnectorCriteria.category
       const konnectorsBySlug = konnectors?.filter(
         konnector => konnector.slug === placeholder.konnectorCriteria.name
       )
@@ -167,11 +166,10 @@ const PlaceholdersSelector = () => {
         )
       )
 
-      const redirectPathSearchParam = `redirectAfterInstall=/paper/files/${
+      const searchParams = buildURLSearchParamsForInstallKonnectorFromIntent(
+        placeholder.konnectorCriteria,
         placeholder.label
-      }/harvest/${konnectorName ? `&slug=${konnectorName}` : ''}${
-        konnectorCategory ? `&category=${konnectorCategory}` : ''
-      }`
+      )
 
       if (konnectorsBySlug?.length > 0 && isKonnectorsConnected) {
         navigate(`/paper/files/${placeholder.label}`)
@@ -180,7 +178,7 @@ const PlaceholdersSelector = () => {
 
         navigate({
           pathname: `${normalizePathname}/installKonnectorIntent`,
-          search: `${redirectPathSearchParam}`
+          search: `${searchParams}`
         })
       }
     } else {

--- a/packages/cozy-mespapiers-lib/src/components/Views/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Views/helpers.js
@@ -56,3 +56,32 @@ export const makeAccountsByFiles = (accounts, files) => {
 
   return { accountsWithFiles, accountsWithoutFiles }
 }
+
+/**
+ * @param {object} konnectorCriteria - Option of the papersDefinition
+ * @param {string} konnectorCriteria.name - Name of the konnector
+ * @param {string} konnectorCriteria.category - Category of the konnector
+ * @param {string} konnectorCriteria.qualificationLabel - Qualification label of the konnector
+ * @param {string} qualificationLabel - Qualification label of the paperDefinition
+ * @returns {string} - URLSearchParams
+ */
+export const buildURLSearchParamsForInstallKonnectorFromIntent = (
+  konnectorCriteria,
+  qualificationLabel
+) => {
+  const paramsObj = {
+    // Useful for redirecting on the route(harvest) opening the login modal
+    redirectAfterInstall: `/paper/files/${qualificationLabel}/harvest/`,
+    ...(konnectorCriteria.name && {
+      slug: konnectorCriteria.name
+    }),
+    ...(konnectorCriteria.category && {
+      category: konnectorCriteria.category
+    }),
+    ...(konnectorCriteria.qualificationLabel && {
+      qualificationLabel: konnectorCriteria.qualificationLabel
+    })
+  }
+
+  return new URLSearchParams(paramsObj).toString()
+}

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -1597,7 +1597,10 @@
           "model": "contact",
           "text": "PaperJSON.generic.owner.text"
         }
-      ]
+      ],
+      "konnectorCriteria": {
+        "qualificationLabel": "pay_sheet"
+      }
     },
     {
       "label": "payment_proof_family_allowance",


### PR DESCRIPTION
As the query param `category` allows you to filter the Store view, `qualificationLabel` allows you to filter on the connectors having this same label.
see https://github.com/cozy/cozy-store/pull/885