### PR TITLE
Update in-memory fullpaths after file rename

### DIFF
--- a/packages/cozy-dataproxy-lib/src/search/SearchEngine.ts
+++ b/packages/cozy-dataproxy-lib/src/search/SearchEngine.ts
@@ -197,6 +197,9 @@ export class SearchEngine {
     this.subscribeDoctype(this.client, CONTACTS_DOCTYPE)
     this.subscribeDoctype(this.client, APPS_DOCTYPE)
 
+    if (this.isLocalSearch) {
+      this.debouncedReplication()
+    }
     // The document indexing should be performed once everything is setup
     await this.indexDocumentsAtInit()
   }
@@ -221,11 +224,10 @@ export class SearchEngine {
       return
     }
     log.debug('[REALTIME] Update doc from index after update : ', doc._id)
-    void indexSingleDoc(this.client, searchIndex.index, doc)
-
     if (this.isLocalSearch) {
       this.debouncedReplication()
     }
+    void indexSingleDoc(this.client, searchIndex.index, doc)
   }
 
   handleDeletedDoc(doc: CozyDoc): void {

--- a/packages/cozy-dataproxy-lib/src/search/helpers/filePaths.spec.ts
+++ b/packages/cozy-dataproxy-lib/src/search/helpers/filePaths.spec.ts
@@ -131,3 +131,38 @@ describe('computeFileFullpath', () => {
     expect(res.path).toEqual('ROOT/MYDIR/file3')
   })
 })
+
+describe('it should correctly handle in-memory paths', () => {
+  beforeEach(() => {
+    resetAllPaths()
+  })
+
+  const dir = {
+    _id: '123',
+    _type: 'io.cozy.files',
+    type: 'directory',
+    dir_id: 'ROOT',
+    name: 'MYDIR',
+    path: 'ROOT/MYDIR'
+  } as IOCozyFile
+  const filewithNoPath = {
+    _id: '000',
+    _type: 'io.cozy.files',
+    type: 'file',
+    dir_id: '123',
+    name: 'file3'
+  } as IOCozyFile
+
+  it('should compute correct path on file', async () => {
+    setFilePaths([dir, filewithNoPath])
+    const res = await computeFileFullpath(client, filewithNoPath)
+    expect(res.path).toEqual('ROOT/MYDIR/file3')
+  })
+
+  it('should compute correct path on file after rename', async () => {
+    setFilePaths([dir, filewithNoPath])
+    const newFileWithFullPath = { ...filewithNoPath, name: 'file4' }
+    const res = await computeFileFullpath(client, newFileWithFullPath)
+    expect(res.path).toEqual('ROOT/MYDIR/file4')
+  })
+})

--- a/packages/cozy-dataproxy-lib/src/search/helpers/normalizeSearchResult.ts
+++ b/packages/cozy-dataproxy-lib/src/search/helpers/normalizeSearchResult.ts
@@ -53,6 +53,10 @@ export const getCleanedFilePath = (doc: CozyDoc): CozyDoc => {
     // Remove the name from the path, which is added at indexing time to search on it
     newPath = path.slice(0, -doc.name.length - 1)
   }
+  if (!newPath) {
+    // Special case for root path
+    newPath = '/'
+  }
 
   return { ...doc, path: newPath }
 }

--- a/packages/cozy-dataproxy-lib/src/search/helpers/normalizeSearchResult.ts
+++ b/packages/cozy-dataproxy-lib/src/search/helpers/normalizeSearchResult.ts
@@ -278,14 +278,17 @@ export const enrichResultsWithDocs = async (
   }
   const docsMap = new Map(docs?.map(doc => [doc._id, doc]))
 
+  const filteredResults = []
   for (const res of enrichedResults) {
     const id = res.id?.toString() // Because of flexsearch Id typing
     const doc = docsMap.get(id)
     if (!doc) {
+      // TODO: remove missing docs from search index
       log.error(`${id} is found in search but not in local data`)
     } else {
       res.doc = doc
+      filteredResults.push(res)
     }
   }
-  return enrichedResults
+  return filteredResults
 }


### PR DESCRIPTION
We noticed the search results are not immediatly updated after a file rename.
This is because the files fullpath are stored in-memory in a Map when relying on PouchDB, as paths are not stored, and we want to speed up their retrieval.
We missed a case to update the in-memory Map after a file change.

This PR also include small fixes that were discovered on the road. 
 