### PR TITLE
revert "feat(Viewer): Add filter condition to display konnectorBlock"

### DIFF
--- a/packages/cozy-viewer/src/Panel/getPanelBlocks.jsx
+++ b/packages/cozy-viewer/src/Panel/getPanelBlocks.jsx
@@ -27,11 +27,7 @@ export const getPanelBlocksSpecs = (isPublic = false) => ({
     component: Qualification
   },
   konnector: {
-    condition: file =>
-      isFromKonnector(file) &&
-      !isPublic &&
-      // When doc has been edited from mespapiers, we don't want to display the konnector block
-      !file.cozyMetadata?.updatedByApps?.find(app => app.slug === 'mespapiers'),
+    condition: file => isFromKonnector(file) && !isPublic,
     component: KonnectorBlock
   },
   certifications: {


### PR DESCRIPTION
This reverts commit bb59023be43e8ad5c6ca22141ece56529f77f5af.

This commit will hide the konnectoBlock as soon as the document is modified via MesPapiers.
However, we only want to hide the konnectoBlock for documents that have already had the carbonCopy metadata AND if the modification only concerns the binary or the metadata.