### PR TITLE
fix(Sharing): Don't rely anymore on parent to show file recipients

### DIFF
--- a/packages/cozy-sharing/src/components/ShareModal/EditableSharingModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal/EditableSharingModal.jsx
@@ -26,15 +26,6 @@ export const EditableSharingModal = ({ document, ...rest }) => {
     share
   } = useSharingContext()
 
-  const shareFileRefId = hasSharedParent(document.path)
-    ? document.dir_id
-    : document._id
-  const recipients = getRecipients(shareFileRefId)
-  const permissions = getDocumentPermissions(shareFileRefId)
-  const link = getSharingLink(shareFileRefId)
-  const sharing = getSharingForSelf(shareFileRefId)
-  const _isOwner = isOwner(shareFileRefId)
-
   return (
     <ShareModal
       createContact={contact => client.create(Contact.doctype, contact)}
@@ -42,14 +33,14 @@ export const EditableSharingModal = ({ document, ...rest }) => {
       documentType={documentType}
       hasSharedChild={documentPath && hasSharedChild(documentPath)}
       hasSharedParent={documentPath && hasSharedParent(documentPath)}
-      isOwner={_isOwner}
-      link={link}
+      isOwner={isOwner(document._id)}
+      link={getSharingLink(document._id)}
       onRevoke={revoke}
       onRevokeSelf={revokeSelf}
       onShare={share}
-      permissions={permissions}
-      recipients={recipients}
-      sharing={sharing}
+      permissions={getDocumentPermissions(document._id)}
+      recipients={getRecipients(document._id)}
+      sharing={getSharingForSelf(document._id)}
       {...rest}
     />
   )


### PR DESCRIPTION
We had done this for the Viewer display, but it causes problems for the Drive modal, which also displays the parent folder share instead of the file share. We're changing the approach here, and we'll change it in the Viewer too.