### PR TITLE
feat(Viewer): Add filter condition to display konnectorBlock

### DIFF
--- a/packages/cozy-viewer/src/Panel/getPanelBlocks.jsx
+++ b/packages/cozy-viewer/src/Panel/getPanelBlocks.jsx
@@ -27,7 +27,11 @@ export const getPanelBlocksSpecs = (isPublic = false) => ({
     component: Qualification
   },
   konnector: {
-    condition: file => isFromKonnector(file) && !isPublic,
+    condition: file =>
+      isFromKonnector(file) &&
+      !isPublic &&
+      // When doc has been edited from mespapiers, we don't want to display the konnector block
+      !file.cozyMetadata?.updatedByApps?.find(app => app.slug === 'mespapiers'),
     component: KonnectorBlock
   },
   certifications: {


### PR DESCRIPTION
When editing the doc from mespapiers, we don't want to display the konnector block.