### PR TITLE
fix: Do not replace replaceState by pushState to avoid strange behavior

### DIFF
--- a/packages/cozy-external-bridge/src/embedded/index.ts
+++ b/packages/cozy-external-bridge/src/embedded/index.ts
@@ -18,7 +18,7 @@ let availableMethods: {
 // eslint-disable-next-line @typescript-eslint/unbound-method
 const originalPushState = history.pushState
 // eslint-disable-next-line @typescript-eslint/unbound-method
-const originalReplaceState = history.pushState
+const originalReplaceState = history.replaceState
 
 const onPopstate = (): void => {
   availableMethods.updateHistory(document.location.href)


### PR DESCRIPTION
To be able to synchronize history between embedded and container apps, we need to patch history.pushState and history.replaceState. But I made a mistake in the patch leading to strange behavior in embedded apps.

Thanks to @Crash-- that spot the issue 🙏