### PR TITLE
feat(cozy-realtime): Add support for shared drives files

### DIFF
--- a/packages/cozy-realtime/src/CozyRealtime.js
+++ b/packages/cozy-realtime/src/CozyRealtime.js
@@ -34,8 +34,10 @@ class CozyRealtime {
    * @param {CozyClient}  options.client A cozy-client instance
    * @param {Function} [options.createWebSocket] The function used to create WebSocket instances
    * @param {object} [options.logger] A custom logger
+   * @param {string} [options.sharedDriveId] - The ID of the shared drive to connect to
    */
   constructor(options) {
+    this.sharedDriveId = options.sharedDriveId
     this.client = getCozyClientFromOptions(options)
     this.createWebSocket = options.createWebSocket || createWebSocket
     this.logger = options.logger || defaultLogger
@@ -83,7 +85,7 @@ class CozyRealtime {
       this.revokeWebSocket()
     }
     this.logger.info('creating a new websocket…')
-    const url = getUrl(this.client)
+    const url = getUrl(this.client, this.sharedDriveId)
     try {
       this.websocket = this.createWebSocket(url, protocol)
       this.websocket.authenticated = false
@@ -295,7 +297,7 @@ class CozyRealtime {
     const has = this.subscriptions.hasSameTypeAndId(sub)
     this.subscriptions.add(sub)
     // send to the server if there wasn't any subscription with that type & id before
-    if (!has && this.isWebSocketAuthenticated()) {
+    if (!this.sharedDriveId && !has && this.isWebSocketAuthenticated()) {
       this.sendSubscription(sub.type, sub.id)
     }
   }
@@ -316,7 +318,7 @@ class CozyRealtime {
     // if there is no more subscription of this type & id
     // then unsubscribe to the server
     const has = this.subscriptions.hasSameTypeAndId(sub)
-    if (!has && this.isWebSocketAuthenticated()) {
+    if (!this.sharedDriveId && !has && this.isWebSocketAuthenticated()) {
       this.sendUnsubscription(sub.type, sub.id)
     }
     // if this was the last subscription, stop the realtime

--- a/packages/cozy-realtime/src/CozyRealtime.spec.js
+++ b/packages/cozy-realtime/src/CozyRealtime.spec.js
@@ -539,6 +539,26 @@ describe('CozyRealtime', () => {
     })
   })
 
+  describe('with sharedDriveId', () => {
+    it('creates a WebSocket using the shared drive URL when provided', async () => {
+      const createWebSocket = jest.fn()
+      const sharedDriveId = 'drive-123'
+      const sharedDriveWsURI =
+        defaultClientUri.replace(/^http/, 'ws') +
+        `sharings/drives/${sharedDriveId}/realtime`
+
+      createSocketServer({ wsuri: sharedDriveWsURI })
+      const realtime = createRealtime({ createWebSocket, sharedDriveId })
+
+      const handler = jest.fn()
+      realtime.subscribe(event, type, handler)
+
+      await sleep(100)
+
+      expect(createWebSocket).toHaveBeenCalledWith(sharedDriveWsURI, protocol)
+    })
+  })
+
   describe('cozy-client events', () => {
     describe('login', () => {
       it('should authenticate again', async () => {

--- a/packages/cozy-realtime/src/utils.js
+++ b/packages/cozy-realtime/src/utils.js
@@ -53,11 +53,13 @@ function getInstanceUri(client) {
  * @param {CozyClient} client - CozyClient instance
  * @return {string} WebSocket url
  */
-export function getUrl(client) {
+export function getUrl(client, sharedDriveId) {
   const url = getInstanceUri(client)
   const protocol = isSecureUrl(url) ? 'wss:' : 'ws:'
   const host = new URL(url).host
-  return `${protocol}//${host}/realtime/`
+  return sharedDriveId
+    ? `${protocol}//${host}/sharings/drives/${sharedDriveId}/realtime`
+    : `${protocol}//${host}/realtime/`
 }
 
 /**


### PR DESCRIPTION
If you want to activate realtime on a given shared drive : 

```javascript
import CozyRealtime from 'cozy-realtime'

const client = ...
const sharedDriveId = 'myshareddriveid'

const realtime = new CozyRealtime({client, sharedDriveId})
realtime.start()
```

```javascript
realtime.stop()
```

To stop the subscription

cozy-stack will automatically subscribe to shared drive files events
As it is implemented now, it is only possible to subscribe to a given shared drive, one at a time.

Needs https://github.com/cozy/cozy-stack/pull/4559 to be merged