### PR TITLE
fix(mespapiers): Wrong writing of the `pay_sheet` qualification

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/Icons/KonnectorIcon.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/Icons/KonnectorIcon.jsx
@@ -32,7 +32,7 @@ export const KonnectorIcon = ({ konnectorCriteria, ...props }) => {
     case 'energy':
       return <Icon icon={KonnectorEnergy} {...props} />
 
-    case 'pay-sheet':
+    case 'pay_sheet':
       return <Icon icon={KonnectorPayslip} {...props} />
 
     default:


### PR DESCRIPTION
In order to display the appropriate icon when you want to add paper via a konnector.