### PR TITLE
feat: Enable HMR on shared Rsbuild configuration

### DIFF
--- a/config/rsbuild-config-cozy-app/getRsbuildConfig.js
+++ b/config/rsbuild-config-cozy-app/getRsbuildConfig.js
@@ -31,7 +31,9 @@ function getRsbuildConfig({
     plugins: [
       pluginEjs(),
       pluginNodePolyfill(),
-      pluginReact(),
+      pluginReact({
+        fastRefresh: import.meta.env.NODE_ENV === 'development'
+      }),
       pluginStylus({
         stylusOptions: {
           // To resolve import from cozy-ui inside stylus files

--- a/config/rsbuild-config-cozy-app/getRsbuildConfig.js
+++ b/config/rsbuild-config-cozy-app/getRsbuildConfig.js
@@ -41,6 +41,19 @@ function getRsbuildConfig({
         }
       })
     ],
+    // Used when running `rsbuild dev`
+    // By default the dev configuration would serve app's files from localhost:300
+    // which is not what we want as we expect to serve apps from a local cozy-stack
+    dev: {
+      // this param tells to put files in the output folder so we can access them from cozy-stack
+      writeToDisk: true,
+      // this param tells the cozy-app which URL to use for the HMR websocket, otherwise it would use the cozy-stack URL by default
+      client: {
+        host: 'rsbuild.cozy.tools', // we cannot use localhost because chromium browsers prevent unsecure websockets to localhost
+        protocol: 'ws',
+        port: '<port>'
+      }
+    },
     output: {
       cleanDistPath: true,
       filename: {


### PR DESCRIPTION
By default Hot Module Rreplacement is configured to work with a localhost dev server

This server is responsible to serve the app and enable HMR

This wouldn't work with our apps because they are meant to be served by a local cozy-stack as a dev environment and so the cozy-app would try to connect to the HMR websocket using the cozy-stack's URL

Also the Rsbuild dev server is configured to serve built files from memory, so the `/build` folder would be empty and the cozy-stack wouldn't see any app

To fix this we can use both `dev.writeToDisk` and `dev.client` configurations

Then in order to benefit from this, the cozy-app should be run using `rsbuild dev` instead of `rsbuild build --watch`

More info:
- https://github.com/web-infra-dev/rsbuild/discussions/4366
- https://rsbuild.dev/config/dev/write-to-disk#writing-to-disk
- https://rsbuild.dev/config/dev/client