### PR TITLE
feat: Always render dataproxy children

### DIFF
--- a/packages/cozy-dataproxy-lib/package.json
+++ b/packages/cozy-dataproxy-lib/package.json
@@ -21,7 +21,7 @@
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-tsconfig-paths": "^1.0.3",
     "babel-preset-cozy-app": "^2.8.1",
-    "cozy-client": "^54.0.0",
+    "cozy-client": "^60.2.0",
     "cozy-device-helper": "^4.0.0",
     "cozy-flags": "^4.7.0",
     "cozy-intent": "^2.30.0",
@@ -51,7 +51,7 @@
     ".": "./dist/index.js"
   },
   "peerDependencies": {
-    "cozy-client": ">=54.0.0",
+    "cozy-client": ">=60.2.0",
     "cozy-device-helper": ">=3.7.1",
     "cozy-flags": ">=4.6.1",
     "cozy-intent": ">=2.26.0",

--- a/packages/cozy-dataproxy-lib/src/dataproxy/DataProxyProvider.jsx
+++ b/packages/cozy-dataproxy-lib/src/dataproxy/DataProxyProvider.jsx
@@ -185,7 +185,7 @@ export const DataProxyProvider = React.memo(({ children }) => {
 
   return (
     <DataProxyContext.Provider value={dataProxy || {}}>
-      {(dataProxyServicesAvailable === false || dataProxy) && children}
+      {children}
       {iframeUrl ? (
         <iframe
           id="DataProxy"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16663,6 +16663,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cozy-client@npm:^60.2.0":
+  version: 60.3.0
+  resolution: "cozy-client@npm:60.3.0"
+  dependencies:
+    "@cozy/minilog": "npm:1.0.0"
+    "@fastify/deepmerge": "npm:^2.0.2"
+    "@types/jest": "npm:^26.0.20"
+    "@types/lodash": "npm:^4.14.170"
+    btoa: "npm:^1.2.1"
+    cozy-stack-client: "npm:^60.1.0"
+    date-fns: "npm:2.29.3"
+    fast-deep-equal: "npm:^3.1.3"
+    json-stable-stringify: "npm:^1.0.1"
+    lodash: "npm:^4.17.13"
+    microee: "npm:^0.0.6"
+    node-fetch: "npm:^2.6.1"
+    node-polyglot: "npm:2.4.2"
+    open: "npm:7.4.2"
+    prop-types: "npm:^15.6.2"
+    react-redux: "npm:^7.2.0"
+    redux: "npm:3 || 4"
+    redux-thunk: "npm:^2.3.0"
+    server-destroy: "npm:^1.0.1"
+    sift: "npm:^6.0.0"
+    url-search-params-polyfill: "npm:^8.0.0"
+  peerDependencies:
+    cozy-device-helper: ">=2.1.0"
+    cozy-flags: ">2.8.6"
+    cozy-intent: ">=2.23.0"
+    cozy-logger: ">1.7.0"
+    react: ^16.7.0
+    react-native: ~0.63.5
+    react-native-google-play-integrity: ^1.1.0
+    react-native-inappbrowser-reborn: ^3.5.1
+    react-native-ios11-devicecheck: ^0.0.3
+  checksum: 10c0/77fe471ecf767cdc8041e59fd3de1566c3d8c9cf8e1a7e8c97e8502c62138cc0bffb88d5f75f2dc6d84076e1d5296254db5c6f1b3c5249158a7b0f1d940557a3
+  languageName: node
+  linkType: hard
+
 "cozy-client@npm:^60.5.0":
   version: 60.5.0
   resolution: "cozy-client@npm:60.5.0"
@@ -16714,7 +16753,7 @@ __metadata:
     babel-plugin-tsconfig-paths: "npm:^1.0.3"
     babel-preset-cozy-app: "npm:^2.8.1"
     comlink: "npm:4.4.1"
-    cozy-client: "npm:^54.0.0"
+    cozy-client: "npm:^60.2.0"
     cozy-device-helper: "npm:^4.0.0"
     cozy-flags: "npm:^4.7.0"
     cozy-intent: "npm:^2.30.0"
@@ -16730,7 +16769,7 @@ __metadata:
     react-router-dom: "npm:6.14.2"
     typescript: "npm:5.5.2"
   peerDependencies:
-    cozy-client: ">=54.0.0"
+    cozy-client: ">=60.2.0"
     cozy-device-helper: ">=3.7.1"
     cozy-flags: ">=4.6.1"
     cozy-intent: ">=2.26.0"


### PR DESCRIPTION
Previously, the rendering of `DataProxyProvider` children were conditioned by the initialization of the dataproxy.

It was because we wanted to avoid timing issues, were the App started to use the DataProxy before it was actually ready.  See https://github.com/cozy/cozy-libs/commit/bdb16705103fa222d631750403d951eee61f4868

We later made it less strict, because if anything make the dataproxy not initialized, nothing is displayed on the app side with no logs, making it hard to debug for the developer.  See
https://github.com/cozy/cozy-libs/pull/2801

However, we still met situations with no rendering, because the dataproxy was not available at all:

- Public sharing: https://github.com/cozy/cozy-drive/pull/3439
- Unsupported shared workers: https://github.com/cozy/cozy-web-data-proxy/pull/36

So now, we always render children, and expect the `DataProxyLink` to handle queries made on non-ready DataProxy by queuing them: https://github.com/cozy/cozy-client/pull/1622