### PR TITLE
fix(cozy-sharing): Do not display loader in public context

### DIFF
--- a/packages/cozy-sharing/src/SharingProvider.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.jsx
@@ -181,6 +181,7 @@ export class SharingProvider extends Component {
     if (this.isPublic) {
       // In public mode, the promise below fails because the methods do not have the required permissions.
       log.warn('fetchAllSharings is not allowed in public context.')
+      this.setState({ allLoaded: true })
       return
     }
     const { doctype, client } = this.props


### PR DESCRIPTION
After the change made in a previous commit, the `allLoaded` state never went to true because there was no more fetch in public context.
To avoid any regression in the rest of the components, we can set it directly to true in a public context.

Ref: d08862d65fd4caaabfd29f116ade0607528345a9