### PR TITLE
feat: Use parent origin instead of document.referrer

### DIFF
--- a/packages/cozy-external-bridge/README.md
+++ b/packages/cozy-external-bridge/README.md
@@ -24,8 +24,9 @@ Import `dist/embedded/bundle.js` script. It exposes method in `window._cozyBridg
 
 At first, you have the following methods in `window._cozyBridge` :
 
-- `isInsideCozy: () => boolean` : check if you are inside a Cozy iframe
-- `setupBridge: () => boolean` : setup bridge
+- `requestParentOrigin: () => Promise<string | undefined>` : request origin from parent iframe; returns undefined if not in an iframe or no answer from iframe
+- `isInsideCozy: (targetOrigin: string) => boolean` : check if target origin is a Cozy origin
+- `setupBridge: (targetOrigin: string) => boolean` : setup bridge to communicate with target origin
 
 After setupping bridge, you have the following methods in `window._cozyBridge` :
 

--- a/packages/cozy-external-bridge/package.json
+++ b/packages/cozy-external-bridge/package.json
@@ -62,7 +62,9 @@
     "build:types": "tsc -p tsconfig-build.json",
     "build:lib": "rspack build",
     "prepublishOnly": "yarn build",
-    "test": "jest --config=./tests/jest.config.js"
+    "test": "jest --config=./tests/jest.config.js",
+    "lint": "cd ../.. && yarn eslint --ext js,jsx,ts packages/cozy-external-bridge"
+
   },
   "types": "dist/index.d.ts"
 }

--- a/packages/cozy-external-bridge/src/container/helpers.ts
+++ b/packages/cozy-external-bridge/src/container/helpers.ts
@@ -10,7 +10,7 @@ export const extractUrl = (url: string): string => {
 export const handleRequestParentOrigin = (
   event: MessageEvent,
   origin: string
-) => {
+): void => {
   // We do not care about message from other origin that our iframe
   if (event.origin !== origin) {
     return

--- a/packages/cozy-external-bridge/src/container/helpers.ts
+++ b/packages/cozy-external-bridge/src/container/helpers.ts
@@ -6,3 +6,15 @@ export const extractUrl = (url: string): string => {
     return url
   }
 }
+
+export const handleRequestParentOrigin = (event: MessageEvent, origin: string) => {
+  // We do not care about message from other origin that our iframe
+  if (event.origin !== origin) {
+    return
+  }
+
+  if (event.source && event.data === 'requestParentOrigin') {
+      // @ts-expect-error TS typing is incorrect
+      event.source.postMessage('answerParentOrigin', event.origin);
+  }
+}

--- a/packages/cozy-external-bridge/src/container/helpers.ts
+++ b/packages/cozy-external-bridge/src/container/helpers.ts
@@ -7,14 +7,17 @@ export const extractUrl = (url: string): string => {
   }
 }
 
-export const handleRequestParentOrigin = (event: MessageEvent, origin: string) => {
+export const handleRequestParentOrigin = (
+  event: MessageEvent,
+  origin: string
+) => {
   // We do not care about message from other origin that our iframe
   if (event.origin !== origin) {
     return
   }
 
   if (event.source && event.data === 'requestParentOrigin') {
-      // @ts-expect-error TS typing is incorrect
-      event.source.postMessage('answerParentOrigin', event.origin);
+    // @ts-expect-error TS typing is incorrect
+    event.source.postMessage('answerParentOrigin', event.origin)
   }
 }

--- a/packages/cozy-external-bridge/src/container/index.ts
+++ b/packages/cozy-external-bridge/src/container/index.ts
@@ -59,13 +59,14 @@ const useParentOrigin = (origin: string) => {
   useEffect(() => {
     if (!client) return
 
-    const requestParentOriginHandler = (event: MessageEvent) => handleRequestParentOrigin(event, origin)
+    const requestParentOriginHandler = (event: MessageEvent) =>
+      handleRequestParentOrigin(event, origin)
 
-    window.addEventListener('message', requestParentOriginHandler);
+    window.addEventListener('message', requestParentOriginHandler)
 
     return () => {
-      window.removeEventListener('message', requestParentOriginHandler);
-    };
+      window.removeEventListener('message', requestParentOriginHandler)
+    }
   }, [client, origin])
 }
 

--- a/packages/cozy-external-bridge/src/container/index.ts
+++ b/packages/cozy-external-bridge/src/container/index.ts
@@ -53,13 +53,13 @@ const useInitialRedirection = (): void => {
 }
 
 // Allow the iframe to request the origin of the parent window
-const useParentOrigin = (origin: string) => {
+const useParentOrigin = (origin: string): void => {
   const client = useClient()
 
   useEffect(() => {
     if (!client) return
 
-    const requestParentOriginHandler = (event: MessageEvent) =>
+    const requestParentOriginHandler = (event: MessageEvent): void =>
       handleRequestParentOrigin(event, origin)
 
     window.addEventListener('message', requestParentOriginHandler)

--- a/packages/cozy-external-bridge/src/embedded/index.ts
+++ b/packages/cozy-external-bridge/src/embedded/index.ts
@@ -60,19 +60,19 @@ const getFlag = async (key: string): Promise<string | boolean> => {
 }
 
 const requestParentOrigin = (): Promise<string | undefined> => {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     // If we are not in an iframe, we return undefined directly
     if (window.self === window.parent) {
       return resolve(undefined)
     }
 
     const handleMessage = (event: any) => {
-      if (event.data === "answerParentOrigin") {
+      if (event.data === 'answerParentOrigin') {
         clearTimeout(timeout)
         window.removeEventListener('message', handleMessage)
         return resolve(event.origin)
       }
-    };
+    }
 
     window.addEventListener('message', handleMessage)
 
@@ -83,8 +83,8 @@ const requestParentOrigin = (): Promise<string | undefined> => {
       window.removeEventListener('message', handleMessage)
       return resolve(undefined)
     }, 1000)
-  });
-};
+  })
+}
 
 const isInsideCozy = (targetOrigin: string): boolean => {
   try {
@@ -106,7 +106,7 @@ const isInsideCozy = (targetOrigin: string): boolean => {
 }
 
 const setupBridge = (targetOrigin: string): void => {
-  if(!targetOrigin) {
+  if (!targetOrigin) {
     console.log('🟣 No target origin, doing nothing')
     return
   }

--- a/packages/cozy-external-bridge/src/embedded/index.ts
+++ b/packages/cozy-external-bridge/src/embedded/index.ts
@@ -66,7 +66,7 @@ const requestParentOrigin = (): Promise<string | undefined> => {
       return resolve(undefined)
     }
 
-    const handleMessage = (event: any) => {
+    const handleMessage = (event: MessageEvent): void => {
       if (event.data === 'answerParentOrigin') {
         clearTimeout(timeout)
         window.removeEventListener('message', handleMessage)


### PR DESCRIPTION
We sent message from iframe to origin infered document.referrer because document.referrer, when in an iframe, is set initially to the iframe URL. But if a redirection happens in the iframe (which happens during an oauth login) document.referrer is updated. So we sent message from iframe to the wrong origin.

Here we introduce a way to ask the parent window, if it exists, his origin. We just take the origin from the parent window answer metadata. We do not trust the parent window.

By doing this, bridge will be able to work even after a reload or a redirection inside the iframe.