### PR TITLE
fix(mespapiers): Use currentStep from props instead hook

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/InformationDialog.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/InformationDialog.jsx
@@ -29,8 +29,13 @@ const InformationDialog = ({ currentStep, onClose, onBack, onSubmit }) => {
     attributes
   } = currentStep
   const { t } = useI18n()
-  const { currentStepIndex, nextStep, isLastStep, allCurrentSteps } =
-    useStepperDialog()
+  const {
+    currentStepIndex,
+    nextStep,
+    isLastStep,
+    allCurrentSteps,
+    currentDefinition
+  } = useStepperDialog()
   const { formData, setFormData } = useFormData()
   const [value, setValue] = useState({})
   const [validInput, setValidInput] = useState({})
@@ -124,6 +129,7 @@ const InformationDialog = ({ currentStep, onClose, onBack, onSubmit }) => {
                   <Component
                     attrs={attrs}
                     formDataValue={formData.metadata[attrs.name]}
+                    currentDefinition={currentDefinition}
                     setValue={setValue}
                     setValidInput={setValidInput}
                     onFocus={setIsFocus}

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
@@ -11,7 +11,6 @@ import {
   checkConstraintsOfIinput,
   makeConstraintsOfInput
 } from '../../../utils/input'
-import { useStepperDialog } from '../../Hooks/useStepperDialog'
 
 const styleFontMono = 'Segoe UI Mono, SF Mono, Roboto Mono, Courier'
 
@@ -48,6 +47,7 @@ const makeInputAdornment = (adornment, currentValue, t) => {
 const InputTextAdapter = ({
   attrs,
   formDataValue,
+  currentDefinition,
   setValue,
   setValidInput,
   onFocus,
@@ -74,7 +74,6 @@ const InputTextAdapter = ({
     () => makeConstraintsOfInput(attrs),
     [attrs]
   )
-  const { currentDefinition } = useStepperDialog()
 
   const isValidInputValue = useMemo(
     () =>
@@ -219,7 +218,7 @@ const InputTextAdapter = ({
       inputProps={{
         maxLength: expectedLength.max,
         minLength: expectedLength.min,
-        inputMode: getInputMode(inputType),
+        inputMode: getInputMode(inputType, null, currentDefinition),
         'data-testid': 'TextField-input'
       }}
       onChange={handleOnChange}

--- a/packages/cozy-mespapiers-lib/src/components/Views/InformationEdit.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/InformationEdit.jsx
@@ -15,7 +15,6 @@ import IlluGenericInputText from '../../assets/icons/IlluGenericInputText.svg'
 import { FILES_DOCTYPE } from '../../doctypes'
 import { makeInputsInformationStep } from '../../helpers/makeInputsInformationStep'
 import CompositeHeader from '../CompositeHeader/CompositeHeader'
-import { StepperDialogProvider } from '../Contexts/StepperDialogProvider'
 import { useScannerI18n } from '../Hooks/useScannerI18n'
 import {
   isInformationEditPermitted,
@@ -89,58 +88,57 @@ const InformationEdit = () => {
     : null
 
   return (
-    <StepperDialogProvider>
-      <Dialog
-        open
-        onClose={onClose}
-        title={dialogTitle}
-        content={
-          <div
-            className={cx(styles['InformationEdit-Dialog-container'], {
-              'is-focused': isFocus && isIOS()
-            })}
-          >
-            {currentEditInformations.isLoading ? (
-              <Spinner size="xlarge" />
-            ) : (
-              <CompositeHeader
-                icon={currentEditInformations.currentStep?.illustration}
-                fallbackIcon={fallbackIcon}
-                iconSize="medium"
-                title={text}
-                text={
-                  <div
-                    className={cx('u-mt-1', {
-                      'u-mh-1': !isMobile
-                    })}
-                  >
-                    {Component && (
-                      <Component
-                        attrs={attrs}
-                        formDataValue={defaultValue}
-                        setValue={setValue}
-                        setValidInput={setValidInput}
-                        onFocus={setIsFocus}
-                        idx={0}
-                      />
-                    )}
-                  </div>
-                }
-              />
-            )}
-          </div>
-        }
-        actions={
-          <Button
-            label={t('common.apply')}
-            onClick={onConfirm}
-            fullWidth
-            disabled={!validInput[0]}
-            busy={isBusy}
-          />
-        }
-      />
-    </StepperDialogProvider>
+    <Dialog
+      open
+      onClose={onClose}
+      title={dialogTitle}
+      content={
+        <div
+          className={cx(styles['InformationEdit-Dialog-container'], {
+            'is-focused': isFocus && isIOS()
+          })}
+        >
+          {currentEditInformations.isLoading ? (
+            <Spinner size="xlarge" />
+          ) : (
+            <CompositeHeader
+              icon={currentEditInformations.currentStep?.illustration}
+              fallbackIcon={fallbackIcon}
+              iconSize="medium"
+              title={text}
+              text={
+                <div
+                  className={cx('u-mt-1', {
+                    'u-mh-1': !isMobile
+                  })}
+                >
+                  {Component && (
+                    <Component
+                      attrs={attrs}
+                      currentDefinition={currentEditInformations.paperDef}
+                      formDataValue={defaultValue}
+                      setValue={setValue}
+                      setValidInput={setValidInput}
+                      onFocus={setIsFocus}
+                      idx={0}
+                    />
+                  )}
+                </div>
+              }
+            />
+          )}
+        </div>
+      }
+      actions={
+        <Button
+          label={t('common.apply')}
+          onClick={onConfirm}
+          fullWidth
+          disabled={!validInput[0]}
+          busy={isBusy}
+        />
+      }
+    />
   )
 }
 


### PR DESCRIPTION
Depending on whether we are on the creation or editing component, the current step is not retrieved in the same way.