### PR TITLE
fix: Export `stylesheet.css` in cozy-dataproxy-lib's package.json

### DIFF
--- a/packages/cozy-dataproxy-lib/package.json
+++ b/packages/cozy-dataproxy-lib/package.json
@@ -58,7 +58,8 @@
   "exports": {
     ".": "./dist/index.js",
     "./api": "./dist/api.js",
-    "./ui": "./dist/ui.js"
+    "./ui": "./dist/ui.js",
+    "./dist/stylesheet.css": "./dist/stylesheet.css"
   },
   "peerDependencies": {
     "cozy-client": ">=51.0.1",


### PR DESCRIPTION
In consuming apps, we use to import the cozy-dataproxy-lib's stylesheet

Since 512e816cfe71a5087060d6cb001dc4f235b744f4 we use some exports in the package.json that may prevent to import the stylesheet

So we want to add this file to exports options

Related commit: 512e816cfe71a5087060d6cb001dc4f235b744f4