### PR TITLE
Add protections for DataProxyProvider

### DIFF
--- a/packages/cozy-dataproxy-lib/src/dataproxy/DataProxyProvider.jsx
+++ b/packages/cozy-dataproxy-lib/src/dataproxy/DataProxyProvider.jsx
@@ -148,7 +148,7 @@ export const DataProxyProvider = React.memo(({ children, options = {} }) => {
     } else {
       initIframe()
     }
-  }, [client, webviewIntent])
+  }, [client, webviewIntent, options])
 
   const onIframeLoaded = useCallback(() => {
     const ifr = document.getElementById('DataProxy')
@@ -177,12 +177,12 @@ export const DataProxyProvider = React.memo(({ children, options = {} }) => {
     [onIframeLoaded]
   )
 
-  useEffect(function () {
+  useEffect(() => {
     window.addEventListener('message', onReceiveMessage)
-    return function () {
+    return () => {
       window.removeEventListener('message', onReceiveMessage)
     }
-  })
+  }, [onReceiveMessage])
 
   useEffect(() => {
     const doAsync = async () => {
@@ -199,11 +199,11 @@ export const DataProxyProvider = React.memo(({ children, options = {} }) => {
       // Request through cozy-client
       const requestLink = async (operation, options) => {
         log.log('Send request to DataProxy : ', operation)
-        if (options.fetchPolicy) {
+        if (options?.fetchPolicy) {
           // Functions cannot be serialized and thus passed to the iframe
           delete options.fetchPolicy
         }
-        return dataProxyCom.requestLink(operation, options)
+        return dataProxyCom.requestLink?.(operation, options)
       }
       const newDataProxy = {
         dataProxyServicesAvailable,
@@ -211,7 +211,6 @@ export const DataProxyProvider = React.memo(({ children, options = {} }) => {
         search,
         requestLink
       }
-
       client.links.forEach(link => {
         if (link.registerDataProxy) {
           // This is required as the DataProxy is not ready when the DataProxyLink is created
@@ -224,7 +223,8 @@ export const DataProxyProvider = React.memo(({ children, options = {} }) => {
     if (dataProxyCom && client?.links) {
       doAsync()
     }
-  }, [dataProxyCom, client, dataProxyServicesAvailable])
+  }, [dataProxyCom, client, dataProxyServicesAvailable, options])
+
   const reloadIframe = useCallback(() => {
     setIframeVersion(v => v + 1)
   }, [])

--- a/packages/cozy-dataproxy-lib/src/dataproxy/DataProxyProvider.jsx
+++ b/packages/cozy-dataproxy-lib/src/dataproxy/DataProxyProvider.jsx
@@ -9,7 +9,17 @@ import Minilog from 'cozy-minilog'
 
 const log = Minilog('👷‍♂️ [DataProxyProvider]')
 
-export const DataProxyContext = React.createContext()
+const noop = async () => {
+  throw new Error('[DataProxy] not ready')
+}
+const defaultValue = Object.freeze({
+  dataProxyServicesAvailable: false,
+  ready: false,
+  search: noop,
+  requestLink: noop
+})
+
+export const DataProxyContext = React.createContext(defaultValue)
 
 export const useDataProxy = () => {
   const context = useContext(DataProxyContext)
@@ -171,6 +181,7 @@ export const DataProxyProvider = React.memo(({ children, options = {} }) => {
       }
       const newDataProxy = {
         dataProxyServicesAvailable,
+        ready: Boolean(dataProxyCom),
         search,
         requestLink
       }
@@ -190,7 +201,7 @@ export const DataProxyProvider = React.memo(({ children, options = {} }) => {
   }, [dataProxyCom, client, dataProxyServicesAvailable])
 
   return (
-    <DataProxyContext.Provider value={dataProxy || {}}>
+    <DataProxyContext.Provider value={dataProxy || defaultValue}>
       {children}
       {iframeUrl ? (
         <iframe

--- a/packages/cozy-dataproxy-lib/src/dataproxy/DataProxyProvider.jsx
+++ b/packages/cozy-dataproxy-lib/src/dataproxy/DataProxyProvider.jsx
@@ -158,17 +158,20 @@ export const DataProxyProvider = React.memo(({ children, options = {} }) => {
 
   const onReceiveMessage = useCallback(
     event => {
-      if (!event.origin.includes('dataproxy')) {
-        return
-      }
-      const eventData = event?.data
-      if (eventData && typeof eventData === 'object') {
+      try {
+        if (typeof event.origin !== 'string') return
+        if (!event.origin.includes('dataproxy')) return
+        const d = event?.data
         if (
-          eventData.type === 'DATAPROXYMESSAGE' &&
-          eventData.payload === 'READY'
+          d &&
+          typeof d === 'object' &&
+          d.type === 'DATAPROXYMESSAGE' &&
+          d.payload === 'READY'
         ) {
           onIframeLoaded()
         }
+      } catch (e) {
+        log.error('[DataProxy] onReceiveMessage error', e)
       }
     },
     [onIframeLoaded]


### PR DESCRIPTION
We noticed some unexplained app crash integrating the DataProxyProvider. The only reported of such cases is on Firefox web, on a Drive with a lot of files.
Let's add defensive protections on the `DataProxyProvider` to avoid app crash if anything goes badly in the dataproxy
 