### PR TITLE
fix: Do not display can't connect link if no vendor link in konnector (SCR-528)

### DIFF
--- a/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
+++ b/packages/cozy-harvest-lib/src/components/AccountForm/index.jsx
@@ -297,7 +297,8 @@ export class AccountForm extends PureComponent {
                   t={t}
                 />
                 {flag('harvest.inappconnectors.enabled') &&
-                  !konnector.clientSide && (
+                  !konnector.clientSide &&
+                  konnector.vendor_link && (
                     <Link
                       className="u-mt-1"
                       variant="body1"


### PR DESCRIPTION
This "can't connect" link displays a link to the vendor website which
has no meaning without any vendor_link
