### PR TITLE
[VO-128] feat: Show group recipients

### DIFF
--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -362,5 +362,19 @@
       "title": "Remove me from sharing",
       "desc": "You keep the content but it won't be updated between your Cozy anymore."
     }
+  },
+  "GroupRecipient": {
+    "secondary": "%{nbMemberReady}/%{nbMember} members",
+    "secondary_you": "including you"
+  },
+  "RevokeGroupItem": {
+    "revoke": {
+      "title": "Remove group from sharing",
+      "desc": "Group members will keep a copy but the changes won't be synchrnoized anymore."
+    },
+    "revokeSelf": {
+      "title": "Remove me from sharing",
+      "desc": "You keep the content but it won't be updated between your Cozy anymore."
+    }
   }
 }

--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -126,16 +126,6 @@
         "hasSharedParent": "it has a shared parent",
         "hasSharedChild": "it contains a shared element"
       },
-      "revoke": {
-        "title": "Remove from sharing",
-        "desc": "This contact will keep a copy but the changes won't be synchrnoized anymore.",
-        "success": "You removed this shared file from %{email}."
-      },
-      "revokeSelf": {
-        "title": "Remove me from sharing",
-        "desc": "You keep the content but it won't be updated between your Cozy anymore.",
-        "success": "You were removed from this sharing."
-      },
       "sharingLink": {
         "title": "Link to share",
         "copy": "Copy",
@@ -201,16 +191,6 @@
         },
         "hasSharedParent": "it has a shared parent",
         "hasSharedChild": "it contains a shared element"
-      },
-      "revoke": {
-        "title": "Remove from sharing",
-        "desc": "This contact will keep a copy but the changes won't be synchrnoized anymore.",
-        "success": "You removed this shared file from %{email}."
-      },
-      "revokeSelf": {
-        "title": "Remove me from sharing",
-        "desc": "You keep the content but it won't be updated between your Cozy anymore.",
-        "success": "You were removed from this sharing."
       },
       "sharingLink": {
         "title": "Link to share",
@@ -338,16 +318,6 @@
         "hasSharedParent": "it has a shared parent",
         "hasSharedChild": "it contains a shared element"
       },
-      "revoke": {
-        "title": "Remove from sharing",
-        "desc": "This contact will keep a copy but the changes won't be synchrnoized anymore.",
-        "success": "You removed this shared file from %{email}."
-      },
-      "revokeSelf": {
-        "title": "Remove me from sharing",
-        "desc": "You keep the content but it won't be updated between your Cozy anymore.",
-        "success": "You were removed from this sharing."
-      },
       "sharingLink": {
         "title": "Link to share",
         "copy": "Copy",
@@ -382,5 +352,15 @@
     "title": "Problem with your sharing",
     "content": "You cannot share %{documentName} with more than %{limit} members.",
     "confirm": "I understand"
+  },
+  "RevokeMemberItem": {
+    "revoke": {
+      "title": "Remove from sharing",
+      "desc": "This contact will keep a copy but the changes won't be synchrnoized anymore."
+    },
+    "revokeSelf": {
+      "title": "Remove me from sharing",
+      "desc": "You keep the content but it won't be updated between your Cozy anymore."
+    }
   }
 }

--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -125,16 +125,6 @@
         "hasSharedParent": "se trouve dans un dossier partagé.",
         "hasSharedChild": "contient un élément partagé."
       },
-      "revoke": {
-        "title": "Arrêter le partage",
-        "desc": "Votre contact conservera une copie mais vos changements ne seront plus synchronisés.",
-        "success": "Vous avez cessé de partager ce fichier avec %{email}."
-      },
-      "revokeSelf": {
-        "title": "Arrêter le partage",
-        "desc": "Vous conservez le contenu mais il ne sera plus mis à jour entre vos Cozy.",
-        "success": "Vous avez été retiré de ce partage."
-      },
       "sharingLink": {
         "title": "Partager",
         "copy": "Copier",
@@ -200,16 +190,6 @@
         },
         "hasSharedParent": "se trouve dans un dossier partagé.",
         "hasSharedChild": "contient un élément partagé."
-      },
-      "revoke": {
-        "title": "Arrêter le partage",
-        "desc": "Votre contact conservera une copie mais vos changements ne seront plus synchronisés.",
-        "success": "Vous avez cessé de partager ce fichier avec %{email}."
-      },
-      "revokeSelf": {
-        "title": "Arrêter le partage",
-        "desc": "Vous conservez le contenu mais il ne sera plus mis à jour entre vos Cozy.",
-        "success": "Vous avez été retiré de ce partage."
       },
       "sharingLink": {
         "title": "Partager",
@@ -336,16 +316,6 @@
         "hasSharedParent": "se trouve dans un dossier partagé.",
         "hasSharedChild": "contient un élément partagé."
       },
-      "revoke": {
-        "title": "Arrêter le partage",
-        "desc": "Votre contact conservera une copie mais vos changements ne seront plus synchronisés.",
-        "success": "Vous avez cessé de partager ce fichier avec %{email}."
-      },
-      "revokeSelf": {
-        "title": "Arrêter le partage",
-        "desc": "Vous conservez le contenu mais il ne sera plus mis à jour entre vos Cozy.",
-        "success": "Vous avez été retiré de ce partage."
-      },
       "sharingLink": {
         "title": "Partager",
         "copy": "Copier",
@@ -380,5 +350,15 @@
     "title": "Problème au niveau de votre partage",
     "content": "Vous ne pouvez pas partager %{documentName} à plus de %{limit} membres.",
     "confirm": "J'ai compris"
+  },
+  "RevokeMemberItem": {
+    "revoke": {
+      "title": "Arrêter le partage",
+      "desc": "Votre contact conservera une copie mais vos changements ne seront plus synchronisés."
+    },
+    "revokeSelf": {
+      "title": "Arrêter le partage",
+      "desc": "Vous conservez le contenu mais il ne sera plus mis à jour entre vos Cozy."
+    }
   }
 }

