### PR TITLE
[PRD-609] fix: Broken file path

### DIFF
--- a/packages/cozy-dataproxy-lib/src/search/helpers/normalizeFile.spec.ts
+++ b/packages/cozy-dataproxy-lib/src/search/helpers/normalizeFile.spec.ts
@@ -1,5 +1,5 @@
 import CozyClient from 'cozy-client'
-import { IOCozyFile } from 'cozy-client/types/types'
+import { IOCozyContact, IOCozyFile } from 'cozy-client/types/types'
 
 import {
   addFilePaths,
@@ -7,6 +7,8 @@ import {
   normalizeFileWithFolders,
   shouldKeepFile
 } from './normalizeFile'
+import { cleanFilePath } from './normalizeSearchResult'
+import { FILES_DOCTYPE } from '../consts'
 import { queryDocById } from '../queries'
 import { CozyDoc } from '../types'
 
@@ -291,5 +293,37 @@ describe('computeFileFullpath', () => {
     const res = await computeFileFullpath(client, filewithNoPath)
 
     expect(res.path).toEqual('ROOT/MYDIR/file3')
+  })
+})
+
+describe('cleanFilePath', () => {
+  it('should return the document unchanged if it is not an IOCozyFile', () => {
+    const doc = { fullname: 'name' } as IOCozyContact
+    expect(cleanFilePath(doc)).toEqual(doc)
+  })
+
+  it('should return the document unchanged if path is undefined', () => {
+    const doc = { _type: FILES_DOCTYPE, name: 'name' } as IOCozyFile
+    expect(cleanFilePath(doc)).toEqual(doc)
+  })
+
+  it('should remove name from path if path ends with name', () => {
+    const doc = {
+      _type: FILES_DOCTYPE,
+      path: '/the/path/myname',
+      name: 'myname'
+    } as IOCozyFile
+    const expected = { ...doc, path: '/the/path' }
+
+    expect(cleanFilePath(doc)).toEqual(expected)
+  })
+
+  it('should return the document unchanged if path does not end with name', () => {
+    const doc = {
+      _type: FILES_DOCTYPE,
+      path: '/the/path/othername',
+      name: 'name'
+    } as IOCozyFile
+    expect(cleanFilePath(doc)).toEqual(doc)
   })
 })

--- a/packages/cozy-dataproxy-lib/src/search/helpers/normalizeFile.spec.ts
+++ b/packages/cozy-dataproxy-lib/src/search/helpers/normalizeFile.spec.ts
@@ -1,5 +1,5 @@
 import CozyClient from 'cozy-client'
-import { IOCozyContact, IOCozyFile } from 'cozy-client/types/types'
+import { IOCozyFile } from 'cozy-client/types/types'
 
 import {
   addFilePaths,
@@ -7,8 +7,6 @@ import {
   normalizeFileWithFolders,
   shouldKeepFile
 } from './normalizeFile'
-import { cleanFilePath } from './normalizeSearchResult'
-import { FILES_DOCTYPE } from '../consts'
 import { queryDocById } from '../queries'
 import { CozyDoc } from '../types'
 
@@ -293,37 +291,5 @@ describe('computeFileFullpath', () => {
     const res = await computeFileFullpath(client, filewithNoPath)
 
     expect(res.path).toEqual('ROOT/MYDIR/file3')
-  })
-})
-
-describe('cleanFilePath', () => {
-  it('should return the document unchanged if it is not an IOCozyFile', () => {
-    const doc = { fullname: 'name' } as IOCozyContact
-    expect(cleanFilePath(doc)).toEqual(doc)
-  })
-
-  it('should return the document unchanged if path is undefined', () => {
-    const doc = { _type: FILES_DOCTYPE, name: 'name' } as IOCozyFile
-    expect(cleanFilePath(doc)).toEqual(doc)
-  })
-
-  it('should remove name from path if path ends with name', () => {
-    const doc = {
-      _type: FILES_DOCTYPE,
-      path: '/the/path/myname',
-      name: 'myname'
-    } as IOCozyFile
-    const expected = { ...doc, path: '/the/path' }
-
-    expect(cleanFilePath(doc)).toEqual(expected)
-  })
-
-  it('should return the document unchanged if path does not end with name', () => {
-    const doc = {
-      _type: FILES_DOCTYPE,
-      path: '/the/path/othername',
-      name: 'name'
-    } as IOCozyFile
-    expect(cleanFilePath(doc)).toEqual(doc)
   })
 })

--- a/packages/cozy-dataproxy-lib/src/search/helpers/normalizeSearchResult.spec.ts
+++ b/packages/cozy-dataproxy-lib/src/search/helpers/normalizeSearchResult.spec.ts
@@ -1,6 +1,8 @@
 import CozyClient from 'cozy-client'
