### PR TITLE
[SCR-115] feat: Add DoctypeDebugCard component

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -41,6 +41,7 @@
     "microee": "^0.0.6",
     "node-polyglot": "^2.4.0",
     "react-final-form": "^3.7.0",
+    "react-json-print": "^0.1.3",
     "react-markdown": "^4.2.2",
     "use-deep-compare-effect": "^1.8.1",
     "uuid": "^3.3.2"

--- a/packages/cozy-harvest-lib/src/datacards/DoctypeDebugCard.jsx
+++ b/packages/cozy-harvest-lib/src/datacards/DoctypeDebugCard.jsx
@@ -1,0 +1,85 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import ReactJsonPrint from 'react-json-print'
+
+import CozyClient, { Q, useQuery, hasQueryBeenLoaded } from 'cozy-client'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import Card from 'cozy-ui/transpiled/react/Card'
+import Divider from 'cozy-ui/transpiled/react/Divider'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+import logger from '../logger'
+
+/**
+ * This component display json extracted doctype data
+ *
+ * @component
+ * @param {Object} props - The component props.
+ * @param {string} props.doctype - The doctype name
+ * @param {Array} props.data - The array of doctype values
+ * @returns {JSX.Element} The rendered DoctypeDebugCard component.
+ */
+const DoctypeDebugCard = ({ sourceAccountIdentifier, konnector, doctype }) => {
+  const savedDocuments = useQuery(
+    Q(doctype)
+      .where({
+        cozyMetadata: {
+          createdByApp: konnector.slug,
+          sourceAccountIdentifier
+        }
+      })
+      .indexFields([
+        'cozyMetadata.createdByApp',
+        'cozyMetadata.sourceAccountIdentifier',
+        'cozyMetadata.updatedAt'
+      ])
+      .sortBy([
+        { 'cozyMetadata.createdByApp': 'desc' },
+        { 'cozyMetadata.sourceAccountIdentifier': 'desc' },
+        { 'cozyMetadata.updatedAt': 'desc' }
+      ])
+      .limitBy(30),
+    {
+      as: `${doctype}/createdByApp/${konnector.slug}/sourceAccountIdentifier/${sourceAccountIdentifier}`,
+      fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000)
+    }
+  )
+  const loaded = hasQueryBeenLoaded(savedDocuments)
+  const failed = savedDocuments.fetchStatus === 'failed'
+  if (failed) {
+    logger.error(`DoctypeDebugCard ${doctype} : failed to fetch`)
+  }
+
+  const clipBoardAvailable = navigator.clipboard?.writeText
+  return !failed && loaded ? (
+    <Card>
+      <Typography variant="button">{doctype}</Typography>
+      {clipBoardAvailable ? (
+        <Button
+          label="copy"
+          variant="text"
+          size="small"
+          onClick={() =>
+            navigator.clipboard
+              .writeText(JSON.stringify(savedDocuments.data, null, 2))
+              .catch(err =>
+                logger.error(
+                  `Could not copy json object to clipboard: ${err.message}`
+                )
+              )
+          }
+        />
+      ) : null}
+      <Divider className="u-ml-0 u-maw-100 u-mb-half" />
+      <ReactJsonPrint dataObject={savedDocuments.data} />
+    </Card>
+  ) : null
+}
+
+DoctypeDebugCard.propTypes = {
+  sourceAccountIdentifier: PropTypes.string,
+  konnector: PropTypes.object,
+  doctype: PropTypes.string
+}
+
+export default DoctypeDebugCard

