### PR TITLE
[VO-1181] chore: Update GitHub Actions to give Lerna access to git history

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}
+          fetch-depth: 0
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint --ext js,jsx,ts,tsx .",
     "lint:md": "remark . -o",
     "test": "lerna run --concurrency 1 --ignore cozy-procedures --ignore cozy-mespapiers-lib test",
-    "build": "DISABLE_V8_COMPILE_CACHE=1 lerna run --scope cozy-device-helper build && lerna run --scope cozy-minilog build && lerna run --parallel --ignore cozy-device-helper --ignore cozy-minilog --ignore cozy-mespapiers-lib build",
+    "build": "DISABLE_V8_COMPILE_CACHE=1 lerna run --scope cozy-device-helper build && lerna run --scope cozy-minilog build && lerna run --ignore cozy-device-helper --ignore cozy-minilog --ignore cozy-mespapiers-lib build",
     "check-constraints": "node scripts/check-packages-constraints.js"
   },
   "devDependencies": {


### PR DESCRIPTION
Since Lerna didn't have access to the git history, it couldn't determine what changes had been made and assume that all packages had been updated