### PR TITLE
fix: Check correct sharing rule in shared drive :bug:

### DIFF
--- a/packages/cozy-sharing/src/SharedDocument.jsx
+++ b/packages/cozy-sharing/src/SharedDocument.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import SharingContext from './context'
 
-export const SharedDocument = ({ docId, children }) => (
+export const SharedDocument = ({ docId, children, driveId }) => (
   <SharingContext.Consumer>
     {({
       hasWriteAccess,
@@ -14,7 +14,7 @@ export const SharedDocument = ({ docId, children }) => (
       revokeSelf
     } = {}) =>
       children({
-        hasWriteAccess: hasWriteAccess(docId),
+        hasWriteAccess: hasWriteAccess(docId, driveId),
         isShared: byDocId !== undefined && byDocId[docId],
         isSharedByMe: byDocId !== undefined && byDocId[docId] && isOwner(docId),
         isSharedWithMe:

--- a/packages/cozy-sharing/src/SharingProvider.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.jsx
@@ -39,7 +39,9 @@ import reducer, {
   getDocumentPermissions,
   hasSharedParent,
   hasSharedChild,
-  getSharedParentPath
+  getSharedParentPath,
+  getSharedDriveSharingType,
+  SHARING_TYPE
 } from './state'
 
 const log = minilog('SharingProvider')
@@ -374,14 +376,26 @@ export class SharingProvider extends Component {
     this.dispatch(revokeSharingLink(perms))
   }
 
-  hasWriteAccess = docId => {
+  hasWriteAccess = (docId, driveId = undefined) => {
     const instanceUri = this.props.client.getStackClient().uri
+
+    /** Split another case for checking sharing type for shared drive
+     * In case of shared drive, we just check if shared drive has write access or not.
+     * All the files / folders inside must follow the sharing rule of shared drive.
+     * `driveId` only exist in files / folders from recipient, so we don't need to check it belong to owner or not.
+     */
+    if (driveId) {
+      return (
+        getSharedDriveSharingType(this.state, driveId, instanceUri) ===
+        SHARING_TYPE.TWO_WAY
+      )
+    }
 
     return (
       !this.state.byDocId ||
       !this.state.byDocId[docId] ||
       isOwner(this.state, docId) ||
-      getSharingType(this.state, docId, instanceUri) === 'two-way'
+      getSharingType(this.state, docId, instanceUri) === SHARING_TYPE.TWO_WAY
     )
   }
 


### PR DESCRIPTION
### Change:

Update the function `hasWriteAccess` in `SharingProvider` to check correct write access in case of shared drive.

### Related to:

[cozy/cozy-drive#3532](https://github.com/cozy/cozy-drive/pull/3532)