### PR TITLE
feat(cozy-viewer): Exposing the components used by apps at the root

### DIFF
--- a/packages/cozy-viewer/src/index.jsx
+++ b/packages/cozy-viewer/src/index.jsx
@@ -8,5 +8,6 @@ export { default as ToolbarButtons } from './components/ToolbarButtons'
 export { default as FooterActionButtons } from './Footer/FooterActionButtons'
 export { default as ForwardButton } from './Footer/ForwardButton'
 export { default as ForwardOrDownloadButton } from './Footer/ForwardOrDownloadButton'
+export { default as SharingButton } from './Footer/Sharing'
 
 export default ViewerContainer


### PR DESCRIPTION
The need for `SharingButton` comes from the migration of cozy-photos