### PR TITLE
feat(Viewer): Hides sharing panel until sharing is fully functional

### DIFF
--- a/packages/cozy-viewer/src/Panel/getPanelBlocks.jsx
+++ b/packages/cozy-viewer/src/Panel/getPanelBlocks.jsx
@@ -39,7 +39,7 @@ export const getPanelBlocksSpecs = (isPublic = false) => ({
     component: Informations
   },
   sharing: {
-    condition: () => !isPublic,
+    condition: () => false,
     component: Sharing
   }
 })


### PR DESCRIPTION
A new PR will come to adjust this condition with a props in the app