### PR TITLE
fix: Remove black background in add recipient input :bug:

### DIFF
--- a/packages/cozy-sharing/src/components/ShareAutosuggest.jsx
+++ b/packages/cozy-sharing/src/components/ShareAutosuggest.jsx
@@ -191,7 +191,8 @@ const ShareAutocomplete = ({
         onBlur: onAutosuggestBlur,
         value: inputValue,
         type: 'email',
-        placeholder
+        placeholder,
+        className: styles['suggestionInput']
       }}
     />
   )

--- a/packages/cozy-sharing/src/styles/autosuggest.styl
+++ b/packages/cozy-sharing/src/styles/autosuggest.styl
@@ -30,6 +30,9 @@
 .suggestionHighlighted
     background var(--actionColorSelected)
 
+.suggestionInput
+  background unset
+
 .recipientsContainer
     display flex
     flex-wrap wrap


### PR DESCRIPTION
### Change:

Remove the black background in Add recipient input in Add shared drive modal.

### Result:

<img width="1122" height="824" alt="CleanShot 2025-09-15 at 09 26 43@2x" src="https://github.com/user-attachments/assets/350bc318-018e-46a9-b73a-cf84e58383e9" />

<img width="1108" height="804" alt="CleanShot 2025-09-15 at 09 26 28@2x" src="https://github.com/user-attachments/assets/caaa8f10-a1ae-4a81-b517-17346a1c5c4e" />

### Note:

Upgrade cozy-sharing version in cozy-drive after merging this PR
