### PR TITLE
fix: Do not execute multiple times bridge methods

### DIFF
--- a/packages/cozy-external-bridge/src/container/useListenBridgeRequests.ts
+++ b/packages/cozy-external-bridge/src/container/useListenBridgeRequests.ts
@@ -25,6 +25,8 @@ export const useListenBridgeRequests = (
   const [isReady, setIsReady] = useState<boolean>(false)
 
   useEffect(() => {
+    if (isReady) return
+
     if (!client) return
 
     const exposedMethods = {


### PR DESCRIPTION
When navigating with updateHistory bridge methods, it was changing signature of navigate from react-router which lead to starting the bridge again and again. So we could then execute multiple times bridge methods.

Now we ensure we start only one time the bridge.