### PR TITLE
fix: Misspelled checkedAttributes -> checkAttributes for bank objects

### DIFF
--- a/packages/cozy-doctypes/src/Document.js
+++ b/packages/cozy-doctypes/src/Document.js
@@ -228,7 +228,7 @@ class Document {
     } else {
       log(
         'debug',
-        `[updateIfDifferent] No need to update ${update._id} because its \`checkedAttributes\` (${this.checkAttributes}) didn't change.`
+        `[updateIfDifferent] No need to update ${update._id} because its \`checkAttributes\` (${this.checkAttributes}) didn't change.`
       )
       return doc
     }

--- a/packages/cozy-doctypes/src/banking/BalanceHistory.js
+++ b/packages/cozy-doctypes/src/banking/BalanceHistory.js
@@ -39,6 +39,6 @@ class BalanceHistory extends Document {
 BalanceHistory.doctype = 'io.cozy.bank.balancehistories'
 BalanceHistory.idAttributes = ['year', 'relationships.account.data._id']
 BalanceHistory.version = 1
-BalanceHistory.checkedAttributes = ['balances']
+BalanceHistory.checkAttributes = ['balances']
 
 module.exports = BalanceHistory

--- a/packages/cozy-doctypes/src/banking/BankAccount.js
+++ b/packages/cozy-doctypes/src/banking/BankAccount.js
@@ -175,7 +175,7 @@ BankAccount.normalizeAccountNumber = matching.normalizeAccountNumber
 BankAccount.doctype = 'io.cozy.bank.accounts'
 BankAccount.idAttributes = ['_id']
 BankAccount.version = 1
-BankAccount.checkedAttributes = null
+BankAccount.checkAttributes = null
 BankAccount.vendorIdAttr = 'vendorId'
 
 module.exports = BankAccount

--- a/packages/cozy-doctypes/src/banking/BankAccountStats.js
+++ b/packages/cozy-doctypes/src/banking/BankAccountStats.js
@@ -49,6 +49,6 @@ class BankAccountStats extends Document {
 BankAccountStats.doctype = 'io.cozy.bank.accounts.stats'
 BankAccountStats.idAttributes = ['_id']
 BankAccountStats.version = 1
-BankAccountStats.checkedAttributes = null
+BankAccountStats.checkAttributes = null
 
 module.exports = BankAccountStats

--- a/packages/cozy-doctypes/src/banking/BankTransaction.js
+++ b/packages/cozy-doctypes/src/banking/BankTransaction.js
@@ -330,7 +330,7 @@ Transaction.version = 1
 Transaction.vendorAccountIdAttr = 'vendorAccountId'
 Transaction.vendorIdAttr = 'vendorId'
 Transaction.idAttributes = ['vendorId']
-Transaction.checkedAttributes = [
+Transaction.checkAttributes = [
   'label',
   'originalBankLabel',
   'automaticCategoryId',


### PR DESCRIPTION
Because of this, all fetched transaction where always updated on stack
which caused a large overhead for each banking connector execution
