### PR TITLE
feat(harvest): Use Sentry as peerDeps

### DIFF
--- a/packages/cozy-harvest-lib/package.json
+++ b/packages/cozy-harvest-lib/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "@cozy/minilog": "^1.0.0",
-    "@sentry/browser": "7.119.0",
     "classnames": "^2.3.1",
     "cozy-bi-auth": "0.0.25",
     "cozy-doctypes": "^1.91.1",
@@ -90,7 +89,8 @@
     "react-dom": "16.13.0",
     "react-router": "3.2.6",
     "react-swipeable-views": "0.13.9",
-    "storybook": "^7.0.23"
+    "storybook": "^7.0.23",
+    "@sentry/react": "7.119.0"
   },
   "peerDependencies": {
     "@babel/runtime": ">=7.12.5",
@@ -104,7 +104,8 @@
     "cozy-ui": ">=111.0.0",
     "leaflet": "^1.7.1",
     "react-router": "3.2.6",
-    "react-router-dom": ">=4.3.1"
+    "react-router-dom": ">=4.3.1",
+    "@sentry/react": ">=7.118.0"
   },
   "sideEffects": false
 }

--- a/packages/cozy-harvest-lib/src/helpers/konnectorBlock.js
+++ b/packages/cozy-harvest-lib/src/helpers/konnectorBlock.js
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/browser'
+import * as Sentry from '@sentry/react'
 import get from 'lodash/get'
 
 import { triggers } from 'cozy-client/dist/models/trigger'

--- a/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
+++ b/packages/cozy-harvest-lib/src/models/ConnectionFlow.js
@@ -1,6 +1,6 @@
 // @ts-check
 // @ts-ignore
-import * as Sentry from '@sentry/browser'
+import * as Sentry from '@sentry/react'
 import clone from 'lodash/clone'
 import MicroEE from 'microee'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5490,6 +5490,17 @@
     "@sentry/utils" "7.119.0"
     localforage "^1.8.1"
 
+"@sentry/react@7.119.0":
+  version "7.119.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.119.0.tgz#79f2c9d94322a3afbfa8af9f5b872f7c2e9b0820"
+  integrity sha512-cf8Cei+qdSA26gx+IMAuc/k44PeBImNzIpXi3930SLhUe44ypT5OZ/44L6xTODHZzTIyMSJPduf59vT2+eW9yg==
+  dependencies:
+    "@sentry/browser" "7.119.0"
+    "@sentry/core" "7.119.0"
+    "@sentry/types" "7.119.0"
+    "@sentry/utils" "7.119.0"
+    hoist-non-react-statics "^3.3.2"
+
 "@sentry/replay@7.119.0":
   version "7.119.0"
   resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.119.0.tgz#50881079d013c77f87a994331d8bcad1d49e0960"


### PR DESCRIPTION
BREAKING CHANGE:
you must have `@sentry/react >= 7.118.0`