+import { IOCozyContact, IOCozyFile } from 'cozy-client/types/types'
 
-import { normalizeSearchResult } from './normalizeSearchResult'
+import { cleanFilePath, normalizeSearchResult } from './normalizeSearchResult'
+import { FILES_DOCTYPE, TYPE_FILE } from '../consts'
 import { RawSearchResult } from '../types'
 
 const fakeFlatDomainClient = {
@@ -339,5 +341,48 @@ describe('Should normalize unknown doctypes', () => {
       subTitle: null,
       url: null
     })
+  })
+})
+
+describe('cleanFilePath', () => {
+  it('should return the document unchanged if it is not an IOCozyFile', () => {
+    const doc = { fullname: 'name' } as IOCozyContact
+    expect(cleanFilePath(doc)).toEqual(doc)
+  })
+
+  it('should return the document unchanged if path is undefined', () => {
+    const doc = { _type: FILES_DOCTYPE, name: 'name' } as IOCozyFile
+    expect(cleanFilePath(doc)).toEqual(doc)
+  })
+
+  it('should return the document unchanged if not a file', () => {
+    const doc = {
+      _type: FILES_DOCTYPE,
+      name: 'name',
+      type: TYPE_FILE
+    } as IOCozyFile
+    expect(cleanFilePath(doc)).toEqual(doc)
+  })
+
+  it('should remove name from path if path ends with name', () => {
+    const doc = {
+      _type: FILES_DOCTYPE,
+      type: TYPE_FILE,
+      path: '/the/path/myname',
+      name: 'myname'
+    } as IOCozyFile
+    const expected = { ...doc, path: '/the/path' }
+
+    expect(cleanFilePath(doc)).toEqual(expected)
+  })
+
+  it('should return the document unchanged if path does not end with name', () => {
+    const doc = {
+      _type: FILES_DOCTYPE,
+      type: TYPE_FILE,
+      path: '/the/path/othername',
+      name: 'name'
+    } as IOCozyFile
+    expect(cleanFilePath(doc)).toEqual(doc)
   })
 })

--- a/packages/cozy-dataproxy-lib/src/search/helpers/normalizeSearchResult.ts
+++ b/packages/cozy-dataproxy-lib/src/search/helpers/normalizeSearchResult.ts
@@ -1,7 +1,7 @@
 import CozyClient, { generateWebLink, models } from 'cozy-client'
 import { IOCozyContact } from 'cozy-client/types/types'
 
-import { APPS_DOCTYPE, TYPE_DIRECTORY } from '../consts'
+import { APPS_DOCTYPE, TYPE_DIRECTORY, TYPE_FILE } from '../consts'
 import {
   CozyDoc,
   RawSearchResult,
@@ -34,8 +34,8 @@ export const cleanFilePath = (doc: CozyDoc): CozyDoc => {
   if (!isIOCozyFile(doc)) {
     return doc
   }
-  const { path, name } = doc
-  if (!path) {
+  const { path, name, type } = doc
+  if (!path || type !== TYPE_FILE) {
     return doc
   }
   let newPath = path

--- a/packages/cozy-dataproxy-lib/src/search/helpers/normalizeSearchResult.ts
+++ b/packages/cozy-dataproxy-lib/src/search/helpers/normalizeSearchResult.ts
@@ -16,7 +16,7 @@ export const normalizeSearchResult = (
   searchResults: RawSearchResult,
   query: string
 ): SearchResult => {
-  const doc = searchResults.doc
+  const doc = cleanFilePath(searchResults.doc)
   const url = buildOpenURL(client, doc)
   const slug = getSearchResultSlug(doc)
   const title = getSearchResultTitle(doc)
@@ -28,6 +28,23 @@ export const normalizeSearchResult = (
   const normalizedRes = { doc, slug, title, subTitle, url }
 
   return normalizedRes
+}
+
+export const cleanFilePath = (doc: CozyDoc): CozyDoc => {
+  if (!isIOCozyFile(doc)) {
+    return doc
+  }
+  const { path, name } = doc
+  if (!path) {
+    return doc
+  }
+  let newPath = path
+  if (path.endsWith(`/${name}`)) {
+    // Remove the name from the path, which is added at indexing time to search on it
+    newPath = path.slice(0, -name.length - 1)
+  }
+
+  return { ...doc, path: newPath }
 }
 
 const getSearchResultTitle = (doc: CozyDoc): string | null => {


### PR DESCRIPTION
With https://github.com/cozy/cozy-libs/pull/2612,
we added the possibility to search on path + name by adding the name in the path, at indexing time.
This breaks the possibility to open file because the path is not what is expected. So we remove the name from the path after search time.