### PR TITLE
[VO-524] fix: Avoir losing cozy-client cache after reload

### DIFF
--- a/packages/cozy-harvest-lib/src/helpers/useKonnectorWithTriggers.js
+++ b/packages/cozy-harvest-lib/src/helpers/useKonnectorWithTriggers.js
@@ -70,7 +70,11 @@ async function getKonnector(client, slug) {
 
 async function getTriggers(client, slug) {
   const { data: allTriggers } = await client.query(
-    Q(TRIGGERS_DOCTYPE).where({ worker: ['client', 'konnector'] })
+    Q(TRIGGERS_DOCTYPE).where({
+      worker: {
+        $in: ['client', 'konnector']
+      }
+    })
   )
   return allTriggers.filter(
     trigger =>


### PR DESCRIPTION
This fix is related to the problem encounter on the home : https://github.com/cozy/cozy-home/pull/2103

Sift can't replay this type of query. It needs an MongoDB operator before the array. 