### PR TITLE
fix: Transmit correct account identifiers on reconnect (SCR-508)

### DIFF
--- a/packages/cozy-harvest-lib/src/components/DumbTriggerManager.jsx
+++ b/packages/cozy-harvest-lib/src/components/DumbTriggerManager.jsx
@@ -29,7 +29,7 @@ const RUNNING = 'RUNNING'
 export class DumbTriggerManager extends Component {
   constructor(props) {
     super(props)
-    const { account } = props
+    const account = props.account || props.flow.account
 
     this.handleOAuthAccountId = this.handleOAuthAccountId.bind(this)
     this.handleSubmit = this.handleSubmit.bind(this)


### PR DESCRIPTION
When the user tries to connecteur a server konnector with
wrong identifiers and fix identifiers and retry conection,
the  previous identifier a resent to the konnector and an
io.cozy.account document, not linked to any trigger is also
created for each atempt.

Now the trigger manager will reuse the account from the
the current ConnectionFlow instance when possible.
