### PR TITLE
fix: Set correct link to open shared drive from toolbar :bug:

### DIFF
--- a/packages/cozy-viewer/src/components/ToolbarFilePath.jsx
+++ b/packages/cozy-viewer/src/components/ToolbarFilePath.jsx
@@ -38,7 +38,9 @@ const ToolbarFilePath = () => {
 
   if (fileWithPath) {
     const appSlug = 'drive'
-    const nativePath = `/folder/${fileWithPath.dir_id}`
+    const nativePath = fileWithPath.driveId
+      ? `/shareddrive/${fileWithPath.driveId}/${fileWithPath.dir_id}`
+      : `/folder/${fileWithPath.dir_id}`
     const path = removeFilenameFromPath(fileWithPath.path)
     const link = makeWebLink({ client, path: nativePath, slug: appSlug })
 


### PR DESCRIPTION
### Change:

Set the correct file path in toolbar of file viewer

### Related to:

[cozy/cozy-drive#3470](https://github.com/cozy/cozy-drive/pull/3470)
