### PR TITLE
feat: Display Scan result page when upload file by flagship

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanWrapper.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Scan/ScanWrapper.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 
 import { useClient, models } from 'cozy-client'
@@ -26,16 +26,20 @@ const { fetchBlobFileById } = models.file
 const ScanWrapper = ({ currentStep, onClose, onBack }) => {
   const client = useClient()
   const [searchParams] = useSearchParams()
-  const { nextStep, currentStepIndex } = useStepperDialog()
+  const { currentStepIndex } = useStepperDialog()
   const { formData, setFormData } = useFormData()
   const { multipage, page } = currentStep
-  const [currentFile, setCurrentFile] = useState(
-    getLastFormDataFile({ formData: formData, currentStepIndex })
-  )
+  const [currentFile, setCurrentFile] = useState(null)
   const [isFilePickerModalOpen, setIsFilePickerModalOpen] = useState(false)
   const webviewIntent = useWebviewIntent()
 
   const fromFlagshipUpload = searchParams.get('fromFlagshipUpload')
+  useEffect(() => {
+    const file = getLastFormDataFile({ formData, currentStepIndex })
+    if (file) {
+      setCurrentFile(file)
+    }
+  }, [formData, currentStepIndex])
 
   const onChangeFile = (file, { replace = false } = {}) => {
     // TODO : Integrate the values recovered by the OCR
@@ -97,8 +101,7 @@ const ScanWrapper = ({ currentStep, onClose, onBack }) => {
     }
   }
 
-  if (!!fromFlagshipUpload && (page === 'front' || page === undefined)) {
-    nextStep()
+  if (!!fromFlagshipUpload && !currentFile && currentStepIndex === 0) {
     return null
   }
 

--- a/packages/cozy-mespapiers-lib/src/components/Views/CreatePaperModal.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/CreatePaperModal.jsx
@@ -74,10 +74,6 @@ const CreatePaperModal = () => {
         const file = makeFileFromBase64(fileToHandle)
 
         if (file && allCurrentSteps?.length > 0) {
-          const nextStep = allCurrentSteps.find(
-            el => el.model !== 'scan' || el.page === 'back'
-          )
-
           setFormData(prev => ({
             ...prev,
             data: [
@@ -91,12 +87,6 @@ const CreatePaperModal = () => {
               }
             ]
           }))
-
-          const stepIndex = allCurrentSteps.findIndex(
-            el => el.model === nextStep.model
-          )
-
-          setCurrentStepIndex(stepIndex)
         }
       } catch (error) {
         log.error(


### PR DESCRIPTION
When uploading (via flagship), we no longer want to arrive after the first Scan step, but rather display the result of this first step, in order to be able to rotate the image if necessary.

Move `getLastFormDataFile` in a useEffect because
during a flagship upload, the first rendering does not have the file in the formData.