### PR TITLE
fix: Upgrade cozy-client peerDep to use search

### DIFF
--- a/packages/cozy-search/package.json
+++ b/packages/cozy-search/package.json
@@ -57,7 +57,7 @@
     "./dist/stylesheet.css": "./dist/stylesheet.css"
   },
   "peerDependencies": {
-    "cozy-client": ">=54.0.0",
+    "cozy-client": ">=54.8.0",
     "cozy-device-helper": ">=3.7.1",
     "cozy-flags": ">=4.6.1",
     "cozy-intent": ">=2.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17153,7 +17153,7 @@ __metadata:
     stylus: "npm:^0.64.0"
     typescript: "npm:5.5.2"
   peerDependencies:
-    cozy-client: ">=54.0.0"
+    cozy-client: ">=54.8.0"
     cozy-device-helper: ">=3.7.1"
     cozy-flags: ">=4.6.1"
     cozy-intent: ">=2.26.0"


### PR DESCRIPTION
Required to benefit from https://github.com/cozy/cozy-client/pull/1612/commits/afc97303f7b38ac0645b94e9e51219e579defb08