--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -360,5 +360,19 @@
       "title": "Arrêter le partage",
       "desc": "Vous conservez le contenu mais il ne sera plus mis à jour entre vos Cozy."
     }
+  },
+  "GroupRecipient": {
+    "secondary": "%{nbMemberReady}/%{nbMember} membres",
+    "secondary_you": "dont vous"
+  },
+  "RevokeGroupItem": {
+    "revoke": {
+      "title": "Arrêter le partage pour le groupe",
+      "desc": "Les membres du groupe conserveront une copie mais vos changements ne seront plus synchronisés"
+    },
+    "revokeSelf": {
+      "title": "Quitter le partage",
+      "desc": "Vous conserverez une copie mais vos changements ne seront plus synchronisés."
+    }
   }
 }

--- a/packages/cozy-sharing/src/components/Avatar/GroupAvatar.jsx
+++ b/packages/cozy-sharing/src/components/Avatar/GroupAvatar.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+import Avatar from 'cozy-ui/transpiled/react/Avatar'
+import TeamIcon from 'cozy-ui/transpiled/react/Icons/Team'
+
+const GroupAvatar = ({ size }) => {
+  return <Avatar icon={TeamIcon} size={size} />
+}
+
+export { GroupAvatar }

--- a/packages/cozy-sharing/src/components/Avatar/GroupAvatar.stories.jsx
+++ b/packages/cozy-sharing/src/components/Avatar/GroupAvatar.stories.jsx
@@ -1,0 +1,13 @@
+import { GroupAvatar } from './GroupAvatar'
+
+const meta = {
+  component: GroupAvatar,
+  args: {}
+}
+
+export default meta
+
+export const Default = {
+  name: 'Default',
+  args: {}
+}

--- a/packages/cozy-sharing/src/components/Recipient/GroupRecipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/GroupRecipient.jsx
@@ -1,0 +1,56 @@
+import React from 'react'
+
+import { useClient } from 'cozy-client'
+import Fade from 'cozy-ui/transpiled/react/Fade'
+import ListItem from 'cozy-ui/transpiled/react/ListItem'
+import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
+import ListItemSecondaryAction from 'cozy-ui/transpiled/react/ListItemSecondaryAction'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
+
+import { GroupRecipientPermissions } from './GroupRecipientPermissions'
+import { FADE_IN_DURATION } from '../../helpers/recipients'
+import { GroupAvatar } from '../Avatar/GroupAvatar'
+
+const GroupRecipient = props => {
+  const { name, members, fadeIn } = props
+  const { t } = useI18n()
+  const client = useClient()
+
+  const nbMember = members.length
+  const nbMemberReady = members.filter(
+    member => !['revoked', 'mail-not-sent'].includes(member.status)
+  ).length
+  const isCurrentInstanceInsideMembers = members.some(
+    member => member.instance === client.options.uri
+  )
+
+  return (
+    <Fade in timeout={fadeIn ? FADE_IN_DURATION : 0}>
+      <ListItem disableGutters>
+        <ListItemIcon>
+          <GroupAvatar size="small" />
+        </ListItemIcon>
+        <ListItemText
+          primary={
+            <Typography className="u-ellipsis" variant="body1">
+              {name}
+            </Typography>
+          }
+          secondary={
+            t('GroupRecipient.secondary', { nbMember, nbMemberReady }) +
+            (isCurrentInstanceInsideMembers
+              ? ` (${t('GroupRecipient.secondary_you')})`
+              : '')
+          }
+        />
+        <ListItemSecondaryAction>
+          <GroupRecipientPermissions {...props} />
+        </ListItemSecondaryAction>
+      </ListItem>
+    </Fade>
+  )
+}
+
+export { GroupRecipient }

--- a/packages/cozy-sharing/src/components/Recipient/GroupRecipient.stories.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/GroupRecipient.stories.jsx
@@ -1,0 +1,38 @@
+import { GroupRecipient } from './GroupRecipient'
+
+const meta = {
+  component: GroupRecipient,
+  args: {
+    name: 'Family',
+    isOwner: true,
+    read_only: false,
+    members: [
+      { status: 'ready' },
+      { status: 'mail-not-sent' },
+      { status: 'pending' },
+      { status: 'revoked' }
+    ],
+    groupIndex: 0
+  }
+}
+
+export default meta
+
+export const Default = {
+  name: 'Default',
+  args: {}
+}
+
+export const InstanceInsideMembers = {
+  name: 'Instance inside members',
+  args: {
+    isOwner: false,
+    instance: 'http://alice.cozy.localhost:8080',
+    members: [
+      { status: 'ready', instance: 'http://alice.cozy.localhost:8080' },
+      { status: 'mail-not-sent' },
+      { status: 'pending' },
+      { status: 'revoked' }
+    ]
+  }
+}

