### PR TITLE
feat(viewer): Improve UX

### DIFF
--- a/packages/cozy-viewer/src/ViewersByFile/PdfJsViewer.jsx
+++ b/packages/cozy-viewer/src/ViewersByFile/PdfJsViewer.jsx
@@ -14,7 +14,8 @@ import { withViewerLocales } from '../hoc/withViewerLocales'
 
 export const MIN_SCALE = 0.25
 export const MAX_SCALE = 3
-export const MAX_PAGES = 3
+export const MAX_PAGES = 40
+export const MAX_SIZE_FILE = 10_485_760 // 10MB
 const KEY_CODE_UP = 38
 const KEY_CODE_DOWN = 40
 const OPACITY_DELAY = 1_000
@@ -85,7 +86,9 @@ export class PdfJsViewer extends Component {
   onLoadSuccess = ({ numPages }) => {
     this.setState({
       totalPages: numPages,
-      renderAllPages: numPages <= MAX_PAGES,
+      renderAllPages:
+        numPages <= MAX_PAGES &&
+        parseInt(this.props.file.size, 10) <= MAX_SIZE_FILE,
       loaded: true
     })
   }

--- a/packages/cozy-viewer/src/ViewersByFile/PdfJsViewer.jsx
+++ b/packages/cozy-viewer/src/ViewersByFile/PdfJsViewer.jsx
@@ -24,12 +24,7 @@ let timeoutOpacity
 const makeInputPageStyle = nbPages => {
   const maxWidth = Math.max(1, String(Math.abs(nbPages)).length - 1)
   return {
-    maxWidth: `${maxWidth}rem`,
-    marginRight: '0.25rem',
-    textAlign: 'center',
-    backgroundColor: 'var(--charcoalGrey)',
-    border: '2px solid var(--borderMainColor)',
-    borderRadius: '5px'
+    maxWidth: `${maxWidth}.5rem`
   }
 }
 
@@ -278,18 +273,22 @@ export class PdfJsViewer extends Component {
                   disabled={currentPage === 1}
                   label={t('Viewer.previous')}
                 />
-                <input
-                  ref={this.inputRef}
-                  type="text"
-                  inputMode="numeric"
-                  style={makeInputPageStyle(totalPages)}
-                  value={pageInputValue}
-                  onChange={this.handleInputPageChange}
-                  onKeyDown={this.handleInputPageKeyDown}
-                  onFocus={this.handleInputPageFocus}
-                  onBlur={this.handleInputPageBlur}
-                />
-                /{totalPages}
+                <label htmlFor="input-page">
+                  <input
+                    ref={this.inputRef}
+                    id="input-page"
+                    className={styles['viewer-pdfviewer-input-page']}
+                    type="text"
+                    inputMode="numeric"
+                    style={makeInputPageStyle(totalPages)}
+                    value={pageInputValue}
+                    onChange={this.handleInputPageChange}
+                    onKeyDown={this.handleInputPageKeyDown}
+                    onFocus={this.handleInputPageFocus}
+                    onBlur={this.handleInputPageBlur}
+                  />
+                  /{totalPages}
+                </label>
                 <ToolbarButton
                   icon="bottom"
                   onClick={this.nextPage}

--- a/packages/cozy-viewer/src/ViewersByFile/PdfJsViewer.jsx
+++ b/packages/cozy-viewer/src/ViewersByFile/PdfJsViewer.jsx
@@ -127,7 +127,8 @@ export class PdfJsViewer extends Component {
           renderFallbackExtraContent={renderFallbackExtraContent}
         />
       )
-    const pageWidth = width ? width * scale : null // newer versions of react-pdf do that automatically
+
+    const pageWidth = width && totalPages > 1 ? width - 15 : width // Remove the scrollbar width to avoid a horizontal scrollbar
 
     return (
       <div
@@ -148,6 +149,7 @@ export class PdfJsViewer extends Component {
                 key={page}
                 pageNumber={page + 1}
                 width={pageWidth}
+                scale={scale}
                 renderAnnotations={false}
                 className={cx('u-mv-1', styles['viewer-pdfviewer-page'])}
               />
@@ -156,6 +158,7 @@ export class PdfJsViewer extends Component {
             <Page
               pageNumber={currentPage}
               width={pageWidth}
+              scale={scale}
               renderAnnotations={false}
               className={styles['viewer-pdfviewer-page']}
             />

--- a/packages/cozy-viewer/src/ViewersByFile/styles.styl
+++ b/packages/cozy-viewer/src/ViewersByFile/styles.styl
@@ -28,6 +28,18 @@
 
 // rules for specific viewers below
 
+.viewer-pdfviewer-input-page
+    margin-right     0.25rem
+    text-align       center
+    color            rgb(255, 255, 255)
+    background-color rgb(50, 54, 63)
+    border           2px solid rgba(255, 255, 255, 0.32)
+    border-radius    2px
+    font-size        0.9rem
+
+    &:focus
+        outline none
+
 .viewer-videoviewer
     video
         width       100%

--- a/packages/cozy-viewer/src/ViewersByFile/styles.styl
+++ b/packages/cozy-viewer/src/ViewersByFile/styles.styl
@@ -66,6 +66,13 @@
     background var(--charcoalGrey)
     color var(--white)
     border-radius .5rem
+    opacity 1
+    transition opacity 0.5s ease-in-out
+
+    &--hidden
+      opacity 0
+      transition opacity 0.5s ease-in-out
+
 
 .viewer-imageviewer
     flex             1 1 100%

--- a/packages/cozy-viewer/src/components/PdfToolbarButton.jsx
+++ b/packages/cozy-viewer/src/components/PdfToolbarButton.jsx
@@ -1,18 +1,20 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import Button from 'cozy-ui/transpiled/react/deprecated/Button'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import Icon from 'cozy-ui/transpiled/react/Icon'
 
 const PdfToolbarButton = ({ icon, onClick, disabled, label }) => (
   <Button
-    iconOnly
-    subtle
-    theme="secondary"
-    className="u-p-half u-m-half"
+    variant="text"
+    color="secondary"
+    className="u-p-half u-m-half u-mah-2"
     icon={icon}
     onClick={onClick}
     disabled={disabled}
-    label={label}
+    label={<Icon icon={icon} size={16} />}
+    aria-label={label}
+    disableRipple
   />
 )
 


### PR DESCRIPTION
This PR improves the UX on the Viewer.
- Adjustment of the number of pages(40) to display the PDF in scroll mode (+ addition of a file weight constraint(10MB)).
  - As a reminder, `react-pdf` uses web workers.
- Possibility of typing the page number (in page-by-page mode) in the small toolbar.
- Hide toolbar after a short period of inactivity(1s). Unless cursor is over or page number edit field is in focus.

![image](https://github.com/user-attachments/assets/a8c3864b-56c5-4403-bf89-01752f93f66c)