### PR TITLE
chore: Display warning for long commit body lines

### DIFF
--- a/packages/commitlint-config-cozy/index.js
+++ b/packages/commitlint-config-cozy/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   rules: {
     'body-leading-blank': [1, 'always'],
-    'body-max-line-length': [2, 'always', 72],
+    'body-max-line-length': [1, 'always', 72],
     'footer-leading-blank': [1, 'always'],
     'header-max-length': [2, 'always', 72],
     'scope-case': [0, 'always', 'lower-case'],

--- a/packages/commitlint-config-cozy/index.spec.js
+++ b/packages/commitlint-config-cozy/index.spec.js
@@ -67,7 +67,7 @@ describe('Commitlint Config Cozy', () => {
         `fix: Bar\n\nWith a small body\n${TOO_LONG}`
       ]
       for (const body of invalidBody) {
-        expect((await lint(body, rules)).valid).toBeFalsy()
+        expect((await lint(body, rules)).warnings.length).toBe(1)
       }
     })
   })


### PR DESCRIPTION
We used to have an error for commit body lines > 72. This is quite annoying because it forces the dev to redo the commit. Furthermore, this rule is not always legitimate, typically when one want to put a long URL, forcing to add a line break in the URL.

So let's display a warning rather than an error.