### PR TITLE
[VO-1033] chore(lerna): Stop verifying the npm read access on publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
       deploy:
         - provider: script
           skip-cleanup: true
-          script: 'git checkout master && git remote set-url origin https://cozy-bot:$GITHUB_TOKEN@github.com/cozy/cozy-libs.git && echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc && yarn lerna publish --yes -m "[skip ci] Publish"'
+          script: 'git checkout master && git remote set-url origin https://cozy-bot:$GITHUB_TOKEN@github.com/cozy/cozy-libs.git && echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc && yarn lerna publish --yes --no-verify-access -m "[skip ci] Publish"'
           on:
             branch: master
             repo: cozy/cozy-libs


### PR DESCRIPTION
Since we change the type of npm token to automation, it has no more read access

In future version, this option can be removed because its the default case. You can found more explanation on the command [documentation](https://github.com/lerna/lerna/tree/main/libs/commands/publish#--verify-access)