### PR TITLE
feat: Improve indexing time

### DIFF
--- a/packages/cozy-dataproxy-lib/src/search/SearchEngine.ts
+++ b/packages/cozy-dataproxy-lib/src/search/SearchEngine.ts
@@ -68,6 +68,8 @@ export class SearchEngine {
     if (!this.client) {
       return
     }
+    let startReplicationTime = 0,
+      endReplicationTime = 0
     if (!this.isLocalSearch) {
       // In case of non-local search, force the indexing for all doctypes
       // For local search, this will be done automatically after initial replication
@@ -88,9 +90,16 @@ export class SearchEngine {
       })
       this.client.on('pouchlink:sync:start', () => {
         log.debug('Started pouch replication')
+        startReplicationTime = performance.now()
       })
       this.client.on('pouchlink:sync:end', () => {
         log.debug('Ended pouch replication')
+        endReplicationTime = performance.now()
+        log.debug(
+          `Replication took ${(
+            endReplicationTime - startReplicationTime
+          ).toFixed(2)}`
+        )
       })
     }
 
@@ -182,9 +191,7 @@ export class SearchEngine {
     })
 
     // There is no persisted path for files: we must add it
-    const completedDocs = this.isLocalSearch
-      ? addFilePaths(this.client, docs)
-      : docs
+    const completedDocs = this.isLocalSearch ? addFilePaths(docs) : docs
     for (const doc of completedDocs) {
       void this.addDocToIndex(flexsearchIndex, doc)
     }

--- a/packages/cozy-dataproxy-lib/src/search/helpers/normalizeFile.spec.ts
+++ b/packages/cozy-dataproxy-lib/src/search/helpers/normalizeFile.spec.ts
@@ -103,18 +103,42 @@ describe('normalizeFileWithFolders', () => {
 })
 
 describe('addFilePaths', () => {
-  test(`should add parent folder's path to files`, () => {
-    const client = {
-      getCollectionFromState: jest.fn().mockReturnValue([
-        {
-          type: 'directory',
-          _type: 'io.cozy.files',
-          _id: 'SOME_DIR_ID',
-          path: 'SOME/PARENT/PATH'
-        }
-      ])
-    } as unknown as CozyClient
+  it(`should add parent folder's path to files`, () => {
+    const docs = [
+      {
+        _id: 'SOME_FILE_ID',
+        _type: 'io.cozy.files',
+        type: 'file',
+        dir_id: 'SOME_DIR_ID',
+        name: 'myfile.txt'
+      },
+      {
+        _id: 'SOME_DIR_ID',
+        _type: 'io.cozy.files',
+        type: 'directory',
+        path: '/mydir',
+        dir_id: 'ROOT_ID'
+      }
+    ] as CozyDoc[]
 
+    const result = addFilePaths(docs)
+
+    expect(result[0]).toStrictEqual({
+      _id: 'SOME_FILE_ID',
+      _type: 'io.cozy.files',
+      type: 'file',
+      dir_id: 'SOME_DIR_ID',
+      name: 'myfile.txt',
+      path: '/mydir/myfile.txt'
+    })
+  })
+
+  it(`should handle no files in results`, () => {
+    const result = addFilePaths([])
+    expect(result).toStrictEqual([])
+  })
+
+  it(`should handle when no parent dir is found`, () => {
     const docs = [
       {
         _id: 'SOME_FILE_ID',
@@ -124,7 +148,7 @@ describe('addFilePaths', () => {
       }
     ] as CozyDoc[]
 
-    const result = addFilePaths(client, docs)
+    const result = addFilePaths(docs)
 
     expect(result).toStrictEqual([
       {
@@ -132,40 +156,7 @@ describe('addFilePaths', () => {
         _type: 'io.cozy.files',
         type: 'file',
         dir_id: 'SOME_DIR_ID',
-        path: 'SOME/PARENT/PATH'
-      }
-    ])
-  })
-
-  test(`should handle no files in results`, () => {
-    const client = {} as unknown as CozyClient
-    const result = addFilePaths(client, [])
-
-    expect(result).toStrictEqual([])
-  })
-
-  test(`should handle when no parent dir is found`, () => {
-    const client = {
-      getCollectionFromState: jest.fn().mockReturnValue([])
-    } as unknown as CozyClient
-
-    const docs = [
-      {
-        _id: 'SOME_FILE_ID',
-        _type: 'io.cozy.files',
-        type: 'file',
-        dir_id: 'SOME_DIR_ID'
-      }
-    ] as CozyDoc[]
-
-    const result = addFilePaths(client, docs)
-
-    expect(result).toStrictEqual([
-      {
-        _id: 'SOME_FILE_ID',
-        _type: 'io.cozy.files',
-        type: 'file',
-        dir_id: 'SOME_DIR_ID'
+        path: ''
       }
     ])
   })


### PR DESCRIPTION
We noticed a huge performance drop at indexing time: for 44K files, it was taking 20000+ ms to index it.
The issue was in the paths computation, that was hugely sub-optimal for no reason.

Now, the indexing takes ~400ms for 44K files.