### PR TITLE
Feat(mespapiers): Suggest a list of choices for configuring the notice period

### DIFF
--- a/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
+++ b/packages/cozy-mespapiers-lib/docs/papersDefinitions.md
@@ -108,7 +108,7 @@ The `isDisplayed` property manages the display of steps. Its different values di
   - `[editText]`: {string} Translation used as title in edition modal. The step text is used by default.
   - `[type]`: {`text`|`number`|`contact`} Type of field (if no mask)
   - `[defaultValue]`: {string|number} Default field value
-  - `[withAdornment]`: {`start`|`end`} Add a text as a prefix or suffix
+  - `[adornment]`: {`start`|`end`} Add a text as a prefix or suffix
     - `[start]`: {string} Add a text as a prefix
     - `[end]`: {string} Add a text as a suffix
   - `[required]`: {boolean} Make the field mandatory

--- a/packages/cozy-mespapiers-lib/package.json
+++ b/packages/cozy-mespapiers-lib/package.json
@@ -21,7 +21,7 @@
     "@testing-library/react-hooks": "8.0.1",
     "babel-preset-cozy-app": "2.0.1",
     "cozy-bar": "^12.0.0",
-    "cozy-client": "^46.6.1",
+    "cozy-client": "^46.7.0",
     "cozy-device-helper": "^3.0.0",
     "cozy-doctypes": "^1.90.0",
     "cozy-flags": "^3.2.2",
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "cozy-bar": ">=12.0.0",
-    "cozy-client": ">=46.6.1",
+    "cozy-client": ">=46.7.0",
     "cozy-device-helper": ">=3.0.0",
     "cozy-doctypes": ">=1.89.3",
     "cozy-flags": ">=3.2.0",

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/InformationDialog.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/InformationDialog.jsx
@@ -120,7 +120,8 @@ const InformationDialog = ({ currentStep, onClose, onBack, onSubmit }) => {
                 <div
                   key={idx}
                   className={cx('u-mh-1', {
-                    ['u-h-3 u-pb-1-half']: hasMarginBottom(idx)
+                    ['u-h-3 u-pb-1-half']: hasMarginBottom(idx),
+                    ['u-stack-m']: attrs.options
                   })}
                 >
                   <Component

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
@@ -1,11 +1,10 @@
 import React, { useState, useEffect, useMemo } from 'react'
 import InputMask from 'react-input-mask'
 
-import InputAdornment from 'cozy-ui/transpiled/react/InputAdornment'
 import TextField from 'cozy-ui/transpiled/react/TextField'
-import Typography from 'cozy-ui/transpiled/react/Typography'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
+import { makeInputAdornment } from './helpers'
 import { defaultProptypes } from './proptypes'
 import {
   checkConstraintsOfIinput,
@@ -26,22 +25,6 @@ const getInputMode = (inputType, mask, currentDefinition) => {
   return inputType === 'number' && currentDefinition?.label !== 'pay_sheet'
     ? 'numeric'
     : 'text'
-}
-
-const makeInputAdornment = (adornment, currentValue, t) => {
-  const result = {}
-  Object.entries(adornment).map(([adornmentPosition, adornmentValue]) => {
-    if (!['start', 'end'].includes(adornmentPosition)) return
-
-    result[`${adornmentPosition}Adornment`] = (
-      <InputAdornment position={adornmentPosition}>
-        <Typography>
-          {t(adornmentValue, { smart_count: currentValue })}
-        </Typography>
-      </InputAdornment>
-    )
-  })
-  return result
 }
 
 const InputTextAdapter = ({
@@ -212,7 +195,11 @@ const InputTextAdapter = ({
       value={currentValue}
       {...(withAdornment && {
         InputProps: {
-          ...makeInputAdornment(withAdornment, currentValue, t)
+          ...makeInputAdornment({
+            adornment: withAdornment,
+            smartcount: currentValue,
+            t
+          })
         }
       })}
       inputProps={{

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/InputTextAdapter.jsx
@@ -41,7 +41,7 @@ const InputTextAdapter = ({
     inputLabel,
     maxLength,
     mask,
-    withAdornment,
+    adornment,
     maskPlaceholder = 'ˍ',
     defaultValue
   } = attrs
@@ -193,10 +193,10 @@ const InputTextAdapter = ({
       error={isError}
       helperText={helperText}
       value={currentValue}
-      {...(withAdornment && {
+      {...(adornment && {
         InputProps: {
           ...makeInputAdornment({
-            adornment: withAdornment,
+            adornment,
             smartcount: currentValue,
             t
           })

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.jsx
@@ -51,8 +51,10 @@ const RadioAdapter = ({
   setValidInput,
   idx
 }) => {
-  const [{ textFieldAttrs, value: currentOptionValue }, setCurrentOption] =
-    useState(getDefaultOption(options, formDataValue) || {})
+  const [
+    { textFieldAttrs: currentOptionTextFieldAttrs, value: currentOptionValue },
+    setCurrentOption
+  ] = useState(getDefaultOption(options, formDataValue) || {})
   const [textValue, setTextValue] = useState(
     getDefaultTextValue(options, formDataValue)
   )
@@ -76,7 +78,7 @@ const RadioAdapter = ({
 
   const handleTextChange = e => {
     const currentValue = e.target.value
-    if (textFieldAttrs.type === 'number') {
+    if (currentOptionTextFieldAttrs.type === 'number') {
       // To force Safari to accept only numbers (regex: numbers or empty values accepted)
       if (/^(?:[0-9]*|)$/.test(currentValue)) {
         handleText(currentValue)
@@ -97,8 +99,8 @@ const RadioAdapter = ({
     setValidInput(prev => ({
       ...prev,
       [idx]:
-        (!required && !textFieldAttrs?.required) ||
-        (!!currentOptionValue && !textFieldAttrs?.required) ||
+        (!required && !currentOptionTextFieldAttrs?.required) ||
+        (!!currentOptionValue && !currentOptionTextFieldAttrs?.required) ||
         !!textValue
     }))
   }, [
@@ -107,7 +109,7 @@ const RadioAdapter = ({
     currentOptionValue,
     textValue,
     required,
-    textFieldAttrs
+    currentOptionTextFieldAttrs
   ])
 
   return options.map((optionGroup, indexOptionGroup) => (
@@ -120,16 +122,16 @@ const RadioAdapter = ({
               onClick={() => handleClick(option)}
               value={currentOptionValue}
             />
-            {option.textFieldAttrs && textFieldAttrs && (
+            {option.textFieldAttrs && currentOptionTextFieldAttrs && (
               <ListItem>
                 <TextField
                   variant="outlined"
-                  label={t(textFieldAttrs.label)}
+                  label={t(currentOptionTextFieldAttrs.label)}
                   value={textValue}
-                  {...(textFieldAttrs.adornment && {
+                  {...(currentOptionTextFieldAttrs.adornment && {
                     InputProps: {
                       ...makeInputAdornment({
-                        adornment: textFieldAttrs.adornment,
+                        adornment: currentOptionTextFieldAttrs.adornment,
                         smartcount: textValue,
                         t
                       })
@@ -138,10 +140,12 @@ const RadioAdapter = ({
                   inputProps={{
                     'data-testid': 'TextField-other',
                     inputMode:
-                      textFieldAttrs.type === 'number' ? 'numeric' : 'text'
+                      currentOptionTextFieldAttrs.type === 'number'
+                        ? 'numeric'
+                        : 'text'
                   }}
                   onChange={handleTextChange}
-                  required={textFieldAttrs.required}
+                  required={currentOptionTextFieldAttrs.required}
                   fullWidth
                 />
               </ListItem>

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.jsx
@@ -33,7 +33,7 @@ const RadioAdapter = ({
     setOptionValue(val)
     setValue(prev => ({
       ...prev,
-      [name]: val
+      [name]: val !== 'other' ? val : textValue || val
     }))
   }
 
@@ -42,14 +42,15 @@ const RadioAdapter = ({
     setTextValue(currentValue)
     setValue(prev => ({
       ...prev,
-      [name]: currentValue
+      [name]: currentValue || optionValue
     }))
   }
 
   /* Set default value */
   useEffect(() => {
-    setValue(prev => ({ ...prev, [name]: optionValue }))
-  }, [name, setValue, optionValue])
+    setValue(prev => ({ ...prev, [name]: textValue || optionValue }))
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- We don't want to update the value when the text/option changes
+  }, [])
 
   /* Necessary to validate or not the validation button of the current step */
   useEffect(() => {

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.jsx
@@ -21,7 +21,7 @@ const getDefaultTextValue = (options, value) => {
 }
 
 const RadioAdapter = ({
-  attrs: { name, options, required },
+  attrs: { name, options, required, inputLabel },
   formDataValue = '',
   setValue,
   setValidInput,
@@ -86,7 +86,7 @@ const RadioAdapter = ({
             <TextField
               type="text"
               variant="outlined"
-              label={t('RadioAdapter.otherLabel')}
+              label={t(inputLabel)}
               value={textValue}
               inputProps={{
                 'data-testid': 'TextField-other'

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.jsx
@@ -10,8 +10,14 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 import RadioAdapterItem from './RadioAdapterItem'
 import { defaultProptypes } from './proptypes'
 
-const isUserValue = (options, value) => {
-  return value && !options.includes(value)
+const isCustomOptionValue = (options, value) => {
+  return !!value && !options.includes(value)
+}
+const getDefaultOptionValue = (options, value) => {
+  return isCustomOptionValue(options, value) ? 'other' : value
+}
+const getDefaultTextValue = (options, value) => {
+  return isCustomOptionValue(options, value) ? value : ''
 }
 
 const RadioAdapter = ({
@@ -22,10 +28,10 @@ const RadioAdapter = ({
   idx
 }) => {
   const [optionValue, setOptionValue] = useState(
-    isUserValue(options, formDataValue) ? 'other' : formDataValue
+    getDefaultOptionValue(options, formDataValue)
   )
   const [textValue, setTextValue] = useState(
-    isUserValue(options, formDataValue) ? formDataValue : ''
+    getDefaultTextValue(options, formDataValue)
   )
   const { t } = useI18n()
 

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.jsx
@@ -16,7 +16,7 @@ import { defaultProptypes } from './proptypes'
  * @returns {boolean}
  */
 const isCustomOptionValue = (options, value) => {
-  return !!value && !options.some(opt => opt.value === value)
+  return !!value && !options.flat().some(opt => opt.value === value)
 }
 
 /**
@@ -26,10 +26,11 @@ const isCustomOptionValue = (options, value) => {
  */
 const getDefaultOption = (options, value) => {
   if (isCustomOptionValue(options, value)) {
-    return options.find(opt => !!opt.textFieldAttrs)
+    return options.flat().find(opt => !!opt.textFieldAttrs)
   }
   return (
-    options.find(opt => opt.value === value) || options.find(opt => opt.checked)
+    options.flat().find(opt => opt.value === value) ||
+    options.flat().find(opt => opt.checked)
   )
 }
 
@@ -108,40 +109,41 @@ const RadioAdapter = ({
     textFieldAttrs
   ])
 
-  return (
-    <Paper>
+  return options.map((optionGroup, indexOptionGroup) => (
+    <Paper key={indexOptionGroup}>
       <List>
-        {options.map((option, index) => (
-          <Fragment key={index}>
+        {optionGroup.map((option, indexOption) => (
+          <Fragment key={`'${indexOptionGroup}${indexOption}`}>
             <RadioAdapterItem
               option={option}
               onClick={() => handleClick(option)}
               value={currentOptionValue}
             />
-            {index !== options.length - 1 && (
+            {option.textFieldAttrs && textFieldAttrs && (
+              <ListItem>
+                <TextField
+                  variant="outlined"
+                  label={t(textFieldAttrs.label)}
+                  value={textValue}
+                  inputProps={{
+                    'data-testid': 'TextField-other',
+                    inputMode:
+                      textFieldAttrs.type === 'number' ? 'numeric' : 'text'
+                  }}
+                  onChange={handleTextChange}
+                  required={textFieldAttrs.required}
+                  fullWidth
+                />
+              </ListItem>
+            )}
+            {indexOption !== optionGroup.length - 1 && (
               <Divider component="li" variant="inset" />
             )}
           </Fragment>
         ))}
-        {textFieldAttrs && (
-          <ListItem>
-            <TextField
-              variant="outlined"
-              label={t(textFieldAttrs.label)}
-              value={textValue}
-              inputProps={{
-                'data-testid': 'TextField-other',
-                inputMode: textFieldAttrs.type === 'number' ? 'numeric' : 'text'
-              }}
-              onChange={handleTextChange}
-              required={textFieldAttrs.required}
-              fullWidth
-            />
-          </ListItem>
-        )}
       </List>
     </Paper>
-  )
+  ))
 }
 
 RadioAdapter.propTypes = defaultProptypes

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.jsx
@@ -8,6 +8,7 @@ import TextField from 'cozy-ui/transpiled/react/TextField'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import RadioAdapterItem from './RadioAdapterItem'
+import { makeInputAdornment } from './helpers'
 import { defaultProptypes } from './proptypes'
 
 /**
@@ -125,6 +126,15 @@ const RadioAdapter = ({
                   variant="outlined"
                   label={t(textFieldAttrs.label)}
                   value={textValue}
+                  {...(textFieldAttrs.adornment && {
+                    InputProps: {
+                      ...makeInputAdornment({
+                        adornment: textFieldAttrs.adornment,
+                        smartcount: textValue,
+                        t
+                      })
+                    }
+                  })}
                   inputProps={{
                     'data-testid': 'TextField-other',
                     inputMode:

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.spec.jsx
@@ -80,4 +80,29 @@ describe('RadioAdapter', () => {
     })
     expect(setValue).toHaveBeenCalled()
   })
+
+  it('calls the setValue function with the right value when the text field is changed', () => {
+    let nextState
+    const setValue = jest.fn().mockImplementation(callback => {
+      nextState = callback({})
+    })
+    const { getByLabelText, getByTestId } = setup({
+      attrs: { name: 'contractType', options },
+      setValue
+    })
+
+    fireEvent.click(getByLabelText('other'))
+    expect(setValue).toHaveBeenCalled()
+    expect(nextState).toEqual({ contractType: 'other' })
+
+    fireEvent.change(getByTestId('TextField-other'), {
+      target: { value: 'test' }
+    })
+    expect(setValue).toHaveBeenCalled()
+    expect(nextState).toEqual({ contractType: 'test' })
+
+    fireEvent.click(getByLabelText('cdd'))
+    expect(setValue).toHaveBeenCalled()
+    expect(nextState).toEqual({ contractType: 'cdd' })
+  })
 })

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.spec.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapter.spec.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-focused-tests */
 import '@testing-library/jest-dom'
 import { render, fireEvent } from '@testing-library/react'
 import React from 'react'
@@ -26,15 +27,17 @@ const setup = ({
 
 describe('RadioAdapter', () => {
   const makeOptions = ({ required } = {}) => [
-    { value: 'cdi', label: 'attributes.contractType.cdi' },
-    { value: 'cdd', label: 'attributes.contractType.cdd' },
-    { value: 'alternate', label: 'attributes.contractType.alternate' },
-    { value: 'internship', label: 'attributes.contractType.internship' },
-    {
-      value: 'other',
-      label: 'attributes.contractType.other',
-      textFieldAttrs: { label: 'textFieldAttrs.label', required }
-    }
+    [
+      { value: 'cdi', label: 'attributes.contractType.cdi' },
+      { value: 'cdd', label: 'attributes.contractType.cdd' },
+      { value: 'alternate', label: 'attributes.contractType.alternate' },
+      {
+        value: 'other',
+        label: 'attributes.contractType.other',
+        textFieldAttrs: { label: 'textFieldAttrs.label', required }
+      }
+    ],
+    [{ value: 'internship', label: 'attributes.contractType.internship' }]
   ]
   const optionsTranslated = ['CDI', 'CDD', 'Alternate', 'Internship', 'Other']
 

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapterItem.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapterItem.jsx
@@ -36,7 +36,7 @@ const RadioAdapterItem = ({ onClick, option, value }) => {
 RadioAdapterItem.propTypes = {
   onClick: PropTypes.func.isRequired,
   option: attrsProptypesOption.isRequired,
-  value: PropTypes.string
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 }
 
 export default RadioAdapterItem

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapterItem.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/RadioAdapterItem.jsx
@@ -6,39 +6,36 @@ import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import Radio from 'cozy-ui/transpiled/react/Radios'
 
+import { attrsProptypesOption } from './proptypes'
 import { useScannerI18n } from '../../Hooks/useScannerI18n'
 
 const RadioAdapterItem = ({ onClick, option, value }) => {
   const scannerT = useScannerI18n()
 
-  const isChecked = inputValue => {
-    return inputValue === value
+  const isChecked = optionValue => {
+    return optionValue === value
   }
 
   return (
     <ListItem button onClick={onClick}>
       <ListItemIcon>
         <Radio
-          inputProps={{ 'aria-label': option }}
-          value={option}
-          checked={isChecked(option)}
+          inputProps={{ 'aria-label': scannerT(option.label) }}
+          value={option.value}
+          checked={isChecked(option.value)}
         />
       </ListItemIcon>
       <ListItemText
-        primary={
-          <div value={option}>
-            {scannerT(`attributes.contractType.${option}`)}
-          </div>
-        }
-        data-testid={`RadioAdapterItem-${option}`}
+        primary={<div value={option.value}>{scannerT(option.label)}</div>}
+        data-testid={`RadioAdapterItem-${option.value}`}
       />
     </ListItem>
   )
 }
 
 RadioAdapterItem.propTypes = {
-  onClick: PropTypes.func,
-  option: PropTypes.string,
+  onClick: PropTypes.func.isRequired,
+  option: attrsProptypesOption.isRequired,
   value: PropTypes.string
 }
 

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/helpers.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/helpers.js
@@ -1,0 +1,27 @@
+import React from 'react'
+
+import InputAdornment from 'cozy-ui/transpiled/react/InputAdornment'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+/**
+ * @param {object} param
+ * @param {{ end: string, start: string }} param.adornment - Adornment object
+ * @param {number} param.smartcount - Value for determining text pluralization
+ * @param {Function} param.t - Translation function
+ * @returns {{ endAdornment?: JSX.Element, startAdornment?: JSX.Element }}
+ */
+export const makeInputAdornment = ({ adornment, smartcount, t }) => {
+  const result = {}
+  Object.entries(adornment).map(([adornmentPosition, adornmentValue]) => {
+    if (!['start', 'end'].includes(adornmentPosition)) return
+
+    result[`${adornmentPosition}Adornment`] = (
+      <InputAdornment position={adornmentPosition}>
+        <Typography>
+          {t(adornmentValue, { smart_count: smartcount })}
+        </Typography>
+      </InputAdornment>
+    )
+  })
+  return result
+}

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/proptypes.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/proptypes.js
@@ -18,7 +18,7 @@ const attrsProptypesWithOption = PropTypes.shape({
   inputLabel: PropTypes.string,
   type: PropTypes.string,
   required: PropTypes.bool,
-  options: PropTypes.arrayOf(attrsProptypesOption),
+  options: PropTypes.arrayOf(PropTypes.arrayOf(attrsProptypesOption)),
   minLength: PropTypes.number,
   maxLength: PropTypes.number,
   mask: PropTypes.string,

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/proptypes.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/proptypes.js
@@ -4,6 +4,10 @@ const attrsProptypesOptionTextFieldAttrs = PropTypes.shape({
   type: PropTypes.string,
   label: PropTypes.string,
   required: PropTypes.bool,
+  adornment: PropTypes.shape({
+    endAdornment: PropTypes.string,
+    startAdornment: PropTypes.string
+  })
 })
 
 export const attrsProptypesOption = PropTypes.shape({

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/proptypes.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/proptypes.js
@@ -11,7 +11,7 @@ const attrsProptypesOptionTextFieldAttrs = PropTypes.shape({
 })
 
 export const attrsProptypesOption = PropTypes.shape({
-  value: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   label: PropTypes.string.isRequired,
   checked: PropTypes.bool,
   textFieldAttrs: attrsProptypesOptionTextFieldAttrs

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/proptypes.js
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/proptypes.js
@@ -1,11 +1,24 @@
 import PropTypes from 'prop-types'
 
-const attrsProptypes = PropTypes.shape({
+const attrsProptypesOptionTextFieldAttrs = PropTypes.shape({
+  type: PropTypes.string,
+  label: PropTypes.string,
+  required: PropTypes.bool,
+})
+
+export const attrsProptypesOption = PropTypes.shape({
+  value: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  checked: PropTypes.bool,
+  textFieldAttrs: attrsProptypesOptionTextFieldAttrs
+})
+
+const attrsProptypesWithOption = PropTypes.shape({
   name: PropTypes.string,
   inputLabel: PropTypes.string,
   type: PropTypes.string,
   required: PropTypes.bool,
-  options: PropTypes.array,
+  options: PropTypes.arrayOf(attrsProptypesOption),
   minLength: PropTypes.number,
   maxLength: PropTypes.number,
   mask: PropTypes.string,
@@ -13,7 +26,7 @@ const attrsProptypes = PropTypes.shape({
 })
 
 export const defaultProptypes = {
-  attrs: attrsProptypes.isRequired,
+  attrs: attrsProptypesWithOption.isRequired,
   defaultValue: PropTypes.string,
   setValue: PropTypes.func.isRequired,
   setValidInput: PropTypes.func.isRequired,

--- a/packages/cozy-mespapiers-lib/src/components/Views/InformationEdit.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Views/InformationEdit.jsx
@@ -110,7 +110,8 @@ const InformationEdit = () => {
               text={
                 <div
                   className={cx('u-mt-1', {
-                    'u-mh-1': !isMobile
+                    'u-mh-1': !isMobile,
+                    ['u-stack-m']: attrs.options
                   })}
                 >
                   {Component && (

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -334,7 +334,7 @@
               "name": "noticePeriod",
               "type": "number",
               "defaultValue": 90,
-              "withAdornment": {
+              "adornment": {
                 "end": "PaperJSON.generic.noticePeriod.endAdornment"
               },
               "maxLength": 3,
@@ -410,7 +410,7 @@
               "name": "noticePeriod",
               "type": "number",
               "defaultValue": 90,
-              "withAdornment": {
+              "adornment": {
                 "end": "PaperJSON.generic.noticePeriod.endAdornment"
               },
               "maxLength": 3,
@@ -634,7 +634,7 @@
               "name": "noticePeriod",
               "type": "number",
               "defaultValue": 90,
-              "withAdornment": {
+              "adornment": {
                 "end": "PaperJSON.generic.noticePeriod.endAdornment"
               },
               "maxLength": 3,
@@ -897,7 +897,7 @@
               "name": "noticePeriod",
               "type": "number",
               "defaultValue": 90,
-              "withAdornment": {
+              "adornment": {
                 "end": "PaperJSON.generic.noticePeriod.endAdornment"
               },
               "maxLength": 3,
@@ -945,7 +945,7 @@
               "name": "noticePeriod",
               "type": "number",
               "defaultValue": 90,
-              "withAdornment": {
+              "adornment": {
                 "end": "PaperJSON.generic.noticePeriod.endAdornment"
               },
               "maxLength": 3,
@@ -1138,7 +1138,7 @@
               "name": "noticePeriod",
               "type": "number",
               "defaultValue": 90,
-              "withAdornment": {
+              "adornment": {
                 "end": "PaperJSON.generic.noticePeriod.endAdornment"
               },
               "maxLength": 3,
@@ -1892,7 +1892,7 @@
               "name": "noticePeriod",
               "type": "number",
               "defaultValue": 90,
-              "withAdornment": {
+              "adornment": {
                 "end": "PaperJSON.generic.noticePeriod.endAdornment"
               },
               "maxLength": 3,
@@ -1952,7 +1952,7 @@
               "name": "noticePeriod",
               "type": "number",
               "defaultValue": 90,
-              "withAdornment": {
+              "adornment": {
                 "end": "PaperJSON.generic.noticePeriod.endAdornment"
               },
               "maxLength": 3,
@@ -2398,7 +2398,7 @@
               "name": "noticePeriod",
               "type": "number",
               "defaultValue": 90,
-              "withAdornment": {
+              "adornment": {
                 "end": "PaperJSON.generic.noticePeriod.endAdornment"
               },
               "maxLength": 3,
@@ -2458,7 +2458,7 @@
               "name": "noticePeriod",
               "type": "number",
               "defaultValue": 90,
-              "withAdornment": {
+              "adornment": {
                 "end": "PaperJSON.generic.noticePeriod.endAdornment"
               },
               "maxLength": 3,
@@ -2855,7 +2855,7 @@
               "name": "noticePeriod",
               "type": "number",
               "defaultValue": 90,
-              "withAdornment": {
+              "adornment": {
                 "end": "PaperJSON.generic.noticePeriod.endAdornment"
               },
               "maxLength": 3,

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -1572,17 +1572,19 @@
               "name": "contractType",
               "type": "radio",
               "options": [
-                {"value": "cdi", "label": "attributes.contractType.cdi"},
-                {"value": "cdd", "label": "attributes.contractType.cdd"},
-                {"value": "alternate", "label": "attributes.contractType.alternate"},
-                {"value": "internship", "label": "attributes.contractType.internship"},
-                {
-                  "value": "other",
-                  "label": "attributes.contractType.other",
-                  "textFieldAttrs": {
-                    "label": "RadioAdapter.otherLabel"
+                [
+                  {"value": "cdi", "label": "attributes.contractType.cdi"},
+                  {"value": "cdd", "label": "attributes.contractType.cdd"},
+                  {"value": "alternate", "label": "attributes.contractType.alternate"},
+                  {"value": "internship", "label": "attributes.contractType.internship"},
+                  {
+                    "value": "other",
+                    "label": "attributes.contractType.other",
+                    "textFieldAttrs": {
+                      "label": "RadioAdapter.otherLabel"
+                    }
                   }
-                }
+                ]
               ]
             }
           ]

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -1572,13 +1572,18 @@
               "name": "contractType",
               "type": "radio",
               "options": [
-                "cdi",
-                "cdd",
-                "alternate",
-                "internship",
-                "other"
-              ],
-              "inputLabel": "RadioAdapter.otherLabel"
+                {"value": "cdi", "label": "attributes.contractType.cdi"},
+                {"value": "cdd", "label": "attributes.contractType.cdd"},
+                {"value": "alternate", "label": "attributes.contractType.alternate"},
+                {"value": "internship", "label": "attributes.contractType.internship"},
+                {
+                  "value": "other",
+                  "label": "attributes.contractType.other",
+                  "textFieldAttrs": {
+                    "label": "RadioAdapter.otherLabel"
+                  }
+                }
+              ]
             }
           ]
         },

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -1578,7 +1578,7 @@
                 "internship",
                 "other"
               ],
-              "inputLabel": "PaperJSON.generic.fileLabel.inputLabel"
+              "inputLabel": "RadioAdapter.otherLabel"
             }
           ]
         },

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions.json
@@ -332,13 +332,28 @@
             },
             {
               "name": "noticePeriod",
-              "type": "number",
-              "defaultValue": 90,
-              "adornment": {
-                "end": "PaperJSON.generic.noticePeriod.endAdornment"
-              },
-              "maxLength": 3,
-              "inputLabel": "PaperJSON.generic.noticePeriod.inputLabel"
+              "type": "radio",
+              "options": [
+                [
+                  {"value": 7, "label": "attributes.noticePeriod.oneWeek"},
+                  {"value": 30, "label": "attributes.noticePeriod.oneMonth"},
+                  {"value": 90, "label": "attributes.noticePeriod.threeMonth", "checked": true},
+                  {"value": 365, "label": "attributes.noticePeriod.oneYear"},
+                  {
+                    "value": "custom",
+                    "label": "attributes.noticePeriod.custom",
+                    "textFieldAttrs": {
+                      "type": "number",
+                      "required": true,
+                      "label": "PaperJSON.generic.noticePeriod.inputLabel",
+                      "adornment": {"end": "PaperJSON.generic.noticePeriod.endAdornment"}
+                    }
+                  }
+                ],
+                [
+                  {"value": 0, "label": "attributes.noticePeriod.noAlert"}
+                ]
+              ]
             },
             {
               "type": "contact",
@@ -408,13 +423,28 @@
           "attributes": [
             {
               "name": "noticePeriod",
-              "type": "number",
-              "defaultValue": 90,
-              "adornment": {
-                "end": "PaperJSON.generic.noticePeriod.endAdornment"
-              },
-              "maxLength": 3,
-              "inputLabel": "PaperJSON.generic.noticePeriod.inputLabel"
+              "type": "radio",
+              "options": [
+                [
+                  {"value": 7, "label": "attributes.noticePeriod.oneWeek"},
+                  {"value": 30, "label": "attributes.noticePeriod.oneMonth"},
+                  {"value": 90, "label": "attributes.noticePeriod.threeMonth", "checked": true},
+                  {"value": 365, "label": "attributes.noticePeriod.oneYear"},
+                  {
+                    "value": "custom",
+                    "label": "attributes.noticePeriod.custom",
+                    "textFieldAttrs": {
+                      "type": "number",
+                      "required": true,
+                      "label": "PaperJSON.generic.noticePeriod.inputLabel",
+                      "adornment": {"end": "PaperJSON.generic.noticePeriod.endAdornment"}
+                    }
+                  }
+                ],
+                [
+                  {"value": 0, "label": "attributes.noticePeriod.noAlert"}
+                ]
+              ]
             }
           ]
         },
@@ -632,13 +662,28 @@
           "attributes": [
             {
               "name": "noticePeriod",
-              "type": "number",
-              "defaultValue": 90,
-              "adornment": {
-                "end": "PaperJSON.generic.noticePeriod.endAdornment"
-              },
-              "maxLength": 3,
-              "inputLabel": "PaperJSON.generic.noticePeriod.inputLabel"
+              "type": "radio",
+              "options": [
+                [
+                  {"value": 7, "label": "attributes.noticePeriod.oneWeek"},
+                  {"value": 30, "label": "attributes.noticePeriod.oneMonth"},
+                  {"value": 90, "label": "attributes.noticePeriod.threeMonth", "checked": true},
+                  {"value": 365, "label": "attributes.noticePeriod.oneYear"},
+                  {
+                    "value": "custom",
+                    "label": "attributes.noticePeriod.custom",
+                    "textFieldAttrs": {
+                      "type": "number",
+                      "required": true,
+                      "label": "PaperJSON.generic.noticePeriod.inputLabel",
+                      "adornment": {"end": "PaperJSON.generic.noticePeriod.endAdornment"}
+                    }
+                  }
+                ],
+                [
+                  {"value": 0, "label": "attributes.noticePeriod.noAlert"}
+                ]
+              ]
             }
           ]
         },
@@ -895,13 +940,28 @@
             },
             {
               "name": "noticePeriod",
-              "type": "number",
-              "defaultValue": 90,
-              "adornment": {
-                "end": "PaperJSON.generic.noticePeriod.endAdornment"
-              },
-              "maxLength": 3,
-              "inputLabel": "PaperJSON.generic.noticePeriod.inputLabel"
+              "type": "radio",
+              "options": [
+                [
+                  {"value": 7, "label": "attributes.noticePeriod.oneWeek"},
+                  {"value": 30, "label": "attributes.noticePeriod.oneMonth"},
+                  {"value": 90, "label": "attributes.noticePeriod.threeMonth", "checked": true},
+                  {"value": 365, "label": "attributes.noticePeriod.oneYear"},
+                  {
+                    "value": "custom",
+                    "label": "attributes.noticePeriod.custom",
+                    "textFieldAttrs": {
+                      "type": "number",
+                      "required": true,
+                      "label": "PaperJSON.generic.noticePeriod.inputLabel",
+                      "adornment": {"end": "PaperJSON.generic.noticePeriod.endAdornment"}
+                    }
+                  }
+                ],
+                [
+                  {"value": 0, "label": "attributes.noticePeriod.noAlert"}
+                ]
+              ]
             },
             {
               "type": "contact",
@@ -943,13 +1003,28 @@
           "attributes": [
             {
               "name": "noticePeriod",
-              "type": "number",
-              "defaultValue": 90,
-              "adornment": {
-                "end": "PaperJSON.generic.noticePeriod.endAdornment"
-              },
-              "maxLength": 3,
-              "inputLabel": "PaperJSON.generic.noticePeriod.inputLabel"
+              "type": "radio",
+              "options": [
+                [
+                  {"value": 7, "label": "attributes.noticePeriod.oneWeek"},
+                  {"value": 30, "label": "attributes.noticePeriod.oneMonth"},
+                  {"value": 90, "label": "attributes.noticePeriod.threeMonth", "checked": true},
+                  {"value": 365, "label": "attributes.noticePeriod.oneYear"},
+                  {
+                    "value": "custom",
+                    "label": "attributes.noticePeriod.custom",
+                    "textFieldAttrs": {
+                      "type": "number",
+                      "required": true,
+                      "label": "PaperJSON.generic.noticePeriod.inputLabel",
+                      "adornment": {"end": "PaperJSON.generic.noticePeriod.endAdornment"}
+                    }
+                  }
+                ],
+                [
+                  {"value": 0, "label": "attributes.noticePeriod.noAlert"}
+                ]
+              ]
             }
           ]
         },
@@ -1136,13 +1211,28 @@
           "attributes": [
             {
               "name": "noticePeriod",
-              "type": "number",
-              "defaultValue": 90,
-              "adornment": {
-                "end": "PaperJSON.generic.noticePeriod.endAdornment"
-              },
-              "maxLength": 3,
-              "inputLabel": "PaperJSON.generic.noticePeriod.inputLabel"
+              "type": "radio",
+              "options": [
+                [
+                  {"value": 7, "label": "attributes.noticePeriod.oneWeek"},
+                  {"value": 30, "label": "attributes.noticePeriod.oneMonth"},
+                  {"value": 90, "label": "attributes.noticePeriod.threeMonth", "checked": true},
+                  {"value": 365, "label": "attributes.noticePeriod.oneYear"},
+                  {
+                    "value": "custom",
+                    "label": "attributes.noticePeriod.custom",
+                    "textFieldAttrs": {
+                      "type": "number",
+                      "required": true,
+                      "label": "PaperJSON.generic.noticePeriod.inputLabel",
+                      "adornment": {"end": "PaperJSON.generic.noticePeriod.endAdornment"}
+                    }
+                  }
+                ],
+                [
+                  {"value": 0, "label": "attributes.noticePeriod.noAlert"}
+                ]
+              ]
             }
           ]
         },
@@ -1890,13 +1980,28 @@
             },
             {
               "name": "noticePeriod",
-              "type": "number",
-              "defaultValue": 90,
-              "adornment": {
-                "end": "PaperJSON.generic.noticePeriod.endAdornment"
-              },
-              "maxLength": 3,
-              "inputLabel": "PaperJSON.generic.noticePeriod.inputLabel"
+              "type": "radio",
+              "options": [
+                [
+                  {"value": 7, "label": "attributes.noticePeriod.oneWeek"},
+                  {"value": 30, "label": "attributes.noticePeriod.oneMonth"},
+                  {"value": 90, "label": "attributes.noticePeriod.threeMonth", "checked": true},
+                  {"value": 365, "label": "attributes.noticePeriod.oneYear"},
+                  {
+                    "value": "custom",
+                    "label": "attributes.noticePeriod.custom",
+                    "textFieldAttrs": {
+                      "type": "number",
+                      "required": true,
+                      "label": "PaperJSON.generic.noticePeriod.inputLabel",
+                      "adornment": {"end": "PaperJSON.generic.noticePeriod.endAdornment"}
+                    }
+                  }
+                ],
+                [
+                  {"value": 0, "label": "attributes.noticePeriod.noAlert"}
+                ]
+              ]
             },
             {
               "type": "contact",
@@ -1950,13 +2055,28 @@
           "attributes": [
             {
               "name": "noticePeriod",
-              "type": "number",
-              "defaultValue": 90,
-              "adornment": {
-                "end": "PaperJSON.generic.noticePeriod.endAdornment"
-              },
-              "maxLength": 3,
-              "inputLabel": "PaperJSON.generic.noticePeriod.inputLabel"
+              "type": "radio",
+              "options": [
+                [
+                  {"value": 7, "label": "attributes.noticePeriod.oneWeek"},
+                  {"value": 30, "label": "attributes.noticePeriod.oneMonth"},
+                  {"value": 90, "label": "attributes.noticePeriod.threeMonth", "checked": true},
+                  {"value": 365, "label": "attributes.noticePeriod.oneYear"},
+                  {
+                    "value": "custom",
+                    "label": "attributes.noticePeriod.custom",
+                    "textFieldAttrs": {
+                      "type": "number",
+                      "required": true,
+                      "label": "PaperJSON.generic.noticePeriod.inputLabel",
+                      "adornment": {"end": "PaperJSON.generic.noticePeriod.endAdornment"}
+                    }
+                  }
+                ],
+                [
+                  {"value": 0, "label": "attributes.noticePeriod.noAlert"}
+                ]
+              ]
             }
           ]
         },
@@ -2396,13 +2516,28 @@
             },
             {
               "name": "noticePeriod",
-              "type": "number",
-              "defaultValue": 90,
-              "adornment": {
-                "end": "PaperJSON.generic.noticePeriod.endAdornment"
-              },
-              "maxLength": 3,
-              "inputLabel": "PaperJSON.generic.noticePeriod.inputLabel"
+              "type": "radio",
+              "options": [
+                [
+                  {"value": 7, "label": "attributes.noticePeriod.oneWeek"},
+                  {"value": 30, "label": "attributes.noticePeriod.oneMonth"},
+                  {"value": 90, "label": "attributes.noticePeriod.threeMonth", "checked": true},
+                  {"value": 365, "label": "attributes.noticePeriod.oneYear"},
+                  {
+                    "value": "custom",
+                    "label": "attributes.noticePeriod.custom",
+                    "textFieldAttrs": {
+                      "type": "number",
+                      "required": true,
+                      "label": "PaperJSON.generic.noticePeriod.inputLabel",
+                      "adornment": {"end": "PaperJSON.generic.noticePeriod.endAdornment"}
+                    }
+                  }
+                ],
+                [
+                  {"value": 0, "label": "attributes.noticePeriod.noAlert"}
+                ]
+              ]
             },
             {
               "type": "contact",
@@ -2456,13 +2591,28 @@
           "attributes": [
             {
               "name": "noticePeriod",
-              "type": "number",
-              "defaultValue": 90,
-              "adornment": {
-                "end": "PaperJSON.generic.noticePeriod.endAdornment"
-              },
-              "maxLength": 3,
-              "inputLabel": "PaperJSON.generic.noticePeriod.inputLabel"
+              "type": "radio",
+              "options": [
+                [
+                  {"value": 7, "label": "attributes.noticePeriod.oneWeek"},
+                  {"value": 30, "label": "attributes.noticePeriod.oneMonth"},
+                  {"value": 90, "label": "attributes.noticePeriod.threeMonth", "checked": true},
+                  {"value": 365, "label": "attributes.noticePeriod.oneYear"},
+                  {
+                    "value": "custom",
+                    "label": "attributes.noticePeriod.custom",
+                    "textFieldAttrs": {
+                      "type": "number",
+                      "required": true,
+                      "label": "PaperJSON.generic.noticePeriod.inputLabel",
+                      "adornment": {"end": "PaperJSON.generic.noticePeriod.endAdornment"}
+                    }
+                  }
+                ],
+                [
+                  {"value": 0, "label": "attributes.noticePeriod.noAlert"}
+                ]
+              ]
             }
           ]
         },
@@ -2853,13 +3003,28 @@
           "attributes": [
             {
               "name": "noticePeriod",
-              "type": "number",
-              "defaultValue": 90,
-              "adornment": {
-                "end": "PaperJSON.generic.noticePeriod.endAdornment"
-              },
-              "maxLength": 3,
-              "inputLabel": "PaperJSON.generic.noticePeriod.inputLabel"
+              "type": "radio",
+              "options": [
+                [
+                  {"value": 7, "label": "attributes.noticePeriod.oneWeek"},
+                  {"value": 30, "label": "attributes.noticePeriod.oneMonth"},
+                  {"value": 90, "label": "attributes.noticePeriod.threeMonth", "checked": true},
+                  {"value": 365, "label": "attributes.noticePeriod.oneYear"},
+                  {
+                    "value": "custom",
+                    "label": "attributes.noticePeriod.custom",
+                    "textFieldAttrs": {
+                      "type": "number",
+                      "required": true,
+                      "label": "PaperJSON.generic.noticePeriod.inputLabel",
+                      "adornment": {"end": "PaperJSON.generic.noticePeriod.endAdornment"}
+                    }
+                  }
+                ],
+                [
+                  {"value": 0, "label": "attributes.noticePeriod.noAlert"}
+                ]
+              ]
             }
           ]
         },

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions_health.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions_health.json
@@ -321,7 +321,7 @@
             {
               "name": "noticePeriod",
               "type": "number",
-              "withAdornment": {
+              "adornment": {
                 "end": "PaperJSON.generic.noticePeriod.endAdornment"
               },
               "maxLength": 3,

--- a/packages/cozy-mespapiers-lib/src/constants/papersDefinitions_health.json
+++ b/packages/cozy-mespapiers-lib/src/constants/papersDefinitions_health.json
@@ -320,12 +320,28 @@
           "attributes": [
             {
               "name": "noticePeriod",
-              "type": "number",
-              "adornment": {
-                "end": "PaperJSON.generic.noticePeriod.endAdornment"
-              },
-              "maxLength": 3,
-              "inputLabel": "PaperJSON.generic.noticePeriod.inputLabel"
+              "type": "radio",
+              "options": [
+                [
+                  {"value": 7, "label": "attributes.noticePeriod.oneWeek"},
+                  {"value": 30, "label": "attributes.noticePeriod.oneMonth"},
+                  {"value": 90, "label": "attributes.noticePeriod.threeMonth", "checked": true},
+                  {"value": 365, "label": "attributes.noticePeriod.oneYear"},
+                  {
+                    "value": "custom",
+                    "label": "attributes.noticePeriod.custom",
+                    "textFieldAttrs": {
+                      "type": "number",
+                      "required": true,
+                      "label": "PaperJSON.generic.noticePeriod.inputLabel",
+                      "adornment": {"end": "PaperJSON.generic.noticePeriod.endAdornment"}
+                    }
+                  }
+                ],
+                [
+                  {"value": 0, "label": "attributes.noticePeriod.noAlert"}
+                ]
+              ]
             }
           ]
         },

--- a/packages/cozy-mespapiers-lib/src/types.js
+++ b/packages/cozy-mespapiers-lib/src/types.js
@@ -8,21 +8,53 @@
  */
 
 /**
- * @typedef {Object} PapersDefinitionsStepAttributes
- * @property {string} name - Name of the attribute.
- * @property {string} type - Type of the attribute.
+ * @typedef {Object} PaperDefinitionStepAttributeOptionsTextFieldAttrs
+ * @property {string} label - Label of the inuput.
  */
 
 /**
- * @typedef {Object} PapersDefinitionsAcquisitionSteps
- * @property {number} occurrence - Number of occurrence for this step.
+ * @typedef {Object} PaperDefinitionStepAttributeOptions
+ * @property {string} value - Value of the input.
+ * @property {string} label - Label of the inuput.
+ * @property {boolean} [checked] - If the input is checked by default.
+ * @property {PaperDefinitionStepAttributeOptionsTextFieldAttrs} [textFieldAttrs] - If the input displays a text field.
+ */
+
+/**
+ * @typedef {'radio'|'date'|'text'|'number'|'contact'} PaperDefinitionStepAttributeType
+ */
+
+/**
+ * @typedef {Object} PaperDefinitionStepAttribute
+ * @property {string} name - Name of the input/metadata.
+ * @property {PaperDefinitionStepAttributeType} type - Type of the input.
+ * @property {string} inputLabel - Label of the inuput.
+ * @property {boolean} [required] - If the input is required.
+ * @property {number} [minLength] - Minimum length of the input.
+ * @property {number} [maxLength] - Maximum length of the input.
+ * @property {string} [mask] - Mask of the input. (eg: *: all characters, 9: number, a: letter)
+ * @property {string} [maskPlaceholder] - Placeholder of the mask.
+ * @property {PaperDefinitionStepAttributeOptions[]} [options] - Array of options.
+ */
+
+/**
+ * @typedef {'scan'|'information'|'contact'} PaperDefinitionAcquisitionStepModel
+ */
+
+/**
+ * @typedef {Object} PaperDefinitionAcquisitionStep
+ * @property {PaperDefinitionAcquisitionStepModel} model - Model of the step.
  * @property {string} illustration - Name of the illustration.
- * @property {string} text - Text of the step.
- * @property {PapersDefinitionsStepAttributes[]} attributes - Array of the attributes.
+ * @property {string} text - Content text of the step.
+ * @property {PaperDefinitionStepAttribute[]} attributes - Array of step attributes.
+ * @property {string} [tooltip] - Tooltip of the step.
+ * @property {boolean} [multipage] - On Scan model, if the step is multipage.
+ * @property {boolean} [multiple] - On Contact model, if the choice of contacts is multiple.
+ * @property {'all'|'ocr'} [isDisplayed] - If the step is displayed only via ocr or always.
  */
 
 /**
- * @typedef {object} PapersDefinitionsKonnectorCriteria
+ * @typedef {object} PaperDefinitionKonnectorCriteria
  * @property {string} [name] - Name of the konnector
  * @property {string} [category] - Category of the konnector
  * @property {string} [qualificationLabel] - Qualification label of the konnector
@@ -32,10 +64,12 @@
  * @typedef {Object} PaperDefinition
  * @property {string} label - Label of Paper.
  * @property {string} icon - Icon of Paper.
- * @property {number} placeholderIndex - Position on the Placeholder list.
- * @property {PapersDefinitionsAcquisitionSteps[]} acquisitionSteps - Array of acquisition steps.
- * @property {string} featureDate - Reference the attribute "name" to be used as main date.
  * @property {number} maxDisplay - Number of document beyond which a "see more" button is displayed.
+ * @property {PaperDefinitionAcquisitionStep[]} acquisitionSteps - Array of acquisition steps.
+ * @property {number} [placeholderIndex] - Position on the Placeholder list.
+ * @property {object[]} [ocrAttributes] - Array of ocr attributes.
+ * @property {string} [featureDate] - Reference the attribute "name" to be used as main date.
+ * @property {PaperDefinitionKonnectorCriteria} [konnectorCriteria] - Criteria for linking paper to a konnector.
  */
 
 export default {}

--- a/packages/cozy-mespapiers-lib/src/types.js
+++ b/packages/cozy-mespapiers-lib/src/types.js
@@ -36,7 +36,7 @@
  * @property {number} [maxLength] - Maximum length of the input.
  * @property {string} [mask] - Mask of the input. (eg: *: all characters, 9: number, a: letter)
  * @property {string} [maskPlaceholder] - Placeholder of the mask.
- * @property {PaperDefinitionStepAttributeOptions[]} [options] - Array of options.
+ * @property {PaperDefinitionStepAttributeOptions[][]} [options] - Array of array of options.
  */
 
 /**

--- a/packages/cozy-mespapiers-lib/src/types.js
+++ b/packages/cozy-mespapiers-lib/src/types.js
@@ -12,6 +12,7 @@
  * @property {'text'|'number'} type - Type of the inuput.
  * @property {string} label - Label of the inuput.
  * @property {boolean} required - If the input is required.
+ * @property {{ endAdornment: string, startAdornment: string }} adornment - Adornment of the input.
  */
 
 /**

--- a/packages/cozy-mespapiers-lib/src/types.js
+++ b/packages/cozy-mespapiers-lib/src/types.js
@@ -17,10 +17,10 @@
 
 /**
  * @typedef {Object} PaperDefinitionStepAttributeOptions
- * @property {string} value - Value of the input.
- * @property {string} label - Label of the inuput.
- * @property {boolean} [checked] - If the input is checked by default.
- * @property {PaperDefinitionStepAttributeOptionsTextFieldAttrs} [textFieldAttrs] - If the input displays a text field.
+ * @property {string|number} value - Value of the option.
+ * @property {string} label - Label of the option.
+ * @property {boolean} [checked] - If the option is checked by default.
+ * @property {PaperDefinitionStepAttributeOptionsTextFieldAttrs} [textFieldAttrs] - If the option displays a text field.
  */
 
 /**
@@ -38,6 +38,7 @@
  * @property {string} [mask] - Mask of the input. (eg: *: all characters, 9: number, a: letter)
  * @property {string} [maskPlaceholder] - Placeholder of the mask.
  * @property {PaperDefinitionStepAttributeOptions[][]} [options] - Array of array of options.
+ * @property {{ endAdornment: string, startAdornment: string }} [adornment] - Adornment of the input.
  */
 
 /**

--- a/packages/cozy-mespapiers-lib/src/types.js
+++ b/packages/cozy-mespapiers-lib/src/types.js
@@ -9,7 +9,9 @@
 
 /**
  * @typedef {Object} PaperDefinitionStepAttributeOptionsTextFieldAttrs
+ * @property {'text'|'number'} type - Type of the inuput.
  * @property {string} label - Label of the inuput.
+ * @property {boolean} required - If the input is required.
  */
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -10631,10 +10631,10 @@ cozy-client@^45.8.1:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^46.6.1:
-  version "46.6.1"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-46.6.1.tgz#019b0b1eb2c339f9b33cc175f31a8b6af459b459"
-  integrity sha512-LpLHK/82+pddeZbCRYlvQQllRVdKD10ik3Ny+xu59QdVc8vpn5ipxqGwzPjQcxX7fcfbpGBjMtP/3MH5IdnUjg==
+cozy-client@^46.7.0:
+  version "46.7.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-46.7.0.tgz#d17d2cb54c9441146930415a84e2fd54dbcd5185"
+  integrity sha512-ksn/aqEKl1Lxv+9gUvv3xvwouOp8EwQL30pN7yHa8ZNeVCUD1Q88VsXeaWrsfdZW+R1xY6QkuoMNEeofoW/pXQ==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"


### PR DESCRIPTION
Cette PR change les étapes d'informations permettant de renseigner le délai de prévenance avant l'expiration du fichier.

Ces dernières étaient présentées sous forme d'un champs texte, elles sont maintenant présentées avec une liste d'options.

Cette liste d'options est une nouvelle implémentation, appliqué également à la liste d'options des types de contrat du papier `work_contract`.