### PR TITLE
[VO-438] fix(GroupRecipientPermissions): Missing document props

### DIFF
--- a/packages/cozy-sharing/src/components/Recipient/GroupRecipientPermissions.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/GroupRecipientPermissions.jsx
@@ -24,7 +24,8 @@ const GroupRecipientPermissions = ({
   groupIndex,
   read_only: isReadOnly = false,
   className,
-  isUserInsideMembers
+  isUserInsideMembers,
+  document
 }) => {
   const { t } = useI18n()
   const buttonRef = useRef()


### PR DESCRIPTION
The prop `document` is needed to revoke a group [here](https://github.com/cozy/cozy-libs/blob/8c480a31c95c93df13d21668a87167e5e9a63103/packages/cozy-sharing/src/components/Recipient/GroupRecipientPermissions.jsx#L45) but I did pass anything so it was crashing. I don't understand why eslint didn't detect this error 🤔