### PR TITLE
chore: Minimize services when cozy-notifications is used

### DIFF
--- a/packages/cozy-notifications/src/webpack/config.js
+++ b/packages/cozy-notifications/src/webpack/config.js
@@ -1,5 +1,7 @@
-import webpack from 'webpack'
 import path from 'path'
+
+import TerserPlugin from 'terser-webpack-plugin'
+import webpack from 'webpack'
 
 export default {
   resolve: {
@@ -8,7 +10,19 @@ export default {
     }
   },
   optimization: {
-    minimize: false
+    minimizer: [
+      // Minimizing everything breaks mjml.
+      // Fix `Element mj-head doesn't exist or is not registered ...` error
+      // when sending a notification at runtime after a build.
+      new TerserPlugin({
+        parallel: true,
+        terserOptions: {
+          mangle: {
+            keep_fnames: true
+          }
+        }
+      })
+    ]
   },
   module: {
     // mjml-core/lib/helpers/mjmlconfig and encoding/lib/iconv-loader use


### PR DESCRIPTION
cozy-notifications uses mjml to generate mail templates. mjml can not be minimized as is. So previously, we disabled minimize for the whole services configuration. It could lead to huge services bundle but it was working.

We discovered that configuring Terser plugin with keep_fnames to true is enough to allow minimization without breaking mjml. So let's use it to reduce services bundle size.

From the Terser plugin documentation :
keep_fnames (default false) -- Pass true to not mangle function names. Pass a regular expression to only keep function names matching that regex. Useful for code relying on Function.prototype.name. See also: the keep_fnames compress option.