### PR TITLE
feat(mespapiers): Rename "stranger" by "foreign"

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/helpers.js
@@ -107,7 +107,7 @@ export const getPaperDefinitionByFile = (papersDefinitions, file) => {
       Object.keys(file.metadata).includes('country') && paper.country
         ? file.metadata.country === 'fr'
           ? paper.country === 'fr'
-          : paper.country === 'stranger'
+          : paper.country === 'foreign'
         : true
 
     return paper.label === file.metadata.qualification.label && countryCondition

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/Edit/helpers.spec.js
@@ -398,7 +398,7 @@ describe('getPaperDefinitionByFile', () => {
 
       expect(res).toMatchObject({ label: 'driver_license', country: 'fr' })
     })
-    it('should return the paperDefinition "driver_license", with the country "stranger" if defined & not "fr"', () => {
+    it('should return the paperDefinition "driver_license", with the country "foreign" if defined & not "fr"', () => {
       const fakeFile = makeFakeFile({
         qualificationLabel: 'driver_license',
         country: 'en'
@@ -407,10 +407,10 @@ describe('getPaperDefinitionByFile', () => {
 
       expect(res).toMatchObject({
         label: 'driver_license',
-        country: 'stranger'
+        country: 'foreign'
       })
     })
-    it('should return the paperDefinition "driver_license", with the country "stranger" if it empty in file', () => {
+    it('should return the paperDefinition "driver_license", with the country "foreign" if it empty in file', () => {
       const fakeFile = makeFakeFile({
         qualificationLabel: 'driver_license',
         country: ''
@@ -419,7 +419,7 @@ describe('getPaperDefinitionByFile', () => {
 
       expect(res).toMatchObject({
         label: 'driver_license',
-        country: 'stranger'
+        country: 'foreign'
       })
     })
   })

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -577,7 +577,7 @@
     {
       "label": "driver_license",
       "placeholderIndex": 3,
-      "country": "stranger",
+      "country": "foreign",
       "icon": "car",
       "featureDate": "expirationDate",
       "maxDisplay": 5,
@@ -591,24 +591,24 @@
         {
           "model": "information",
           "illustration": "Planet.svg",
-          "text": "PaperJSON.generic.stranger.country.text",
+          "text": "PaperJSON.generic.foreign.country.text",
           "attributes": [
             {
               "name": "country",
               "type": "text",
-              "inputLabel": "PaperJSON.generic.stranger.country.inputLabel"
+              "inputLabel": "PaperJSON.generic.foreign.country.inputLabel"
             }
           ]
         },
         {
           "model": "information",
           "illustration": "IlluGenericInputDate.svg",
-          "text": "PaperJSON.generic.stranger.obtentionDate.text",
+          "text": "PaperJSON.generic.foreign.obtentionDate.text",
           "attributes": [
             {
               "name": "obtentionDate",
               "type": "date",
-              "inputLabel": "PaperJSON.generic.stranger.obtentionDate.inputLabel"
+              "inputLabel": "PaperJSON.generic.foreign.obtentionDate.inputLabel"
             }
           ]
         },
@@ -1072,7 +1072,7 @@
     },
     {
       "label": "national_id_card",
-      "country": "stranger",
+      "country": "foreign",
       "icon": "people",
       "featureDate": "expirationDate",
       "maxDisplay": 4,
@@ -1094,12 +1094,12 @@
         {
           "model": "information",
           "illustration": "Planet.svg",
-          "text": "PaperJSON.generic.stranger.country.text",
+          "text": "PaperJSON.generic.foreign.country.text",
           "attributes": [
             {
               "name": "country",
               "type": "text",
-              "inputLabel": "PaperJSON.generic.stranger.country.inputLabel"
+              "inputLabel": "PaperJSON.generic.foreign.country.inputLabel"
             }
           ]
         },

--- a/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
@@ -93,7 +93,7 @@ const filterPlaceholderByLabelAndCountry = ({
     ? country == null
       ? paperDefinition.country === 'fr'
       : paperDefinition.country === country ||
-        paperDefinition.country === 'stranger'
+        paperDefinition.country === 'foreign'
     : true
 
   return label === paperDefinition.label && countryCondition

--- a/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.spec.js
@@ -240,14 +240,14 @@ describe('findPlaceholders', () => {
       const placeholders = findPlaceholderByLabelAndCountry(
         mockPapersDefinitions,
         'driver_license',
-        'stranger'
+        'foreign'
       )
 
       expect(placeholders).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             label: 'driver_license',
-            country: 'stranger'
+            country: 'foreign'
           })
         ])
       )
@@ -263,7 +263,7 @@ describe('findPlaceholders', () => {
         expect.arrayContaining([
           expect.objectContaining({
             label: 'driver_license',
-            country: 'stranger'
+            country: 'foreign'
           })
         ])
       )

--- a/packages/cozy-mespapiers-lib/src/locales/en.json
+++ b/packages/cozy-mespapiers-lib/src/locales/en.json
@@ -230,7 +230,7 @@
       "ocrResult": {
         "text": "Check and complete the following information"
       },
-      "stranger": {
+      "foreign": {
         "country": {
           "inputLabel": "Beneficiary nationality",
           "text": "What is the Nationality of the beneficiary?"

--- a/packages/cozy-mespapiers-lib/src/locales/fr.json
+++ b/packages/cozy-mespapiers-lib/src/locales/fr.json
@@ -230,7 +230,7 @@
       "ocrResult": {
         "text": "Vérifier et compléter les informations suivantes"
       },
-      "stranger": {
+      "foreign": {
         "country": {
           "inputLabel": "Nationalité du bénéficiaire",
           "text": "Quelle est la nationalité du bénéficiaire ?"

--- a/packages/cozy-mespapiers-lib/test/mockPaperDefinitions.js
+++ b/packages/cozy-mespapiers-lib/test/mockPaperDefinitions.js
@@ -101,24 +101,24 @@ export const mockPapersDefinitions = [
       {
         model: 'information',
         illustration: 'IlluDriverLicenseNumberHelp.png',
-        text: 'PaperJSON.generic.stranger.country.text',
+        text: 'PaperJSON.generic.foreign.country.text',
         attributes: [
           {
             name: 'country',
             type: 'text',
-            inputLabel: 'PaperJSON.generic.stranger.country.inputLabel'
+            inputLabel: 'PaperJSON.generic.foreign.country.inputLabel'
           }
         ]
       },
       {
         model: 'information',
         illustration: 'IlluDriverLicenseObtentionDateHelp.png',
-        text: 'PaperJSON.generic.stranger.obtentionDate.text',
+        text: 'PaperJSON.generic.foreign.obtentionDate.text',
         attributes: [
           {
             name: 'obtentionDate',
             type: 'date',
-            inputLabel: 'PaperJSON.generic.stranger.obtentionDate.inputLabel'
+            inputLabel: 'PaperJSON.generic.foreign.obtentionDate.inputLabel'
           }
         ]
       },
@@ -131,7 +131,7 @@ export const mockPapersDefinitions = [
   },
   {
     label: 'driver_license',
-    country: 'stranger',
+    country: 'foreign',
     icon: 'car',
     featureDate: 'obtentionDate',
     maxDisplay: 2,
@@ -145,24 +145,24 @@ export const mockPapersDefinitions = [
       {
         model: 'information',
         illustration: 'IlluDriverLicenseNumberHelp.png',
-        text: 'PaperJSON.generic.stranger.country.text',
+        text: 'PaperJSON.generic.foreign.country.text',
         attributes: [
           {
             name: 'country',
             type: 'text',
-            inputLabel: 'PaperJSON.generic.stranger.country.inputLabel'
+            inputLabel: 'PaperJSON.generic.foreign.country.inputLabel'
           }
         ]
       },
       {
         model: 'information',
         illustration: 'IlluDriverLicenseObtentionDateHelp.png',
-        text: 'PaperJSON.generic.stranger.obtentionDate.text',
+        text: 'PaperJSON.generic.foreign.obtentionDate.text',
         attributes: [
           {
             name: 'obtentionDate',
             type: 'date',
-            inputLabel: 'PaperJSON.generic.stranger.obtentionDate.inputLabel'
+            inputLabel: 'PaperJSON.generic.foreign.obtentionDate.inputLabel'
           }
         ]
       },


### PR DESCRIPTION
Changement de la traduction EN, car "stranger" n'est pas très juste dans ce contexte.