--- a/packages/cozy-harvest-lib/src/datacards/DoctypeDebugCard.stories.jsx
+++ b/packages/cozy-harvest-lib/src/datacards/DoctypeDebugCard.stories.jsx
@@ -1,0 +1,179 @@
+import React from 'react'
+
+import { CozyProvider } from 'cozy-client'
+import { createFakeClient } from 'cozy-client/dist/mock'
+
+import DoctypeDebugCard from './DoctypeDebugCard'
+
+const meta = {
+  component: DoctypeDebugCard,
+  render: () => {
+    const data = [
+      {
+        _id: '180e24edac1433626f57a548481c045b',
+        _rev: '1-40014a89ba8dddc04d9718461e543303',
+        amount: 51.77,
+        cozyMetadata: {
+          createdAt: '2023-09-01T08:20:45.774Z',
+          createdByApp: 'template',
+          createdByAppVersion: '1.0.0',
+          doctypeVersion: 1,
+          metadataVersion: 1,
+          sourceAccount: '180e24edac1433626f57a548481aa62d',
+          sourceAccountIdentifier: 'testSourceAccountIdentifier',
+          updatedAt: '2023-09-01T08:20:45.774Z',
+          updatedByApps: [
+            {
+              date: '2023-09-01T08:20:45.774Z',
+              slug: 'template',
+              version: '1.0.0'
+            }
+          ]
+        },
+        currency: 'EUR',
+        date: '2023-09-01T08:20:31.338Z',
+        filename: '2023-09-01_template_51.77EUR.jpg',
+        fileurl:
+          'http://books.toscrape.com/media/cache/2c/da/2cdad67c44b002e7ead0cc35693c0e8b.jpg',
+        invoice: 'io.cozy.files:180e24edac1433626f57a548481aca62',
+        matchingCriterias: {
+          labelRegex: '\\bbooks\\b'
+        },
+        title: 'A Light in the Attic',
+        vendor: 'template'
+      },
+      {
+        _id: '180e24edac1433626f57a548481c136e',
+        _rev: '1-54702210d9be33650da61001cdff18cc',
+        amount: 45.17,
+        cozyMetadata: {
+          createdAt: '2023-09-01T08:20:45.837Z',
+          createdByApp: 'template',
+          createdByAppVersion: '1.0.0',
+          doctypeVersion: 1,
+          metadataVersion: 1,
+          sourceAccount: '180e24edac1433626f57a548481aa62d',
+          sourceAccountIdentifier: 'testSourceAccountIdentifier',
+          updatedAt: '2023-09-01T08:20:45.837Z',
+          updatedByApps: [
+            {
+              date: '2023-09-01T08:20:45.837Z',
+              slug: 'template',
+              version: '1.0.0'
+            }
+          ]
+        },
+        currency: 'EUR',
+        date: '2023-09-01T08:20:31.400Z',
+        filename: '2023-09-01_template_45.17EUR.jpg',
+        fileurl:
+          'http://books.toscrape.com/media/cache/27/a5/27a53d0bb95bdd88288eaf66c9230d7e.jpg',
+        invoice: 'io.cozy.files:180e24edac1433626f57a548481ad96a',
+        matchingCriterias: {
+          labelRegex: '\\bbooks\\b'
+        },
+        title: "It's Only the Himalayas",
+        vendor: 'template'
+      },
+      {
+        _id: '180e24edac1433626f57a548481c179f',
+        _rev: '1-d1b5f977455d918b2c2b9fd27f2e8120',
+        amount: 51.33,
+        cozyMetadata: {
+          createdAt: '2023-09-01T08:20:45.884Z',
+          createdByApp: 'template',
+          createdByAppVersion: '1.0.0',
+          doctypeVersion: 1,
+          metadataVersion: 1,
+          sourceAccount: '180e24edac1433626f57a548481aa62d',
+          sourceAccountIdentifier: 'testSourceAccountIdentifier',
+          updatedAt: '2023-09-01T08:20:45.884Z',
+          updatedByApps: [
+            {
+              date: '2023-09-01T08:20:45.884Z',
+              slug: 'template',
+              version: '1.0.0'
+            }
+          ]
+        },
+        currency: 'EUR',
+        date: '2023-09-01T08:20:31.400Z',
+        filename: '2023-09-01_template_51.33EUR.jpg',
+        fileurl:
+          'http://books.toscrape.com/media/cache/0b/bc/0bbcd0a6f4bcd81ccb1049a52736406e.jpg',
+        invoice: 'io.cozy.files:180e24edac1433626f57a548481ae79c',
+        matchingCriterias: {
+          labelRegex: '\\bbooks\\b'
+        },
+        title: 'Libertarianism for Beginners',
+        vendor: 'template'
+      },
+      {
+        _id: '180e24edac1433626f57a548481c1c75',
+        _rev: '1-292df85b486fe8e67ce5d4d4c5293771',
+        amount: 37.59,
+        cozyMetadata: {
+          createdAt: '2023-09-01T08:20:45.935Z',
+          createdByApp: 'template',
+          createdByAppVersion: '1.0.0',
+          doctypeVersion: 1,
+          metadataVersion: 1,
+          sourceAccount: '180e24edac1433626f57a548481aa62d',
+          sourceAccountIdentifier: 'testSourceAccountIdentifier',
+          updatedAt: '2023-09-01T08:20:45.935Z',
+          updatedByApps: [
+            {
+              date: '2023-09-01T08:20:45.935Z',
+              slug: 'template',
+              version: '1.0.0'
+            }
+          ]
+        },
+        currency: 'EUR',
+        date: '2023-09-01T08:20:31.400Z',
+        filename: '2023-09-01_template_37.59EUR.jpg',
+        fileurl:
+          'http://books.toscrape.com/media/cache/09/a3/09a3aef48557576e1a85ba7efea8ecb7.jpg',
+        invoice: 'io.cozy.files:180e24edac1433626f57a548481af3d8',
+        matchingCriterias: {
+          labelRegex: '\\bbooks\\b'
+        },
+        title: 'Mesaerion: The Best Science Fiction Stories 1800-1849',
+        vendor: 'template'
+      }
+    ]
+
+    const client = createFakeClient({
+      queries: {
+        'doctypeDebugCard_io.cozy.bills': {
+          doctype: 'io.cozy.bills',
+          definition: {
+            doctype: 'io.cozy.bills',
+            id: `io.cozy.bills/createdByApp/template/sourceAccountIdentifier/testSourceAccountIdentifier`
+          },
+          data
+        }
+      }
+    })
+
+    const konnector = {
+      slug: 'template'
+    }
+
+    return (
+      <CozyProvider client={client}>
+        <DoctypeDebugCard
+          doctype="io.cozy.bills"
+          konnector={konnector}
+          sourceAccountIdentifier="testSourceAccountIdentifier"
+        />
+      </CozyProvider>
+    )
+  }
+}
+
+export default meta
+
+export const Default = {
+  name: 'default'
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -22913,6 +22913,11 @@ react-is@^16.12.0, react-is@^16.13.0, react-is@^16.13.1, react-is@^16.6.0, react
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-json-print@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/react-json-print/-/react-json-print-0.1.3.tgz#a773233d76d7b6d01e764d826ffde9940af1e08a"
+  integrity sha512-PxLI+cuhpZ7AKlcwZWXWxK6UnDjTkA9YcXyFKlwo9rw44vELsXBr0t5jYKTja1mDm6XzI+vdmhAVPyeNUNAUug==
+
 react-jsonschema-form@^1.8.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/react-jsonschema-form/-/react-jsonschema-form-1.8.1.tgz#9c962f29a55b3fe071d8edf2fc3430f05f1b7ed9"


### PR DESCRIPTION
This component will display data for a given konnector, doctype and sourceAccountIdentifier.
Only the last 30 last documents will be fetched.

The "COPY" button also put a json representation of the data in the clipboard

Only integrated in a storybook at the moment :

![image](https://github.com/cozy/cozy-libs/assets/228695/ca7a2cf5-6428-4d28-afb4-2ddfb6e70e44)

