### PR TITLE
[PRD-610] feat: Add secondaryUrl to search result

### DIFF
--- a/packages/cozy-dataproxy-lib/src/search/helpers/normalizeSearchResult.spec.ts
+++ b/packages/cozy-dataproxy-lib/src/search/helpers/normalizeSearchResult.spec.ts
@@ -40,7 +40,8 @@ describe('Should normalize files results', () => {
       slug: 'drive',
       title: 'SOME_FILE_NAME',
       subTitle: 'SOME/FILE/PATH',
-      url: 'https://claude-drive.mycozy.cloud/#/folder/SOME_DIR_ID/file/SOME_FILE_ID'
+      url: 'https://claude-drive.mycozy.cloud/#/folder/SOME_DIR_ID/file/SOME_FILE_ID',
+      secondaryUrl: 'https://claude-drive.mycozy.cloud/#/folder/SOME_DIR_ID'
     })
   })
 
@@ -73,7 +74,8 @@ describe('Should normalize files results', () => {
       slug: 'notes',
       title: 'SOME_NOTE_NAME.cozy-note',
       subTitle: 'SOME/NOTE/PATH',
-      url: 'https://claude-notes.mycozy.cloud/#/n/SOME_NOTE_ID'
+      url: 'https://claude-notes.mycozy.cloud/#/n/SOME_NOTE_ID',
+      secondaryUrl: 'https://claude-drive.mycozy.cloud/#/folder/SOME_DIR_ID'
     })
   })
 
@@ -101,7 +103,8 @@ describe('Should normalize files results', () => {
       slug: 'drive',
       title: 'SOME_FOLDER_NAME',
       subTitle: 'SOME/FOLDER/PATH',
-      url: 'https://claude-drive.mycozy.cloud/#/folder/SOME_FODLER_ID'
+      url: 'https://claude-drive.mycozy.cloud/#/folder/SOME_FODLER_ID',
+      secondaryUrl: 'https://claude-drive.mycozy.cloud/#/folder/SOME_FODLER_ID'
     })
   })
 })
@@ -131,7 +134,8 @@ describe('Should normalize contacts results', () => {
       slug: 'contacts',
       title: 'John Doe',
       subTitle: 'Developper',
-      url: 'https://claude-contacts.mycozy.cloud/#/SOME_CONTACT_ID'
+      url: 'https://claude-contacts.mycozy.cloud/#/SOME_CONTACT_ID',
+      secondaryUrl: null
     })
   })
 
@@ -159,7 +163,8 @@ describe('Should normalize contacts results', () => {
       slug: 'contacts',
       title: 'John Claude Doe',
       subTitle: 'Developper',
-      url: 'https://claude-contacts.mycozy.cloud/#/SOME_CONTACT_ID'
+      url: 'https://claude-contacts.mycozy.cloud/#/SOME_CONTACT_ID',
+      secondaryUrl: null
     })
   })
 
@@ -186,7 +191,8 @@ describe('Should normalize contacts results', () => {
       slug: 'contacts',
       title: null,
       subTitle: 'Developper',
-      url: 'https://claude-contacts.mycozy.cloud/#/SOME_CONTACT_ID'
+      url: 'https://claude-contacts.mycozy.cloud/#/SOME_CONTACT_ID',
+      secondaryUrl: null
     })
   })
 
@@ -214,7 +220,8 @@ describe('Should normalize contacts results', () => {
       slug: 'contacts',
       title: 'John Doe',
       subTitle: null,
-      url: 'https://claude-contacts.mycozy.cloud/#/SOME_CONTACT_ID'
+      url: 'https://claude-contacts.mycozy.cloud/#/SOME_CONTACT_ID',
+      secondaryUrl: null
     })
   })
 
@@ -246,7 +253,8 @@ describe('Should normalize contacts results', () => {
       slug: 'contacts',
       title: 'John Doe',
       subTitle: 'JohnDoe@cozy.mail',
-      url: 'https://claude-contacts.mycozy.cloud/#/SOME_CONTACT_ID'
+      url: 'https://claude-contacts.mycozy.cloud/#/SOME_CONTACT_ID',
+      secondaryUrl: null
     })
   })
 })
@@ -281,7 +289,8 @@ describe('Should normalize apps results', () => {
       slug: 'drive',
       title: 'Cozy Drive',
       subTitle: 'Some app description',
-      url: 'https://claude-drive.mycozy.cloud/#/'
+      url: 'https://claude-drive.mycozy.cloud/#/',
+      secondaryUrl: null
     })
   })
 
@@ -309,7 +318,8 @@ describe('Should normalize apps results', () => {
       slug: 'drive',
       title: 'Cozy Drive',
       subTitle: 'Cozy Drive',
-      url: 'https://claude-drive.mycozy.cloud/#/'
+      url: 'https://claude-drive.mycozy.cloud/#/',
+      secondaryUrl: null
     })
   })
 })
@@ -339,7 +349,8 @@ describe('Should normalize unknown doctypes', () => {
       slug: null,
       title: null,
       subTitle: null,
-      url: null
+      url: null,
+      secondaryUrl: null
     })
   })
 })

--- a/packages/cozy-dataproxy-lib/src/search/helpers/normalizeSearchResult.ts
+++ b/packages/cozy-dataproxy-lib/src/search/helpers/normalizeSearchResult.ts
@@ -18,6 +18,7 @@ export const normalizeSearchResult = (
 ): SearchResult => {
   const doc = cleanFilePath(searchResults.doc)
   const url = buildOpenURL(client, doc)
+  const secondaryUrl = buildSecondaryURL(client, doc, url)
   const slug = getSearchResultSlug(doc)
   const title = getSearchResultTitle(doc)
   const subTitle = getSearchResultSubTitle(client, {
@@ -25,7 +26,7 @@ export const normalizeSearchResult = (
     doc,
     query
   })
-  const normalizedRes = { doc, slug, title, subTitle, url }
+  const normalizedRes = { doc, slug, title, subTitle, url, secondaryUrl }
 
   return normalizedRes
 }
@@ -186,6 +187,30 @@ const buildOpenURL = (client: CozyClient, doc: CozyDoc): string | null => {
     slug,
     subDomainType: client.getInstanceOptions().subdomain,
     hash: urlHash,
+    pathname: '',
+    searchParams: []
+  })
+}
+
+const buildSecondaryURL = (
+  client: CozyClient,
+  doc: CozyDoc,
+  url: string | null
+): string | null => {
+  if (!isIOCozyFile(doc) || !url) {
+    return null
+  }
+
+  if (doc.type === TYPE_DIRECTORY) {
+    return url
+  }
+
+  const folderURLHash = `/folder/${doc.dir_id}`
+  return generateWebLink({
+    cozyUrl: client.getStackClient().uri,
+    slug: 'drive',
+    subDomainType: client.getInstanceOptions().subdomain,
+    hash: folderURLHash,
     pathname: '',
     searchParams: []
   })

--- a/packages/cozy-dataproxy-lib/src/search/types.ts
+++ b/packages/cozy-dataproxy-lib/src/search/types.ts
@@ -47,6 +47,7 @@ export interface SearchResult {
   title: string | null
   subTitle: string | null
   url: string | null
+  secondaryUrl: string | null
 }
 
 export interface SearchIndex {


### PR DESCRIPTION
This is useful to allow click on subtitle, typically for a directory path below a file result