### PR TITLE
[SCR-165] feat: Use sourceAccountIdentifier in files datacard

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorBlock.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorBlock.jsx
@@ -32,7 +32,10 @@ const KonnectorBlock = ({ file }) => {
   const client = useClient()
   const { t } = useI18n()
   const slug = get(file, 'cozyMetadata.uploadedBy.slug')
-  const sourceAccount = get(file, 'cozyMetadata.sourceAccount')
+  const sourceAccountIdentifier = get(
+    file,
+    'cozyMetadata.sourceAccountIdentifier'
+  )
 
   // TODO To be removed when UI's AppIcon use getIconURL from Cozy-Client
   // instead of its own see https://github.com/cozy/cozy-ui/issues/1723
@@ -45,17 +48,22 @@ const KonnectorBlock = ({ file }) => {
   }, [client, slug])
 
   useEffect(() => {
-    const fetchKonnector = async ({ client, t, slug, sourceAccount }) => {
+    const fetchKonnector = async ({
+      client,
+      t,
+      slug,
+      sourceAccountIdentifier
+    }) => {
       const konnector = await fetchKonnectorData({
         client,
         t,
         slug,
-        sourceAccount
+        sourceAccountIdentifier
       })
       setKonnector(konnector)
     }
-    fetchKonnector({ client, t, slug, sourceAccount })
-  }, [client, t, slug, sourceAccount])
+    fetchKonnector({ client, t, slug, sourceAccountIdentifier })
+  }, [client, t, slug, sourceAccountIdentifier])
 
   if (!konnector) {
     return (

--- a/packages/cozy-harvest-lib/src/connections/accounts.js
+++ b/packages/cozy-harvest-lib/src/connections/accounts.js
@@ -1,7 +1,7 @@
 import keyBy from 'lodash/keyBy'
 import merge from 'lodash/merge'
 
-import { Q } from 'cozy-client'
+import { Q, models } from 'cozy-client'
 import { triggers as triggersModel } from 'cozy-client/dist/models/trigger'
 
 import assert from '../assert'
@@ -171,9 +171,19 @@ export const saveAccount = (client, konnector, account) => {
     client && konnector && account,
     'Must pass both client, konnector and account to saveAccount'
   )
+
+  const sourceAccountIdentifier = models.account.getAccountLogin(account)
+  const updatedAccount = { ...account }
+  if (sourceAccountIdentifier) {
+    updatedAccount.cozyMetadata = {
+      ...account.cozyMetadata,
+      sourceAccountIdentifier
+    }
+  }
+
   return account._id
-    ? updateAccount(client, account)
-    : createAccount(client, konnector, account)
+    ? updateAccount(client, updatedAccount)
+    : createAccount(client, konnector, updatedAccount)
 }
 
 /**

--- a/packages/cozy-harvest-lib/src/connections/accounts.spec.js
+++ b/packages/cozy-harvest-lib/src/connections/accounts.spec.js
@@ -88,7 +88,7 @@ const fixtures = {
 describe('Account mutations', () => {
   beforeEach(() => {
     client.create.mockResolvedValue({ data: fixtures.existingAccount })
-    client.save.mockResolvedValue({ data: fixtures.existingAccount })
+    client.save.mockImplementation(async account => ({ data: account }))
   })
 
   afterEach(() => {
@@ -361,7 +361,7 @@ describe('Account mutations', () => {
     it('calls CozyClient::save and returns account', async () => {
       const account = await updateAccount(client, fixtures.simpleAccount)
       expect(client.save).toHaveBeenCalledWith(fixtures.simpleAccount)
-      expect(account).toEqual(fixtures.existingAccount)
+      expect(account).toEqual(fixtures.simpleAccount)
     })
   })
 
@@ -395,10 +395,10 @@ describe('Account mutations', () => {
         newSimpleAccount
       )
 
-      expect(client.create).toHaveBeenCalledWith(
-        'io.cozy.accounts',
-        newSimpleAccount
-      )
+      expect(client.create).toHaveBeenCalledWith('io.cozy.accounts', {
+        ...newSimpleAccount,
+        cozyMetadata: { sourceAccountIdentifier: 'login' }
+      })
       expect(account).toEqual(fixtures.existingAccount)
     })
 
@@ -408,8 +408,14 @@ describe('Account mutations', () => {
         fixtures.konnector,
         fixtures.existingAccount
       )
-      expect(client.save).toHaveBeenCalledWith(fixtures.existingAccount)
-      expect(account).toEqual(fixtures.existingAccount)
+      const accountWithSourceAccountIdentifier = {
+        ...fixtures.existingAccount,
+        cozyMetadata: { sourceAccountIdentifier: 'login' }
+      }
+      expect(client.save).toHaveBeenCalledWith(
+        accountWithSourceAccountIdentifier
+      )
+      expect(account).toStrictEqual(accountWithSourceAccountIdentifier)
     })
   })
 })

--- a/packages/cozy-harvest-lib/src/datacards/DoctypeDebugCard.jsx
+++ b/packages/cozy-harvest-lib/src/datacards/DoctypeDebugCard.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import ReactJsonPrint from 'react-json-print'
+
 import CozyClient, {
   Q,
   useQuery,

--- a/packages/cozy-harvest-lib/src/datacards/FileDataCard.jsx
+++ b/packages/cozy-harvest-lib/src/datacards/FileDataCard.jsx
@@ -148,9 +148,14 @@ const FileCard = ({ files, loading, konnector, trigger, accountId }) => {
   )
 }
 
-const FileDataCard = ({ accountId, konnector, trigger }) => {
+const FileDataCard = ({
+  konnector,
+  trigger,
+  accountId,
+  sourceAccountIdentifier
+}) => {
   const { data, fetchStatus } = useDataCardFiles(
-    accountId,
+    sourceAccountIdentifier,
     trigger.message.folder_to_save
   )
   const isLoading = fetchStatus === 'loading'
@@ -168,6 +173,7 @@ const FileDataCard = ({ accountId, konnector, trigger }) => {
           konnector={konnector}
           trigger={trigger}
           accountId={accountId}
+          sourceAccountIdentifier={sourceAccountIdentifier}
         />
       )}
     </>

--- a/packages/cozy-harvest-lib/src/datacards/useDataCardFiles.js
+++ b/packages/cozy-harvest-lib/src/datacards/useDataCardFiles.js
@@ -38,7 +38,7 @@ const useSourceAccountIdentifierFiles = sourceAccountIdentifier =>
       ])
       .limitBy(5),
     {
-      as: `fileDataCard_io.cozy.accounts.sourceAccountIdentifier/${sourceAccountIdentifier}/io.cozy.files`,
+      as: `fileDataCard_io.cozy.files/sourceAccountIdentifier/${sourceAccountIdentifier}`,
       fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000)
     }
   )

--- a/packages/cozy-harvest-lib/src/helpers/konnectorBlock.spec.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectorBlock.spec.js
@@ -22,9 +22,10 @@ const setup = async ({
   isInError = { error: null },
   t = x => x
 } = {}) => {
-  jest
-    .spyOn(konnectorBlock, 'isAccountConnected')
-    .mockResolvedValue(isAccountConnected)
+  jest.spyOn(konnectorBlock, 'isAccountConnected').mockResolvedValue({
+    accountConnected: isAccountConnected,
+    sourceAccount: '012345'
+  })
   jest
     .spyOn(konnectorBlock, 'isInMaintenance')
     .mockResolvedValue(isInMaintenance)
@@ -34,7 +35,7 @@ const setup = async ({
     client,
     t: t,
     slug: 'pajemploi',
-    sourceAccount: '012345'
+    sourceAccountIdentifier: 'login'
   })
 }
 

--- a/packages/cozy-harvest-lib/src/helpers/queries.js
+++ b/packages/cozy-harvest-lib/src/helpers/queries.js
@@ -28,10 +28,13 @@ export const buildAppsRegistryQueryBySlug = slug => {
   return { definition: query.definition(), options: query.options }
 }
 
-export const buildAccountQuery = accountId => ({
-  definition: Q('io.cozy.accounts').getById(accountId),
+export const buildAccountQuery = ({ slug, sourceAccountIdentifier }) => ({
+  definition: Q('io.cozy.accounts').where({
+    account_type: slug,
+    'cozyMetadata.sourceAccountIdentifier': sourceAccountIdentifier
+  }),
   options: {
-    as: `io.cozy.accounts/${accountId}`,
+    as: `io.cozy.accounts/account_type/${slug}/sourceAccountIdentifier/${sourceAccountIdentifier}`,
     fetchPolicy: defaultFetchPolicy
   }
 })


### PR DESCRIPTION
Now that datacardOptions component also gives sourceAccountIdentifier,
use it to request the list of files.

This way, the files datacard will find files even when the user
disconnects/connects his konnector account.
