### PR TITLE
feat(cozy-viewer): Use new `downloadFile()` method from cozy-client

### DIFF
--- a/packages/cozy-viewer/package.json
+++ b/packages/cozy-viewer/package.json
@@ -50,7 +50,7 @@
     "react-pdf": "^5.7.2"
   },
   "peerDependencies": {
-    "cozy-client": ">=48.8.0",
+    "cozy-client": ">=49.0.0",
     "cozy-device-helper": ">=2.0.0",
     "cozy-harvest-lib": ">=6.7.3",
     "cozy-intent": ">=1.16.1",

--- a/packages/cozy-viewer/src/NoViewer/DownloadButton.jsx
+++ b/packages/cozy-viewer/src/NoViewer/DownloadButton.jsx
@@ -2,18 +2,19 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import { withClient } from 'cozy-client'
+import { downloadFile } from 'cozy-client/dist/models/file'
+import { useWebviewIntent } from 'cozy-intent'
 import Button from 'cozy-ui/transpiled/react/deprecated/Button'
 import { FileDoctype } from 'cozy-ui/transpiled/react/proptypes'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
-import { downloadFile } from '../helpers'
-
 const DownloadButton = ({ client, file, url }) => {
   const { t } = useI18n()
+  const webviewIntent = useWebviewIntent()
 
   return (
     <Button
-      onClick={() => downloadFile({ client, file, url })}
+      onClick={() => downloadFile({ client, file, url, webviewIntent })}
       label={t('Viewer.download')}
     />
   )

--- a/packages/cozy-viewer/src/ViewersByFile/PdfMobileViewer.jsx
+++ b/packages/cozy-viewer/src/ViewersByFile/PdfMobileViewer.jsx
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types'
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 
 import { useClient } from 'cozy-client'
+import { downloadFile } from 'cozy-client/dist/models/file'
+import { useWebviewIntent } from 'cozy-intent'
 import FileImageLoader from 'cozy-ui/transpiled/react/FileImageLoader'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import { FileDoctype } from 'cozy-ui/transpiled/react/proptypes'
@@ -19,6 +21,7 @@ export const PdfMobileViewer = ({ file, url, t, gestures }) => {
   const { showAlert } = useAlert()
 
   const client = useClient()
+  const webviewIntent = useWebviewIntent()
 
   const onImageError = () => {
     setLoading(false)
@@ -32,7 +35,7 @@ export const PdfMobileViewer = ({ file, url, t, gestures }) => {
   const handleOnClick = useCallback(
     async file => {
       try {
-        await client.collection('io.cozy.files').download(file)
+        await downloadFile({ client, file, webviewIntent })
       } catch (error) {
         showAlert({
           message: t('Viewer.error.generic'),
@@ -42,7 +45,7 @@ export const PdfMobileViewer = ({ file, url, t, gestures }) => {
         })
       }
     },
-    [client, showAlert, t]
+    [client, showAlert, t, webviewIntent]
   )
 
   useEffect(() => {

--- a/packages/cozy-viewer/src/components/Toolbar.jsx
+++ b/packages/cozy-viewer/src/components/Toolbar.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import { useClient } from 'cozy-client'
+import { downloadFile } from 'cozy-client/dist/models/file'
+import { useWebviewIntent } from 'cozy-intent'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
 import DownloadIcon from 'cozy-ui/transpiled/react/Icons/Download'
@@ -17,7 +19,6 @@ import PrintButton from './PrintButton'
 import { ToolbarFilePath } from './ToolbarFilePath'
 import styles from './styles.styl'
 import { extractChildrenCompByName } from '../Footer/helpers'
-import { downloadFile } from '../helpers'
 import { useEncrypted } from '../providers/EncryptedProvider'
 
 const useClasses = makeStyles(theme => ({
@@ -42,6 +43,7 @@ const Toolbar = ({
   const client = useClient()
   const classes = useClasses()
   const { t } = useI18n()
+  const webviewIntent = useWebviewIntent()
 
   const { url } = useEncrypted()
 
@@ -88,7 +90,7 @@ const Toolbar = ({
             <IconButton
               className="u-white"
               aria-label={t('Viewer.download')}
-              onClick={() => downloadFile({ client, file, url })}
+              onClick={() => downloadFile({ client, file, url, webviewIntent })}
             >
               <Icon icon={DownloadIcon} />
             </IconButton>

--- a/packages/cozy-viewer/src/helpers.js
+++ b/packages/cozy-viewer/src/helpers.js
@@ -46,13 +46,6 @@ export const isValidForPanel = ({ file }) => {
   )
 }
 
-export const downloadFile = async ({ client, file, url }) => {
-  if (isEncrypted(file)) {
-    return client.collection('io.cozy.files').forceFileDownload(url, file.name)
-  }
-  return client.collection('io.cozy.files').download(file)
-}
-
 export const isFileEncrypted = file => isEncrypted(file)
 
 export const formatDate = ({ f, lang, date }) => {

--- a/packages/cozy-viewer/src/helpers.spec.js
+++ b/packages/cozy-viewer/src/helpers.spec.js
@@ -1,11 +1,9 @@
-import { createMockClient } from 'cozy-client'
 import {
   KNOWN_DATE_METADATA_NAMES,
   KNOWN_INFORMATION_METADATA_NAMES
 } from 'cozy-client/dist/models/paper'
 
 import {
-  downloadFile,
   getCurrentModel,
   buildEditAttributePath,
   isEditableAttribute,
@@ -13,29 +11,6 @@ import {
 } from './helpers'
 
 describe('helpers', () => {
-  describe('download', () => {
-    const client = new createMockClient({})
-    const mockDownload = jest.fn()
-    const mockForceFileDownload = jest.fn()
-    client.collection = jest.fn(() => ({
-      download: mockDownload,
-      forceFileDownload: mockForceFileDownload
-    }))
-
-    it('should call download when file is not encrypted', async () => {
-      const file = { name: 'toto.txt' }
-
-      await downloadFile({ client, file })
-      expect(mockDownload).toHaveBeenCalledWith(file)
-    })
-
-    it('should call forceFileDownload when file is encrypted', async () => {
-      const file = { name: 'encrypted-toto.txt', encrypted: true }
-      const url = 'blob:http://thedecryptedtoto'
-      await downloadFile({ client, file, url })
-      expect(mockForceFileDownload).toHaveBeenCalledWith(url, file.name)
-    })
-  })
   describe('getCurrentModel', () => {
     const expected = 'information'
     it.each([


### PR DESCRIPTION
In cozy/cozy-client#1518 we implemented a new `downloadFile()` that allow to download files as before in a browser, but will download files through cozy-intent when hosted in the Flagship app

This commit will replace the old way to download files with the new one using `downloadFile()`

BREAKING CHANGE: `downloadFile()` method has been removed from `cozy-viewer/src/helpers.js`. Use the one from
`cozy-client/dist/models/file` instead

BREAKING CHANGE: cozy-viewer now requires cozy-client >= 49.0.0 (used for offline support)
___

Related PRs:
- cozy/cozy-client#1518
- cozy/cozy-flagship-app#1237

___

TODO:

- [x] Update cozy-client preedDep after cozy/cozy-client#1507 is merged