### PR TITLE
fix(mespapiers): The `selectedThemes` argument of `makeQualificationLabelsWithoutFiles` may be undefined.

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/Papers/helpers.js
@@ -267,7 +267,7 @@ export const makeAccountFromPapers = (papers, accounts) => {
 /**
  * Create a list of qualification labels without files
  * @param {{ konnector: import('cozy-client/types/types').IOCozyKonnector, konnectorQualifLabelsWithoutFile: string[] }[]} konnectorsWithAccounts
- * @param {import('cozy-client/types/types').Theme[]} selectedThemes - Array of selected themes
+ * @param {import('cozy-client/types/types').Theme[]} [selectedThemes] - Array of selected themes
  * @returns {string[]} - Array of qualification labels without files
  */
 export const makeQualificationLabelsWithoutFiles = (
@@ -279,7 +279,7 @@ export const makeQualificationLabelsWithoutFiles = (
       return konnectorQualifLabelsWithoutFile?.map(qualificationLabel => {
         const themeLabel = getThemeByItem({ label: qualificationLabel }).label
         const showCategoryItemByKonnector =
-          !selectedThemes.length ||
+          !selectedThemes?.length ||
           selectedThemes.some(
             selectedTheme => selectedTheme.label === themeLabel
           )


### PR DESCRIPTION
This function is called in the `ContentWhenSearching` & `ContentWhenNotSearching` components, in the latter there is no notion of search and therefore `selectedThemes` is not transmitted.