### PR TITLE
feat: Enable search options

### DIFF
--- a/packages/cozy-dataproxy-lib/src/dataproxy/DataProxyProvider.jsx
+++ b/packages/cozy-dataproxy-lib/src/dataproxy/DataProxyProvider.jsx
@@ -16,7 +16,7 @@ export const useDataProxy = () => {
   return context
 }
 
-export const DataProxyProvider = React.memo(({ children }) => {
+export const DataProxyProvider = React.memo(({ children, options = {} }) => {
   const client = useClient()
   const [iframeUrl, setIframeUrl] = useState()
   const [dataProxy, setDataProxy] = useState()
@@ -82,8 +82,7 @@ export const DataProxyProvider = React.memo(({ children }) => {
 
   const search = async search => {
     log.log('Send search query to DataProxy iframe')
-
-    const result = await dataProxy.search(search)
+    const result = await dataProxy.search(search, options)
 
     return result
   }

--- a/packages/cozy-dataproxy-lib/src/search/SearchEngine.spec.js
+++ b/packages/cozy-dataproxy-lib/src/search/SearchEngine.spec.js
@@ -1,11 +1,10 @@
 import { createMockClient } from 'cozy-client'
 
-import SearchEngine from './SearchEngine'
-import { APPS_DOCTYPE, CONTACTS_DOCTYPE, FILES_DOCTYPE } from './consts'
-
+import { SearchEngine } from './SearchEngine'
+import * as consts from './consts'
 jest.mock('cozy-client')
 jest.mock('flexsearch')
-jest.mock('flexsearch/dist/module/lang/latin/balance')
+jest.mock('flexsearch/dist/module/lang/latin/simple')
 
 jest.mock('./helpers/client', () => ({
   getPouchLink: jest.fn()
@@ -13,37 +12,60 @@ jest.mock('./helpers/client', () => ({
 jest.mock('./helpers/getSearchEncoder', () => ({
   getSearchEncoder: jest.fn()
 }))
+jest.mock('./consts', () => ({
+  LIMIT_DOCTYPE_SEARCH: 3,
+  SEARCH_SCHEMA: {
+    'io.cozy.files': ['name', 'path'],
+    'io.cozy.contacts': ['displayName', 'fullname'],
+    'io.cozy.apps': ['slug', 'name']
+  },
+  DOCTYPE_DEFAULT_ORDER: {
+    'io.cozy.apps': 0,
+    'io.cozy.contacts': 1,
+    'io.cozy.files': 2
+  },
+  FILES_DOCTYPE: 'io.cozy.files',
+  CONTACTS_DOCTYPE: 'io.cozy.contacts',
+  APPS_DOCTYPE: 'io.cozy.apps'
+}))
 
 describe('sortSearchResults', () => {
   let searchEngine
-
   beforeEach(() => {
     const client = createMockClient()
     searchEngine = new SearchEngine(client)
   })
-
   afterEach(() => {
     jest.clearAllMocks()
   })
 
   it('should sort results by doctype order', () => {
     const searchResults = [
-      { doctype: FILES_DOCTYPE, doc: { _type: FILES_DOCTYPE } },
-      { doctype: APPS_DOCTYPE, doc: { _type: APPS_DOCTYPE } },
-      { doctype: CONTACTS_DOCTYPE, doc: { _type: CONTACTS_DOCTYPE } }
+      { doctype: consts.FILES_DOCTYPE, doc: { _type: consts.FILES_DOCTYPE } },
+      { doctype: consts.APPS_DOCTYPE, doc: { _type: consts.APPS_DOCTYPE } },
+      {
+        doctype: consts.CONTACTS_DOCTYPE,
+        doc: { _type: consts.CONTACTS_DOCTYPE }
+      }
     ]
 
     const sortedResults = searchEngine.sortSearchResults(searchResults)
 
-    expect(sortedResults[0].doctype).toBe(APPS_DOCTYPE)
-    expect(sortedResults[1].doctype).toBe(CONTACTS_DOCTYPE)
-    expect(sortedResults[2].doctype).toBe(FILES_DOCTYPE)
+    expect(sortedResults[0].doctype).toBe(consts.APPS_DOCTYPE)
+    expect(sortedResults[1].doctype).toBe(consts.CONTACTS_DOCTYPE)
+    expect(sortedResults[2].doctype).toBe(consts.FILES_DOCTYPE)
   })
 
   it('should sort apps by slug', () => {
     const searchResults = [
-      { doctype: APPS_DOCTYPE, doc: { slug: 'appB', _type: APPS_DOCTYPE } },
-      { doctype: APPS_DOCTYPE, doc: { slug: 'appA', _type: APPS_DOCTYPE } }
+      {
+        doctype: consts.APPS_DOCTYPE,
+        doc: { slug: 'appB', _type: consts.APPS_DOCTYPE }
+      },
+      {
+        doctype: consts.APPS_DOCTYPE,
+        doc: { slug: 'appA', _type: consts.APPS_DOCTYPE }
+      }
     ]
 
     const sortedResults = searchEngine.sortSearchResults(searchResults)
@@ -55,12 +77,12 @@ describe('sortSearchResults', () => {
   it('should sort contacts by displayName', () => {
     const searchResults = [
       {
-        doctype: CONTACTS_DOCTYPE,
-        doc: { displayName: 'June', _type: CONTACTS_DOCTYPE }
+        doctype: consts.CONTACTS_DOCTYPE,
+        doc: { displayName: 'June', _type: consts.CONTACTS_DOCTYPE }
       },
       {
-        doctype: CONTACTS_DOCTYPE,
-        doc: { displayName: 'Alice', _type: CONTACTS_DOCTYPE }
+        doctype: consts.CONTACTS_DOCTYPE,
+        doc: { displayName: 'Alice', _type: consts.CONTACTS_DOCTYPE }
       }
     ]
 
@@ -73,18 +95,22 @@ describe('sortSearchResults', () => {
   it('should sort files by type and name', () => {
     const searchResults = [
       {
-        doctype: FILES_DOCTYPE,
-        doc: { name: 'fileB', type: 'file', _type: FILES_DOCTYPE },
+        doctype: consts.FILES_DOCTYPE,
+        doc: { name: 'fileB', type: 'file', _type: consts.FILES_DOCTYPE },
         fields: ['name']
       },
       {
-        doctype: FILES_DOCTYPE,
-        doc: { name: 'fileA', type: 'file', _type: FILES_DOCTYPE },
+        doctype: consts.FILES_DOCTYPE,
+        doc: { name: 'fileA', type: 'file', _type: consts.FILES_DOCTYPE },
         fields: ['name']
       },
       {
-        doctype: FILES_DOCTYPE,
-        doc: { name: 'folderA', type: 'directory', _type: FILES_DOCTYPE },
+        doctype: consts.FILES_DOCTYPE,
+        doc: {
+          name: 'folderA',
+          type: 'directory',
+          _type: consts.FILES_DOCTYPE
+        },
         fields: ['name']
       }
     ]
@@ -99,42 +125,42 @@ describe('sortSearchResults', () => {
   it('should sort files first if they match on name, then path', () => {
     const searchResults = [
       {
-        doctype: FILES_DOCTYPE,
+        doctype: consts.FILES_DOCTYPE,
         doc: {
           name: 'test11',
           path: 'test/test11',
           type: 'file',
-          _type: FILES_DOCTYPE
+          _type: consts.FILES_DOCTYPE
         },
         fields: ['name']
       },
       {
-        doctype: FILES_DOCTYPE,
+        doctype: consts.FILES_DOCTYPE,
         doc: {
           name: 'test1',
           path: 'test/test1',
           type: 'file',
-          _type: FILES_DOCTYPE
+          _type: consts.FILES_DOCTYPE
         },
         fields: ['name']
       },
       {
-        doctype: FILES_DOCTYPE,
+        doctype: consts.FILES_DOCTYPE,
         doc: {
           name: 'DirName1',
           path: 'test1/path',
           type: 'directory',
-          _type: FILES_DOCTYPE
+          _type: consts.FILES_DOCTYPE
         },
         fields: ['path']
       },
       {
-        doctype: FILES_DOCTYPE,
+        doctype: consts.FILES_DOCTYPE,
         doc: {
           name: 'DirName2',
           path: 'test1/path',
           type: 'directory',
-          _type: FILES_DOCTYPE
+          _type: consts.FILES_DOCTYPE
         },
         fields: ['name']
       }
@@ -146,5 +172,50 @@ describe('sortSearchResults', () => {
     expect(sortedResults[1].doc.name).toBe('test1') // File match on name
     expect(sortedResults[2].doc.name).toBe('test11') // File match on name
     expect(sortedResults[3].doc.name).toBe('DirName1') // Directory
+  })
+})
+
+describe('limitSearchResults', () => {
+  let searchEngine
+  beforeEach(() => {
+    const client = createMockClient()
+    searchEngine = new SearchEngine(client)
+  })
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+  it('should return all results if doctype count is below or equal the limit', () => {
+    const searchResults = [
+      { doctype: consts.FILES_DOCTYPE, id: 1 },
+      { doctype: consts.FILES_DOCTYPE, id: 2 },
+      { doctype: consts.FILES_DOCTYPE, id: 3 }
+    ]
+
+    const filteredResults = searchEngine.limitSearchResults(searchResults)
+    expect(filteredResults).toEqual(searchResults)
+  })
+
+  it('should filter results exceeding the limit for a specific doctype', () => {
+    const searchResults = [
+      { doctype: consts.FILES_DOCTYPE, id: 1 },
+      { doctype: consts.FILES_DOCTYPE, id: 2 },
+      { doctype: consts.FILES_DOCTYPE, id: 3 },
+      { doctype: consts.FILES_DOCTYPE, id: 4 },
+      { doctype: consts.CONTACTS_DOCTYPE, id: 5 }
+    ]
+
+    const filteredResults = searchEngine.limitSearchResults(searchResults)
+    expect(filteredResults).toEqual([
+      { doctype: consts.FILES_DOCTYPE, id: 1 },
+      { doctype: consts.FILES_DOCTYPE, id: 2 },
+      { doctype: consts.FILES_DOCTYPE, id: 3 },
+      { doctype: consts.CONTACTS_DOCTYPE, id: 5 }
+    ])
+  })
+
+  it('should return an empty array if input is empty', () => {
+    const searchResults = []
+    const filteredResults = searchEngine.limitSearchResults(searchResults)
+    expect(filteredResults).toEqual([])
   })
 })

--- a/packages/cozy-dataproxy-lib/src/search/consts.ts
+++ b/packages/cozy-dataproxy-lib/src/search/consts.ts
@@ -33,7 +33,7 @@ export const TRASH_DIR_ID = 'io.cozy.files.trash-dir'
 export const SHARED_DRIVES_DIR_ID = 'io.cozy.files.shared-drives-dir'
 
 export const LIMIT_DOCTYPE_SEARCH = 100
-export const DOCTYPE_ORDER = {
+export const DOCTYPE_DEFAULT_ORDER = {
   [APPS_DOCTYPE]: 0,
   [CONTACTS_DOCTYPE]: 1,
   [FILES_DOCTYPE]: 2

--- a/packages/cozy-dataproxy-lib/src/search/types.ts
+++ b/packages/cozy-dataproxy-lib/src/search/types.ts
@@ -35,6 +35,10 @@ export const isSearchedDoctype = (
   return searchedDoctypes.includes(doctype)
 }
 
+export interface SearchOptions {
+  doctypes: string[] // Specify which doctypes should be searched, and their order
+}
+
 export interface RawSearchResult
   extends FlexSearch.EnrichedDocumentSearchResultSetUnitResultUnit<CozyDoc> {
   fields: string[]

--- a/packages/cozy-dataproxy-lib/tests/jest.config.js
+++ b/packages/cozy-dataproxy-lib/tests/jest.config.js
@@ -12,7 +12,7 @@ const config = {
     './src/search/helpers/getSearchEncoder.ts'
   ],
   rootDir: '../',
-  testMatch: ['./**/*.spec.{ts,tsx}'],
+  testMatch: ['./**/*.spec.{ts,tsx,js}'],
   coverageThreshold: {
     global: {
       branches: 80,


### PR DESCRIPTION
It is now possible to pass a `doctypes` options to the search, that serves two purposes:
- Specify which doctypes should be searched
- Specify the doctype  order of the results