### PR TITLE
feat: Improve sharings retrieval performances

### DIFF
--- a/packages/cozy-sharing/src/SharingProvider.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.jsx
@@ -186,7 +186,7 @@ export class SharingProvider extends Component {
     }
     const { doctype, client } = this.props
     const [sharings, permissions, apps] = await Promise.all([
-      this.sharingCol.findByDoctype(doctype),
+      this.sharingCol.findByDoctype(doctype, { withSharedDocs: false }),
       this.permissionCol.findLinksByDoctype(doctype),
       client.fetchQueryAndGetFromState(fetchApps())
     ])


### PR DESCRIPTION
When dealing with large sharings, requesting the list of sharings can be quite slow, i.e. several seconds.  This is because by default this route returns the list of *all* shared docs. So if we deal with thousands of docs, this is slow to compute and transmit.

We do not need this list of shared docs, so let's disable it.

Rely on https://github.com/cozy/cozy-stack/pull/4548 and https://github.com/cozy/cozy-client/pull/1619