### PR TITLE
fix: Declare assetPrefixes for dev mode in shared Rsbuild configuration

### DIFF
--- a/config/rsbuild-config-cozy-app/getRsbuildConfig.js
+++ b/config/rsbuild-config-cozy-app/getRsbuildConfig.js
@@ -130,6 +130,9 @@ function getRsbuildConfig({
       },
       ...(hasPublic && {
         public: {
+          dev: {
+            assetPrefix: '/public'
+          },
           html: {
             template: './src/targets/public/index.ejs'
           },
@@ -149,6 +152,9 @@ function getRsbuildConfig({
       }),
       ...(hasIntents && {
         intents: {
+          dev: {
+            assetPrefix: '/intents'
+          },
           html: {
             template: './src/targets/intents/index.ejs'
           },


### PR DESCRIPTION
When in dev mode the `output.assetPrefix` value will be ignored, so we should also declare `assetPrefixes` in the `dev` section