### PR TITLE
chore(cozy-logger): Fix types

### DIFF
--- a/packages/cozy-logger/index.d.ts
+++ b/packages/cozy-logger/index.d.ts
@@ -1,12 +1,12 @@
 declare module 'cozy-logger' {
-  declare function log(
+  function log(
     type: 'debug' | 'info' | 'warn' | 'error' | 'ok' | 'critical',
     message: string,
     label?: string,
     namespace?: string
   ): void
 
-  declare namespace log {
+  namespace log {
     export const addFilter: (filter: unknown) => number
 
     export const namespace: (


### PR DESCRIPTION
The nested `declare` is not necessary and may cause problems on `cozy-client`.