### PR TITLE
fix: Do not rely on attributes

### DIFF
--- a/packages/cozy-sharing/__tests__/fixtures.js
+++ b/packages/cozy-sharing/__tests__/fixtures.js
@@ -326,8 +326,15 @@ export const PERM_WITHOUT_DOC = {
 
 export const APPS = [
   {
-    type: 'io.cozy.apps',
+    _type: 'io.cozy.apps',
     id: 'io.cozy.apps/drive',
+    _id: 'io.cozy.apps/drive',
+    name: 'Drive',
+    name_prefix: 'Cozy',
+    editor: 'Cozy',
+    type: 'webapp',
+    slug: 'drive',
+    state: 'ready',
     attributes: {
       name: 'Drive',
       name_prefix: 'Cozy',
@@ -343,8 +350,15 @@ export const APPS = [
     }
   },
   {
-    type: 'io.cozy.apps',
+    _type: 'io.cozy.apps',
     id: 'io.cozy.apps/photos',
+    _id: 'io.cozy.apps/photos',
+    name: 'Photos',
+    name_prefix: 'Cozy',
+    editor: 'Cozy',
+    type: 'webapp',
+    slug: 'photos',
+    state: 'ready',
     attributes: {
       name: 'Photos',
       name_prefix: 'Cozy',

--- a/packages/cozy-sharing/src/state.js
+++ b/packages/cozy-sharing/src/state.js
@@ -621,9 +621,7 @@ const getAppUrlForDoctype = (state, documentType) => {
 }
 
 const getAppUrl = (apps, appName) => {
-  const app = apps.find(
-    a => a.attributes.slug === appName && a.attributes.state === 'ready'
-  )
+  const app = apps.find(a => a?.slug === appName && a?.state === 'ready')
   if (!app) {
     throw new Error(`Sharing link: app ${appName} not installed`)
   }


### PR DESCRIPTION
The `attributes` object is provided in the stack response because of JSON-API formatting. However, the cozy-client normalization makes it useless because we spread all the content at the root document. Furthermore, relying on `attributes` for incoming situation where we query a local PouchDB rather than the stack.