### PR TITLE
feat: Add offline related methods to cozy-intent and to cozy-device-helper

### DIFF
--- a/packages/cozy-device-helper/src/flagship.ts
+++ b/packages/cozy-device-helper/src/flagship.ts
@@ -16,6 +16,7 @@ export interface FlagshipMetadata {
   biometry_type?: BiometryType
   immersive?: boolean
   navbarHeight?: number
+  offline_available?: boolean
   platform?: Record<string, unknown>
   route?: FlagshipRoutes
   settings_PINEnabled?: boolean
@@ -40,3 +41,6 @@ export const getFlagshipMetadata = (): FlagshipMetadata =>
 
 export const isFlagshipApp = (): boolean =>
   getGlobalWindow()?.cozy?.flagship !== undefined
+
+export const isFlagshipOfflineSupported = (): boolean =>
+  getGlobalWindow()?.cozy?.flagship?.offline_available

--- a/packages/cozy-device-helper/src/index.ts
+++ b/packages/cozy-device-helper/src/index.ts
@@ -21,4 +21,8 @@ export { isCordova } from './cordova'
 export { nativeLinkOpen } from './link'
 export { openDeeplinkOrRedirect } from './deeplink'
 
-export { isFlagshipApp, getFlagshipMetadata } from './flagship'
+export {
+  isFlagshipApp,
+  isFlagshipOfflineSupported,
+  getFlagshipMetadata
+} from './flagship'

--- a/packages/cozy-intent/src/api/models/methods.ts
+++ b/packages/cozy-intent/src/api/models/methods.ts
@@ -27,6 +27,7 @@ interface _NativeMethodsRegister {
   openAppOSSettings: () => Promise<null>
   isAvailable: (featureName: string) => Promise<boolean>
   flagshipLinkRequest: (operation: unknown) => Promise<unknown>
+  downloadFile: (file: unknown) => Promise<unknown>
 }
 
 export type NativeMethodsRegister = _NativeMethodsRegister & PostMeDefault

--- a/packages/cozy-intent/src/api/models/methods.ts
+++ b/packages/cozy-intent/src/api/models/methods.ts
@@ -26,6 +26,7 @@ interface _NativeMethodsRegister {
   ocr: (base64: string) => unknown
   openAppOSSettings: () => Promise<null>
   isAvailable: (featureName: string) => Promise<boolean>
+  flagshipLinkRequest: (operation: unknown) => Promise<unknown>
 }
 
 export type NativeMethodsRegister = _NativeMethodsRegister & PostMeDefault


### PR DESCRIPTION
`flagshipLinkRequest` intent will be used by new `FlagshipLink` link in cozy-client