### PR TITLE
feat(mespapiers): Rename file when referenced contact change

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/ContactEditDialog.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/ContactEditDialog.jsx
@@ -65,7 +65,13 @@ const ContactEditDialog = ({
       actions={
         <Button
           label={t('common.apply')}
-          onClick={() => onConfirm(contactIdsSelected)}
+          onClick={() =>
+            onConfirm(
+              contactsList.filter(contact =>
+                contactIdsSelected.includes(contact._id)
+              )
+            )
+          }
           fullWidth
           disabled={contactIdsSelected.length === 0}
           busy={isBusy}

--- a/packages/cozy-mespapiers-lib/src/components/Views/ContactEdit.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/ContactEdit.jsx
@@ -33,8 +33,34 @@ const ContactEdit = () => {
     navigate('..')
   }
 
-  const onConfirm = async contactIdsSelected => {
+  const onConfirm = async contactSelected => {
     setIsBusy(true)
+    const contactIdsSelected = contactSelected.map(contact => contact._id)
+
+    // Rename only if one referenced contact exist and the contact step is not multiple
+    if (
+      contacts.length === 1 &&
+      !currentEditInformation.currentStep?.multiple
+    ) {
+      const oldContactNameSelected = contacts[0].displayName
+      const hasOldContactNameInFilename =
+        currentEditInformation.file.name.includes(oldContactNameSelected)
+      const hasDifferentContactSelected = contactSelected.every(
+        contact => contact.displayName !== oldContactNameSelected
+      )
+
+      // Update filename if the old contact name is in the filename and the new contact selected is different
+      if (hasOldContactNameInFilename && hasDifferentContactSelected) {
+        const newContactNameSelected = contactSelected[0].displayName
+        currentEditInformation.file = {
+          ...currentEditInformation.file,
+          name: currentEditInformation.file.name.replace(
+            oldContactNameSelected,
+            newContactNameSelected
+          )
+        }
+      }
+    }
     await updateReferencedContact({
       client,
       currentFile: currentEditInformation.file,


### PR DESCRIPTION
In case there is only one contact referenced, we want to update the file name if it contains the name of the old contact.