### PR TITLE
feat: Use specific extension for Docs notes

### DIFF
--- a/packages/cozy-external-bridge/src/container/useListenBridgeRequests.ts
+++ b/packages/cozy-external-bridge/src/container/useListenBridgeRequests.ts
@@ -54,9 +54,10 @@ export const useListenBridgeRequests = (
           .collection('io.cozy.files')
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           .createFile('Empty content', {
-            name: `New Docs ${new Date().toISOString()}.md`,
+            name: `New Docs ${new Date().toISOString()}.docs-note`,
             dirId,
-            metadata: { externalId }
+            metadata: { externalId },
+            contentType: 'text/markdown'
           })) as {
           data: Promise<object>
         }


### PR DESCRIPTION
Using `.md` extension for Docs notes makes sense, as it is indeed a markdown that is exported as file content.
However, this can be problematic in case the user uses the desktop client and ends up editing the markdown in an external editor: the markdown will be overwritten by Docs the next time the note is opened in the app.

To prevent such situation, we use a special `.docs-note` in the same spirit than `.cozy-note`. However, we keep the `text/markdown` mimetype to identify the file as true markdown.

Following https://github.com/cozy/cozy-drive/pull/3395