### PR TITLE
[SCR-116] feat: Doctype debug cards integration

### DIFF
--- a/packages/cozy-harvest-lib/src/components/Datacards/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/Datacards/index.jsx
@@ -1,5 +1,7 @@
 import React, { useMemo } from 'react'
 
+import { models } from 'cozy-client'
+
 import { useDatacardOptions } from './DatacardOptionsContext'
 
 const findSuitableDataCards = (datacardOptions, datacardContext) => {
@@ -24,6 +26,7 @@ const Datacards = ({ konnector, account, trigger }) => {
           konnector={konnector}
           trigger={trigger}
           accountId={trigger.message.account}
+          sourceAccountIdentifier={models.account.getAccountLogin(account)}
         />
       ))}
     </>

--- a/packages/cozy-harvest-lib/src/datacards/DoctypeDebugCard.jsx
+++ b/packages/cozy-harvest-lib/src/datacards/DoctypeDebugCard.jsx
@@ -1,8 +1,12 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import ReactJsonPrint from 'react-json-print'
-
-import CozyClient, { Q, useQuery, hasQueryBeenLoaded } from 'cozy-client'
+import CozyClient, {
+  Q,
+  useQuery,
+  hasQueryBeenLoaded,
+  RealTimeQueries
+} from 'cozy-client'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import Card from 'cozy-ui/transpiled/react/Card'
 import Divider from 'cozy-ui/transpiled/react/Divider'
@@ -53,6 +57,7 @@ const DoctypeDebugCard = ({ sourceAccountIdentifier, konnector, doctype }) => {
   const clipBoardAvailable = navigator.clipboard?.writeText
   return !failed && loaded ? (
     <Card>
+      <RealTimeQueries doctype={doctype} />
       <Typography variant="button">{doctype}</Typography>
       {clipBoardAvailable ? (
         <Button

--- a/packages/cozy-harvest-lib/src/datacards/datacardOptions.js
+++ b/packages/cozy-harvest-lib/src/datacards/datacardOptions.js
@@ -9,6 +9,9 @@
 
 import get from 'lodash/get'
 
+import flag from 'cozy-flags'
+
+import DoctypeDebugCard from './DoctypeDebugCard'
 import FileDataCard from './FileDataCard'
 import GeoDataCard from './GeoDataCard'
 
@@ -25,8 +28,45 @@ const filesDatacard = {
   match: ({ trigger }) => get(trigger, 'message.folder_to_save')
 }
 
+const filesDebugDatacard = {
+  component: options =>
+    DoctypeDebugCard({ doctype: 'io.cozy.files', ...options }),
+  match: ({ konnector }) =>
+    hasPermission(konnector, 'io.cozy.files') &&
+    flag('harvest.show-doctype-debug-cards')
+}
+
+const identitiesDebugDatacard = {
+  component: options =>
+    DoctypeDebugCard({ doctype: 'io.cozy.identities', ...options }),
+  match: ({ konnector }) =>
+    hasPermission(konnector, 'io.cozy.identities') &&
+    flag('harvest.show-doctype-debug-cards')
+}
+
+const billsDebugDatacard = {
+  component: options =>
+    DoctypeDebugCard({ doctype: 'io.cozy.bills', ...options }),
+  match: ({ konnector }) =>
+    hasPermission(konnector, 'io.cozy.bills') &&
+    flag('harvest.show-doctype-debug-cards')
+}
+
 const options = {
-  datacards: [timeseriesGeoJSONDatacard, filesDatacard]
+  datacards: [
+    timeseriesGeoJSONDatacard,
+    filesDatacard,
+    filesDebugDatacard,
+    identitiesDebugDatacard,
+    billsDebugDatacard
+  ]
+}
+
+function hasPermission(konnector, doctype) {
+  return (
+    Object.values(konnector.permissions).filter(x => x.type === doctype)
+      .length > 0
+  )
 }
 
 export default options


### PR DESCRIPTION

![image](https://github.com/cozy/cozy-libs/assets/228695/c2ba66fd-9e54-4dac-95c6-fa378d089047)


- feat: Pass the sourceAccountIdentifier to harvest cards
- feat: Add doctype debug cards for bills, files and identities
- feat: Add realtime to doctype debug cards
