### PR TITLE
feat(mespapiers): Change behavior when searching a contact

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/SearchResult/FlexsearchResultLine.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/SearchResult/FlexsearchResultLine.jsx
@@ -2,15 +2,17 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 
-import { isFile } from 'cozy-client/dist/models/file'
+import { useClient } from 'cozy-client'
 import ListItemByDoc from 'cozy-ui/transpiled/react/ListItem/ListItemByDoc'
 
+import { makeFlexsearchResultLineOnClick } from './helpers'
 import useActions from './useActions'
 import { useMultiSelection } from '../Hooks/useMultiSelection'
 
 const FlexsearchResultLine = ({ doc, expandedAttributesProps }) => {
   const actions = useActions([doc])
   const navigate = useNavigate()
+  const client = useClient()
   const { pathname, search } = useLocation()
   const {
     isMultiSelectionActive,
@@ -33,19 +35,14 @@ const FlexsearchResultLine = ({ doc, expandedAttributesProps }) => {
     )
   }
 
-  const handleClick = !isFile(doc)
-    ? undefined
-    : () => {
-        const qualificationLabel = doc?.metadata?.qualification?.label
-
-        if (isMultiSelectionActive) {
-          changeCurrentMultiSelectionFile(doc)
-        } else {
-          navigate(`/paper/files/${qualificationLabel}/${doc._id}`, {
-            state: { background: `${pathname}${search}` }
-          })
-        }
-      }
+  const handleClick = makeFlexsearchResultLineOnClick({
+    client,
+    doc,
+    navigate,
+    navigateState: { background: `${pathname}${search}` },
+    isMultiSelectionActive,
+    changeCurrentMultiSelectionFile
+  })
 
   return (
     <>

--- a/packages/cozy-mespapiers-lib/src/components/SearchResult/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/SearchResult/helpers.js
@@ -1,0 +1,41 @@
+import { generateWebLink } from 'cozy-client'
+import { isContact } from 'cozy-client/dist/models/contact'
+import { isFile } from 'cozy-client/dist/models/file'
+
+export const makeFlexsearchResultLineOnClick = ({
+  client,
+  doc,
+  navigate,
+  navigateState,
+  isMultiSelectionActive,
+  changeCurrentMultiSelectionFile
+}) => {
+  if (isContact(doc)) {
+    return () => {
+      const contactId = doc._id
+      const webLink = generateWebLink({
+        slug: 'contacts',
+        cozyUrl: client.getStackClient().uri,
+        subDomainType: client.getInstanceOptions().subdomain,
+        pathname: '/',
+        hash: `/${contactId}`
+      })
+
+      window.open(webLink, '_blank')
+    }
+  }
+
+  if (isFile(doc)) {
+    return () => {
+      const qualificationLabel = doc?.metadata?.qualification?.label
+
+      if (isMultiSelectionActive) {
+        changeCurrentMultiSelectionFile(doc)
+      } else {
+        navigate(`/paper/files/${qualificationLabel}/${doc._id}`, {
+          state: navigateState
+        })
+      }
+    }
+  }
+}

--- a/packages/cozy-mespapiers-lib/src/components/SearchResult/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/SearchResult/helpers.spec.js
@@ -1,0 +1,96 @@
+import { isContact } from 'cozy-client/dist/models/contact'
+import { isFile } from 'cozy-client/dist/models/file'
+
+import { makeFlexsearchResultLineOnClick } from './helpers'
+
+jest.mock('cozy-client/dist/models/contact', () => ({
+  isContact: jest.fn()
+}))
+jest.mock('cozy-client/dist/models/file', () => ({
+  isFile: jest.fn()
+}))
+
+describe('makeFlexsearchResultLineOnClick', () => {
+  const client = {
+    getStackClient: () => ({ uri: 'https://cozy.localhost:8080' }),
+    getInstanceOptions: () => ({ subdomain: 'cozy' })
+  }
+  const navigate = jest.fn()
+  const navigateState = { background: '/paper/search' }
+  const changeCurrentMultiSelectionFile = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should return a function that opens a new tab when the doc is a contact', () => {
+    window.open = jest.fn()
+    isContact.mockReturnValue(true)
+    const doc = {
+      _id: 'contactId'
+    }
+    const isMultiSelectionActive = false
+    const onClick = makeFlexsearchResultLineOnClick({
+      client,
+      doc,
+      navigate,
+      navigateState,
+      isMultiSelectionActive,
+      changeCurrentMultiSelectionFile
+    })
+    onClick()
+
+    expect(window.open).toHaveBeenCalledWith(
+      'https://cozy-contacts.localhost:8080/#/contactId',
+      '_blank'
+    )
+  })
+
+  it('should return a function that navigates to a new page when the doc is a file', () => {
+    isFile.mockReturnValue(true)
+    const doc = {
+      _id: 'fileId',
+      metadata: {
+        qualification: {
+          label: 'qualificationLabel'
+        }
+      }
+    }
+    const isMultiSelectionActive = false
+    const onClick = makeFlexsearchResultLineOnClick({
+      client,
+      doc,
+      navigate,
+      navigateState,
+      isMultiSelectionActive,
+      changeCurrentMultiSelectionFile
+    })
+    onClick()
+
+    expect(navigate).toHaveBeenCalledWith(
+      '/paper/files/qualificationLabel/fileId',
+      {
+        state: { background: '/paper/search' }
+      }
+    )
+  })
+
+  it('should return a function that changes the current multi selection file when the doc is a file and the multi selection is active', () => {
+    isFile.mockReturnValue(true)
+    const doc = {
+      _id: 'fileId'
+    }
+    const isMultiSelectionActive = true
+    const onClick = makeFlexsearchResultLineOnClick({
+      client,
+      doc,
+      navigate,
+      navigateState,
+      isMultiSelectionActive,
+      changeCurrentMultiSelectionFile
+    })
+    onClick()
+
+    expect(changeCurrentMultiSelectionFile).toHaveBeenCalledWith(doc)
+  })
+})


### PR DESCRIPTION
When clicking on the search result, we are redirected to the Cozy Contacts app. (Same behavior as the "See in Cozy Contacts" option)