### PR TITLE
[SCR-114] fix: Get sourceAccountIdentifier with getAccountName

### DIFF
--- a/packages/cozy-harvest-lib/src/components/Datacards/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/Datacards/index.jsx
@@ -26,7 +26,7 @@ const Datacards = ({ konnector, account, trigger }) => {
           konnector={konnector}
           trigger={trigger}
           accountId={trigger.message.account}
-          sourceAccountIdentifier={models.account.getAccountLogin(account)}
+          sourceAccountIdentifier={models.account.getAccountName(account)}
         />
       ))}
     </>


### PR DESCRIPTION
This way, we get the sourceAccountIdentifier for both following cases :
 - ccc accounts which all have `auth.accountName`
 - node konnectors accounts which follow the getAccountLogin logic since
 getAccountName defaults to getAccountLogin value.
