### PR TITLE
fix: Reconnect realtime after refreshed token

### DIFF
--- a/packages/cozy-realtime/src/CozyRealtime.js
+++ b/packages/cozy-realtime/src/CozyRealtime.js
@@ -552,7 +552,7 @@ class CozyRealtime {
     // If this happenned, we should throw the socket and reconnect.
     //  Let's do that in all cases, as it won't be frequent anyways.
     if (this.hasWebSocket()) {
-      this.revokeWebSocket()
+      this.reconnect()
     }
   }
 


### PR DESCRIPTION
This is a good one: after a token refresh made by cozy-client, the handler `onClientTokenRefreshed` is called.
It is supposed to reconnect, as mentioned in the function comments. However, probably due to exhaustion or evil clipboard, the realtime was **revoked** rather than reconnected.

This was probably causing the realtime failures that we noticed before without spotting the source.