### PR TITLE
feat(MesPapiers): Filter with several themes

### DIFF
--- a/packages/cozy-mespapiers-lib/package.json
+++ b/packages/cozy-mespapiers-lib/package.json
@@ -45,7 +45,6 @@
     "classnames": "2.3.2",
     "date-fns": "2.23.0",
     "flexsearch": "0.7.31",
-    "fuse.js": "6.6.2",
     "pdf-lib": "1.17.1",
     "react-input-mask": "3.0.0-alpha.2"
   },

--- a/packages/cozy-mespapiers-lib/src/components/Home/ContentFlexsearch.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/ContentFlexsearch.jsx
@@ -8,10 +8,10 @@ const ContentFlexsearch = ({
   contacts,
   papers,
   konnectors,
-  selectedTheme,
+  selectedThemes,
   searchValue
 }) => {
-  const isSearching = searchValue.length > 0 || Boolean(selectedTheme)
+  const isSearching = searchValue.length > 0 || Boolean(selectedThemes.length)
 
   if (isSearching) {
     return (
@@ -20,7 +20,7 @@ const ContentFlexsearch = ({
         contacts={contacts}
         konnectors={konnectors}
         searchValue={searchValue}
-        selectedTheme={selectedTheme}
+        selectedThemes={selectedThemes}
       />
     )
   }
@@ -38,7 +38,7 @@ ContentFlexsearch.propTypes = {
   contacts: PropTypes.array,
   papers: PropTypes.array,
   konnectors: PropTypes.array,
-  selectedTheme: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  selectedThemes: PropTypes.arrayOf(PropTypes.object),
   searchValue: PropTypes.string
 }
 

--- a/packages/cozy-mespapiers-lib/src/components/Home/ContentWhenSearching.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/ContentWhenSearching.jsx
@@ -16,7 +16,7 @@ const ContentWhenSearching = ({
   contacts,
   konnectors,
   searchValue,
-  selectedTheme
+  selectedThemes
 }) => {
   const { t } = useI18n()
 
@@ -30,7 +30,7 @@ const ContentWhenSearching = ({
     papers,
     contacts,
     searchValue,
-    selectedTheme
+    selectedThemes
   })
 
   if (loading) {
@@ -56,7 +56,7 @@ const ContentWhenSearching = ({
       <PaperGroup
         papersByCategories={papersByCategories}
         konnectors={konnectors}
-        selectedTheme={selectedTheme}
+        selectedThemes={selectedThemes}
       />
     )
   }
@@ -73,7 +73,7 @@ ContentWhenSearching.propTypes = {
   contacts: PropTypes.array,
   papers: PropTypes.array,
   konnectors: PropTypes.array,
-  selectedTheme: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  selectedThemes: PropTypes.arrayOf(PropTypes.object),
   searchValue: PropTypes.string
 }
 

--- a/packages/cozy-mespapiers-lib/src/components/Home/HomeLayout.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/HomeLayout.jsx
@@ -10,7 +10,7 @@ import FeaturedPlaceholdersList from '../Placeholders/FeaturedPlaceholdersList'
 import { useSearch } from '../Search/SearchProvider'
 
 const HomeLayout = ({ contacts, papers, konnectors }) => {
-  const [selectedTheme, setSelectedTheme] = useState('')
+  const [selectedThemes, setSelectedThemes] = useState([])
   const [searchValue, setSearchValue] = useState('')
   const { isMultiSelectionActive } = useMultiSelection()
   const { papersDefinitions } = usePapersDefinitions()
@@ -25,16 +25,16 @@ const HomeLayout = ({ contacts, papers, konnectors }) => {
       getFeaturedPlaceholders({
         papersDefinitions,
         files: papers,
-        selectedTheme
+        selectedThemes
       }),
-    [papersDefinitions, papers, selectedTheme]
+    [papersDefinitions, papers, selectedThemes]
   )
 
   return (
     <>
       <SearchHeader
-        selectedTheme={selectedTheme}
-        setSelectedTheme={setSelectedTheme}
+        selectedThemes={selectedThemes}
+        setSelectedThemes={setSelectedThemes}
         searchValue={searchValue}
         setSearchValue={setSearchValue}
       />
@@ -42,7 +42,7 @@ const HomeLayout = ({ contacts, papers, konnectors }) => {
         contacts={contacts}
         papers={papers}
         konnectors={konnectors}
-        selectedTheme={selectedTheme}
+        selectedThemes={selectedThemes}
         searchValue={searchValue}
       />
       {!isMultiSelectionActive && (

--- a/packages/cozy-mespapiers-lib/src/components/Home/SearchHeader.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/SearchHeader.jsx
@@ -63,7 +63,7 @@ const SearchHeader = ({
           <div>
             <FilterButton
               badge={{
-                active: Boolean(selectedThemes.length),
+                active: !hasThemeFilter && Boolean(selectedThemes.length),
                 content: selectedThemes.length
               }}
               onClick={() => setIsThemesFilterDisplayed(prev => !prev)}

--- a/packages/cozy-mespapiers-lib/src/components/Home/SearchHeader.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Home/SearchHeader.jsx
@@ -13,8 +13,8 @@ import ThemesFilter from '../ThemesFilter'
 const SearchHeader = ({
   searchValue,
   setSearchValue,
-  selectedTheme,
-  setSelectedTheme
+  selectedThemes,
+  setSelectedThemes
 }) => {
   const { t } = useI18n()
   const { isDesktop } = useBreakpoints()
@@ -25,8 +25,18 @@ const SearchHeader = ({
     if (!isDesktop || isMultiSelectionActive) setIsThemesFilterDisplayed(false)
   }
 
-  const handleThemeSelection = nextValue => {
-    setSelectedTheme(oldValue => (nextValue === oldValue ? '' : nextValue))
+  const handleThemeSelection = theme => {
+    setSelectedThemes(selectedThemes => {
+      const selectedThemeExists = selectedThemes.some(
+        selectedTheme => selectedTheme.label === theme.label
+      )
+      if (selectedThemeExists) {
+        return selectedThemes.filter(
+          selectedTheme => selectedTheme.label !== theme.label
+        )
+      }
+      return [...selectedThemes, theme]
+    })
   }
 
   const hasFilterButton = !isDesktop || (isDesktop && isMultiSelectionActive)
@@ -53,8 +63,8 @@ const SearchHeader = ({
           <div>
             <FilterButton
               badge={{
-                active: Boolean(selectedTheme),
-                content: 1
+                active: Boolean(selectedThemes.length),
+                content: selectedThemes.length
               }}
               onClick={() => setIsThemesFilterDisplayed(prev => !prev)}
             />
@@ -74,7 +84,7 @@ const SearchHeader = ({
           id="theme-filters"
         >
           <ThemesFilter
-            selectedTheme={selectedTheme}
+            selectedThemes={selectedThemes}
             handleThemeSelection={handleThemeSelection}
           />
         </div>
@@ -84,8 +94,8 @@ const SearchHeader = ({
 }
 
 SearchHeader.propTypes = {
-  selectedTheme: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  setSelectedTheme: PropTypes.func,
+  selectedThemes: PropTypes.arrayOf(PropTypes.object),
+  setSelectedThemes: PropTypes.func,
   searchValue: PropTypes.string,
   setSearchValue: PropTypes.func
 }

--- a/packages/cozy-mespapiers-lib/src/components/Home/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Home/helpers.js
@@ -1,13 +1,3 @@
-import Fuse from 'fuse.js'
-
-const fuse = new Fuse([], {
-  findAllMatches: true,
-  threshold: 0.3,
-  ignoreLocation: true,
-  ignoreFieldNorm: true,
-  keys: ['name', 'translatedQualificationLabel', 'contact']
-})
-
 /**
  * Check if a theme has an item with a specific label
  * @param {import('cozy-client/types/types').Theme[]} themes - list of themes
@@ -17,48 +7,6 @@ const fuse = new Fuse([], {
 export const hasItemByLabel = (themes, label) => {
   if (themes.length === 0) return true
   return themes.some(({ items }) => items.some(item => item.label === label))
-}
-
-export const filterPapersByThemeAndSearchValue = ({
-  files,
-  theme,
-  search,
-  scannerT
-}) => {
-  let filteredFiles = files
-
-  if (search || theme) {
-    const simpleFiles = files.map(({ file, contact }) => ({
-      _id: file._id,
-      name: file.name,
-      qualificationLabel: file.metadata.qualification.label,
-      translatedQualificationLabel: scannerT(
-        `items.${file.metadata.qualification.label}`
-      ),
-      contact
-    }))
-
-    let filteredSimplesFiles = simpleFiles
-
-    if (search) {
-      fuse.setCollection(simpleFiles)
-      filteredSimplesFiles = fuse.search(search).map(result => result.item)
-    }
-
-    if (theme) {
-      filteredSimplesFiles = filteredSimplesFiles.filter(simpleFile =>
-        hasItemByLabel(theme, simpleFile.qualificationLabel)
-      )
-    }
-
-    filteredFiles = files
-      .filter(({ file }) =>
-        filteredSimplesFiles.some(simpleFile => simpleFile._id === file._id)
-      )
-      .sort((a, b) => b.file.updated_at.localeCompare(a.file.updated_at))
-  }
-
-  return filteredFiles
 }
 
 /**

--- a/packages/cozy-mespapiers-lib/src/components/Home/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Home/helpers.js
@@ -8,10 +8,15 @@ const fuse = new Fuse([], {
   keys: ['name', 'translatedQualificationLabel', 'contact']
 })
 
-// TODO: hasItemByLabel should be in cozy-client : https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/models/document/documentTypeDataHelpers.js
-export const hasItemByLabel = (theme, label) => {
-  if (!theme) return true
-  return theme.items.some(item => item.label === label)
+/**
+ * Check if a theme has an item with a specific label
+ * @param {import('cozy-client/types/types').Theme[]} themes - list of themes
+ * @param {string} label - label to check
+ * @returns {boolean} - true if the theme has an item with the label
+ */
+export const hasItemByLabel = (themes, label) => {
+  if (themes.length === 0) return true
+  return themes.some(({ items }) => items.some(item => item.label === label))
 }
 
 export const filterPapersByThemeAndSearchValue = ({

--- a/packages/cozy-mespapiers-lib/src/components/Home/helpers.spec.js
+++ b/packages/cozy-mespapiers-lib/src/components/Home/helpers.spec.js
@@ -1,152 +1,11 @@
-import get from 'lodash/get'
 import MockDate from 'mockdate'
 
-import {
-  filterPapersByThemeAndSearchValue,
-  hasItemByLabel,
-  makePapersGroupByQualificationLabel
-} from './helpers'
-
-const locales = {
-  items: {
-    isp_invoice: 'Facture internet',
-    driver_license: 'Permis de conduire',
-    phone_invoice: 'Facture téléphonique'
-  }
-}
-
-const scannerT = x => get(locales, x)
-
-const files = [
-  {
-    file: {
-      _id: 'file01',
-      name: 'Facture internet',
-      metadata: { qualification: { label: 'isp_invoice' } },
-      updated_at: '2021-01-01:09:00.000000+01:00'
-    }
-  },
-  {
-    file: {
-      _id: 'file02',
-      name: 'Permis de conduire',
-      metadata: { qualification: { label: 'driver_license' } },
-      updated_at: '2021-05-01:09:00.000000+01:00'
-    },
-    contact: 'Alice Durand'
-  },
-  {
-    file: {
-      _id: 'file03',
-      name: 'Facture minitel',
-      metadata: { qualification: { label: 'phone_invoice' } },
-      updated_at: '2021-11-01:09:00.000000+01:00'
-    }
-  },
-  {
-    file: {
-      _id: 'file04',
-      name: "Dernier avis d'imposition",
-      metadata: { qualification: { label: 'tax_notice' } },
-      updated_at: '2022-07-01:09:00.000000+01:00'
-    },
-    contact: 'Alice et Bob Durand'
-  }
-]
-
-describe('filterPapersByThemeAndSearchValue', () => {
-  describe('with only theme selected', () => {
-    test('when one qualification label matches', () => {
-      const res = filterPapersByThemeAndSearchValue({
-        files,
-        theme: {
-          items: [{ label: 'isp_invoice' }]
-        },
-        search: '',
-        scannerT
-      })
-
-      expect(res).toHaveLength(1)
-      expect(res).toContain(files[0])
-    })
-
-    test('when two qualifiation labels matches', () => {
-      const res = filterPapersByThemeAndSearchValue({
-        files,
-        theme: {
-          items: [{ label: 'isp_invoice' }, { label: 'phone_invoice' }]
-        },
-        search: '',
-        scannerT
-      })
-
-      expect(res).toHaveLength(2)
-      expect(res).toContain(files[0])
-      expect(res).toContain(files[2])
-    })
-  })
-
-  describe('with only search value', () => {
-    test('when names matches', () => {
-      const res = filterPapersByThemeAndSearchValue({
-        files,
-        theme: '',
-        search: 'facture',
-        scannerT
-      })
-
-      expect(res).toHaveLength(2)
-      expect(res).toContain(files[0])
-      expect(res).toContain(files[2])
-    })
-
-    test('when qualification labels matches', () => {
-      const res = filterPapersByThemeAndSearchValue({
-        files,
-        theme: '',
-        search: 'téléphonique',
-        scannerT
-      })
-
-      expect(res).toHaveLength(1)
-      expect(res).toContain(files[2])
-    })
-
-    test('when contact matches', () => {
-      const res = filterPapersByThemeAndSearchValue({
-        files,
-        theme: '',
-        search: 'alice d',
-        scannerT
-      })
-
-      expect(res).toHaveLength(2)
-      expect(res).toContain(files[1])
-      expect(res).toContain(files[3])
-    })
-  })
-
-  describe('with theme selected and search value', () => {
-    it('should return only the correct files', () => {
-      const res = filterPapersByThemeAndSearchValue({
-        files,
-        theme: {
-          items: [{ label: 'isp_invoice' }]
-        },
-        search: 'facture',
-        scannerT
-      })
-
-      expect(res).toHaveLength(1)
-      expect(res).toContain(files[0])
-    })
-  })
-})
+import { hasItemByLabel, makePapersGroupByQualificationLabel } from './helpers'
 
 describe('hasItemByLabel', () => {
   it('should return true', () => {
     const res = hasItemByLabel(
-      { items: [{ label: 'isp_invoice' }] },
+      [{ items: [{ label: 'isp_invoice' }] }],
       'isp_invoice'
     )
 
@@ -155,7 +14,7 @@ describe('hasItemByLabel', () => {
 
   it('should return false', () => {
     const res = hasItemByLabel(
-      { items: [{ label: 'isp_invoice' }] },
+      [{ items: [{ label: 'isp_invoice' }] }],
       'phone_invoice'
     )
 

--- a/packages/cozy-mespapiers-lib/src/components/Papers/KonnectorsCategories.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/KonnectorsCategories.jsx
@@ -7,7 +7,7 @@ import CategoryItemByKonnector from './CategoryItemByKonnector'
 import { makeQualificationLabelsWithoutFiles } from './helpers'
 import { queryAccounts } from '../../helpers/queries'
 
-const KonnectorsCategories = ({ konnectors, selectedTheme, onClick }) => {
+const KonnectorsCategories = ({ konnectors, selectedThemes, onClick }) => {
   const { data: accounts, ...accountsQueryLeft } = useQuery(
     queryAccounts.definition,
     queryAccounts.options
@@ -23,7 +23,7 @@ const KonnectorsCategories = ({ konnectors, selectedTheme, onClick }) => {
 
   const qualificationLabelsWithoutFiles = makeQualificationLabelsWithoutFiles(
     konnectorsWithAccounts,
-    selectedTheme
+    selectedThemes
   )
 
   return qualificationLabelsWithoutFiles.map((qualificationLabel, index) => (
@@ -39,7 +39,7 @@ const KonnectorsCategories = ({ konnectors, selectedTheme, onClick }) => {
 
 KonnectorsCategories.propTypes = {
   konnectors: PropTypes.arrayOf(PropTypes.object),
-  selectedTheme: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  selectedThemes: PropTypes.arrayOf(PropTypes.object),
   onClick: PropTypes.func
 }
 

--- a/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/PaperGroup.jsx
@@ -8,7 +8,7 @@ import CategoryItemByPaper from './CategoryItemByPaper'
 import KonnectorsCategories from './KonnectorsCategories'
 import { useMultiSelection } from '../Hooks/useMultiSelection'
 
-const PaperGroup = ({ papersByCategories, konnectors, selectedTheme }) => {
+const PaperGroup = ({ papersByCategories, konnectors, selectedThemes }) => {
   const navigate = useNavigate()
   const { isMultiSelectionActive, setSelectedQualificationLabel } =
     useMultiSelection()
@@ -37,7 +37,7 @@ const PaperGroup = ({ papersByCategories, konnectors, selectedTheme }) => {
         ))}
       <KonnectorsCategories
         konnectors={konnectors}
-        selectedTheme={selectedTheme}
+        selectedThemes={selectedThemes}
         onClick={goPapersList}
       />
     </List>
@@ -47,7 +47,7 @@ const PaperGroup = ({ papersByCategories, konnectors, selectedTheme }) => {
 PaperGroup.propTypes = {
   papersByCategories: PropTypes.object,
   konnectors: PropTypes.arrayOf(PropTypes.object),
-  selectedTheme: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
+  selectedThemes: PropTypes.arrayOf(PropTypes.object)
 }
 
 export default PaperGroup

--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
@@ -264,16 +264,25 @@ export const makeAccountFromPapers = (papers, accounts) => {
   return account
 }
 
+/**
+ * Create a list of qualification labels without files
+ * @param {{ konnector: import('cozy-client/types/types').IOCozyKonnector, konnectorQualifLabelsWithoutFile: string[] }[]} konnectorsWithAccounts
+ * @param {import('cozy-client/types/types').Theme[]} selectedThemes - Array of selected themes
+ * @returns {string[]} - Array of qualification labels without files
+ */
 export const makeQualificationLabelsWithoutFiles = (
   konnectorsWithAccounts,
-  selectedTheme
+  selectedThemes
 ) => {
   return konnectorsWithAccounts
     .flatMap(({ konnectorQualifLabelsWithoutFile }) => {
       return konnectorQualifLabelsWithoutFile?.map(qualificationLabel => {
         const themeLabel = getThemeByItem({ label: qualificationLabel }).label
         const showCategoryItemByKonnector =
-          !selectedTheme || selectedTheme.label === themeLabel
+          !selectedThemes.length ||
+          selectedThemes.some(
+            selectedTheme => selectedTheme.label === themeLabel
+          )
 
         return showCategoryItemByKonnector ? qualificationLabel : undefined
       })

--- a/packages/cozy-mespapiers-lib/src/components/Search/useSearchResult.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Search/useSearchResult.jsx
@@ -3,7 +3,15 @@ import { useState, useEffect } from 'react'
 import { useSearch } from './SearchProvider'
 import { useMultiSelection } from '../Hooks/useMultiSelection'
 
-const useSearchResult = ({ papers, contacts, searchValue, selectedTheme }) => {
+/**
+ * @param {Object} params
+ * @param {import('cozy-client/types/types').IOCozyFile[]} params.papers
+ * @param {object[]} params.contacts
+ * @param {string} params.searchValue
+ * @param {import('cozy-client/types/types').Theme[]} params.selectedThemes
+ * @returns {import('../../types').SearchResult} Result of the search
+ */
+const useSearchResult = ({ papers, contacts, searchValue, selectedThemes }) => {
   const { search } = useSearch()
   const { isMultiSelectionActive } = useMultiSelection()
   const [searchResult, setSearchResult] = useState({
@@ -11,7 +19,7 @@ const useSearchResult = ({ papers, contacts, searchValue, selectedTheme }) => {
     hasResult: null,
     filteredDocs: null,
     firstSearchResultMatchingAttributes: null,
-    showResultByGroup: null
+    showResultByGroup: false
   })
 
   useEffect(() => {
@@ -30,7 +38,7 @@ const useSearchResult = ({ papers, contacts, searchValue, selectedTheme }) => {
         await search({
           docs: docsToBeSearched,
           value: searchValue,
-          tag: selectedTheme?.label
+          tag: selectedThemes.map(selectedTheme => selectedTheme.label)
         })
 
       const hasResult = filteredDocs?.length > 0
@@ -50,7 +58,7 @@ const useSearchResult = ({ papers, contacts, searchValue, selectedTheme }) => {
     contacts,
     search,
     searchValue,
-    selectedTheme,
+    selectedThemes,
     isMultiSelectionActive
   ])
 

--- a/packages/cozy-mespapiers-lib/src/components/ThemesFilter/ThemesFilter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ThemesFilter/ThemesFilter.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 
 import CircleButton from 'cozy-ui/transpiled/react/CircleButton'
@@ -6,8 +7,8 @@ import Icon from 'cozy-ui/transpiled/react/Icon'
 import { useThemeLabel } from './useThemeLabel'
 import { getThemesList } from '../../helpers/themes'
 
-const FilterButton = ({ item, isSelected, onClick }) => {
-  const label = useThemeLabel(item.label)
+const FilterButton = ({ theme, isSelected, onClick }) => {
+  const label = useThemeLabel(theme.label)
 
   return (
     <CircleButton
@@ -16,26 +17,39 @@ const FilterButton = ({ item, isSelected, onClick }) => {
       onClick={onClick}
       data-testid="ThemesFilter"
     >
-      <Icon icon={item.icon} />
+      <Icon icon={theme.icon} />
     </CircleButton>
   )
 }
 
-const ThemesFilter = ({ selectedTheme, handleThemeSelection }) => {
-  const items = getThemesList()
+FilterButton.propTypes = {
+  theme: PropTypes.object,
+  isSelected: PropTypes.bool,
+  onClick: PropTypes.func
+}
+
+const ThemesFilter = ({ selectedThemes, handleThemeSelection }) => {
+  const themes = getThemesList()
 
   return (
     <>
-      {items.map(item => (
+      {themes.map(theme => (
         <FilterButton
-          key={item.id}
-          item={item}
-          isSelected={selectedTheme.id === item.id}
-          onClick={() => handleThemeSelection(item)}
+          key={theme.id}
+          theme={theme}
+          isSelected={selectedThemes.some(
+            selectedTheme => selectedTheme.id === theme.id
+          )}
+          onClick={() => handleThemeSelection(theme)}
         />
       ))}
     </>
   )
+}
+
+ThemesFilter.propTypes = {
+  selectedThemes: PropTypes.arrayOf(PropTypes.object),
+  handleThemeSelection: PropTypes.func
 }
 
 export default ThemesFilter

--- a/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.js
@@ -50,21 +50,21 @@ export const isPaperEnabled = paperDefinition =>
  * Filters and sorts the list of featured Placeholders.
  * @param {PaperDefinition[]} papersDefinitions Array of PapersDefinition
  * @param {IOCozyFile[]} files Array of IOCozyFile
- * @param {object} selectedTheme Theme selected
+ * @param {import('cozy-client/types/types').Theme[]} selectedThemes Array of Themes selected
  * @returns {PaperDefinition[]} Array of PapersDefinition filtered with the prop "placeholderIndex"
  */
 export const getFeaturedPlaceholders = ({
   papersDefinitions,
   files = [],
-  selectedTheme = ''
+  selectedThemes = []
 }) => {
   return papersDefinitions
     .filter(
       paperDefinition =>
         hasNoFileWithSameQualificationLabel(files, paperDefinition) &&
         isPaperEnabled(paperDefinition) &&
-        (selectedTheme
-          ? hasItemByLabel(selectedTheme, paperDefinition.label)
+        (selectedThemes.length
+          ? hasItemByLabel(selectedThemes, paperDefinition.label)
           : paperDefinition.placeholderIndex)
     )
     .sort((a, b) => a.placeholderIndex - b.placeholderIndex)

--- a/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/findPlaceholders.spec.js
@@ -74,9 +74,11 @@ describe('findPlaceholders', () => {
       it('should return list of placeholders', () => {
         const featuredPlaceholders = getFeaturedPlaceholders({
           papersDefinitions: mockPapersDefinitions,
-          selectedTheme: {
-            items: [{ label: 'isp_invoice' }, { label: 'tax_notice' }]
-          }
+          selectedThemes: [
+            {
+              items: [{ label: 'isp_invoice' }, { label: 'tax_notice' }]
+            }
+          ]
         })
 
         expect(featuredPlaceholders).toEqual(
@@ -103,9 +105,11 @@ describe('findPlaceholders', () => {
         const featuredPlaceholders = getFeaturedPlaceholders({
           papersDefinitions: mockPapersDefinitions,
           files: fakeIspInvoiceFile,
-          selectedTheme: {
-            items: [{ label: 'isp_invoice' }, { label: 'tax_notice' }]
-          }
+          selectedThemes: [
+            {
+              items: [{ label: 'isp_invoice' }, { label: 'tax_notice' }]
+            }
+          ]
         })
 
         expect(featuredPlaceholders).toEqual(
@@ -132,9 +136,11 @@ describe('findPlaceholders', () => {
         const featuredPlaceholders = getFeaturedPlaceholders({
           papersDefinitions: mockPapersDefinitions,
           files: fakeIspInvoiceFile,
-          selectedTheme: {
-            items: [{ label: 'health_certificate' }]
-          }
+          selectedThemes: [
+            {
+              items: [{ label: 'health_certificate' }]
+            }
+          ]
         })
 
         expect(featuredPlaceholders).toEqual(

--- a/packages/cozy-mespapiers-lib/src/types.js
+++ b/packages/cozy-mespapiers-lib/src/types.js
@@ -1,0 +1,10 @@
+/**
+ * @typedef {Object} SearchResult
+ * @property {boolean} loading
+ * @property {boolean} hasResult
+ * @property {import('cozy-client/types/types').IOCozyFile[]} filteredDocs
+ * @property {Object} firstSearchResultMatchingAttributes
+ * @property {boolean} showResultByGroup
+ */
+
+export default {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10636,28 +10636,6 @@ cozy-flags@^2.5.0:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^22.5.5:
-  version "22.5.5"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-22.5.5.tgz#71111ac185c104b350d26301f3a18a6e1165f399"
-  integrity sha512-JVD1x7iOwkDU4VTzeWjwd2JzmUAjMCicvrtoHcYk5PXsoLIcmm6celcZ3lx332/8Ak6t5i+/mx5Aq5cG7igXUA==
-  dependencies:
-    "@cozy/minilog" "^1.0.0"
-    "@sentry/browser" "^6.0.1"
-    classnames "^2.3.1"
-    cozy-bi-auth "0.0.25"
-    cozy-doctypes "^1.89.5"
-    cozy-logger "^1.10.4"
-    date-fns "^1.30.1"
-    final-form "^4.18.5"
-    lodash "^4.17.19"
-    microee "^0.0.6"
-    node-polyglot "^2.4.0"
-    react-final-form "^3.7.0"
-    react-json-print "^0.1.3"
-    react-markdown "^4.2.2"
-    use-deep-compare-effect "^1.8.1"
-    uuid "^3.3.2"
-
 cozy-interapp@0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.5.4.tgz#2573f1800f073c84c289267d04234954d88eae0c"
@@ -14075,11 +14053,6 @@ functions-have-names@^1.2.2, functions-have-names@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
-
-fuse.js@6.6.2:
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.6.2.tgz#fe463fed4b98c0226ac3da2856a415576dc9a111"
-  integrity sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==
 
 gauge@^4.0.3:
   version "4.0.4"


### PR DESCRIPTION
Cette PR ajoute la possibilité de sélectionner plusieurs thèmes dans le filtre de recherche, auparavant bloqué à un seul choix.

J'ai pu remarquer également que la lib `fuse.js` était toujours en dépendance, alors que nous utilisons depuis quelques temps `flexsearch` à la place. Je l'ai donc supprimé, ainsi qu'une fonction inutilisée qui l'utilisait.