### PR TITLE
feat: Add NativeFileSharingProvider and shareNative action

### DIFF
--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -84,7 +84,8 @@
           "readWrite": "write"
         }
       }
-    }
+    },
+    "send": "Send..."
   },
   "Sharings": {
     "unavailable": {

--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -82,7 +82,8 @@
         "readOnly": "lecture",
         "readWrite": "modification"
       }
-    }
+    },
+    "send": "Envoyer..."
   },
   "Sharings": {
     "unavailable": {

--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -67,6 +67,8 @@
     "cozy-client": ">=51.4.0",
     "cozy-realtime": "^3.11.0",
     "cozy-ui": ">=113.5.0",
+    "cozy-intent": ">=2.29.1",
+    "cozy-device-helper": ">=3.7.1",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-router": "^5.0.1"

--- a/packages/cozy-sharing/src/actions/shareNative.js
+++ b/packages/cozy-sharing/src/actions/shareNative.js
@@ -1,0 +1,52 @@
+import React, { forwardRef } from 'react'
+
+import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import ReplyIcon from 'cozy-ui/transpiled/react/Icons/Reply'
+import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+
+import { getActionsI18n } from '../hoc/withLocales'
+
+const makeComponent = (label, icon) => {
+  const Component = forwardRef((props, ref) => {
+    return (
+      <ActionsMenuItem {...props} ref={ref}>
+        <ListItemIcon>
+          <Icon icon={icon} />
+        </ListItemIcon>
+        <ListItemText primary={label} />
+      </ActionsMenuItem>
+    )
+  })
+  Component.displayName = 'ShareNative'
+
+  return Component
+}
+
+export const shareNative = ({
+  shareFilesNative,
+  isNativeFileSharingAvailable
+}) => {
+  const { t } = getActionsI18n()
+
+  const label = t('Share.send')
+  const icon = ReplyIcon
+
+  return {
+    name: 'shareNative',
+    label,
+    icon,
+    displayCondition: selectedFiles => {
+      return (
+        isNativeFileSharingAvailable &&
+        selectedFiles.every(selectedFile => selectedFile.type === 'file')
+      )
+    },
+    action: data => {
+      const idsToShare = data.map(d => d._id)
+      shareFilesNative(idsToShare)
+    },
+    Component: makeComponent(label, icon)
+  }
+}

--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -29,4 +29,9 @@ export { ShareButtonWithRecipients } from './ShareButtonWithRecipients'
 export { DOCUMENT_TYPE } from './helpers/documentType'
 export { default as OpenSharingLinkButton } from './OpenSharingLinkButton'
 export { default as OpenSharingLinkFabButton } from './OpenSharingLinkFabButton'
+export {
+  NativeFileSharingProvider,
+  useNativeFileSharing
+} from './providers/NativeFileSharingProvider'
 export { openSharingLink } from './actions/openSharingLink'
+export { shareNative } from './actions/shareNative'

--- a/packages/cozy-sharing/src/providers/NativeFileSharingProvider.jsx
+++ b/packages/cozy-sharing/src/providers/NativeFileSharingProvider.jsx
@@ -1,0 +1,47 @@
+import React, { useState, useEffect, createContext, useContext } from 'react'
+
+import { isFlagshipApp } from 'cozy-device-helper'
+import { useWebviewIntent } from 'cozy-intent'
+
+const NativeFileSharingContext = createContext()
+
+export const useNativeFileSharing = () => {
+  const context = useContext(NativeFileSharingContext)
+
+  if (!context) {
+    throw new Error('useFileSharing must be used within a FileSharingProvider')
+  }
+  return context
+}
+
+export const NativeFileSharingProvider = ({ children }) => {
+  const webviewIntent = useWebviewIntent()
+
+  const [isNativeFileSharingAvailable, setIsNativeFileSharingAvailable] =
+    useState(false)
+
+  useEffect(() => {
+    const checkNativeFileSharingAvailability = async () => {
+      const availability =
+        isFlagshipApp() &&
+        (await webviewIntent.call('isAvailable', 'shareFiles'))
+
+      setIsNativeFileSharingAvailable(availability)
+    }
+    checkNativeFileSharingAvailability()
+  }, [webviewIntent])
+
+  const shareFilesNative = async filesIds => {
+    return await webviewIntent.call('shareFiles', filesIds)
+  }
+
+  return (
+    <NativeFileSharingContext.Provider
+      value={{ isNativeFileSharingAvailable, shareFilesNative }}
+    >
+      {children}
+    </NativeFileSharingContext.Provider>
+  )
+}
+
+export default NativeFileSharingProvider


### PR DESCRIPTION
Add a provider and a action to expose an ActionMenu action that can share files with mobile device share capabilities.

shareFilesNative from the NativeFileSharingProvider must be passed to the action.

Inspired from code in mespapiers. It will be used in cozy-drive, cozy-notes and mespapiers.