### PR TITLE
 Use navigator.clipboard instead of copy-text-to-clipboard

### DIFF
--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@cozy/minilog": "^1.0.0",
     "classnames": "^2.2.6",
-    "copy-text-to-clipboard": "^2.1.1",
     "cozy-device-helper": "^3.0.0",
     "cozy-doctypes": "^1.89.4",
     "lodash": "^4.17.19",

--- a/packages/cozy-sharing/src/components/ShareByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareByLink.jsx
@@ -1,4 +1,3 @@
-import copy from 'copy-text-to-clipboard'
 import PropTypes from 'prop-types'
 import React, { useState, useEffect, useCallback } from 'react'
 
@@ -25,20 +24,23 @@ const ShareByLink = ({ link, document, documentType, onEnable }) => {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
 
   const copyLinkToClipboard = useCallback(
-    ({ isAutomaticCopy }) => {
-      if (copy(link)) {
+    async ({ isAutomaticCopy }) => {
+      try {
+        await navigator.clipboard.writeText(link)
         setAlert({
           open: true,
           severity: 'success',
           message: t(`${documentType}.share.shareByLink.copied`)
         })
-      } else if (!isAutomaticCopy) {
-        // In case of automatic copy, the browser can block the copy request. This is not shown to the user since it is expected and can be circumvented by clicking directly on the copy link
-        setAlert({
-          open: true,
-          severity: 'error',
-          message: t(`${documentType}.share.shareByLink.failed`)
-        })
+      } catch {
+        if (!isAutomaticCopy) {
+          // In case of automatic copy, the browser can block the copy request. This is not shown to the user since it is expected and can be circumvented by clicking directly on the copy link
+          setAlert({
+            open: true,
+            severity: 'error',
+            message: t(`${documentType}.share.shareByLink.failed`)
+          })
+        }
       }
     },
     [documentType, link, t]

--- a/yarn.lock
+++ b/yarn.lock
@@ -10318,11 +10318,6 @@ copy-text-to-clipboard@3.2.0:
   resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.0.tgz#0202b2d9bdae30a49a53f898626dcc3b49ad960b"
   integrity sha512-RnJFp1XR/LOBDckxTib5Qjr/PMfkatD0MUCQgdpqS8MdKiNUzBjAQBEN6oUy+jW7LI93BBG3DtMB2KOOKpGs2Q==
 
-copy-text-to-clipboard@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-2.1.1.tgz#5340e8620976d2dd9de0ff11493d13a80d600fd2"
-  integrity sha512-oSuMj4ArDGSLcLPsDhzWOhalzOVV0ErCHNfZNNr+spC+iWJ6PVSLzPPrJw/rcdFZyOhugn8iw6O0nrpY/ZrEMg==
-
 copy-webpack-plugin@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-4.6.0.tgz#e7f40dd8a68477d405dd1b7a854aae324b158bae"


### PR DESCRIPTION
copy-text-to-clipboard use deprecated command.exec which does not
work anymore on some desktop browser.