### PR TITLE
fix: Correct link in clipboard when sharing an album

### DIFF
--- a/packages/cozy-sharing/src/components/ShareRestrictionModal/ShareRestrictionModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareRestrictionModal/ShareRestrictionModal.jsx
@@ -18,6 +18,7 @@ import {
   revokePermissions,
   createPermissions
 } from './helpers'
+import { getAppSlugFromDocumentType } from '../../helpers/link'
 import {
   checkIsPermissionHasExpiresDate,
   checkIsPermissionHasPassword,
@@ -90,7 +91,7 @@ export const ShareRestrictionModal = ({ file, onClose }) => {
         cozyUrl: client.getStackClient().uri,
         searchParams: [['sharecode', perms.attributes.shortcodes.code]],
         pathname: '/public',
-        slug: 'drive',
+        slug: getAppSlugFromDocumentType({ documentType }),
         subDomainType: client.capabilities.flat_subdomains ? 'flat' : 'nested'
       })
       await copyToClipboard(url, { t, showAlert })
@@ -112,7 +113,7 @@ export const ShareRestrictionModal = ({ file, onClose }) => {
         cozyUrl: client.getStackClient().uri,
         searchParams: [['sharecode', perms.attributes.shortcodes.code]],
         pathname: '/public',
-        slug: 'drive',
+        slug: getAppSlugFromDocumentType({ documentType }),
         subDomainType: client.capabilities.flat_subdomains ? 'flat' : 'nested'
       })
       await copyToClipboard(url, { t, showAlert })

--- a/packages/cozy-sharing/src/helpers/link.js
+++ b/packages/cozy-sharing/src/helpers/link.js
@@ -2,3 +2,12 @@ import { DOCUMENT_TYPE } from './documentType'
 
 export const isOnlyReadOnlyLinkAllowed = ({ documentType }) =>
   documentType === DOCUMENT_TYPE.ALBUMS
+
+export const getAppSlugFromDocumentType = ({ documentType }) => {
+  switch (documentType) {
+    case DOCUMENT_TYPE.ALBUMS:
+      return 'photos'
+    default:
+      return 'drive'
+  }
+}


### PR DESCRIPTION
When creating or modifying a share by link for an album, it was generating and copying in clipboard a link to drive app instead of photos app.

This is not an issue for notes.