### PR TITLE
feat(mespapiers): Homogenize the behavior of `importAuto`

### DIFF
--- a/packages/cozy-mespapiers-lib/src/helpers/queries.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/queries.js
@@ -125,14 +125,6 @@ export const buildTriggersQueryByKonnectorSlug = (slug, enabled) => ({
   }
 })
 
-export const buildKonnectorsQuery = () => ({
-  definition: () => Q(KONNECTORS_DOCTYPE),
-  options: {
-    as: `${KONNECTORS_DOCTYPE}`,
-    fetchPolicy: defaultFetchPolicy
-  }
-})
-
 export const buildKonnectorsQueryById = (id, enabled = true) => ({
   definition: () => Q(KONNECTORS_DOCTYPE).getById(id),
   options: {


### PR DESCRIPTION
Today for documents that we retrieve via a single konnector we have 2 different behaviors depending on where I perform the action of adding the document.

Case 1: If we add the document from the home page and the konnector is already installed, we are just redirected to the category.

Case 2: If we add the document from the document category this opens the harvest modal.

This commit allows you to open the harvest modal even from the home page.