### PR TITLE
feat(Viewer): Upgrade cozy-sharing

### DIFF
--- a/packages/cozy-viewer/package.json
+++ b/packages/cozy-viewer/package.json
@@ -54,7 +54,7 @@
     "cozy-harvest-lib": ">=32.2.5",
     "cozy-intent": ">=2.29.1",
     "cozy-logger": ">=1.9.0",
-    "cozy-sharing": ">=21.0.0",
+    "cozy-sharing": ">=21.2.2",
     "cozy-ui": ">=117.2.0",
     "react": ">=16.12.0",
     "react-dom": ">=16.12.0"


### PR DESCRIPTION
BREAKING CHANGE: You must have `cozy-sharing >= 21.2.2`