### PR TITLE
fix(harvest): Konnector slug now relies on createdByApp in KonnectrBlock

### DIFF
--- a/packages/cozy-harvest-lib/src/components/KonnectorBlock.jsx
+++ b/packages/cozy-harvest-lib/src/components/KonnectorBlock.jsx
@@ -31,7 +31,7 @@ const KonnectorBlock = ({ file }) => {
   const [konnector, setKonnector] = useState()
   const client = useClient()
   const { t } = useI18n()
-  const slug = get(file, 'cozyMetadata.uploadedBy.slug')
+  const slug = get(file, 'cozyMetadata.createdByApp')
   const sourceAccountIdentifier = get(
     file,
     'cozyMetadata.sourceAccountIdentifier'


### PR DESCRIPTION
instead of uploadedBy.slug. Because an app can edit the document and so the uploadedBy.slug key will be updated with the name of the app, erasing the konnector slug.

approche validée auprès de @KillianCourvoisier et @doubleface 