### PR TITLE
fix: Set correct featureDate in papersDefinitions

### DIFF
--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -295,7 +295,7 @@
       "country": "fr",
       "placeholderIndex": 2,
       "icon": "car",
-      "featureDate": "carObtentionDate",
+      "featureDate": "expirationDate",
       "maxDisplay": 4,
       "acquisitionSteps": [
         {
@@ -579,7 +579,7 @@
       "placeholderIndex": 3,
       "country": "stranger",
       "icon": "car",
-      "featureDate": "obtentionDate",
+      "featureDate": "expirationDate",
       "maxDisplay": 5,
       "acquisitionSteps": [
         {
@@ -2191,7 +2191,7 @@
       "label": "passport",
       "placeholderIndex": 4,
       "icon": "people",
-      "featureDate": "issueDate",
+      "featureDate": "expirationDate",
       "maxDisplay": 5,
       "acquisitionSteps": [
         {
@@ -2635,7 +2635,7 @@
     {
       "label": "transport_card",
       "icon": "people",
-      "featureDate": "referencedDate",
+      "featureDate": "expirationDate",
       "maxDisplay": 4,
       "acquisitionSteps": [
         {


### PR DESCRIPTION
This property allows you to define which date should be displayed in the list under the names of each paper.
Here we correct the non-existent and/or unwanted values.