### PR TITLE
fix: Submit 2FA form on click (SCR-777)

### DIFF
--- a/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
+++ b/packages/cozy-harvest-lib/src/components/TwoFAModal.jsx
@@ -137,6 +137,7 @@ export class TwoFAModal extends PureComponent {
                 label={t('twoFAForm.CTA')}
                 busy={isJobRunning}
                 disabled={isJobRunning || !twoFACode}
+                onClick={this.handleSubmit}
                 fullWidth
               />
             ) : null}


### PR DESCRIPTION
I don't understand how this feature could work before, but it worked in
version 1.76.0 of the home application with harvest version 23.0.0.

With this click handler, I cannot detect any double submit of the form.
