### PR TITLE
feat: Add options object in NativeService args

### DIFF
--- a/packages/cozy-intent/src/api/models/events.ts
+++ b/packages/cozy-intent/src/api/models/events.ts
@@ -10,6 +10,10 @@ export type NativeEvent = {
   }
 }
 
+export type PostMeMessageOptions = {
+  slug: string
+}
+
 export type PostMeMessage = {
   action: string
   args: unknown[]

--- a/packages/cozy-intent/src/api/models/messengers.ts
+++ b/packages/cozy-intent/src/api/models/messengers.ts
@@ -3,9 +3,9 @@ import { Connection } from 'post-me'
 import { NativeMessenger } from '../../api'
 
 export interface MessengerRegister {
-  id: { connection: Connection; messenger: NativeMessenger }
+  id: { connection: Connection; messenger: NativeMessenger; slug: string }
   [key: string]:
-    | { connection?: Connection; messenger: NativeMessenger }
+    | { connection?: Connection; messenger: NativeMessenger; slug: string }
     | undefined
 }
 

--- a/packages/cozy-intent/src/api/models/methods.ts
+++ b/packages/cozy-intent/src/api/models/methods.ts
@@ -1,4 +1,4 @@
-import { AppManifest, FlagshipUI } from '../../api'
+import { AppManifest, FlagshipUI, PostMeMessageOptions } from '../../api'
 
 type PostMeDefault = Record<string, (...args: unknown[]) => Promise<null>>
 
@@ -13,10 +13,8 @@ interface _NativeMethodsRegister {
     app: AppManifest,
     iconParams?: DOMRect
   ) => Promise<null>
-  openSettingBiometry: () => Promise<boolean>
   setDefaultRedirection: (defaultRedirection: string) => Promise<null>
   setFlagshipUI: (flagshipUI: FlagshipUI, caller?: string) => Promise<null>
-  showSplashScreen: () => Promise<null>
   toggleSetting: (
     settingName: 'biometryLock' | 'PINLock' | 'autoLock',
     params?: Record<string, unknown>
@@ -31,5 +29,14 @@ interface _NativeMethodsRegister {
 }
 
 export type NativeMethodsRegister = _NativeMethodsRegister & PostMeDefault
+
+type WithOptions<T> = {
+  [K in keyof T]: T[K] extends (...args: infer A) => infer R
+    ? (options: PostMeMessageOptions, ...args: A) => R
+    : never
+}
+
+export type NativeMethodsRegisterWithOptions =
+  WithOptions<NativeMethodsRegister>
 
 export type WebviewMethods = Record<string, () => unknown>

--- a/packages/cozy-intent/src/api/services/NativeService.spec.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.spec.ts
@@ -78,7 +78,7 @@ describe('NativeService', () => {
 
     const nativeService = new NativeService(nativeMethods, MockNativeMessenger)
 
-    nativeService.registerWebview('some_uri', webviewRef)
+    nativeService.registerWebview('some_uri', 'some_slug', webviewRef)
 
     await nativeService.tryEmit(
       {
@@ -117,7 +117,7 @@ describe('NativeService', () => {
 
       const nativeService = new NativeService(nativeMethods)
 
-      nativeService.registerWebview('some_uri', webviewRef)
+      nativeService.registerWebview('some_uri', 'some_slug', webviewRef)
 
       expect(NativeMessenger).toHaveBeenNthCalledWith(1, webviewRef)
     })
@@ -134,10 +134,10 @@ describe('NativeService', () => {
 
       const nativeService = new NativeService(nativeMethods)
 
-      nativeService.registerWebview('some_uri', webviewRef)
+      nativeService.registerWebview('some_uri', 'some_slug', webviewRef)
 
       expect(() => {
-        nativeService.registerWebview('some_uri', webviewRef)
+        nativeService.registerWebview('some_uri', 'some_slug', webviewRef)
       }).not.toThrow()
 
       expect(mockDebug).toHaveBeenCalled()
@@ -156,7 +156,7 @@ describe('NativeService', () => {
 
       const nativeService = new NativeService(nativeMethods)
 
-      nativeService.registerWebview('some_uri', webviewRef)
+      nativeService.registerWebview('some_uri', 'some_slug', webviewRef)
 
       expect(NativeMessenger).toHaveBeenNthCalledWith(1, webviewRef)
     })
@@ -174,8 +174,8 @@ describe('NativeService', () => {
 
       const nativeService = new NativeService(nativeMethods)
 
-      nativeService.registerWebview('some_uri', webviewRef)
-      nativeService.registerWebview('some_uri', webviewRef)
+      nativeService.registerWebview('some_uri', 'some_slug', webviewRef)
+      nativeService.registerWebview('some_uri', 'some_slug', webviewRef)
 
       const baseUrlFromWebview = 'some_uri'
       expect(mockDebug).toHaveBeenLastCalledWith(
@@ -215,7 +215,7 @@ describe('NativeService', () => {
     })
 
     it('Should try to init a webview', async () => {
-      nativeService.registerWebview('bar.com', {
+      nativeService.registerWebview('bar.com', 'bar', {
         injectJavaScript: jest.fn(),
         props: {
           source: {
@@ -286,7 +286,7 @@ describe('NativeService', () => {
         MockNativeMessenger
       )
 
-      nativeService.registerWebview('some_uri', webviewRef)
+      nativeService.registerWebview('some_uri', 'some_slug', webviewRef)
 
       await expect(
         nativeService.tryEmit(
@@ -304,6 +304,7 @@ describe('NativeService', () => {
         type: '@post-me',
         methodName: 'setFlagshipUI',
         args: [
+          { slug: 'some_slug' },
           { bottomTheme: 'dark', componentId: 'SOME_COMPONENT_ID' },
           'SOME_CALLER_NAME'
         ]
@@ -328,7 +329,7 @@ describe('NativeService', () => {
         MockNativeMessenger
       )
 
-      nativeService.registerWebview('some_uri', webviewRef)
+      nativeService.registerWebview('some_uri', 'some_slug', webviewRef)
 
       await expect(
         nativeService.tryEmit(
@@ -345,7 +346,10 @@ describe('NativeService', () => {
       expect(onMessageMock).toHaveBeenNthCalledWith(1, {
         type: '@post-me',
         methodName: 'setTheme',
-        args: [{ homeTheme: 'inverted', componentId: 'SOME_COMPONENT_ID' }]
+        args: [
+          { slug: 'some_slug' },
+          { homeTheme: 'inverted', componentId: 'SOME_COMPONENT_ID' }
+        ]
       })
 
       expect(mockDebug).toHaveBeenCalled()

--- a/packages/cozy-intent/src/api/services/NativeService.ts
+++ b/packages/cozy-intent/src/api/services/NativeService.ts
@@ -56,7 +56,11 @@ export class NativeService {
   private isInitMessage = (message: PostMeMessage): boolean =>
     message.message === strings.webviewIsRendered
 
-  public registerWebview = (uri: string, ref: WebviewRef): void => {
+  public registerWebview = (
+    uri: string,
+    slug: string,
+    ref: WebviewRef
+  ): void => {
     log(strings.logging.registering(uri))
 
     if (this.messengerRegister[uri])
@@ -69,7 +73,8 @@ export class NativeService {
       [uri]: {
         messenger: isNativeDevMode()
           ? DebugNativeMessenger(messenger)
-          : messenger
+          : messenger,
+        slug
       }
     }
 
@@ -151,6 +156,10 @@ export class NativeService {
     if (registeredWebview === undefined) {
       return log(interpolate(strings.errorEmitMessage, { webviewUri }))
     }
+
+    message.args?.unshift({
+      slug: registeredWebview.slug
+    })
 
     registeredWebview.messenger.onMessage(message)
   }


### PR DESCRIPTION
When receiving an intent on the flagship app, we want to know which webview sent the intent. Here we inject at the beginning of the `args` array an `options` object with the `webviewUri`.

*Example*

On a front end app, we will do

`webviewIntent.call('multiply', 2, 3)`

On flagship app, we will set a local method

`multiply: (options, arg1, arg2) => return arg1 * arg2`

=> the options object has been added at the beginning of the `args` array

We also add a new NativeMethodsRegisterWithOptions to modelize this new behavior.

BREAKING: A options object has been added in NativeService message args. You need to update your local methods (see example). FLAGSHIP APP ONLY. Nothing to do on a front end app.