### PR TITLE
fix(mespapiers): Change variant Alert

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Actions/utils.js
+++ b/packages/cozy-mespapiers-lib/src/components/Actions/utils.js
@@ -121,7 +121,11 @@ export const forwardFile = async ({
     }
     navigator.share(shareData)
   } catch (error) {
-    showAlert({ message: t('viewer.shareData.error'), severity: 'error' })
+    showAlert({
+      message: t('viewer.shareData.error'),
+      severity: 'error',
+      variant: 'filled'
+    })
   }
 }
 
@@ -148,7 +152,11 @@ export const downloadFiles = async ({ client, files, showAlert, t }) => {
 
       fileCollection.forceFileDownload(`${downloadURL}?Dl=1`, filename)
     } catch (error) {
-      showAlert({ message: t(downloadFileError(error)), severity: 'error' })
+      showAlert({
+        message: t(downloadFileError(error)),
+        severity: 'error',
+        variant: 'filled'
+      })
     }
   } else {
     const ids = files.map(f => f.id)
@@ -185,10 +193,18 @@ export const trashFiles = async ({ client, files, showAlert, t }) => {
       await client.destroy(file)
     }
 
-    showAlert({ message: t('common.trashFile.success'), severity: 'success' })
+    showAlert({
+      message: t('common.trashFile.success'),
+      severity: 'success',
+      variant: 'filled'
+    })
   } catch (err) {
     if (!isAlreadyInTrash(err)) {
-      showAlert({ message: t('common.trashFile.error'), severity: 'error' })
+      showAlert({
+        message: t('common.trashFile.error'),
+        severity: 'error',
+        variant: 'filled'
+      })
     }
   }
 }
@@ -213,12 +229,14 @@ export const removeQualification = async ({ client, files, showAlert, t }) => {
 
     showAlert({
       message: t('common.removeQualification.success'),
-      severity: 'success'
+      severity: 'success',
+      variant: 'filled'
     })
   } catch (err) {
     showAlert({
       message: t('common.removeQualification.error'),
-      severity: 'error'
+      severity: 'error',
+      variant: 'filled'
     })
   }
 }

--- a/packages/cozy-mespapiers-lib/src/components/Contexts/PapersDefinitionsProvider.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Contexts/PapersDefinitionsProvider.jsx
@@ -73,7 +73,8 @@ const PapersDefinitionsProvider = ({ children }) => {
                 path: appFolderPath
               }
             ),
-            severity: 'error'
+            severity: 'error',
+            variant: 'filled'
           })
           setPapersDefinitions(
             buildPapersDefinitions(papersJSON.papersDefinitions, scannerT)

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/SubmitButton.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/SubmitButton.jsx
@@ -53,10 +53,18 @@ const SubmitButton = ({ onSubmit, disabled, formData }) => {
         i18n: { t, f, scannerT }
       })
 
-      showAlert({ message: t('common.saveFile.success'), severity: 'success' })
+      showAlert({
+        message: t('common.saveFile.success'),
+        severity: 'success',
+        variant: 'filled'
+      })
     } catch (error) {
       log.error('Error when submitting', error)
-      showAlert({ message: t('common.saveFile.error'), severity: 'error' })
+      showAlert({
+        message: t('common.saveFile.error'),
+        severity: 'error',
+        variant: 'filled'
+      })
     } finally {
       onSubmit()
     }

--- a/packages/cozy-mespapiers-lib/src/components/Multiselect/ShareBottomSheet.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Multiselect/ShareBottomSheet.jsx
@@ -36,7 +36,8 @@ const ShareBottomSheet = ({ onClose, fileId, docs }) => {
         message: t('ShareBottomSheet.attachmentResponse.success', {
           smart_count: idsToShare.length
         }),
-        severity: 'success'
+        severity: 'success',
+        variant: 'filled'
       })
       if (isMultiSelectionActive) {
         navigate('/paper', { replace: true })
@@ -48,7 +49,8 @@ const ShareBottomSheet = ({ onClose, fileId, docs }) => {
 
       showAlert({
         message: t('ShareBottomSheet.attachmentResponse.error'),
-        severity: 'error'
+        severity: 'error',
+        variant: 'filled'
       })
     }
   }

--- a/packages/cozy-mespapiers-lib/src/helpers/copyToClipboard.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/copyToClipboard.js
@@ -16,12 +16,14 @@ export const copyToClipboard = async (value, { t, showAlert } = {}) => {
     await navigator.clipboard.writeText(value)
     showAlert({
       message: t('action.copyReminderContent.success'),
-      severity: 'success'
+      severity: 'success',
+      variant: 'filled'
     })
   } catch (error) {
     showAlert({
       message: t('action.copyReminderContent.error'),
-      severity: 'error'
+      severity: 'error',
+      variant: 'filled'
     })
     log.error(
       "Error in 'copyToClipboard' function when trying to copy to clipboard",


### PR DESCRIPTION
The Alert component has the `standard` `variant` by default, on the app we need the `filled`
The `standard` has a transparency that we don't want to have here.