### PR TITLE
[PRD-609] Allow search on name and path

### DIFF
--- a/packages/cozy-dataproxy-lib/src/search/queries/index.ts
+++ b/packages/cozy-dataproxy-lib/src/search/queries/index.ts
@@ -17,6 +17,10 @@ interface AllDocsResponse {
   rows: DBRow[]
 }
 
+interface QueryResponseSingleDoc {
+  data: CozyDoc
+}
+
 export const queryFilesForSearch = async (
   client: CozyClient
 ): Promise<CozyDoc[]> => {
@@ -42,4 +46,15 @@ export const queryAllDocs = async (
   doctype: string
 ): Promise<CozyDoc[]> => {
   return client.queryAll<CozyDoc[]>(Q(doctype).limitBy(null))
+}
+
+export const queryDocById = async (
+  client: CozyClient,
+  doctype: string,
+  id: string
+): Promise<CozyDoc> => {
+  const resp = (await client.query(Q(doctype).getById(id), {
+    singleDocData: true
+  })) as QueryResponseSingleDoc
+  return resp.data
 }


### PR DESCRIPTION
Say you have a "Foo" directory with a "bar.txt" in it. Let's assume this
bar.txt is duplicated in many locations. You want to search specifically
for it by typing "Foo bar".
It wasn't possible before because of how flexsearch works: it searches
by indexed attributes, here the `path` and the `name`. In this example,
"Foo bar" will not match the name, neither the path.

As a workaround, we now force the path computing at indexing time for
all files. This path is not persisted in PouchDB, as the stack does not
store it for files (but it does for directories).
Note that even though the stack returns the file's path when we query
it, we need to add the file name, as it does not include it.