### PR TITLE
feat: Remove some logic in ImportAuto action

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Actions/Items/importAuto.js
+++ b/packages/cozy-mespapiers-lib/src/components/Actions/Items/importAuto.js
@@ -1,7 +1,6 @@
 import React, { forwardRef } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
-import { isQueryLoading, useQuery } from 'cozy-client'
 import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
@@ -9,10 +8,6 @@ import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import Konnector from '../../../assets/icons/Konnectors.svg'
-import {
-  buildAccountsQueryBySlugs,
-  buildKonnectorsQueryBySlug
-} from '../../../helpers/queries'
 import withLocales from '../../../locales/withLocales'
 import { buildURLSearchParamsForInstallKonnectorFromIntent } from '../../Views/helpers'
 
@@ -28,33 +23,6 @@ export const importAuto = ({ paperDefinition, importAutoOnclick }) => {
         const normalizePathname = pathname.split('/create')[0]
 
         const { konnectorCriteria, label } = paperDefinition
-        const { name: konnectorName } = konnectorCriteria || {}
-
-        const queryKonnector = buildKonnectorsQueryBySlug(konnectorName)
-        const { data: konnectors, ...konnectorsQueryLeft } = useQuery(
-          queryKonnector.definition,
-          queryKonnector.options
-        )
-        const isKonnectorsLoading = isQueryLoading(konnectorsQueryLeft)
-
-        const hasKonnector = Boolean(konnectors?.length > 0)
-        const konnectorSlugs = konnectors?.map(konnector => konnector.slug)
-        const queryAccounts = buildAccountsQueryBySlugs(
-          konnectorSlugs,
-          hasKonnector
-        )
-        const { data: accounts, ...accountsQueryLeft } = useQuery(
-          queryAccounts.definition,
-          queryAccounts.options
-        )
-        const isAccountsLoading =
-          hasKonnector && isQueryLoading(accountsQueryLeft)
-
-        const isKonnectorsConnected = accounts?.some(account =>
-          konnectorSlugs?.some(
-            konnectorSlug => account.account_type === konnectorSlug
-          )
-        )
 
         const searchParams = buildURLSearchParamsForInstallKonnectorFromIntent(
           konnectorCriteria,
@@ -62,27 +30,16 @@ export const importAuto = ({ paperDefinition, importAutoOnclick }) => {
         )
 
         const handleClick = () => {
-          if (konnectors?.length > 0 && isKonnectorsConnected) {
-            navigate(`/paper/files/${label}`)
-          } else {
-            navigate({
-              pathname: `${normalizePathname}/installKonnectorIntent`,
-              search: `${searchParams}`
-            })
-          }
+          navigate({
+            pathname: `${normalizePathname}/installKonnectorIntent`,
+            search: `${searchParams}`
+          })
+
           importAutoOnclick()
         }
 
-        const itemDisabled =
-          konnectorName && isKonnectorsLoading && isAccountsLoading
-
         return (
-          <ActionsMenuItem
-            {...props}
-            ref={ref}
-            onClick={handleClick}
-            disabled={itemDisabled}
-          >
+          <ActionsMenuItem {...props} ref={ref} onClick={handleClick}>
             <ListItemIcon>
               <Icon icon={Konnector} size={24} />
             </ListItemIcon>


### PR DESCRIPTION
After several uses, it appears that the expected action following clicking on "Recover automatically" should not change and should always suggest installing a connector, or connecting an account if it is already installed.