### PR TITLE
fix(mespapiers): Ensure country code used for translation is valid

### DIFF
--- a/packages/cozy-mespapiers-lib/package.json
+++ b/packages/cozy-mespapiers-lib/package.json
@@ -21,7 +21,7 @@
     "@testing-library/react-hooks": "8.0.1",
     "babel-preset-cozy-app": "2.0.1",
     "cozy-bar": "^12.2.3",
-    "cozy-client": "^47.1.2",
+    "cozy-client": "^47.2.0",
     "cozy-device-helper": "^3.0.0",
     "cozy-doctypes": "^1.90.0",
     "cozy-flags": "^3.2.2",
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "cozy-bar": ">=12.2.3",
-    "cozy-client": ">=47.1.2",
+    "cozy-client": ">=47.2.0",
     "cozy-device-helper": ">=3.0.0",
     "cozy-doctypes": ">=1.90.0",
     "cozy-flags": ">=3.2.2",

--- a/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/CountryListAdapter.jsx
+++ b/packages/cozy-mespapiers-lib/src/components/ModelSteps/widgets/CountryListAdapter.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, Fragment } from 'react'
 
 import {
   getAllCountries,
-  checkCountryCode
+  isValidCountryCodeTranslation
 } from 'cozy-client/dist/models/country/countries'
 import { getLocalizer } from 'cozy-client/dist/models/country/locales'
 import Divider from 'cozy-ui/transpiled/react/Divider'
@@ -23,15 +23,22 @@ export const CountryListAdapter = ({
   idx
 }) => {
   const { t, lang } = useI18n()
-  const translatedFormDataValue = checkCountryCode(formDataValue)
-    ? getLocalizer(lang)(`nationalities.${formDataValue}`)
+  const { t: tCountry } = getLocalizer(lang)
+
+  const translatedFormDataValue = isValidCountryCodeTranslation(
+    lang,
+    formDataValue
+  )
+    ? tCountry(`nationalities.${formDataValue}`)
     : null
   const [searchValue, setSearchValue] = useState(translatedFormDataValue || '')
   const [displayedOptionCount, setDisplayedOptionCount] = useState(
     DISPLAYED_OPTION_COUNT
   )
   const [currentOption, setCurrentOption] = useState({
-    value: formDataValue || ''
+    value: isValidCountryCodeTranslation(lang, formDataValue)
+      ? formDataValue
+      : ''
   })
 
   const handleViewMore = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10631,10 +10631,10 @@ cozy-client@^45.15.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^47.1.2:
-  version "47.1.2"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-47.1.2.tgz#bcd7ead86cba201fabaa1c613cc253ea90b66549"
-  integrity sha512-Yo36FyfLk8JQpAZKQyvr7H8uf306u5QMzBsb6oX3tGGBCgGieWDJVWzpGfxGbob6wW8Nn6Otl0qO9/LIec+xyg==
+cozy-client@^47.2.0:
+  version "47.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-47.2.0.tgz#bcfaffc3737546ccf961098259fbf27ce8f54496"
+  integrity sha512-VkrcsL8Yti6DHz3DhhT9Lh/ayn2NCzqvhvojHWivrZGnxvUX6D6p9dvinNKJguyT8fATlIIfd7hY8ptx7F0yPg==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
@@ -25761,7 +25761,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -25784,15 +25784,6 @@ string-width@^1.0.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
@@ -25977,7 +25968,7 @@ stringify-object@^3.2.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -26009,13 +26000,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -28262,7 +28246,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -28290,15 +28274,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Via l'OCR, le valeur provient d'un champs texte, il peut donc y avoir des valeurs comme "fra", "bob", "aa", etc.

Ces cas n'étaient pas gérés et provoquaient des problèmes lors de l'édition.