### PR TITLE
feat(cozy-sharing): Add isShortLabel prop to OpenSharing's buttons

### DIFF
--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -28,7 +28,7 @@
       "anyoneWithTheLink": "Anyone with the link",
       "accessCount": "%{count} people have access"
     },
-    "create-cozy": "Create my cozy",
+    "create-cozy": "Create |||| Create my cozy",
     "members": {
       "count": "%{smart_count} member |||| %{smart_count} members",
       "others": "and 1 other… |||| and %{smart_count} others…",
@@ -59,8 +59,8 @@
       "shared_from": "The items below are displayed from ![avatar](%{image}) **%{name}**'s Cozy. You can add a link to this share in your Cozy",
       "whats_cozy": "Cozy is a secure digital home for all your data, hosted in France - ",
       "know_more": "More information",
-      "sync_to_mine": "Synchronise in my Cozy",
-      "add_to_mine": "Add to my Cozy",
+      "sync_to_mine": "Synchronise |||| Synchronise in my Cozy",
+      "add_to_mine": "Add |||| Add to my Cozy",
       "close": "Close"
     },
     "permissionLink": {

--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -28,7 +28,7 @@
       "anyoneWithTheLink": "N'importe qui avec le lien",
       "accessCount": "%{count} personnes y ont accès"
     },