--- a/packages/cozy-sharing/src/components/Recipient/GroupRecipientPermissions.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/GroupRecipientPermissions.jsx
@@ -1,0 +1,77 @@
+import React, { useState, useRef } from 'react'
+
+import { useClient } from 'cozy-client'
+import ActionsMenu from 'cozy-ui/transpiled/react/ActionsMenu'
+import {
+  makeActions,
+  divider
+} from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
+import DropdownButton from 'cozy-ui/transpiled/react/DropdownButton'
+import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
+
+import { permission } from './actions/permission'
+import { revokeGroup } from './actions/revokeGroup'
+
+const GroupRecipientPermissions = ({
+  isOwner,
+  instance,
+  read_only: isReadOnly = false,
+  className
+}) => {
+  const { t } = useI18n()
+  const buttonRef = useRef()
+  const client = useClient()
+
+  const [isMenuDisplayed, setMenuDisplayed] = useState(false)
+
+  const instanceMatchesClient =
+    instance !== undefined && instance === client.options.uri
+  const shouldShowMenu = (instanceMatchesClient && !isOwner) || isOwner
+
+  const toggleMenu = () => setMenuDisplayed(!isMenuDisplayed)
+  const hideMenu = () => setMenuDisplayed(false)
+
+  const handleRevocation = () => {
+    // TODO : Need to be implemented
+  }
+
+  const type = isReadOnly ? 'one-way' : 'two-way'
+
+  const actions = makeActions([permission, divider, revokeGroup], {
+    t,
+    type,
+    isOwner,
+    handleRevocation
+  })
+
+  return (
+    <div className={className}>
+      {shouldShowMenu && (
+        <>
+          <DropdownButton
+            ref={buttonRef}
+            aria-controls="simple-menu"
+            aria-haspopup="true"
+            onClick={toggleMenu}
+            textVariant="body2"
+          >
+            {t(`Share.type.${type}`).toLowerCase()}
+          </DropdownButton>
+          <ActionsMenu
+            ref={buttonRef}
+            open={isMenuDisplayed}
+            actions={actions}
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'right'
+            }}
+            autoClose
+            onClose={hideMenu}
+          />
+        </>
+      )}
+    </div>
+  )
+}
+
+export { GroupRecipientPermissions }

--- a/packages/cozy-sharing/src/components/Recipient/GroupRecipientPermissions.stories.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/GroupRecipientPermissions.stories.jsx
@@ -1,0 +1,41 @@
+import { GroupRecipientPermissions } from './GroupRecipientPermissions'
+
+const meta = {
+  component: GroupRecipientPermissions,
+  args: {
+    onRevoke: () => {},
+    onRevokeSelf: () => {},
+    type: 'two-way',
+    status: 'ready',
+    groupIndex: 0
+  },
+  argTypes: {
+    status: {
+      control: 'select',
+      options: ['ready', 'mail-not-sent', 'pending', 'seen', 'owner'],
+      defaultValue: 'ready'
+    },
+    type: {
+      control: 'select',
+      options: ['one-way', 'two-way'],
+      defaultValue: 'two-way'
+    }
+  }
+}
+
+export default meta
+
+export const Owner = {
+  name: 'Owner',
+  args: {
+    isOwner: true
+  }
+}
+
+export const Self = {
+  name: 'Self',
+  args: {
+    isOwner: false,
+    instance: 'http://alice.cozy.localhost:8080'
+  }
+}

