### PR TITLE
fix: We should request the files for the right slug and account

### DIFF
--- a/packages/cozy-harvest-lib/src/datacards/FileDataCard.jsx
+++ b/packages/cozy-harvest-lib/src/datacards/FileDataCard.jsx
@@ -156,7 +156,8 @@ const FileDataCard = ({
 }) => {
   const { data, fetchStatus } = useDataCardFiles(
     sourceAccountIdentifier,
-    trigger.message.folder_to_save
+    trigger.message.folder_to_save,
+    konnector.slug
   )
   const isLoading = fetchStatus === 'loading'
   const noFiles = fetchStatus === 'empty' || fetchStatus === 'failed'

--- a/packages/cozy-harvest-lib/src/datacards/useDataCardFiles.js
+++ b/packages/cozy-harvest-lib/src/datacards/useDataCardFiles.js
@@ -21,12 +21,13 @@ const useFolderToSaveFiles = folderToSaveId =>
     }
   )
 
-const useSourceAccountIdentifierFiles = sourceAccountIdentifier =>
+const useSourceAccountIdentifierFiles = (sourceAccountIdentifier, slug) =>
   useQuery(
     Q('io.cozy.files')
       .where({
         'cozyMetadata.sourceAccountIdentifier': sourceAccountIdentifier,
-        trashed: false
+        trashed: false,
+        'cozyMetadata.createdByApp': slug
       })
       .indexFields([
         'cozyMetadata.sourceAccountIdentifier',
@@ -79,13 +80,18 @@ const getResponse = (folderToSaveFiles, sourceAccountIdentifierFiles) => {
   return { fetchStatus: 'loading' }
 }
 
-export const useDataCardFiles = (sourceAccountIdentifier, folderToSaveId) => {
+export const useDataCardFiles = (
+  sourceAccountIdentifier,
+  folderToSaveId,
+  slug
+) => {
   if (!sourceAccountIdentifier || !folderToSaveId)
     throw new Error('Missing arguments in useDataCardFiles, cannot fetch files')
 
   const folderToSaveFiles = useFolderToSaveFiles(folderToSaveId)
   const sourceAccountIdentifierFiles = useSourceAccountIdentifierFiles(
-    sourceAccountIdentifier
+    sourceAccountIdentifier,
+    slug
   )
 
   return useMemo(


### PR DESCRIPTION
Since https://github.com/cozy/cozy-libs/pull/2447/files we changed the way to fetch the files related to a konnector by using the sourceAccountIdentifier.

But this sourceAccountIdentifier can be the same for other konnectors, so if we had several konnectors with the same sourceAccountIdentifier (since it's generaly your main mail address...) we'll display the wrong files.

We should also filter by konnector slug.