### PR TITLE
Edgecases search

### DIFF
--- a/packages/cozy-dataproxy-lib/src/search/indexDocs.spec.js
+++ b/packages/cozy-dataproxy-lib/src/search/indexDocs.spec.js
@@ -1,0 +1,94 @@
+import { initSearchIndex } from './indexDocs'
+
+describe('indexDocs', () => {
+  it('should create a flexsearch index', () => {
+    const flexsearchIndex = initSearchIndex('io.cozy.files')
+    expect(flexsearchIndex).toBeDefined()
+  })
+
+  it('should correctly index a file on name', () => {
+    const flexsearchIndex = initSearchIndex('io.cozy.files')
+    const doc = {
+      _id: '1',
+      name: 'test'
+    }
+    flexsearchIndex.add(doc)
+    expect(flexsearchIndex.search('test')).toEqual([
+      {
+        field: 'name',
+        result: ['1']
+      }
+    ])
+  })
+
+  it('should correctly index a file on path', () => {
+    const flexsearchIndex = initSearchIndex('io.cozy.files')
+    const doc = {
+      _id: '1',
+      path: '/mypath/test'
+    }
+    flexsearchIndex.add(doc)
+    expect(flexsearchIndex.search('test')).toEqual([
+      {
+        field: 'path',
+        result: ['1']
+      }
+    ])
+  })
+
+  it('should correctly index string with accents thanks to encoder', () => {
+    const flexsearchIndex = initSearchIndex('io.cozy.files')
+    const doc1 = {
+      _id: '1',
+      name: 'ééébbb'
+    }
+    const doc2 = {
+      _id: '2',
+      name: 'àààbbb'
+    }
+    flexsearchIndex.add(doc1)
+    flexsearchIndex.add(doc2)
+    expect(flexsearchIndex.search('eeebb')).toEqual([
+      {
+        field: 'name',
+        result: ['1']
+      }
+    ])
+
+    expect(flexsearchIndex.search('ééé')).toEqual([
+      {
+        field: 'name',
+        result: ['1']
+      }
+    ])
+    expect(flexsearchIndex.search('aaa')).toEqual([
+      {
+        field: 'name',
+        result: ['2']
+      }
+    ])
+    expect(flexsearchIndex.search('ààà')).toEqual([
+      {
+        field: 'name',
+        result: ['2']
+      }
+    ])
+  })
+
+  it('should correctly index tricky strings', () => {
+    const flexsearchIndex = initSearchIndex('io.cozy.files')
+    // The tokenizer will tokenize 'UI-UX' as ['UI', 'UX'], so it will work
+    // only if the character length is at least 2
+    const doc = {
+      _id: '3',
+      name: 'UI-UX Guideline.cozy-note'
+    }
+    flexsearchIndex.add(doc)
+    expect(flexsearchIndex.search('UI-UX')).toEqual([
+      {
+        field: 'name',
+        result: ['3']
+      }
+    ])
+  })
+})

--- a/packages/cozy-dataproxy-lib/src/search/indexDocs.ts
+++ b/packages/cozy-dataproxy-lib/src/search/indexDocs.ts
@@ -21,7 +21,7 @@ export const initSearchIndex = (
     tokenize: 'reverse', // See https://github.com/nextapps-de/flexsearch?tab=readme-ov-file#tokenizer
     encode: getSearchEncoder(),
     // @ts-expect-error minlength is not described by Flexsearch types but exists
-    minlength: 3,
+    minlength: 2,
     document: {
       id: '_id',
       index: fieldsToIndex,

--- a/packages/cozy-dataproxy-lib/tests/jest.config.js
+++ b/packages/cozy-dataproxy-lib/tests/jest.config.js
@@ -11,6 +11,7 @@ const config = {
     './src/search/types.ts',
     './src/search/helpers/getSearchEncoder.ts'
   ],
+  transformIgnorePatterns: ['node_modules/(?!(flexsearch)/)'],
   rootDir: '../',
   testMatch: ['./**/*.spec.{ts,tsx,js}'],
   coverageThreshold: {


### PR DESCRIPTION
With the current search setting, this case was not working:

```
filename: "UI-UX Guideline.cozy-note"
search: "UI-UX"
```

This is because the tokenizer takes the `-` as a separator and we end up
with ["UI", "UX"] tokens. As the minimal word length was 3, they were
skipped from the indexation.

So, we now specify a 2 minimal word length to handle this kind of cases.
Note this will slightly increase the index size