### PR TITLE
fix: Use sourceAccountIdentifier instead sourceAccount

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
@@ -14,7 +14,9 @@ export const RETURN_URL_KEY = 'returnUrl'
 const { getDisplayName } = models.contact
 
 const hasContactsInFile = file => file.contacts.length > 0
-const isFromKonnector = file => Boolean(file.cozyMetadata?.sourceAccount)
+const isFromKonnector = file => {
+  return Boolean(file.cozyMetadata?.sourceAccountIdentifier)
+}
 
 /**
  * Get all contact ids referenced on files


### PR DESCRIPTION
It is necessary to base it on `sourceAccountIdentifier` and not the `sourceAccount`, because the latter is not synchronized between two reconnections of konnector.