### PR TITLE
[DAT-73] Fix encoder search

### DIFF
--- a/packages/cozy-dataproxy-lib/src/search/SearchEngine.ts
+++ b/packages/cozy-dataproxy-lib/src/search/SearchEngine.ts
@@ -182,7 +182,7 @@ export class SearchEngine {
       tokenize: 'reverse', // See https://github.com/nextapps-de/flexsearch?tab=readme-ov-file#tokenizer
       encode: getSearchEncoder(),
       // @ts-expect-error minlength is not described by Flexsearch types but exists
-      minlength: 2,
+      minlength: 3,
       document: {
         id: '_id',
         index: fieldsToIndex,

--- a/packages/cozy-dataproxy-lib/src/search/helpers/getSearchEncoder.ts
+++ b/packages/cozy-dataproxy-lib/src/search/helpers/getSearchEncoder.ts
@@ -1,7 +1,7 @@
 import FlexSearch from 'flexsearch'
 // @ts-expect-error module/lang/latin/balance is not described by Flexsearch types but exists
-import { encode as encode_balance } from 'flexsearch/dist/module/lang/latin/balance'
+import { encode as encode_simple } from 'flexsearch/dist/module/lang/latin/simple'
 
 export const getSearchEncoder = (): FlexSearch.Encoders => {
-  return encode_balance as FlexSearch.Encoders
+  return encode_simple as FlexSearch.Encoders
 }


### PR DESCRIPTION
Sometimes a search could return surprising results, with no clear match. For instance a "test" search would return a file with the name "dist.pdf".
This is because we used the "balance" encoder, which performs a "literal" transformation on text, e.g. "d" matches "t", "i" matches "e", and so on. Thus, "dist" is transformed into "test", hence the matching.
See all examples here: https://github.com/nextapps-de/flexsearch/blob/master/src/lang/latin/balance.js#L24

This is not wanted in our case, and makes the index bigger, so we disable it and use "simple" encoder instead, that handle case and charset tranformations