### PR TITLE
chore: Remove flaky crash on CI build

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint --ext js,jsx,ts,tsx .",
     "lint:md": "remark . -o",
     "test": "lerna run --concurrency 1 --ignore cozy-procedures --ignore cozy-mespapiers-lib test",
-    "build": "lerna run --scope cozy-device-helper build && lerna run --scope cozy-minilog build && lerna run --parallel --ignore cozy-device-helper --ignore cozy-minilog --ignore cozy-mespapiers-lib build",
+    "build": "DISABLE_V8_COMPILE_CACHE=1 lerna run --scope cozy-device-helper build && lerna run --scope cozy-minilog build && lerna run --parallel --ignore cozy-device-helper --ignore cozy-minilog --ignore cozy-mespapiers-lib build",
     "check-constraints": "node scripts/check-packages-constraints.js"
   },
   "devDependencies": {


### PR DESCRIPTION
This commit aims to remove flaky crash on CI build due to node. We follow the solution proposed inside https://github.com/nodejs/node/issues/51555 that disable compile cache on v8

When the build inside CI was running on some package fail with this errors : 
```
#
# Fatal error in , line 0
# unreachable code
#
#
#
#FailureMessage Object: 0x7fff3a2df8b0
```
or : 
```
Segmentation fault (core dump)
```