### PR TITLE
feat: Update withFileUrl and Toolbar to be used in shared drive :sparkles:

### DIFF
--- a/packages/cozy-viewer/src/components/Toolbar.jsx
+++ b/packages/cozy-viewer/src/components/Toolbar.jsx
@@ -112,7 +112,8 @@ const Toolbar = ({
             onClick={() =>
               download({ encryptedUrl: url }).action([file], {
                 client,
-                webviewIntent
+                webviewIntent,
+                driveId: file.driveId
               })
             }
           />

--- a/packages/cozy-viewer/src/hoc/withFileUrl.jsx
+++ b/packages/cozy-viewer/src/hoc/withFileUrl.jsx
@@ -65,7 +65,7 @@ const withFileUrl = BaseComponent =>
 
     getDownloadLink(file) {
       return this.context.client
-        .collection('io.cozy.files')
+        .collection('io.cozy.files', { driveId: file.driveId })
         .getDownloadLinkById(file._id, file.name)
     }
 


### PR DESCRIPTION
### What has been changed?

To view a file in shared drive, the file should be downloaded with `driveId`, so `withFileUrl` and `Toolbar` need to be added `driveId` into download action

### Related issue:

[cozy/cozy-drive#2807](https://github.com/cozy/cozy-drive/pull/3436)