### PR TITLE
fix: Prevent registering RealtimePlugin if it is already registered

### DIFF
--- a/packages/cozy-dataproxy-lib/src/search/@types/cozy-client.d.ts
+++ b/packages/cozy-dataproxy-lib/src/search/@types/cozy-client.d.ts
@@ -159,7 +159,8 @@ declare module 'cozy-client' {
   }
 
   export default class CozyClient {
-    plugins: unknown
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    plugins: Record<string, any>
     constructor(rawOptions?: ClientOptions)
     getStackClient(): StackClient
     getInstanceOptions(): InstanceOptions

--- a/packages/cozy-dataproxy-lib/src/search/@types/cozy-realtime.d.ts
+++ b/packages/cozy-dataproxy-lib/src/search/@types/cozy-realtime.d.ts
@@ -1,3 +1,4 @@
 declare module 'cozy-realtime' {
   export const RealtimePlugin = (): null => null
+  RealtimePlugin.pluginName = 'realtime'
 }

--- a/packages/cozy-dataproxy-lib/src/search/SearchEngine.ts
+++ b/packages/cozy-dataproxy-lib/src/search/SearchEngine.ts
@@ -127,7 +127,9 @@ export class SearchEngine {
     void this.indexDocuments()
 
     // Ensure login is done before plugin register
-    this.client.registerPlugin(RealtimePlugin, {})
+    if (!this.client.plugins[RealtimePlugin.pluginName]) {
+      this.client.registerPlugin(RealtimePlugin, {})
+    }
 
     // Realtime subscription
     this.handleUpdatedOrCreatedDoc = this.handleUpdatedOrCreatedDoc.bind(this)
@@ -139,7 +141,6 @@ export class SearchEngine {
 
   subscribeDoctype(client: CozyClient, doctype: string): void {
     /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/unbound-method */
-    // @ts-expect-error Client's plugins are not typed
     const realtime = client.plugins.realtime
     realtime.subscribe('created', doctype, this.handleUpdatedOrCreatedDoc)
     realtime.subscribe('updated', doctype, this.handleUpdatedOrCreatedDoc)


### PR DESCRIPTION
The flagship app already register the RealtimePlugin so the SearchEngine would try to register it a second time

We assume the consuming app should be responsible to do the registration so the solution would be to remove it from the SearchEngine initialization

But in order to ensure backward compatibility, we chose to keep the registration here but protected behind a check so the SearchEngine would register it only if not already registered