### PR TITLE
feat: Update deps and peer deps for cozy-viewer

### DIFF
--- a/packages/cozy-viewer/package.json
+++ b/packages/cozy-viewer/package.json
@@ -53,7 +53,7 @@
     "cozy-client": ">=50.0.0",
     "cozy-device-helper": ">=2.0.0",
     "cozy-harvest-lib": ">=30.2.0",
-    "cozy-intent": ">=2.25.0",
+    "cozy-intent": ">=2.26.0",
     "cozy-logger": ">=1.9.0",
     "cozy-sharing": ">=14.1.0",
     "cozy-ui": ">=112.2.0",


### PR DESCRIPTION
This commit purpose is to trigger a breaking change because I forget it in
a24596a1ec085df5cef9328a649c76c8dab910a9

BREAKING CHANGE: you must now use `cozy-client >= 50.0.0`,
`cozy-harvest-lib >=30.2.0`, `cozy-intent >= 2.26.0` and
`cozy-ui >= 112.2.0`