### PR TITLE
fix(mespapiers): Create a paper if myself does not exist

### DIFF
--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/ContactDialog.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/ContactDialog.jsx
@@ -21,6 +21,7 @@ const ContactDialog = ({ currentStep, onClose, onBack, onSubmit }) => {
   const { formData, setFormData } = useFormData()
   const { currentStepIndex, nextStep, isLastStep } = useStepperDialog()
   const [currentUser, setCurrentUser] = useState(null)
+  const [currentUserLoaded, setCurrentUserLoaded] = useState(false)
   const [contactsSelected, setContactsSelected] = useState([])
   const [contactModalOpened, setContactModalOpened] = useState(false)
   const { illustration, text, multiple } = currentStep
@@ -31,12 +32,15 @@ const ContactDialog = ({ currentStep, onClose, onBack, onSubmit }) => {
   useEffect(() => {
     const init = async () => {
       const myself = await fetchCurrentUser(client)
-      setCurrentUser(myself)
-      setFormData(prev => ({
-        ...prev,
-        contacts: [myself]
-      }))
-      setContactsSelected([myself])
+      if (myself) {
+        setCurrentUser(myself)
+        setFormData(prev => ({
+          ...prev,
+          contacts: [myself]
+        }))
+        setContactsSelected([myself])
+      }
+      setCurrentUserLoaded(true)
     }
     init()
   }, [client, setFormData])
@@ -67,7 +71,7 @@ const ContactDialog = ({ currentStep, onClose, onBack, onSubmit }) => {
             iconSize="small"
             title={t(text)}
             text={
-              currentUser && (
+              currentUserLoaded ? (
                 <Paper elevation={2} className="u-mt-1 u-mh-half">
                   <ContactList
                     className="u-pv-0"
@@ -79,7 +83,7 @@ const ContactDialog = ({ currentStep, onClose, onBack, onSubmit }) => {
                     setContactModalOpened={setContactModalOpened}
                   />
                 </Paper>
-              )
+              ) : null
             }
           />
         }

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/ContactList.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/ContactList.jsx
@@ -36,7 +36,7 @@ const ContactList = ({
     []
   )
   const [contactsList, setContactsList] = useState([
-    currentUser,
+    ...(currentUser ? [currentUser] : []),
     ...contactsLocalSession
   ])
 
@@ -116,7 +116,7 @@ ContactList.propTypes = {
   /** Determine whether the user can select several contacts */
   multiple: PropTypes.bool,
   /** Contact object representing the current user */
-  currentUser: PropTypes.object.isRequired,
+  currentUser: PropTypes.object,
   className: PropTypes.string,
   contactModalOpened: PropTypes.bool.isRequired,
   setContactModalOpened: PropTypes.func.isRequired,

--- a/packages/cozy-mespapiers-lib/src/helpers/fetchCurrentUser.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/fetchCurrentUser.js
@@ -1,8 +1,17 @@
 import { CONTACTS_DOCTYPE } from '../doctypes'
 
+/**
+ * Fetch the current user
+ * @param {import('cozy-client/types/CozyClient').default} client - CozyClient instance
+ * @returns {Promise<import('cozy-client/types/types').IOCozyContact | null>}
+ */
 export const fetchCurrentUser = async client => {
-  const contactCollection = client.collection(CONTACTS_DOCTYPE)
-  const { data: currentUser } = await contactCollection.findMyself()
+  try {
+    const contactCollection = client.collection(CONTACTS_DOCTYPE)
+    const { data: currentUser } = await contactCollection.findMyself()
 
-  return currentUser[0]
+    return currentUser[0] || null
+  } catch (error) {
+    return null
+  }
 }

--- a/packages/cozy-mespapiers-lib/src/helpers/fetchCurrentUser.spec.js
+++ b/packages/cozy-mespapiers-lib/src/helpers/fetchCurrentUser.spec.js
@@ -12,4 +12,26 @@ describe('fetchCurrentUser', () => {
     expect(currentUser.fullname).toBeTruthy()
     expect(currentUser).toHaveProperty('me', true)
   })
+  it('should return "null" if the current user is not found', async () => {
+    const client = {
+      collection: jest.fn(() => ({
+        findMyself: jest.fn(() => ({ data: [] }))
+      }))
+    }
+    const currentUser = await fetchCurrentUser(client)
+
+    expect(currentUser).toBeNull()
+  })
+  it('should return "null" if the current user is fetching it throws an error', async () => {
+    const client = {
+      collection: jest.fn(() => ({
+        findMyself: jest.fn(() => {
+          throw new Error('Error')
+        })
+      }))
+    }
+    const currentUser = await fetchCurrentUser(client)
+
+    expect(currentUser).toBeNull()
+  })
 })


### PR DESCRIPTION
Today if myself doesn't exist, the contact modal in the paper creation process displays nothing and prevents validation of the step.
As it's possible to delete myself in cozy-contacts for example, we must not block the creation of paper depending on its existence.