### PR TITLE
fix(sharing): Sharing suggestions now pops over the dialog container

### DIFF
--- a/packages/cozy-sharing/src/components/SharedDrive/DumbSharedDriveModal.jsx
+++ b/packages/cozy-sharing/src/components/SharedDrive/DumbSharedDriveModal.jsx
@@ -33,6 +33,10 @@ export const DumbSharedDriveModal = withLocales(
         disableGutters
         onClose={onClose}
         title={title}
+        classes={{ paper: 'u-ov-visible' }}
+        componentsProps={{
+          dialogContent: { className: 'u-ov-visible' }
+        }}
         content={
           <div>
             <div className="u-ph-2">


### PR DESCRIPTION
As it's shown in the cozy-ui doc https://github.com/cozy/cozy-ui/pull/2857 a menu or dropdown should be used with popover to avoid being trapped in the dialog container. But it was painful to do it here with react-autosuggest, so I simply add visible overflow on the dialog instead.

However I'm not prepared to generalize visible overflow on all dialogs, so no change in cozy-ui for now.