### PR TITLE
refactor: Remove cozy-bi-auth dependency (SCR-297)

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@cozy/minilog": "^1.0.0",
     "classnames": "^2.3.1",
-    "cozy-bi-auth": "0.0.25",
     "cozy-doctypes": "^1.97.1",
     "cozy-logger": "^1.16.1",
     "date-fns": "2.30.0",

--- a/packages/cozy-harvest-lib/src/policies/biWebView.js
+++ b/packages/cozy-harvest-lib/src/policies/biWebView.js
@@ -10,7 +10,6 @@ import get from 'lodash/get'
 import keyBy from 'lodash/keyBy'
 import set from 'lodash/set'
 
-import { biErrorMap } from 'cozy-bi-auth'
 import { Q } from 'cozy-client'
 import PromiseCache from 'cozy-client/dist/promise-cache'
 import { receiveMutationResult } from 'cozy-client/dist/store'
@@ -447,9 +446,7 @@ export const findAccountWithBiConnection = async ({
  */
 export const convertBIErrortoKonnectorJobError = error => {
   const errorCode = error ? error.code : null
-  const cozyErrorMessage = errorCode
-    ? biErrorMap[errorCode] || extraBIErrorMap[errorCode] || null
-    : null
+  const cozyErrorMessage = errorCode ? biErrorMap[errorCode] || null : null
   const errorMessage =
     cozyErrorMessage ||
     (errorCode ? `UNKNOWN_ERROR.${errorCode}` : 'UNKNOWN_ERROR')
@@ -461,13 +458,16 @@ export const convertBIErrortoKonnectorJobError = error => {
 export const isBudgetInsightConnector = konnector =>
   konnector?.partnership?.domain === 'budget-insight.com'
 
-/**
- * This error map is not in the bi-auth package since it is not really
- * satisfying to have "config" mapped to LOGIN_FAILED. It might change.
- * We should not have this error if we validate the fields in the
- * front-end.
- */
-const extraBIErrorMap = {
+const biErrorMap = {
+  actionNeeded: 'USER_ACTION_NEEDED',
+  wrongpass: 'LOGIN_FAILED',
+  decoupled: 'USER_ACTION_NEEDED.TWOFA_NEEDED.APP',
+  passwordExpired: 'USER_ACTION_NEEDED.CHANGE_PASSWORD',
+  SCARequired: 'USER_ACTION_NEEDED.SCA_REQUIRED',
+  webauthRequired: 'USER_ACTION_NEEDED.WEBAUTH_REQUIRED',
+  websiteUnavailable: 'VENDOR_DOWN.BANK_DOWN',
+  additionalInformationNeeded: 'CHALLENGE_ASKED',
+  bug: 'VENDOR_DOWN',
   config: 'LOGIN_FAILED',
   ACCOUNT_WITH_SAME_IDENTIFIER_ALREADY_DEFINED:
     'ACCOUNT_WITH_SAME_IDENTIFIER_ALREADY_DEFINED'

--- a/yarn.lock
+++ b/yarn.lock
@@ -9271,11 +9271,6 @@ base64id@2.0.0, base64id@~2.0.0:
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-2.0.0.tgz#2770ac6bc47d312af97a8bf9a634342e0cd25cb6"
   integrity sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==
 
-base64url@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
-  integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
-
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -10993,15 +10988,6 @@ cosmiconfig@^8.2.0:
     js-yaml "^4.1.0"
     parse-json "^5.2.0"
     path-type "^4.0.0"
-
-cozy-bi-auth@0.0.25:
-  version "0.0.25"
-  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.25.tgz#00947925dc3cbb664f4fa54cedde80e47d55fdd0"
-  integrity sha512-GsGuQ+tWbD6qhoD3EaAb9+qtGY90dY1F2n3+4Y1GHy5NBjPyRORPygOADaFgQmrX+u6QrrSJLAWh7EMAzxUH6w==
-  dependencies:
-    cozy-logger "^1.3.0"
-    lodash "^4.17.20"
-    node-jose "^1.1.4"
 
 cozy-client-js@0.19.0:
   version "0.19.0"
@@ -19048,11 +19034,6 @@ lolex@^5.0.0:
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-long@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
-  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
-
 longest-streak@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
@@ -20281,17 +20262,6 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
-  version "1.0.8"
-  uid "3dc4c2a245ab39079bc2f73546bccf80847be14c"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
-  dependencies:
-    "@juggle/resize-observer" "^3.1.3"
-    jest-environment-jsdom-sixteen "^1.0.3"
-    react-spring "9.0.0-rc.3"
-    react-use-gesture "^7.0.8"
-    react-use-measure "^2.0.0"
-
 "mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
   resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
@@ -20488,11 +20458,6 @@ node-forge@^0.7.1:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.6.tgz#fdf3b418aee1f94f0ef642cd63486c77ca9724ac"
 
-node-forge@^0.8.5:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.8.5.tgz#57906f07614dc72762c84cef442f427c0e1b86ee"
-  integrity sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==
-
 node-forge@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
@@ -20517,22 +20482,6 @@ node-gyp@^10.0.0:
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
-
-node-jose@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/node-jose/-/node-jose-1.1.4.tgz#af3f44a392e586d26b123b0e12dc09bef1e9863b"
-  integrity sha512-L31IFwL3pWWcMHxxidCY51ezqrDXMkvlT/5pLTfNw5sXmmOLJuN6ug7txzF/iuZN55cRpyOmoJrotwBQIoo5Lw==
-  dependencies:
-    base64url "^3.0.1"
-    browserify-zlib "^0.2.0"
-    buffer "^5.5.0"
-    es6-promise "^4.2.8"
-    lodash "^4.17.15"
-    long "^4.0.0"
-    node-forge "^0.8.5"
-    process "^0.11.10"
-    react-zlib-js "^1.0.4"
-    uuid "^3.3.3"
 
 node-libs-browser@^2.0.0, node-libs-browser@^2.2.1:
   version "2.2.1"
@@ -23710,11 +23659,6 @@ react-use-measure@^2.0.0:
   integrity sha512-7K2HIGaPMl3Q9ZQiEVjen3tRXl4UDda8LiTPy/QxP8dP2rl5gPBhf7mMH6MVjjRNv3loU7sNzey/ycPNnHVTxQ==
   dependencies:
     debounce "^1.2.0"
-
-react-zlib-js@^1.0.4:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/react-zlib-js/-/react-zlib-js-1.0.5.tgz#7bb433e1a4ae53a8e6f361b3d36166baf5bbc60f"
-  integrity sha512-TLcPdmqhIl+ylwOwlfm1WUuI7NVvhAv3L74d1AabhjyaAbmLOROTA/Q4EQ/UMCFCOjIkVim9fT3UZOQSFk/mlA==
 
 react@16.12.0, react@^16.12.0:
   version "16.12.0"
@@ -27791,7 +27735,7 @@ uuid@^10.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
   integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
 
-uuid@^3.3.2, uuid@^3.3.3:
+uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==


### PR DESCRIPTION
Since harvest is the last using it and this package is not maintained
anymore. Let's keep this error map in harvest itself
