### PR TITLE
[VO-591] feat: Allow the possibility to override the mode even on Travis CI

### DIFF
--- a/packages/cozy-app-publish/src/cozy-app-publish.js
+++ b/packages/cozy-app-publish/src/cozy-app-publish.js
@@ -76,6 +76,10 @@ parser.addArgument('--verbose', {
   help: 'print additional logs',
   action: 'storeTrue'
 })
+parser.addArgument('--mode', {
+  help: 'Override the publication mode (default: manual)',
+  choices: Object.values(MODES)
+})
 
 const handleError = error => {
   logger.error(colorize.red(`Publishing failed: ${error.message}`))
@@ -91,8 +95,10 @@ try {
   handleError(error)
 }
 
-function _getPublishMode() {
-  if (process.env.TRAVIS === 'true') {
+function _getPublishMode(mode) {
+  if (mode) {
+    return mode
+  } else if (process.env.TRAVIS === 'true') {
     return MODES.TRAVIS
   } else {
     // default mode
@@ -101,7 +107,7 @@ function _getPublishMode() {
 }
 
 async function publishApp(cliOptions) {
-  const publishMode = _getPublishMode()
+  const publishMode = _getPublishMode(cliOptions.mode)
   const publishFn = scripts[publishMode]
 
   logger.log(


### PR DESCRIPTION
This PR will allow me to use manual mode into a Travis CI to complete the continuous deployment on cozy-settings. I use semantic-release to manage tags. The problem is that the version on Travis CI is determined by TRAVIS_TAG which is set before the start of the CI and not during the process.