### PR TITLE
feat: Do not rebuild search index from scratch 

### DIFF
--- a/packages/cozy-dataproxy-lib/package.json
+++ b/packages/cozy-dataproxy-lib/package.json
@@ -32,7 +32,7 @@
     "cozy-intent": "^2.29.2",
     "cozy-logger": "^1.16.1",
     "cozy-minilog": "^3.9.1",
-    "cozy-pouch-link": "^50.3.1",
+    "cozy-pouch-link": "^53.2.1",
     "cozy-realtime": "^5.6.3",
     "cozy-ui": "^111.19.0",
     "cross-fetch": "^4.0.0",

--- a/packages/cozy-dataproxy-lib/src/search/SearchEngine.ts
+++ b/packages/cozy-dataproxy-lib/src/search/SearchEngine.ts
@@ -310,11 +310,14 @@ export class SearchEngine {
     return index
   }
 
-  search(query: string, options: SearchOptions | undefined): SearchResult[] {
-    if (!this.searchIndexes) {
-      // TODO: What if the indexing is running but not finished yet?
+  search(
+    query: string,
+    options: SearchOptions | undefined
+  ): SearchResult[] | null {
+    if (!this.searchIndexes || Object.keys(this.searchIndexes).length < 1) {
+      // The indexing might be running but not finished yet
       log.warn('[SEARCH] No search index available')
-      return []
+      return null
     }
 
     const allResults = this.searchOnIndexes(query, options?.doctypes)

--- a/packages/cozy-dataproxy-lib/src/search/consts.ts
+++ b/packages/cozy-dataproxy-lib/src/search/consts.ts
@@ -38,3 +38,5 @@ export const DOCTYPE_DEFAULT_ORDER = {
   [CONTACTS_DOCTYPE]: 1,
   [FILES_DOCTYPE]: 2
 }
+
+export const DATAPROXY_STORAGE_PREFIX = '@dataproxy'

--- a/packages/cozy-dataproxy-lib/src/search/indexDocs.ts
+++ b/packages/cozy-dataproxy-lib/src/search/indexDocs.ts
@@ -1,0 +1,107 @@
+import FlexSearch from 'flexsearch'
+
+import CozyClient from 'cozy-client'
+
+import { SearchEngine } from './SearchEngine'
+import { SEARCH_SCHEMA } from './consts'
+import { getPouchLink } from './helpers/client'
+import { getSearchEncoder } from './helpers/getSearchEncoder'
+import {
+  addFilePaths,
+  computeFileFullpath,
+  shouldKeepFile
+} from './helpers/normalizeFile'
+import { CozyDoc, isIOCozyFile, SearchIndex } from './types'
+
+export const initSearchIndex = (
+  doctype: keyof typeof SEARCH_SCHEMA
+): FlexSearch.Document<CozyDoc, true> => {
+  const fieldsToIndex = SEARCH_SCHEMA[doctype]
+
+  const flexsearchIndex = new FlexSearch.Document<CozyDoc, true>({
+    tokenize: 'reverse', // See https://github.com/nextapps-de/flexsearch?tab=readme-ov-file#tokenizer
+    encode: getSearchEncoder(),
+    // @ts-expect-error minlength is not described by Flexsearch types but exists
+    minlength: 3,
+    document: {
+      id: '_id',
+      index: fieldsToIndex,
+      store: true
+    }
+  })
+  return flexsearchIndex
+}
+
+export const indexAllDocs = (
+  flexsearchIndex: FlexSearch.Document<CozyDoc, true>,
+  docs: CozyDoc[],
+  isLocalSearch: boolean
+): FlexSearch.Document<CozyDoc, true> => {
+  // There is no persisted path for files: we must add it
+  const completedDocs = isLocalSearch ? addFilePaths(docs) : docs
+  for (const doc of completedDocs) {
+    if (shouldIndexDoc(doc)) {
+      flexsearchIndex.add(doc)
+    } else {
+      // Should not index doc: remove it from index if it exists
+      flexsearchIndex.remove(doc._id!)
+    }
+  }
+  return flexsearchIndex
+}
+
+export const indexSingleDoc = async (
+  client: CozyClient,
+  flexsearchIndex: FlexSearch.Document<CozyDoc, true>,
+  doc: CozyDoc
+): Promise<void> => {
+  if (shouldIndexDoc(doc)) {
+    let docToIndex = doc
+    if (isIOCozyFile(doc)) {
+      // Add path for files
+      docToIndex = await computeFileFullpath(client, doc)
+    }
+    flexsearchIndex.add(docToIndex)
+  } else {
+    // Should not index doc: remove it from index if it exists
+    flexsearchIndex.remove(doc._id!)
+  }
+}
+
+export const indexOnChanges = async (
+  searchEngine: SearchEngine,
+  searchIndex: SearchIndex,
+  doctype: string
+): Promise<SearchIndex> => {
+  const pouchLink = getPouchLink(searchEngine.client)
+  if (!searchEngine.isLocalSearch || !pouchLink) {
+    // No need to handle incremental indexation for non-local search:
+    // it is already done through realtime
+    return searchIndex
+  }
+  const lastSeq = searchIndex.lastSeq || 0
+  const changes = await pouchLink.getChanges(doctype, {
+    include_docs: true,
+    since: lastSeq
+  })
+
+  for (const change of changes.results) {
+    if (change.deleted) {
+      searchIndex.index.remove(change.id)
+    } else {
+      const normalizedDoc = { ...change.doc, _type: doctype } as CozyDoc
+      void indexSingleDoc(searchEngine.client, searchIndex.index, normalizedDoc)
+    }
+  }
+
+  searchIndex.lastSeq = changes.last_seq
+  searchIndex.lastUpdated = new Date().toISOString()
+  return searchIndex
+}
+
+const shouldIndexDoc = (doc: CozyDoc): boolean => {
+  if (isIOCozyFile(doc)) {
+    return shouldKeepFile(doc)
+  }
+  return true
+}

--- a/packages/cozy-dataproxy-lib/src/search/storage.ts
+++ b/packages/cozy-dataproxy-lib/src/search/storage.ts
@@ -1,0 +1,128 @@
+import Minilog from 'cozy-minilog'
+
+import {
+  DATAPROXY_STORAGE_PREFIX,
+  SEARCH_SCHEMA,
+  SEARCHABLE_DOCTYPES,
+  SearchedDoctype
+} from './consts'
+import { initSearchIndex } from './indexDocs'
+import { CozyDoc, SearchIndex, SearchIndexes, StorageInterface } from './types'
+
+const log = Minilog('🗂️ [Index storage]')
+
+const EXPORT_DATE_KEY = 'searchExportDate'
+const INDEX_KEYS = 'searchIndexKeys'
+const LAST_SEQ_KEY = 'searchIndexLastSeq'
+const LAST_UPDATED_KEY = 'searchIndexLastUpdated'
+
+const buildStorageKey = (doctype: string, key: string): string => {
+  return `${DATAPROXY_STORAGE_PREFIX}:${doctype}:${key}`
+}
+
+export const persistExportDate = async (
+  storage: StorageInterface
+): Promise<void> => {
+  const date = new Date().toISOString()
+  await storage?.storeData(
+    `${DATAPROXY_STORAGE_PREFIX}:${EXPORT_DATE_KEY}`,
+    date
+  )
+}
+
+export const getExportDate = async (
+  storage: StorageInterface
+): Promise<string | null> => {
+  return storage?.getData<string>(
+    `${DATAPROXY_STORAGE_PREFIX}:${EXPORT_DATE_KEY}`
+  )
+}
+
+export const exportSearchIndexes = async (
+  storage: StorageInterface,
+  searchIndexes: SearchIndexes
+): Promise<void> => {
+  if (!storage) {
+    return
+  }
+  log.info('Start indexes export')
+
+  for (const key of Object.keys(searchIndexes)) {
+    const doctype = key as SearchedDoctype
+    const searchIndex = searchIndexes[doctype]
+    const keys: string[] = []
+
+    await searchIndex.index.export((key: string | number, data: unknown) => {
+      // do the saving as async
+      keys.push(key as string)
+      const value = JSON.stringify(data)
+      if (value) {
+        void storage.storeData(buildStorageKey(doctype, key as string), data)
+      }
+      return
+    })
+
+    await storage.storeData(buildStorageKey(doctype, INDEX_KEYS), keys)
+    await storage.storeData(
+      buildStorageKey(doctype, LAST_SEQ_KEY),
+      searchIndex.lastSeq
+    )
+    await storage.storeData(
+      buildStorageKey(doctype, LAST_UPDATED_KEY),
+      searchIndex.lastUpdated
+    )
+  }
+  await persistExportDate(storage)
+}
+
+export const importSearchIndexes = async (
+  storage: StorageInterface
+): Promise<SearchIndexes> => {
+  log.info('Start indexes import')
+
+  const searchIndexes = {} as SearchIndexes
+  if (!storage) {
+    return searchIndexes
+  }
+
+  for (const doctype of SEARCHABLE_DOCTYPES) {
+    const index = initSearchIndex(doctype as keyof typeof SEARCH_SCHEMA)
+    const startImportDoctype = performance.now()
+
+    const keys = await storage.getData<string[]>(
+      buildStorageKey(doctype, INDEX_KEYS)
+    )
+    if (!keys) {
+      log.warn(`No keys available to import index ${doctype}`)
+      continue
+    }
+
+    for (const key of keys) {
+      const data = await storage.getData<CozyDoc>(buildStorageKey(doctype, key))
+      if (data) {
+        await index.import(key, data)
+      }
+    }
+    const lastSeq = await storage.getData<number>(
+      buildStorageKey(doctype, LAST_SEQ_KEY)
+    )
+    const lastUpdated = await storage.getData<string>(
+      buildStorageKey(doctype, LAST_UPDATED_KEY)
+    )
+    const searchIndex: SearchIndex = {
+      index,
+      lastSeq,
+      lastUpdated
+    }
+    searchIndexes[doctype] = searchIndex
+
+    const endImportDoctype = performance.now()
+
+    log.debug(
+      `${doctype} import took ${(endImportDoctype - startImportDoctype).toFixed(
+        2
+      )} ms`
+    )
+  }
+  return searchIndexes
+}

--- a/packages/cozy-dataproxy-lib/src/search/types.ts
+++ b/packages/cozy-dataproxy-lib/src/search/types.ts
@@ -57,9 +57,14 @@ export interface SearchResult {
 export interface SearchIndex {
   index: FlexSearch.Document<CozyDoc, true>
   lastSeq: number | null
-  lastUpdated: string
+  lastUpdated: string | null
 }
 
 export type SearchIndexes = {
   [key in SearchedDoctype]: SearchIndex
+}
+
+export interface StorageInterface {
+  storeData(key: string, value: unknown): Promise<void>
+  getData<T>(key: string): Promise<T | null>
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11218,6 +11218,31 @@ cozy-client@^53.1.1:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
+cozy-client@^53.2.0:
+  version "53.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-53.2.0.tgz#e7e17dcd1bf235c12aae2d381c4201cae50d23b2"
+  integrity sha512-2DFhaNmagUJm2TpcOq81vLZL9J+IXGPSwccZQFQyoEWVK33n9vLzA09/zQs0XaUq+W3Hqq2mwZpjt8JjDSoSEQ==
+  dependencies:
+    "@cozy/minilog" "1.0.0"
+    "@types/jest" "^26.0.20"
+    "@types/lodash" "^4.14.170"
+    btoa "^1.2.1"
+    cozy-stack-client "^53.2.0"
+    date-fns "2.29.3"
+    json-stable-stringify "^1.0.1"
+    lodash "^4.17.13"
+    microee "^0.0.6"
+    node-fetch "^2.6.1"
+    node-polyglot "2.4.2"
+    open "7.4.2"
+    prop-types "^15.6.2"
+    react-redux "^7.2.0"
+    redux "3 || 4"
+    redux-thunk "^2.3.0"
+    server-destroy "^1.0.1"
+    sift "^6.0.0"
+    url-search-params-polyfill "^8.0.0"
+
 cozy-device-helper@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-2.0.0.tgz#1d08b6cb74709ef941b4d8214f13a6dc7e3910ec"
@@ -11278,12 +11303,21 @@ cozy-keys-lib@^6.1.1:
     tldjs "^2.3.1"
     zxcvbn "^4.4.2"
 
-cozy-pouch-link@^50.0.0, cozy-pouch-link@^50.3.1:
+cozy-pouch-link@^50.0.0:
   version "50.4.0"
   resolved "https://registry.yarnpkg.com/cozy-pouch-link/-/cozy-pouch-link-50.4.0.tgz#6cd18521a8652502783d35ec6735de40af47ce62"
   integrity sha512-7CkyEpsjjxE/24oMsxOcrQT+FWi7LPK0kYKx/KoiD7VX1QxHcZSubjnPjREJJkECs1JwIiAH5z/h99qVO4hArQ==
   dependencies:
     cozy-client "^50.4.0"
+    pouchdb-browser "^7.2.2"
+    pouchdb-find "^7.2.2"
+
+cozy-pouch-link@^53.2.1:
+  version "53.2.1"
+  resolved "https://registry.yarnpkg.com/cozy-pouch-link/-/cozy-pouch-link-53.2.1.tgz#395626335c8cb1fc24ecef837ab2b0078d146658"
+  integrity sha512-dw43+BRG+a4BkszuLc8EmzpwaXvFBWu1guSrPYkzzqCvmL4AGeULrnblepk8RN/Yw1dGUrjLJdNs8/UrXzOSGA==
+  dependencies:
+    cozy-client "^53.2.0"
     pouchdb-browser "^7.2.2"
     pouchdb-find "^7.2.2"
 
@@ -11355,6 +11389,15 @@ cozy-stack-client@^53.0.0:
   version "53.0.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-53.0.0.tgz#c3ad5354e4779547ce8fe58976ea79249fb64742"
   integrity sha512-gpQ+8qsRpip0brxavxgQqSoOAsR8KzpDxURPYtdeCa/00Xz1NIbXun29TWPVcNvVVNNZxbtpn0CBHyZpnVEDbw==
+  dependencies:
+    detect-node "^2.0.4"
+    mime "^2.4.0"
+    qs "^6.7.0"
+
+cozy-stack-client@^53.2.0:
+  version "53.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-53.2.0.tgz#434479d6617e4dd6c8135fcdc95f2697b0103692"
+  integrity sha512-iaK1LMMrBJJd10Y116xV9V9MORig6LtEmm6Jn9W821w+hkBkpV/QIKQHTEcerxyiydcqXQBm0c6jaFzmgTmL+g==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
Each time a searchEngine is instanciated, we used to rebuild the search
indexes from scratch, i.e. query the local database and compute the
indexes.  This can be quite time consuming, especially in slow mobile
devices. Therefore, we now export the search indexes on disk, and import
them at init time.  We save the lastSeq for each index, to be the
starting point of the next changes batch updates, fetched from the local
database after a remote replication.

Some measures, performed on a 8K files database:

**Redmi Note 10**

- Query all io.cozy.files : 3700ms
- Build files index : 6500ms
- **Total: 10200 ms**

- **Import persisted index: 800 ms**
- Export index: 1057ms

**OnePlus Nord 4**

- Query all io.cozy.files : 2000ms
- Build files index : 2900ms
- **Total: 4900 ms**

- **Import persisted index: 332 ms**
- Export index: 363ms

If we compare the query+build index time w.r.t the import time, we have
a ~13x time improvement before the index is ready to use.