### PR TITLE
feat(cozy-external-bridge): Expose notification API

### DIFF
--- a/packages/cozy-external-bridge/src/container/useListenBridgeRequests.ts
+++ b/packages/cozy-external-bridge/src/container/useListenBridgeRequests.ts
@@ -132,6 +132,19 @@ export const useListenBridgeRequests = (
           `Navigating to ${url} because received ${newUrl} from embedded app`
         )
         navigate(BRIDGE_ROUTE_PREFIX + url, { replace: true })
+      },
+      requestNotificationPermission:
+        async (): Promise<NotificationPermission> => {
+          return await Notification.requestPermission()
+        },
+      sendNotification: ({
+        title,
+        body
+      }: {
+        title: string
+        body: string
+      }): void => {
+        new Notification(title, { body })
       }
     }
 

--- a/packages/cozy-external-bridge/src/embedded/index.ts
+++ b/packages/cozy-external-bridge/src/embedded/index.ts
@@ -10,6 +10,8 @@ let availableMethods: {
   getFlag: (key: string) => Promise<string | boolean>
   createDocs: (data: object) => Promise<object>
   updateDocs: (data: object) => Promise<object>
+  requestNotificationPermission: () => Promise<NotificationPermission>
+  sendNotification: (data: { title: string; body: string }) => Promise<void>
   search: (searchQuery: string) => Promise<object[]>
 }
 
@@ -83,6 +85,27 @@ const search = async (searchQuery: string): Promise<object[]> => {
   return results
 }
 
+const requestNotificationPermission =
+  async (): Promise<NotificationPermission> => {
+    console.log('🟣 Requesting notification permission...')
+    const notificationPermission =
+      await availableMethods.requestNotificationPermission()
+    console.log(
+      '🟣 Notification permission request result: ',
+      notificationPermission
+    )
+    return notificationPermission
+  }
+
+const sendNotification = async (data: {
+  title: string
+  body: string
+}): Promise<void> => {
+  console.log('🟣 Sending notification...')
+  await availableMethods.sendNotification(data)
+  console.log('🟣 Notification sent')
+}
+
 const requestParentOrigin = (): Promise<string | undefined> => {
   return new Promise(resolve => {
     // If we are not in an iframe, we return undefined directly
@@ -153,6 +176,8 @@ const setupBridge = (targetOrigin: string): void => {
     getFlag,
     createDocs,
     updateDocs,
+    requestNotificationPermission,
+    sendNotification,
     search
   }
 


### PR DESCRIPTION
Notifications can not be requested and sent from iframe. So let's expose this API in the bridge so the parent frame can execute these methods.

For the moment in draft to talk about the API.