--- a/packages/cozy-sharing/src/components/Recipient/MemberRecipient.stories.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/MemberRecipient.stories.jsx
@@ -8,7 +8,10 @@ const meta = {
     status: 'ready',
     recipientConfirmationData: null,
     verifyRecipient: () => {},
-    fadeIn: true
+    fadeIn: true,
+    type: 'two-way',
+    onRevoke: () => {},
+    onRevokeSelf: () => {}
   },
   argTypes: {
     status: {
@@ -31,6 +34,14 @@ export const Owner = {
   args: {
     isOwner: true,
     status: 'owner'
+  }
+}
+
+export const SameInstance = {
+  name: 'SameInstance',
+  args: {
+    isOwner: false,
+    instance: 'http://alice.cozy.localhost:8080'
   }
 }
 

--- a/packages/cozy-sharing/src/components/Recipient/MemberRecipientPermissions.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/MemberRecipientPermissions.jsx
@@ -24,7 +24,7 @@ const MemberRecipientPermissions = ({
   onRevoke,
   onRevokeSelf,
   sharingId,
-  index
+  memberIndex
 }) => {
   const { t } = useI18n()
   const buttonRef = useRef()
@@ -47,12 +47,12 @@ const MemberRecipientPermissions = ({
   const handleRevocation = useCallback(async () => {
     setRevoking(true)
     if (isOwner) {
-      await onRevoke(document, sharingId, index)
+      await onRevoke(document, sharingId, memberIndex)
     } else {
       await onRevokeSelf(document)
     }
     setRevoking(false)
-  }, [isOwner, onRevoke, onRevokeSelf, document, sharingId, index])
+  }, [isOwner, onRevoke, onRevokeSelf, document, sharingId, memberIndex])
 
   const actions = makeActions([permission, divider, revokeMember], {
     t,

--- a/packages/cozy-sharing/src/components/Recipient/MemberRecipientPermissions.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/MemberRecipientPermissions.jsx
@@ -1,17 +1,18 @@
 import React, { useState, useRef, useCallback } from 'react'
 
 import { useClient } from 'cozy-client'
+import ActionsMenu from 'cozy-ui/transpiled/react/ActionsMenu'
+import {
+  makeActions,
+  divider
+} from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
 import DropdownButton from 'cozy-ui/transpiled/react/DropdownButton'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import EyeIcon from 'cozy-ui/transpiled/react/Icons/Eye'
-import RenameIcon from 'cozy-ui/transpiled/react/Icons/Rename'
-import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Typography from 'cozy-ui/transpiled/react/Typography'
-import ActionMenu, {
-  ActionMenuItem
-} from 'cozy-ui/transpiled/react/deprecated/ActionMenu'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
+
+import { permission } from './actions/permission'
+import { revokeMember } from './actions/revokeMember'
 
 const MemberRecipientPermissions = ({
   isOwner,
@@ -19,7 +20,6 @@ const MemberRecipientPermissions = ({
   instance,
   type,
   document,
-  documentType,
   className,
   onRevoke,
   onRevokeSelf,
@@ -29,8 +29,10 @@ const MemberRecipientPermissions = ({
   const { t } = useI18n()
   const buttonRef = useRef()
   const client = useClient()
+
   const [revoking, setRevoking] = useState(false)
-  const [isMenuDisplayed, setIsMenuDisplayed] = useState(false)
+  const [isMenuDisplayed, setMenuDisplayed] = useState(false)
+
   const instanceMatchesClient =
     instance !== undefined && instance === client.options.uri
   const contactIsOwner = status === 'owner'
@@ -39,21 +41,25 @@ const MemberRecipientPermissions = ({
     !contactIsOwner &&
     ((instanceMatchesClient && !isOwner) || isOwner)
 
-  const showMenu = () => setIsMenuDisplayed(true)
-  const hideMenu = () => setIsMenuDisplayed(false)
+  const toggleMenu = () => setMenuDisplayed(!isMenuDisplayed)
+  const hideMenu = () => setMenuDisplayed(false)
 
-  const onRevokeClick = useCallback(async () => {
+  const handleRevocation = useCallback(async () => {
     setRevoking(true)
     if (isOwner) {
       await onRevoke(document, sharingId, index)
     } else {
       await onRevokeSelf(document)
     }
-
     setRevoking(false)
   }, [isOwner, onRevoke, onRevokeSelf, document, sharingId, index])
 
-  const PermissionIcon = type === 'two-way' ? RenameIcon : EyeIcon
+  const actions = makeActions([permission, divider, revokeMember], {
+    t,
+    type,
+    isOwner,
+    handleRevocation
+  })
 
   return (
     <div className={className}>
@@ -66,47 +72,25 @@ const MemberRecipientPermissions = ({
       {shouldShowMenu && (
         <>
           <DropdownButton
-            onClick={showMenu}
             ref={buttonRef}
+            aria-controls="simple-menu"
+            aria-haspopup="true"
+            onClick={toggleMenu}
             textVariant="body2"
           >
             {t(`Share.type.${type}`).toLowerCase()}
           </DropdownButton>
-          {isMenuDisplayed && (
-            <ActionMenu
-              onClose={hideMenu}
-              popperOptions={{
-                placement: 'bottom-end',
-                strategy: 'fixed'
-              }}
-              anchorElRef={buttonRef}
-            >
-              <ActionMenuItem
-                left={
-                  <Icon icon={PermissionIcon} color="var(--primaryTextColor)" />
-                }
-              >
-                {t(`Share.type.${type}`)}
-              </ActionMenuItem>
-
-              <hr />
-              <ActionMenuItem
-                onClick={onRevokeClick}
-                left={<Icon icon={TrashIcon} color="var(--errorColor)" />}
-              >
-                <Typography className="u-error" variant="body1">
-                  {isOwner
-                    ? t(`${documentType}.share.revoke.title`)
-                    : t(`${documentType}.share.revokeSelf.title`)}
-                </Typography>
-                <Typography variant="caption" color="textSecondary">
-                  {isOwner
-                    ? t(`${documentType}.share.revoke.desc`)
-                    : t(`${documentType}.share.revokeSelf.desc`)}
-                </Typography>
-              </ActionMenuItem>
-            </ActionMenu>
-          )}
+          <ActionsMenu
+            ref={buttonRef}
+            open={isMenuDisplayed}
+            actions={actions}
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'right'
+            }}
+            autoClose
+            onClose={hideMenu}
+          />
         </>
       )}
     </div>

--- a/packages/cozy-sharing/src/components/Recipient/MemberRecipientPermissions.stories.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/MemberRecipientPermissions.stories.jsx
@@ -2,12 +2,39 @@ import MemberRecipientPermissions from './MemberRecipientPermissions'
 
 const meta = {
   component: MemberRecipientPermissions,
-  args: {}
+  args: {
+    onRevoke: () => {},
+    onRevokeSelf: () => {},
+    type: 'two-way',
+    status: 'ready'
+  },
+  argTypes: {
+    status: {
+      control: 'select',
+      options: ['ready', 'mail-not-sent', 'pending', 'seen', 'owner'],
+      defaultValue: 'ready'
+    },
+    type: {
+      control: 'select',
+      options: ['one-way', 'two-way'],
+      defaultValue: 'two-way'
+    }
+  }
 }
 
 export default meta
 
-export const Default = {
-  name: 'Default',
-  args: {}
+export const Owner = {
+  name: 'Owner',
+  args: {
+    isOwner: true
+  }
+}
+
+export const Self = {
+  name: 'Self',
+  args: {
+    isOwner: false,
+    instance: 'http://alice.cozy.localhost:8080'
+  }
 }

--- a/packages/cozy-sharing/src/components/Recipient/RecipientList.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/RecipientList.jsx
@@ -28,7 +28,7 @@ const RecipientList = ({
     return (
       <MemberRecipient
         {...recipient}
-        key={`key_r_${recipient.index}`}
+        key={recipient.index}
         isOwner={isOwner}
         document={document}
         documentType={documentType}

--- a/packages/cozy-sharing/src/components/Recipient/RecipientList.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/RecipientList.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { GroupRecipient } from './GroupRecipient'
 import MemberRecipient from './MemberRecipient'
 import { usePrevious } from '../../helpers/hooks'
 import { filterAndReworkRecipients } from '../../helpers/recipients'
@@ -24,6 +25,22 @@ const RecipientList = ({
     const recipientConfirmationData = recipientsToBeConfirmed.find(
       user => user.email === recipient.email
     )
+
+    const isGroupRecipient = recipient.members
+    if (isGroupRecipient) {
+      return (
+        <GroupRecipient
+          {...recipient}
+          isOwner={isOwner}
+          key={recipient.index}
+          document={document}
+          documentType={documentType}
+          onRevoke={onRevoke}
+          onRevokeSelf={onRevokeSelf}
+          fadeIn={recipient.hasBeenJustAdded}
+        />
+      )
+    }
 
     return (
       <MemberRecipient

--- a/packages/cozy-sharing/src/components/Recipient/RecipientList.stories.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/RecipientList.stories.jsx
@@ -26,3 +26,37 @@ export const Owner = {
     isOwner: true
   }
 }
+
+export const WithGroup = {
+  name: 'With group',
+  args: {
+    recipients: [
+      ...recipients,
+      {
+        id: '2c8d4d5abbec5b4606a1ebe01a021dfd',
+        name: 'Famille',
+        addedBy: 0,
+        read_only: false,
+        index: 0,
+        members: [
+          {
+            status: 'pending',
+            email: 'ben@gmail.com',
+            only_in_groups: true,
+            groups: [0],
+            type: 'two-way',
+            index: 1
+          },
+          {
+            status: 'pending',
+            email: 'bob@gmail.com',
+            only_in_groups: true,
+            groups: [0],
+            type: 'two-way',
+            index: 2
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/cozy-sharing/src/components/Recipient/actions/permission.js
+++ b/packages/cozy-sharing/src/components/Recipient/actions/permission.js
@@ -1,0 +1,31 @@
+import React, { forwardRef } from 'react'
+
+import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import EyeIcon from 'cozy-ui/transpiled/react/Icons/Eye'
+import RenameIcon from 'cozy-ui/transpiled/react/Icons/Rename'
+import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+
+const permission = ({ t, type }) => {
+  const title = t(`Share.type.${type}`)
+  const icon = type === 'two-way' ? RenameIcon : EyeIcon
+
+  return {
+    name: 'permission',
+    label: title,
+    icon,
+    action: null,
+    Component: forwardRef(function RevokeItem(props, ref) {
+      return (
+        <ActionsMenuItem {...props} ref={ref} button={false}>
+          <ListItemIcon>
+            <Icon icon={icon} />
+          </ListItemIcon>
+          <ListItemText primary={title} />
+        </ActionsMenuItem>
+      )
+    })
+  }
+}
+export { permission }

--- a/packages/cozy-sharing/src/components/Recipient/actions/revokeGroup.js
+++ b/packages/cozy-sharing/src/components/Recipient/actions/revokeGroup.js
@@ -1,0 +1,39 @@
+import React, { forwardRef } from 'react'
+
+import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import ForbiddenIcon from 'cozy-ui/transpiled/react/Icons/Forbidden'
+import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+const revokeGroup = ({ t, isOwner, handleRevocation }) => {
+  const revokeType = isOwner ? 'revoke' : 'revokeSelf'
+  const title = t(`RevokeGroupItem.${revokeType}.title`)
+  const desc = t(`RevokeGroupItem.${revokeType}.desc`)
+
+  const icon = ForbiddenIcon
+
+  return {
+    name: 'revokeMember',
+    label: title,
+    icon,
+    action: () => {
+      handleRevocation()
+    },
+    Component: forwardRef(function RevokeMemberItem(props, ref) {
+      return (
+        <ActionsMenuItem {...props} ref={ref}>
+          <ListItemIcon>
+            <Icon icon={icon} color="var(--errorColor)" />
+          </ListItemIcon>
+          <ListItemText
+            primary={<Typography color="error">{title}</Typography>}
+            secondary={desc}
+          />
+        </ActionsMenuItem>
+      )
+    })
+  }
+}
+export { revokeGroup }

--- a/packages/cozy-sharing/src/components/Recipient/actions/revokeMember.js
+++ b/packages/cozy-sharing/src/components/Recipient/actions/revokeMember.js
@@ -1,0 +1,39 @@
+import React, { forwardRef } from 'react'
+
+import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
+import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+const revokeMember = ({ t, isOwner, handleRevocation }) => {
+  const revokeType = isOwner ? 'revoke' : 'revokeSelf'
+  const title = t(`RevokeMemberItem.${revokeType}.title`)
+  const desc = t(`RevokeMemberItem.${revokeType}.desc`)
+
+  const icon = TrashIcon
+
+  return {
+    name: 'revokeMember',
+    label: title,
+    icon,
+    action: () => {
+      handleRevocation()
+    },
+    Component: forwardRef(function RevokeMemberItem(props, ref) {
+      return (
+        <ActionsMenuItem {...props} ref={ref}>
+          <ListItemIcon>
+            <Icon icon={icon} color="var(--errorColor)" />
+          </ListItemIcon>
+          <ListItemText
+            primary={<Typography color="error">{title}</Typography>}
+            secondary={desc}
+          />
+        </ActionsMenuItem>
+      )
+    })
+  }
+}
+export { revokeMember }

--- a/packages/cozy-sharing/src/components/ShareByEmail.jsx
+++ b/packages/cozy-sharing/src/components/ShareByEmail.jsx
@@ -17,13 +17,13 @@ import {
   hasReachRecipientsLimit
 } from '../helpers/recipients'
 import { getSuccessMessage } from '../helpers/successMessage'
-import { contactsResponseType, groupsResponseType } from '../propTypes'
+import { contactsResponseType, contactGroupsResponseType } from '../propTypes'
 import { isReadOnlySharing } from '../state'
 import styles from '../styles/share.styl'
 
 export const ShareByEmail = ({
   contacts,
-  groups,
+  contactGroups,
   document,
   sharingDesc,
   onShare,
@@ -140,7 +140,7 @@ export const ShareByEmail = ({
           onPick={recipient => onRecipientPick(recipient)}
           onRemove={recipient => onRecipientRemove(recipient)}
           contacts={contacts}
-          groups={groups}
+          contactGroups={contactGroups}
           recipients={recipients}
         />
       </div>
@@ -168,7 +168,7 @@ export const ShareByEmail = ({
 ShareByEmail.propTypes = {
   currentRecipients: PropTypes.arrayOf(PropTypes.object),
   contacts: contactsResponseType.isRequired,
-  groups: groupsResponseType.isRequired,
+  contactGroups: contactGroupsResponseType.isRequired,
   document: PropTypes.object.isRequired,
   documentType: PropTypes.string.isRequired,
   sharingDesc: PropTypes.string.isRequired,

--- a/packages/cozy-sharing/src/components/ShareByEmail.jsx
+++ b/packages/cozy-sharing/src/components/ShareByEmail.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 
 import { useClient } from 'cozy-client'
+import flag from 'cozy-flags'
 import Alerter from 'cozy-ui/transpiled/react/deprecated/Alerter'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
@@ -11,6 +12,7 @@ import ShareSubmit from './Sharesubmit'
 import ShareTypeSelect from './Sharetypeselect'
 import { getOrCreateFromArray } from '../helpers/contacts'
 import {
+  mergeRecipients,
   spreadGroupAndMergeRecipients,
   hasReachRecipientsLimit
 } from '../helpers/recipients'
@@ -47,11 +49,9 @@ export const ShareByEmail = ({
   }
 
   const onRecipientPick = recipient => {
-    const mergedRecipients = spreadGroupAndMergeRecipients(
-      recipients,
-      recipient,
-      contacts
-    )
+    const mergedRecipients = flag('sharing.show-recipient-groups')
+      ? mergeRecipients(recipients, recipient)
+      : spreadGroupAndMergeRecipients(recipients, recipient, contacts)
     setRecipients(mergedRecipients)
   }
 

--- a/packages/cozy-sharing/src/components/ShareByEmail.jsx
+++ b/packages/cozy-sharing/src/components/ShareByEmail.jsx
@@ -1,4 +1,3 @@
-import get from 'lodash/get'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 
@@ -11,9 +10,11 @@ import { ShareRecipientsLimitModal } from './ShareRecipientsLimitModal'
 import ShareSubmit from './Sharesubmit'
 import ShareTypeSelect from './Sharetypeselect'
 import { getOrCreateFromArray } from '../helpers/contacts'
-import { hasReachRecipientsLimit } from '../helpers/recipients'
+import {
+  spreadGroupAndMergeRecipients,
+  hasReachRecipientsLimit
+} from '../helpers/recipients'
 import { getSuccessMessage } from '../helpers/successMessage'
-import { Group } from '../models'
 import { contactsResponseType, groupsResponseType } from '../propTypes'
 import { isReadOnlySharing } from '../state'
 import styles from '../styles/share.styl'
@@ -46,31 +47,12 @@ export const ShareByEmail = ({
   }
 
   const onRecipientPick = recipient => {
-    let contactsToAdd
-    if (recipient._type === Group.doctype) {
-      const groupId = recipient.id
-      contactsToAdd = contacts.data.filter(contact => {
-        const contactGroupIds = get(
-          contact,
-          'relationships.groups.data',
-          []
-        ).map(group => group._id)
-
-        return contactGroupIds.includes(groupId)
-      })
-    } else {
-      contactsToAdd = [recipient]
-    }
-
-    const filtered = contactsToAdd
-      .filter(
-        contact =>
-          (contact.email && contact.email.length > 0) ||
-          (contact.cozy && contact.cozy.length > 0)
-      )
-      .filter(contact => !recipients.find(r => r === contact))
-
-    setRecipients([...recipients, ...filtered])
+    const mergedRecipients = spreadGroupAndMergeRecipients(
+      recipients,
+      recipient,
+      contacts
+    )
+    setRecipients(mergedRecipients)
   }
 
   const onRecipientRemove = recipient => {

--- a/packages/cozy-sharing/src/components/ShareByEmail.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareByEmail.spec.jsx
@@ -30,7 +30,7 @@ describe('ShareByEmailComponent', () => {
       contacts: {
         data: []
       },
-      groups: { data: [] },
+      contactGroups: { data: [] },
       documentType: 'Files',
       onShare,
       document,

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
@@ -15,10 +15,10 @@ import styles from '../styles/share.styl'
  */
 const SharingContent = ({
   contacts,
+  contactGroups,
   createContact,
   document,
   documentType,
-  groups,
   hasSharedParent,
   isOwner,
   needsContactsPermission,
@@ -66,11 +66,11 @@ const SharingContent = ({
       {showShareByEmail && (
         <DumbShareByEmail
           contacts={contacts}
+          contactGroups={contactGroups}
           createContact={createContact}
           currentRecipients={recipients}
           document={document}
           documentType={documentType}
-          groups={groups}
           needsContactsPermission={needsContactsPermission}
           onShare={onShare}
           sharing={sharing}

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
@@ -315,7 +315,7 @@ const getMockProps = () => {
       _id: 'SOME_DOCUMENT_ID'
     },
     documentType: 'Organizations',
-    groups: {
+    contactGroups: {
       id: 'groups',
       definition: {
         doctype: 'io.cozy.contacts.groups'

--- a/packages/cozy-sharing/src/components/ShareDialogTwoStepsConfirmationContainer.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogTwoStepsConfirmationContainer.jsx
@@ -91,10 +91,10 @@ const RejectRecipientActions = ({ reject, cancel }) => {
  */
 const ShareDialogTwoStepsConfirmationContainer = ({
   contacts,
+  contactGroups,
   createContact,
   document,
   documentType,
-  groups,
   hasSharedParent,
   isOwner,
   link,
@@ -211,10 +211,10 @@ const ShareDialogTwoStepsConfirmationContainer = ({
     dialogContent = (
       <DialogContentOnShare
         contacts={contacts}
+        contactGroups={contactGroups}
         createContact={createContact}
         document={document}
         documentType={documentType}
-        groups={groups}
         hasSharedParent={hasSharedParent}
         isOwner={isOwner}
         needsContactsPermission={needsContactsPermission}

--- a/packages/cozy-sharing/src/components/ShareDialogTwoStepsConfirmationContainer.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogTwoStepsConfirmationContainer.spec.jsx
@@ -342,7 +342,7 @@ const getMockProps = () => {
       _id: 'SOME_DOCUMENT_ID'
     },
     documentType: 'Organizations',
-    groups: {
+    contactGroups: {
       id: 'groups',
       definition: {
         doctype: 'io.cozy.contacts.groups'

--- a/packages/cozy-sharing/src/components/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal.jsx
@@ -5,13 +5,13 @@ import flag from 'cozy-flags'
 
 import ShareDialogCozyToCozy from './ShareDialogCozyToCozy'
 import ShareDialogOnlyByLink from './ShareDialogOnlyByLink'
-import { contactsResponseType, groupsResponseType } from '../propTypes'
+import { contactsResponseType, contactGroupsResponseType } from '../propTypes'
 export const ShareModal = ({
   contacts,
+  contactGroups,
   createContact,
   document,
   documentType = 'Document',
-  groups,
   hasSharedChild,
   hasSharedParent,
   isOwner,
@@ -57,10 +57,10 @@ export const ShareModal = ({
   ) : (
     <ShareDialogCozyToCozy
       contacts={contacts}
+      contactGroups={contactGroups}
       createContact={createContact}
       document={document}
       documentType={documentType}
-      groups={groups}
       hasSharedParent={hasSharedParent}
       isOwner={isOwner}
       link={link}
@@ -89,10 +89,10 @@ export default ShareModal
 
 ShareModal.propTypes = {
   contacts: contactsResponseType.isRequired,
+  contactGroups: contactGroupsResponseType.isRequired,
   createContact: PropTypes.func.isRequired,
   document: PropTypes.object.isRequired,
   documentType: PropTypes.string,
-  groups: groupsResponseType.isRequired,
   hasSharedChild: PropTypes.bool,
   hasSharedParent: PropTypes.bool,
   isOwner: PropTypes.bool,

--- a/packages/cozy-sharing/src/components/ShareModal/EditableSharingModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal/EditableSharingModal.jsx
@@ -3,8 +3,8 @@ import React from 'react'
 
 import { useClient, useQueryAll } from 'cozy-client'
 
-import SharingContext from '../../context'
 import { useFetchDocumentPath } from '../../hooks/useFetchDocumentPath'
+import { useSharingContext } from '../../hooks/useSharingContext'
 import { Contact } from '../../models'
 import { buildContactsQuery, buildGroupsQuery } from '../../queries/queries'
 import { default as DumbShareModal } from '../ShareModal'
@@ -22,49 +22,45 @@ export const EditableSharingModal = ({ document, ...rest }) => {
   const groupsQuery = buildGroupsQuery()
   const groupsResult = useQueryAll(groupsQuery.definition, groupsQuery.options)
 
+  const {
+    documentType,
+    getDocumentPermissions,
+    getRecipients,
+    getSharingForSelf,
+    getSharingLink,
+    hasSharedChild,
+    hasSharedParent,
+    isOwner,
+    revoke,
+    revokeSelf,
+    revokeSharingLink,
+    share,
+    shareByLink,
+    updateDocumentPermissions
+  } = useSharingContext()
+
   return (
-    <SharingContext.Consumer>
-      {({
-        documentType,
-        getDocumentPermissions,
-        getRecipients,
-        getSharingForSelf,
-        getSharingLink,
-        hasSharedChild,
-        hasSharedParent,
-        isOwner,
-        revoke,
-        revokeSelf,
-        revokeSharingLink,
-        share,
-        shareByLink,
-        updateDocumentPermissions
-      }) => {
-        return (
-          <DumbShareModal
-            contacts={contactsResult}
-            createContact={contact => client.create(Contact.doctype, contact)}
-            document={document}
-            documentType={documentType}
-            groups={groupsResult}
-            hasSharedChild={documentPath && hasSharedChild(documentPath)}
-            hasSharedParent={documentPath && hasSharedParent(documentPath)}
-            isOwner={isOwner(document.id)}
-            link={getSharingLink(document.id)}
-            onRevoke={revoke}
-            onRevokeLink={revokeSharingLink}
-            onRevokeSelf={revokeSelf}
-            onShare={share}
-            onShareByLink={shareByLink}
-            onUpdateShareLinkPermissions={updateDocumentPermissions}
-            permissions={getDocumentPermissions(document.id)}
-            recipients={getRecipients(document.id)}
-            sharing={getSharingForSelf(document.id)}
-            {...rest}
-          />
-        )
-      }}
-    </SharingContext.Consumer>
+    <DumbShareModal
+      contacts={contactsResult}
+      createContact={contact => client.create(Contact.doctype, contact)}
+      document={document}
+      documentType={documentType}
+      groups={groupsResult}
+      hasSharedChild={documentPath && hasSharedChild(documentPath)}
+      hasSharedParent={documentPath && hasSharedParent(documentPath)}
+      isOwner={isOwner(document.id)}
+      link={getSharingLink(document.id)}
+      onRevoke={revoke}
+      onRevokeLink={revokeSharingLink}
+      onRevokeSelf={revokeSelf}
+      onShare={share}
+      onShareByLink={shareByLink}
+      onUpdateShareLinkPermissions={updateDocumentPermissions}
+      permissions={getDocumentPermissions(document.id)}
+      recipients={getRecipients(document.id)}
+      sharing={getSharingForSelf(document.id)}
+      {...rest}
+    />
   )
 }
 

--- a/packages/cozy-sharing/src/components/ShareModal/EditableSharingModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal/EditableSharingModal.jsx
@@ -6,7 +6,10 @@ import { useClient, useQueryAll } from 'cozy-client'
 import { useFetchDocumentPath } from '../../hooks/useFetchDocumentPath'
 import { useSharingContext } from '../../hooks/useSharingContext'
 import { Contact } from '../../models'
-import { buildContactsQuery, buildGroupsQuery } from '../../queries/queries'
+import {
+  buildContactsQuery,
+  buildContactGroupsQuery
+} from '../../queries/queries'
 import { default as DumbShareModal } from '../ShareModal'
 
 export const EditableSharingModal = ({ document, ...rest }) => {
@@ -19,8 +22,11 @@ export const EditableSharingModal = ({ document, ...rest }) => {
     contactsQuery.options
   )
 
-  const groupsQuery = buildGroupsQuery()
-  const groupsResult = useQueryAll(groupsQuery.definition, groupsQuery.options)
+  const contactGroupsQuery = buildContactGroupsQuery()
+  const contactGroupsResult = useQueryAll(
+    contactGroupsQuery.definition,
+    contactGroupsQuery.options
+  )
 
   const {
     documentType,
@@ -42,10 +48,10 @@ export const EditableSharingModal = ({ document, ...rest }) => {
   return (
     <DumbShareModal
       contacts={contactsResult}
+      contactGroups={contactGroupsResult}
       createContact={contact => client.create(Contact.doctype, contact)}
       document={document}
       documentType={documentType}
-      groups={groupsResult}
       hasSharedChild={documentPath && hasSharedChild(documentPath)}
       hasSharedParent={documentPath && hasSharedParent(documentPath)}
       isOwner={isOwner(document.id)}

--- a/packages/cozy-sharing/src/components/ShareModal/EditableSharingModal.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal/EditableSharingModal.spec.jsx
@@ -33,8 +33,8 @@ describe('EditableSharingModal', () => {
         <EditableSharingModal
           client={client}
           contacts={{ data: [] }}
+          contactGroups={{ data: [] }}
           document={document}
-          groups={{ data: [] }}
           t={x => x}
           onClose={() => {}}
         />

--- a/packages/cozy-sharing/src/components/ShareRecipientsInput.jsx
+++ b/packages/cozy-sharing/src/components/ShareRecipientsInput.jsx
@@ -2,11 +2,11 @@ import PropTypes from 'prop-types'
 import React, { useState, useEffect } from 'react'
 
 import ShareAutosuggest from './ShareAutosuggest'
-import { contactsResponseType, groupsResponseType } from '../propTypes'
+import { contactsResponseType, contactGroupsResponseType } from '../propTypes'
 
 const ShareRecipientsInput = ({
   contacts,
-  groups,
+  contactGroups,
   recipients,
   placeholder,
   onPick,
@@ -19,19 +19,19 @@ const ShareRecipientsInput = ({
       loading &&
       !contacts.hasMore &&
       contacts.fetchStatus === 'loaded' &&
-      !groups.hasMore &&
-      groups.fetchStatus === 'loaded'
+      !contactGroups.hasMore &&
+      contactGroups.fetchStatus === 'loaded'
     ) {
       setLoading(false)
     }
-  }, [contacts, groups, loading])
+  }, [contacts, contactGroups, loading])
 
   const onShareAutosuggestFocus = () => {
     if (
       contacts.hasMore ||
       contacts.fetchStatus === 'loading' ||
-      groups.hasMore ||
-      groups.fetchStatus === 'loading'
+      contactGroups.hasMore ||
+      contactGroups.fetchStatus === 'loading'
     ) {
       setLoading(true)
     }
@@ -42,7 +42,7 @@ const ShareRecipientsInput = ({
     if (contacts.hasMore || contacts.fetchStatus === 'loading') {
       return contacts.data
     } else {
-      return [...contacts.data, ...groups.data]
+      return [...contacts.data, ...contactGroups.data]
     }
   }
 
@@ -61,7 +61,7 @@ const ShareRecipientsInput = ({
 
 ShareRecipientsInput.propTypes = {
   contacts: contactsResponseType.isRequired,
-  groups: groupsResponseType.isRequired,
+  contactGroups: contactGroupsResponseType.isRequired,
   recipients: PropTypes.array,
   placeholder: PropTypes.string,
   onPick: PropTypes.func.isRequired,

--- a/packages/cozy-sharing/src/components/ShareRecipientsInput.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareRecipientsInput.spec.jsx
@@ -33,7 +33,7 @@ describe('ShareRecipientsInput component', () => {
           }
         ]
       },
-      groups: {
+      contactGroups: {
         id: 'groups',
         fetchStatus: 'loaded',
         hasMore: false,
@@ -99,7 +99,7 @@ describe('ShareRecipientsInput component', () => {
           }
         ]
       },
-      groups: {
+      contactGroups: {
         id: 'groups',
         fetchStatus: 'loaded',
         hasMore: false,

--- a/packages/cozy-sharing/src/helpers/recipients.js
+++ b/packages/cozy-sharing/src/helpers/recipients.js
@@ -86,3 +86,7 @@ export const spreadGroupAndMergeRecipients = (
 
   return [...recipients, ...filtered]
 }
+
+export const mergeRecipients = (recipients, newRecipient) => {
+  return [...recipients, newRecipient]
+}

--- a/packages/cozy-sharing/src/helpers/successMessage.spec.js
+++ b/packages/cozy-sharing/src/helpers/successMessage.spec.js
@@ -8,7 +8,7 @@ describe('getSuccessMessage method', () => {
       hasMore: false,
       fetchStatus: 'loaded'
     },
-    groups: {
+    contactGroups: {
       id: 'groups',
       data: [],
       hasMore: false,

--- a/packages/cozy-sharing/src/propTypes.js
+++ b/packages/cozy-sharing/src/propTypes.js
@@ -15,7 +15,7 @@ export const contactsResponseType = PropTypes.shape({
   lastUpdate: PropTypes.number
 })
 
-export const groupsResponseType = PropTypes.shape({
+export const contactGroupsResponseType = PropTypes.shape({
   count: PropTypes.number,
   data: PropTypes.arrayOf(Group.propType),
   definition: PropTypes.object,

--- a/packages/cozy-sharing/src/queries/queries.js
+++ b/packages/cozy-sharing/src/queries/queries.js
@@ -59,7 +59,7 @@ export const buildContactsQuery = () => ({
   }
 })
 
-export const buildGroupsQuery = () => ({
+export const buildContactGroupsQuery = () => ({
   definition: Q(Group.doctype),
   options: {
     as: 'io.cozy.contacts.groups'


### PR DESCRIPTION
This PR is the first step to add the support of recipient groups. It allow user to add a contact group as a sharing recipient.
It also included the display of recipient groups into the sharing modal behind the flag `sharing.show-recipient-groups`

![Capture d’écran 2024-03-12 à 18 00 10](https://github.com/cozy/cozy-libs/assets/7434420/8846f60a-4904-4f44-8155-9ddf7c857c31)

Some of refactor was done before into https://github.com/cozy/cozy-libs/pull/2463