### PR TITLE
fix(Viewer): Now use the folder as a reference when sharing

### DIFF
--- a/packages/cozy-viewer/src/Panel/Sharing.jsx
+++ b/packages/cozy-viewer/src/Panel/Sharing.jsx
@@ -26,12 +26,15 @@ const Sharing = ({ file, t }) => {
     getDocumentPermissions,
     getSharingLink,
     allLoaded,
+    hasSharedParent,
     getRecipients
   } = useSharingContext()
 
-  const recipients = getRecipients(file._id)
-  const permissions = getDocumentPermissions(file._id)
-  const link = getSharingLink(file._id)
+  const shareFileRefId = hasSharedParent(file.path) ? file.dir_id : file._id
+  const recipients = getRecipients(shareFileRefId)
+  const permissions = getDocumentPermissions(shareFileRefId)
+  const link = getSharingLink(shareFileRefId)
+  const _isOwner = isOwner(shareFileRefId)
 
   return (
     <>
@@ -56,7 +59,7 @@ const Sharing = ({ file, t }) => {
             <MemberRecipientLite
               key={recipient.index}
               recipient={recipient}
-              isOwner={isOwner(file._id)}
+              isOwner={_isOwner}
             />
           ))
         ) : (

--- a/packages/cozy-viewer/src/ViewerContainer.jsx
+++ b/packages/cozy-viewer/src/ViewerContainer.jsx
@@ -35,7 +35,7 @@ const ViewerContainer = props => {
   const [isReadOnly, setIsReadOnly] = useState(true)
   const client = useClient()
   useExtendI18n(locales)
-  const { hasWriteAccess } = useSharingContext()
+  const { hasWriteAccess, hasSharedParent } = useSharingContext()
 
   const currentFile = files[currentIndex]
   const fileCount = files.length
@@ -59,13 +59,17 @@ const ViewerContainer = props => {
             document: currentFile,
             client
           })
-        : !hasWriteAccess(currentFile._id)
+        : !hasWriteAccess(
+            hasSharedParent(currentFile.path)
+              ? currentFile.dir_id
+              : currentFile._id
+          )
 
       setIsReadOnly(res)
     }
 
     getIsReadOnly()
-  }, [client, currentFile, hasWriteAccess, isPublic])
+  }, [client, currentFile, hasWriteAccess, hasSharedParent, isPublic])
 
   return (
     <AlertProvider>


### PR DESCRIPTION
When sharing a file from Cozy to Cozy, if a doc is not shared but inside a shared folder, the sharing must relies on the folder and not the file