### PR TITLE
fix: Remove LLM sources tags

### DIFF
--- a/packages/cozy-search/src/components/Conversations/ChatItemLabel.jsx
+++ b/packages/cozy-search/src/components/Conversations/ChatItemLabel.jsx
@@ -2,9 +2,23 @@ import React from 'react'
 
 import Markdown from 'cozy-ui/transpiled/react/Markdown'
 
+/**
+ * Sanitize chat content by removing special sources tags like
+ * [REF]...[/REF] or [doc_X] that are not currently handled.
+ *
+ * @param {string} content - content to sanitize
+ * @returns {string} sanitized content
+ */
+const sanitizeContent = content => {
+  return content
+    .replace(/\s?\[REF\][\s\S]*?\[\/REF\]/g, '')
+    .replace(/\s?\[doc_\d+\]/g, '')
+}
+
 const ChatItemLabel = ({ label }) => {
+  const content = sanitizeContent(label)
   if (typeof label === 'string') {
-    return <Markdown content={label} />
+    return <Markdown content={content} />
   }
 
   return label


### PR DESCRIPTION
Some LLM adds special sources tags such as `[REF]doc_X[/REF]` or `[doc_X]`.  As it is not handled by the UI, we simply remove them.