### PR TITLE
fix(Viewer): Now use intent inner dialog backdrop instead of custom one

### DIFF
--- a/packages/cozy-viewer/src/components/IntentOpener.jsx
+++ b/packages/cozy-viewer/src/components/IntentOpener.jsx
@@ -1,17 +1,7 @@
 import PropTypes from 'prop-types'
-import React, { useState } from 'react'
+import React from 'react'
 
-import Backdrop from 'cozy-ui/transpiled/react/Backdrop'
 import IntentDialogOpener from 'cozy-ui/transpiled/react/IntentDialogOpener'
-import Portal from 'cozy-ui/transpiled/react/Portal'
-
-const PortalBackdrop = ({ children, ...props }) => {
-  return (
-    <Portal into="body">
-      <Backdrop {...props}>{children}</Backdrop>
-    </Portal>
-  )
-}
 
 const IntentOpener = ({
   action,
@@ -21,8 +11,6 @@ const IntentOpener = ({
   children,
   ...props
 }) => {
-  const [isLoading, setIsLoading] = useState(true)
-
   if (disabled) {
     return children
   }
@@ -33,14 +21,13 @@ const IntentOpener = ({
       action={action}
       doctype={doctype}
       options={options}
-      Component={PortalBackdrop}
-      invisible={!isLoading}
-      isOver
       showCloseButton={false}
       iframeProps={{
-        spinnerProps: { className: 'u-m-0', middle: true, color: 'white' },
-        setIsLoading
+        spinnerProps: { className: 'u-m-0', middle: true, color: 'white' }
       }}
+      fullScreen
+      fullWidth
+      PaperComponent="div"
     >
       {children}
     </IntentDialogOpener>


### PR DESCRIPTION
Le fait d'utiliser Portal faisait qu'une fois l'intent ouvert, avec un input dans la modale, un onBlur était exécuté de suite après le onFocus. Donc impossible d'éditer le champ.

Ici on utilise le comportement par défaut, à savoir une Dialog, qui elle-même embarque Portal et Backdrop. On remplace simplement le PaperComponent pour avoir le rendu attendu, à savoir uniquement le Backdrop visible.