### PR TITLE
fix: Do not save identifiers in vault when no vendor_link (SCR-531)

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -73,7 +73,7 @@
     "cozy-keys-lib": "^6.0.0",
     "cozy-realtime": "^5.0.0",
     "cozy-tsconfig": "^1.2.0",
-    "cozy-ui": "^103.2.0",
+    "cozy-ui": "^103.12.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.6",
     "form-data": "4.0.0",
@@ -101,7 +101,7 @@
     "cozy-interapp": ">=0.9.0",
     "cozy-keys-lib": ">=6.0.0",
     "cozy-realtime": ">=4.2.8",
-    "cozy-ui": ">=103.2.0",
+    "cozy-ui": ">=103.12.0",
     "leaflet": "^1.7.1",
     "react-router": "3.2.6",
     "react-router-dom": ">=4.3.1"

--- a/packages/cozy-harvest-lib/src/components/DumbTriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/DumbTriggerManager.jsx
@@ -201,10 +201,10 @@ export class DumbTriggerManager extends Component {
 
     if (paywall === null) {
       const konnectorPolicy = findKonnectorPolicy(konnector)
-      if (konnectorPolicy.saveInVault) {
+      if (konnectorPolicy.shouldSaveInVault(konnector)) {
         if (!vaultClient) {
           throw new Error(
-            'Konnector policy `saveInVault` is true, but no vault has been passed in the context of the TriggerManager. You can wrap it the TriggerManager in a VaultUnlockProvider or VaultProvider (from cozy-keys-lib).'
+            'Konnector policy `shouldSaveInVault` is true, but no vault has been passed in the context of the TriggerManager. You can wrap it the TriggerManager in a VaultUnlockProvider or VaultProvider (from cozy-keys-lib).'
           )
         }
         const isVaultLocked = await vaultClient.isLocked()

--- a/packages/cozy-harvest-lib/src/components/TriggerManager.spec.jsx
+++ b/packages/cozy-harvest-lib/src/components/TriggerManager.spec.jsx
@@ -207,7 +207,7 @@ describe('TriggerManager', () => {
 
       it('should show the new account form without any warning', async () => {
         findKonnectorPolicy.mockReturnValue({
-          saveInVault: false,
+          shouldSaveInVault: () => false,
           isRunnable: () => true
         })
         const { findByLabelText, findByTitle } = render(

--- a/packages/cozy-harvest-lib/src/konnector-policies.js
+++ b/packages/cozy-harvest-lib/src/konnector-policies.js
@@ -5,6 +5,7 @@ import { konnectorPolicy as cliskPolicy } from './policies/clisk'
 const defaultKonnectorPolicy = {
   accountContainsAuth: true,
   saveInVault: true,
+  shouldSaveInVault: konnector => Boolean(konnector.vendor_link),
   onAccountCreation: null,
   // eslint-disable-next-line no-unused-vars
   match: konnector => true,

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -100,7 +100,7 @@ export const createOrUpdateAccount = async ({
     logger.debug('Creating the account...')
   }
 
-  const { onAccountCreation, saveInVault } = konnectorPolicy
+  const { onAccountCreation, shouldSaveInVault } = konnectorPolicy
 
   let accountToSave = clone(account) || {}
 
@@ -135,7 +135,7 @@ export const createOrUpdateAccount = async ({
     })
   }
 
-  if (cipher && saveInVault) {
+  if (cipher && shouldSaveInVault(konnector)) {
     accountToSave = accounts.setVaultCipherRelationship(
       accountToSave,
       cipher.id
@@ -487,7 +487,7 @@ export class ConnectionFlow {
       )
 
       let cipher
-      if (konnectorPolicy.saveInVault) {
+      if (konnectorPolicy.shouldSaveInVault(konnector)) {
         cipher = await createOrUpdateCipher(vaultClient, cipherId, {
           account,
           konnector,

--- a/packages/cozy-harvest-lib/src/policies/biWebView.js
+++ b/packages/cozy-harvest-lib/src/policies/biWebView.js
@@ -381,7 +381,7 @@ export const konnectorPolicy = {
   isRunnable: () => true,
   name: 'budget-insight-webview',
   match: isBiWebViewConnector,
-  saveInVault: false,
+  shouldSaveInVault: () => false,
   onAccountCreation: onBIAccountCreation,
   fetchExtraOAuthUrlParams: fetchExtraOAuthUrlParams,
   handleOAuthAccount,

--- a/packages/cozy-harvest-lib/src/policies/clisk.js
+++ b/packages/cozy-harvest-lib/src/policies/clisk.js
@@ -138,7 +138,7 @@ export const konnectorPolicy = {
   needsAccountAndTriggerCreation: false,
   needsTriggerLaunch: false,
   onLaunch,
-  saveInVault: false,
+  shouldSaveInVault: () => false,
   accountContainsAuth: false,
   onAccountCreation: null,
   fetchExtraOAuthUrlParams: null,

--- a/packages/cozy-harvest-lib/src/types.js
+++ b/packages/cozy-harvest-lib/src/types.js
@@ -48,6 +48,7 @@
  * @typedef KonnectorPolicy
  * @property {Boolean} accountContainsAuth
  * @property {Boolean} saveInVault
+ * @property {Function} shouldSaveInVault
  * @property {Function} onAccountCreation
  * @property {Function} match
  * @property {String} name

--- a/packages/cozy-harvest-lib/test/fixtures.js
+++ b/packages/cozy-harvest-lib/test/fixtures.js
@@ -5,6 +5,7 @@ const fixtures = {
   },
   konnector: {
     slug: 'konnectest',
+    vendor_link: 'https://cozy.io',
     fields: {
       username: {
         type: 'text'
@@ -23,6 +24,7 @@ const fixtures = {
     _type: 'io.cozy.konnectors',
     name: 'myBills',
     slug: 'mybills',
+    vendor_link: 'https://cozy.io',
     fields: {
       advancedFields: {
         folderPath: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10870,10 +10870,10 @@ cozy-ui@93.1.1:
     react-swipeable-views "^0.13.3"
     rooks "^5.11.2"
 
-cozy-ui@^103.2.0:
-  version "103.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-103.2.0.tgz#cb516fc76d4f6c4e1ec3b4d85aed9c9dca9a4adc"
-  integrity sha512-wUtJ5Z97AJFTFGkh5K+46uPYh8kfeeU3hFsLsFnK3t+ZpKo4A9Cw8qu1W5NNXgXGP6tg3pZdtQLIdKA7x/EZ1A==
+cozy-ui@^103.12.0:
+  version "103.12.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-103.12.0.tgz#111aec19c38ec7899532def34430c8033ab5d9c7"
+  integrity sha512-izwOiTja/S2JpAgB2dt6GgdSgqlVIghcYPw7Hx7uhWRQ/1334Ng0X2iGqasxOtcQRN/7IycNv0/FDuh9acH+CQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"
@@ -10895,7 +10895,6 @@ cozy-ui@^103.2.0:
     piwik-react-router "0.12.1"
     react-chartjs-2 "4.1.0"
     react-markdown "^4.0.8"
-    react-middle-ellipsis "1.2.2"
     react-pdf "^5.7.2"
     react-popper "^2.2.3"
     react-remove-scroll "^2.4.0"
@@ -19917,6 +19916,17 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+  version "1.0.8"
+  uid "3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  dependencies:
+    "@juggle/resize-observer" "^3.1.3"
+    jest-environment-jsdom-sixteen "^1.0.3"
+    react-spring "9.0.0-rc.3"
+    react-use-gesture "^7.0.8"
+    react-use-measure "^2.0.0"
+
 "mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
   resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
@@ -23066,11 +23076,6 @@ react-markdown@^4.0.8, react-markdown@^4.2.2:
     unified "^6.1.5"
     unist-util-visit "^1.3.0"
     xtend "^4.0.1"
-
-react-middle-ellipsis@1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/react-middle-ellipsis/-/react-middle-ellipsis-1.2.2.tgz#e1676fe2fbc864ea7e2fc25bedc53db2635bb2a9"
-  integrity sha512-tTsyS/hOjT3C5WjpueAx1/WsYUVnNlUnDRCKSffGT1ns7b0NbSi6FGVVPDLTxn207B0sVjNTbMnk1HFGWd5hzA==
 
 react-pdf@^4.0.5:
   version "4.1.0"


### PR DESCRIPTION
The konnector identifiers won't be saved in vault when
the konnector's manifest does not have any vendor_link.

This avoids to have the whole list of identifiers displayed to
the user when he tries to configure a konnector without
any vendor_link, like NextCloud.

- **fix: Minor upgrade of cozy-ui**

BREAKING CHANGE: you must have `cozy-ui >= 103.12.0`
