### PR TITLE
fix: Revert "feat: Do not use flexsearch store"

### DIFF
--- a/packages/cozy-dataproxy-lib/src/search/helpers/normalizeSearchResult.spec.ts
+++ b/packages/cozy-dataproxy-lib/src/search/helpers/normalizeSearchResult.spec.ts
@@ -3,7 +3,7 @@ import { IOCozyContact, IOCozyFile } from 'cozy-client/types/types'
 
 import { cleanFilePath, normalizeSearchResult } from './normalizeSearchResult'
 import { FILES_DOCTYPE } from '../consts'
-import { EnrichedSearchResult } from '../types'
+import { RawSearchResult } from '../types'
 
 const fakeFlatDomainClient = {
   getStackClient: () => ({
@@ -27,7 +27,7 @@ describe('Should normalize files results', () => {
     const searchResult = {
       doctype: 'io.cozy.files',
       doc: doc
-    } as unknown as EnrichedSearchResult
+    } as unknown as RawSearchResult
 
     const result = normalizeSearchResult(
       fakeFlatDomainClient,
@@ -61,7 +61,7 @@ describe('Should normalize files results', () => {
     const searchResult = {
       doctype: 'io.cozy.files',
       doc: doc
-    } as unknown as EnrichedSearchResult
+    } as unknown as RawSearchResult
 
     const result = normalizeSearchResult(
       fakeFlatDomainClient,
@@ -91,7 +91,7 @@ describe('Should normalize files results', () => {
     const searchResult = {
       doctype: 'io.cozy.files',
       doc: doc
-    } as unknown as EnrichedSearchResult
+    } as unknown as RawSearchResult
 
     const result = normalizeSearchResult(
       fakeFlatDomainClient,
@@ -122,7 +122,7 @@ describe('Should normalize contacts results', () => {
       doctype: 'io.cozy.files',
       doc: doc,
       fields: ['displayName', 'jobTitle']
-    } as unknown as EnrichedSearchResult
+    } as unknown as RawSearchResult
 
     const result = normalizeSearchResult(
       fakeFlatDomainClient,
@@ -151,7 +151,7 @@ describe('Should normalize contacts results', () => {
       doctype: 'io.cozy.files',
       doc: doc,
       fields: ['displayName', 'jobTitle']
-    } as unknown as EnrichedSearchResult
+    } as unknown as RawSearchResult
 
     const result = normalizeSearchResult(
       fakeFlatDomainClient,
@@ -179,7 +179,7 @@ describe('Should normalize contacts results', () => {
       doctype: 'io.cozy.files',
       doc: doc,
       fields: ['displayName', 'jobTitle']
-    } as unknown as EnrichedSearchResult
+    } as unknown as RawSearchResult
 
     const result = normalizeSearchResult(
       fakeFlatDomainClient,
@@ -208,7 +208,7 @@ describe('Should normalize contacts results', () => {
       doctype: 'io.cozy.files',
       doc: doc,
       fields: []
-    } as unknown as EnrichedSearchResult
+    } as unknown as RawSearchResult
 
     const result = normalizeSearchResult(
       fakeFlatDomainClient,
@@ -241,7 +241,7 @@ describe('Should normalize contacts results', () => {
       doctype: 'io.cozy.files',
       doc: doc,
       fields: ['displayName', 'email[]:address']
-    } as unknown as EnrichedSearchResult
+    } as unknown as RawSearchResult
 
     const result = normalizeSearchResult(
       fakeFlatDomainClient,
@@ -277,7 +277,7 @@ describe('Should normalize apps results', () => {
       doctype: 'io.cozy.files',
       doc: doc,
       fields: ['displayName', 'email[]:address']
-    } as unknown as EnrichedSearchResult
+    } as unknown as RawSearchResult
 
     const result = normalizeSearchResult(
       fakeFlatDomainClient,
@@ -306,7 +306,7 @@ describe('Should normalize apps results', () => {
       doctype: 'io.cozy.files',
       doc: doc,
       fields: ['displayName', 'email[]:address']
-    } as unknown as EnrichedSearchResult
+    } as unknown as RawSearchResult
 
     const result = normalizeSearchResult(
       fakeFlatDomainClient,
@@ -337,7 +337,7 @@ describe('Should normalize unknown doctypes', () => {
       doctype: 'io.cozy.files',
       doc: doc,
       fields: ['displayName', 'email[]:address']
-    } as unknown as EnrichedSearchResult
+    } as unknown as RawSearchResult
 
     const result = normalizeSearchResult(
       fakeFlatDomainClient,

--- a/packages/cozy-dataproxy-lib/src/search/helpers/normalizeSearchResult.ts
+++ b/packages/cozy-dataproxy-lib/src/search/helpers/normalizeSearchResult.ts
@@ -4,7 +4,7 @@ import { IOCozyContact } from 'cozy-client/types/types'
 import { APPS_DOCTYPE, TYPE_DIRECTORY } from '../consts'
 import {
   CozyDoc,
-  EnrichedSearchResult,
+  RawSearchResult,
   isIOCozyApp,
   isIOCozyContact,
   isIOCozyFile,
@@ -13,7 +13,7 @@ import {
 
 export const normalizeSearchResult = (
   client: CozyClient,
-  searchResults: EnrichedSearchResult,
+  searchResults: RawSearchResult,
   query: string
 ): SearchResult => {
   const doc = cleanFilePath(searchResults.doc)

--- a/packages/cozy-dataproxy-lib/src/search/queries/index.ts
+++ b/packages/cozy-dataproxy-lib/src/search/queries/index.ts
@@ -21,10 +21,6 @@ interface QueryResponseSingleDoc {
   data: CozyDoc
 }
 
-interface QueryResponseMultipleDoc {
-  data: CozyDoc[]
-}
-
 export const queryFilesForSearch = async (
   client: CozyClient
 ): Promise<CozyDoc[]> => {
@@ -60,24 +56,5 @@ export const queryDocById = async (
   const resp = (await client.query(Q(doctype).getById(id), {
     singleDocData: true
   })) as QueryResponseSingleDoc
-  return resp.data
-}
-
-export const queryDocsByIds = async (
-  client: CozyClient,
-  doctype: string,
-  ids: string[],
-  { fromStore = true } = {}
-): Promise<CozyDoc[]> => {
-  if (fromStore) {
-    // This is much more efficient to query from store than PouchDB
-    const allDocs = client.getCollectionFromState(doctype)
-    const docs = allDocs.filter(doc => doc._id && ids.includes(doc._id))
-    return docs as CozyDoc[]
-  }
-
-  const resp = (await client.query(
-    Q(doctype).getByIds(ids)
-  )) as QueryResponseMultipleDoc
   return resp.data
 }

--- a/packages/cozy-dataproxy-lib/src/search/types.ts
+++ b/packages/cozy-dataproxy-lib/src/search/types.ts
@@ -35,14 +35,10 @@ export const isSearchedDoctype = (
   return searchedDoctypes.includes(doctype)
 }
 
-export interface RawSearchResult {
+export interface RawSearchResult
+  extends FlexSearch.EnrichedDocumentSearchResultSetUnitResultUnit<CozyDoc> {
   fields: string[]
   doctype: SearchedDoctype
-  id: string
-}
-
-export interface EnrichedSearchResult extends RawSearchResult {
-  doc: CozyDoc
 }
 
 export interface SearchResult {


### PR DESCRIPTION
This reverts commit 104ea850ef9b2bf5ae5094f5d10f81bf8872bcf1. As we dynamically compute the path, that is not stored on PouchDB, it is required to store it in the cozy-client store and thus update all the files accordingly with the path.
However, this is not usual to do so and might lead to unexpected side-effects.
So for safety, we revert this commit for now and might rethink this later.