### PR TITLE
fix: Use sourceAccountIdentifier and konnector slug to show viewer modal

### DIFF
--- a/packages/cozy-harvest-lib/src/connections/accounts.js
+++ b/packages/cozy-harvest-lib/src/connections/accounts.js
@@ -24,24 +24,6 @@ export const createAccount = async (client, konnector, attributes) => {
   return data
 }
 
-/**
- *  Build an account query for the given konnector.
- * ("getById" throws an error even if the query is not enabled)
- * @param {string} accountId - io.cozy.accounts document's id
- * @returns {object} - a query spec
- */
-export const buildAccountQueryById = accountId => {
-  return {
-    definition: () =>
-      Q(ACCOUNTS_DOCTYPE).where({
-        _id: accountId
-      }),
-    options: {
-      as: `${ACCOUNTS_DOCTYPE}/${accountId}`
-    }
-  }
-}
-
 export const createAccountQuerySpec = accountId => {
   if (!accountId) {
     throw new Error('createAccountQuerySpec called with undefined accountId')

--- a/packages/cozy-harvest-lib/src/datacards/ViewerModal.jsx
+++ b/packages/cozy-harvest-lib/src/datacards/ViewerModal.jsx
@@ -1,16 +1,54 @@
 import React, { useContext } from 'react'
 import { useParams } from 'react-router-dom'
 
+import { models, useQuery } from 'cozy-client'
 import Viewer from 'cozy-ui/transpiled/react/Viewer'
 import Overlay from 'cozy-ui/transpiled/react/deprecated/Overlay'
 
 import { useDataCardFiles } from './useDataCardFiles'
 import { MountPointContext } from '../components/MountPointContext'
+import { buildAccountQueryById } from '../helpers/queries'
 
 export const ViewerModal = () => {
   const { accountId, folderToSaveId, fileIndex } = useParams()
+
+  const buildAccountQuery = buildAccountQueryById(accountId)
+  const accountResult = useQuery(
+    buildAccountQuery.definition,
+    buildAccountQuery.options
+  )
+
+  const sourceAccountIdentifier = models.account.getAccountName(
+    accountResult.data
+  )
+  const konnectorSlug = accountResult.data?.account_type
+
+  if (!sourceAccountIdentifier || !konnectorSlug) return <Overlay />
+
+  return (
+    <ViewerModalContent
+      sourceAccountIdentifier={sourceAccountIdentifier}
+      folderToSaveId={folderToSaveId}
+      konnectorSlug={konnectorSlug}
+      accountId={accountId}
+      fileIndex={fileIndex}
+    />
+  )
+}
+
+const ViewerModalContent = ({
+  sourceAccountIdentifier,
+  folderToSaveId,
+  konnectorSlug,
+  accountId,
+  fileIndex
+}) => {
   const { pushHistory, replaceHistory } = useContext(MountPointContext)
-  const { data, fetchStatus } = useDataCardFiles(accountId, folderToSaveId)
+  const { data, fetchStatus } = useDataCardFiles(
+    sourceAccountIdentifier,
+    folderToSaveId,
+    konnectorSlug
+  )
   const handleCloseViewer = () => replaceHistory(`/accounts/${accountId}`)
   const handleFileChange = (_file, newIndex) =>
     pushHistory(`/viewer/${accountId}/${folderToSaveId}/${newIndex}`)

--- a/packages/cozy-harvest-lib/src/helpers/queries.js
+++ b/packages/cozy-harvest-lib/src/helpers/queries.js
@@ -38,6 +38,24 @@ export const buildAccountQuery = ({ slug, sourceAccountIdentifier }) => ({
     fetchPolicy: defaultFetchPolicy
   }
 })
+
+/**
+ *  Build an account query for the given konnector.
+ * ("getById" throws an error even if the query is not enabled)
+ * @param {string} accountId - io.cozy.accounts document's id
+ * @returns {object} - a query spec
+ */
+export const buildAccountQueryById = accountId => {
+  return {
+    definition: () => Q('io.cozy.accounts').getById(accountId),
+    options: {
+      as: `io.cozy.accounts/${accountId}`,
+      fetchPolicy: defaultFetchPolicy,
+      singleDocData: true
+    }
+  }
+}
+
 /**
  *
  * @param {string} accountId


### PR DESCRIPTION
Parameter of useDataCardFiles change but we didn't update ViewerModal properly. I chose to search this param with a query to io.cozy.accounts as we had already this information without changing route path.  This is a temporary fix and I think we need to refactor the viewer part to have an abstraction to account in this modal