### PR TITLE
feat: Add support for requestLink

### DIFF
--- a/packages/cozy-dataproxy-lib/src/dataproxy/DataProxyProvider.jsx
+++ b/packages/cozy-dataproxy-lib/src/dataproxy/DataProxyProvider.jsx
@@ -152,9 +152,19 @@ export const DataProxyProvider = React.memo(({ children }) => {
         return result
       }
 
+      // Request through cozy-client
+      const requestLink = async (operation, options) => {
+        log.log('Send request to DataProxy : ', operation)
+        if (options.fetchPolicy) {
+          // Functions cannot be serialized and thus passed to the iframe
+          delete options.fetchPolicy
+        }
+        return dataProxy.requestLink(operation, options)
+      }
       const newValue = {
         dataProxyServicesAvailable,
-        search
+        search,
+        requestLink
       }
 
       client.links.forEach(link => {


### PR DESCRIPTION
This adds the capacity to request the cozy-client through the DataProxy,
and then relying on local Pouch or remote Stack

:warning: This relies on #2772 that should be merged first