### PR TITLE
fix(mespapiers): Manage the case where we have no contacts referenced

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Hooks/useReferencedContact.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Hooks/useReferencedContact.jsx
@@ -31,6 +31,6 @@ const useReferencedContact = files => {
     isContactByIdsQueryEnabled &&
     (isQueryLoading(contactsQueryResult) || contactsQueryResult.hasMore)
 
-  return { contacts, isLoadingContacts }
+  return { contacts: contacts || [], isLoadingContacts }
 }
 export default useReferencedContact


### PR DESCRIPTION
In this case `data` is `null` and not an empty array.
We therefore make sure to always return the same type whatever the value returned by `data`.

fix of https://github.com/cozy/cozy-libs/pull/2401