-    "create-cozy": "Créer mon Cozy",
+    "create-cozy": "Créer |||| Créer mon Cozy",
     "members": {
       "count": "%{smart_count} membre |||| %{smart_count} membres",
       "others": "et 1 autre… |||| et %{smart_count} autres…",
@@ -59,8 +59,8 @@
       "shared_from": "Les éléments ci-dessous sont affichés depuis le Cozy de ![avatar](%{image}) **%{name}**. Vous pouvez ajouter un lien vers ce partage dans votre Cozy.",
       "whats_cozy": "Cozy est un domicile numérique sécurisé pour toutes vos données, hébergé en France - ",
       "know_more": "En savoir plus",
-      "sync_to_mine": "Synchroniser dans mon Cozy",
-      "add_to_mine": "Ajouter à mon Cozy",
+      "sync_to_mine": "Synchroniser |||| Synchroniser dans mon Cozy",
+      "add_to_mine": "Ajouter |||| Ajouter à mon Cozy",
       "close": "Fermer"
     },
     "permissionLink": {

--- a/packages/cozy-sharing/src/OpenSharingLinkButton.jsx
+++ b/packages/cozy-sharing/src/OpenSharingLinkButton.jsx
@@ -15,11 +15,13 @@ import withLocales from './hoc/withLocales'
  * @param {Object} props - The props for the component.
  * @param {string} props.link - The URL to be opened when the button is clicked.
  * @param {boolean} [props.isSharingShortcutCreated=false] - Indicates if a sharing shortcut has been created. (default false)
+ * @param {boolean} [props.isShortLabel] - Display a short label for the button.
  * @param {Object} [props] - Additional props to be passed to the Button component.
  */
 const OpenSharingLinkButton = ({
   link,
   isSharingShortcutCreated = false,
+  isShortLabel = false,
   ...props
 }) => {
   const { t } = useI18n()
@@ -31,6 +33,7 @@ const OpenSharingLinkButton = ({
   const { icon, label } = getIconWithlabel({
     link,
     isSharingShortcutCreated,
+    isShortLabel,
     t
   })
 
@@ -46,7 +49,8 @@ const OpenSharingLinkButton = ({
 
 OpenSharingLinkButton.propTypes = {
   link: PropTypes.string,
-  isSharingShortcutCreated: PropTypes.bool
+  isSharingShortcutCreated: PropTypes.bool,
+  isShortLabel: PropTypes.bool
 }
 
 export default withLocales(OpenSharingLinkButton)

--- a/packages/cozy-sharing/src/OpenSharingLinkFabButton.jsx
+++ b/packages/cozy-sharing/src/OpenSharingLinkFabButton.jsx
@@ -24,11 +24,13 @@ const makeStyles = customStyle => {
  * @param {Object} props - The props for the component.
  * @param {string} props.link - The URL to be opened when the button is clicked.
  * @param {boolean} [props.isSharingShortcutCreated=false] - Indicates if a sharing shortcut has been created. (default false)
+ * @param {boolean} [props.isShortLabel] - Display a short label for the button.
  * @param {Object} [props] - Additional props to be passed to the ExtendableFab component.
  */
 const OpenSharingLinkFabButton = ({
   link,
   isSharingShortcutCreated = false,
+  isShortLabel,
   ...props
 }) => {
   const { style = {}, ...rest } = props
@@ -42,6 +44,7 @@ const OpenSharingLinkFabButton = ({
   const { icon, label } = getIconWithlabel({
     link,
     isSharingShortcutCreated,
+    isShortLabel,
     t
   })
 
@@ -60,7 +63,8 @@ const OpenSharingLinkFabButton = ({
 
 OpenSharingLinkFabButton.propTypes = {
   link: PropTypes.string.isRequired,
-  isSharingShortcutCreated: PropTypes.bool
+  isSharingShortcutCreated: PropTypes.bool,
+  isShortLabel: PropTypes.bool
 }
 
 export default withLocales(OpenSharingLinkFabButton)

--- a/packages/cozy-sharing/src/actions/openSharingLink.js
+++ b/packages/cozy-sharing/src/actions/openSharingLink.js
@@ -27,12 +27,14 @@ const makeComponent = (label, icon) => {
 export const openSharingLink = ({
   isSharingShortcutCreated,
   openSharingLinkDisplayed = true,
+  isShortLabel = false,
   link
 }) => {
   const { t } = getActionsI18n()
   const { icon, label } = getIconWithlabel({
     link,
     isSharingShortcutCreated,
+    isShortLabel,
     t
   })
 

--- a/packages/cozy-sharing/src/components/SharingBanner/components/PublicBanner.jsx
+++ b/packages/cozy-sharing/src/components/SharingBanner/components/PublicBanner.jsx
@@ -57,12 +57,12 @@ const SharingBannerCozyToCozy = ({
   const action = () => openExternalLink(discoveryLink)
   const buttonOne = isSharingShortcutCreated
     ? {
-        label: t('Share.banner.sync_to_mine'),
+        label: t('Share.banner.sync_to_mine', { smart_count: 2 }),
         icon: 'sync-cozy',
         action
       }
     : {
-        label: t('Share.banner.add_to_mine'),
+        label: t('Share.banner.add_to_mine', { smart_count: 2 }),
         icon: 'to-the-cloud',
         action
       }
@@ -120,7 +120,7 @@ const SharingBannerByLink = ({ onClose }) => {
         <Button
           component="a"
           variant="text"
-          label={t('Share.create-cozy')}
+          label={t('Share.create-cozy', { smart_count: 2 })}
           icon={CozyHomeLinkIcon}
           href={HOME_LINK_HREF}
         />

--- a/packages/cozy-sharing/src/helpers/sharings.js
+++ b/packages/cozy-sharing/src/helpers/sharings.js
@@ -70,12 +70,28 @@ export const openExternalLink = url => {
  * @param {object} params.t
  * @returns {{ icon: React.Component, label: string }}
  */
-export const getIconWithlabel = ({ link, isSharingShortcutCreated, t }) => {
+export const getIconWithlabel = ({
+  link,
+  isSharingShortcutCreated,
+  isShortLabel,
+  t
+}) => {
   if (link === CREATE_COZY_HREF) {
-    return { icon: ToTheCloudIcon, label: t('Share.create-cozy') }
+    return {
+      icon: ToTheCloudIcon,
+      label: t('Share.create-cozy', { smart_count: isShortLabel ? 1 : 2 })
+    }
   }
   if (!isSharingShortcutCreated) {
-    return { icon: CloudPlusOutlinedIcon, label: t('Share.banner.add_to_mine') }
+    return {
+      icon: CloudPlusOutlinedIcon,
+      label: t('Share.banner.add_to_mine', {
+        smart_count: isShortLabel ? 1 : 2
+      })
+    }
   }
-  return { icon: SyncIcon, label: t('Share.banner.sync_to_mine') }
+  return {
+    icon: SyncIcon,
+    label: t('Share.banner.sync_to_mine', { smart_count: isShortLabel ? 1 : 2 })
+  }
 }


### PR DESCRIPTION
- [x] Merge https://github.com/cozy/cozy-libs/pull/2655 before

In some cases, as in the Viewer, we want to display shorter text.