### PR TITLE
fix: Use user locale on last konnector execution date (SCR-916)

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorBlock.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorBlock.jsx
@@ -30,7 +30,7 @@ import { fetchKonnectorData } from '../helpers/konnectorBlock'
 const KonnectorBlock = ({ file }) => {
   const [konnector, setKonnector] = useState()
   const client = useClient()
-  const { t } = useI18n()
+  const { t, lang } = useI18n()
   const slug = get(file, 'cozyMetadata.createdByApp')
   const sourceAccountIdentifier = get(
     file,
@@ -84,6 +84,7 @@ const KonnectorBlock = ({ file }) => {
   const label = makeLabel({
     t,
     konnector,
+    lang,
     trigger,
     isRunning: trigger.current_state.status === 'running'
   })

--- a/packages/cozy-harvest-lib/src/components/cards/helpers.js
+++ b/packages/cozy-harvest-lib/src/components/cards/helpers.js
@@ -1,5 +1,8 @@
 // @ts-check
-import { formatLocallyDistanceToNow } from 'cozy-ui/transpiled/react/providers/I18n/format'
+import {
+  formatLocallyDistanceToNow,
+  initFormat
+} from 'cozy-ui/transpiled/react/providers/I18n/format'
 
 import { isDisconnected } from '../../helpers/konnectors'
 import { getLastSuccessDate } from '../../helpers/triggers'
@@ -20,9 +23,14 @@ const getDifferenceInMillisecondes = date => {
  * @param {import('cozy-client/types/types').IOCozyKonnector} options.konnector - Associated Connector
  * @param {object} options.trigger - Associated trigger
  * @param {object} options.isRunning - If the connector is running
+ * @param {string} options.lang - lang identifier ('fr', 'en')
  * @returns {string}
  */
-export const makeLabel = ({ t, konnector, trigger, isRunning }) => {
+export const makeLabel = ({ t, konnector, trigger, isRunning, lang }) => {
+  if (lang) {
+    // force current language for cozy-ui formatLocallyDistanceToNow
+    initFormat(lang)(new Date(), 'yyyy-MM-dd HH:mm:ss')
+  }
   const lastSuccessDate = getLastSuccessDate(trigger)
   if (isRunning) {
     return t('card.launchTrigger.lastSync.syncing')

--- a/packages/cozy-harvest-lib/src/components/cards/helpers.spec.js
+++ b/packages/cozy-harvest-lib/src/components/cards/helpers.spec.js
@@ -38,6 +38,7 @@ describe('makeLabel', () => {
     it('should return "Sync. ago..." if lastSuccessDate is defined and > 5 minutes', () => {
       const res = makeLabel({
         t,
+        lang: 'fr',
         trigger: {
           current_state: { last_success: '2020-12-25T11:55:00.000Z' }
         },


### PR DESCRIPTION
Force user locale used by cozy-ui's `formatLocallyDistanceToNow` function
Avoid `Sync. Il y a about 23 hours` messages