### PR TITLE
fix: Upload empty Docs file

### DIFF
--- a/packages/cozy-external-bridge/package.json
+++ b/packages/cozy-external-bridge/package.json
@@ -13,7 +13,7 @@
     "comlink": "4.4.1"
   },
   "peerDependencies": {
-    "cozy-client": ">=54.0.0",
+    "cozy-client": ">=58.4.0",
     "cozy-flags": ">=4.7.0",
     "cozy-minilog": ">=3.10.0",
     "react": ">=16.12.0",

--- a/packages/cozy-external-bridge/src/container/useListenBridgeRequests.ts
+++ b/packages/cozy-external-bridge/src/container/useListenBridgeRequests.ts
@@ -53,7 +53,7 @@ export const useListenBridgeRequests = (
         const { data: createdFile } = (await client
           .collection('io.cozy.files')
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          .createFile('Empty content', {
+          .createFile('', {
             name: `New Docs ${new Date().toISOString()}.docs-note`,
             dirId,
             metadata: { externalId },
@@ -87,22 +87,7 @@ export const useListenBridgeRequests = (
         if (!files || files.length < 1) return
 
         const file = files[0]
-
-        if (content) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-          const { data: uploadedFile } = (await client
-            .collection('io.cozy.files')
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-            .updateFile(content, {
-              fileId: file._id,
-              name: file.name,
-              metadata: file.metadata
-            })) as {
-            data: Promise<object>
-          }
-
-          return uploadedFile
-        } else if (name) {
+        if (name) {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-call
           const { data: updatedFile } = (await client
             .collection('io.cozy.files')
@@ -110,13 +95,29 @@ export const useListenBridgeRequests = (
             .update({
               id: file._id,
               metadata: file.metadata,
-              name: `${name}.md`
+              name: `${name}.docs-note`,
+              contentType: 'text/markdown'
             })) as {
             data: Promise<object>
           }
 
           return updatedFile
         }
+
+        // An undefined file content will throw on cozy-client side
+        const dataContent = content === undefined ? '' : content
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        const { data: uploadedFile } = (await client
+          .collection('io.cozy.files')
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+          .updateFile(dataContent, {
+            fileId: file._id,
+            name: file.name,
+            metadata: file.metadata
+          })) as {
+          data: Promise<object>
+        }
+        return uploadedFile
       },
       search: async (searchQuery: string): Promise<object[]> => {
         return await dataProxy.search(searchQuery)

--- a/yarn.lock
+++ b/yarn.lock
@@ -16711,7 +16711,7 @@ __metadata:
     react-router-dom: "npm:6.14.2"
     typescript: "npm:5.5.2"
   peerDependencies:
-    cozy-client: ">=54.0.0"
+    cozy-client: ">=58.4.0"
     cozy-flags: ">=4.7.0"
     cozy-minilog: ">=3.10.0"
     react: ">=16.12.0"


### PR DESCRIPTION
We now create empty Docs file at their creation to avoid any side-effect such as RAG indexation.
We also create Docs file with `.docs-note` extension to avoid any edition of the markdown by an external editor that would be overwritten by Docs.  See https://github.com/cozy/cozy-libs/pull/2789
 