### PR TITLE
feat: Add websearch toggle to AI chat input

### DIFF
--- a/packages/cozy-search/src/components/AssistantProvider.d.ts
+++ b/packages/cozy-search/src/components/AssistantProvider.d.ts
@@ -25,6 +25,8 @@ export interface AssistantContextValue {
   setSelectedTwakeKnowledge: React.Dispatch<
     React.SetStateAction<TwakeKnowledgeState>
   >
+  websearchEnabled: boolean
+  setWebsearchEnabled: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 export function useAssistant(): AssistantContextValue

--- a/packages/cozy-search/src/components/AssistantProvider.jsx
+++ b/packages/cozy-search/src/components/AssistantProvider.jsx
@@ -32,6 +32,7 @@ const AssistantProvider = ({ children }) => {
     chat: []
   })
   const [openedKnowledgePanel, setOpenedKnowledgePanel] = useState(null)
+  const [websearchEnabled, setWebsearchEnabled] = useState(false)
 
   const value = useMemo(
     () => ({
@@ -50,7 +51,9 @@ const AssistantProvider = ({ children }) => {
       setSelectedAssistantId,
       setIsOpenSearchConversation,
       setOpenedKnowledgePanel,
-      setSelectedTwakeKnowledge
+      setSelectedTwakeKnowledge,
+      websearchEnabled,
+      setWebsearchEnabled
     }),
     [
       isOpenCreateAssistant,
@@ -60,7 +63,8 @@ const AssistantProvider = ({ children }) => {
       selectedAssistantId,
       isOpenSearchConversation,
       openedKnowledgePanel,
-      selectedTwakeKnowledge
+      selectedTwakeKnowledge,
+      websearchEnabled
     ]
   )
 

--- a/packages/cozy-search/src/components/Conversations/ConversationBar.jsx
+++ b/packages/cozy-search/src/components/Conversations/ConversationBar.jsx
@@ -12,6 +12,7 @@ import useEventListener from 'cozy-ui/transpiled/react/hooks/useEventListener'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'twake-i18n'
 
+import WebsearchButton from './WebsearchButton'
 import styles from './styles.styl'
 
 const ConversationBar = ({
@@ -21,6 +22,8 @@ const ConversationBar = ({
   onKeyDown,
   onSend,
   onCancel,
+  websearchEnabled,
+  onToggleWebsearch,
   ...props
 }) => {
   const { t } = useI18n()
@@ -74,29 +77,39 @@ const ConversationBar = ({
             },
             autoFocus: !isMobile,
             inputComponent: ComposerPrimitive.Input,
-            endAdornment: isRunning ? (
-              <IconButton className="u-p-0 u-mr-half">
-                <Button
-                  size="small"
-                  component="div"
-                  className="u-miw-auto u-w-2 u-h-2 u-bdrs-circle"
-                  classes={{ label: 'u-flex u-w-auto' }}
-                  label={<Icon icon={StopIcon} size={12} />}
-                  onClick={onCancel}
+            endAdornment: (
+              <>
+                <WebsearchButton
+                  websearchEnabled={websearchEnabled}
+                  onToggleWebsearch={onToggleWebsearch}
                 />
-              </IconButton>
-            ) : (
-              <IconButton className="u-p-0 u-mr-half">
-                <Button
-                  size="small"
-                  component="div"
-                  className="u-miw-auto u-w-2 u-h-2 u-bdrs-circle"
-                  classes={{ label: 'u-flex u-w-auto' }}
-                  label={<Icon icon={PaperplaneIcon} size={12} rotate={-45} />}
-                  disabled={isEmpty}
-                  onClick={handleSend}
-                />
-              </IconButton>
+                {isRunning ? (
+                  <IconButton className="u-p-0 u-mr-half">
+                    <Button
+                      size="small"
+                      component="div"
+                      className="u-miw-auto u-w-2 u-h-2 u-bdrs-circle"
+                      classes={{ label: 'u-flex u-w-auto' }}
+                      label={<Icon icon={StopIcon} size={12} />}
+                      onClick={onCancel}
+                    />
+                  </IconButton>
+                ) : (
+                  <IconButton className="u-p-0 u-mr-half">
+                    <Button
+                      size="small"
+                      component="div"
+                      className="u-miw-auto u-w-2 u-h-2 u-bdrs-circle"
+                      classes={{ label: 'u-flex u-w-auto' }}
+                      label={
+                        <Icon icon={PaperplaneIcon} size={12} rotate={-45} />
+                      }
+                      disabled={isEmpty}
+                      onClick={handleSend}
+                    />
+                  </IconButton>
+                )}
+              </>
             ),
             onKeyDown: handleKeyDown
           }

--- a/packages/cozy-search/src/components/Conversations/ConversationComposer.jsx
+++ b/packages/cozy-search/src/components/Conversations/ConversationComposer.jsx
@@ -20,7 +20,8 @@ const ConversationComposer = () => {
   const composerRuntime = useComposerRuntime()
   const isRunning = useThread(state => state.isRunning)
   const isThreadEmpty = useThread(state => state.messages.length === 0)
-  const { setOpenedKnowledgePanel } = useAssistant()
+  const { setOpenedKnowledgePanel, websearchEnabled, setWebsearchEnabled } =
+    useAssistant()
 
   const value = useComposer(state => state.text)
   const isEmpty = useComposer(state => state.isEmpty)
@@ -49,6 +50,10 @@ const ConversationComposer = () => {
     [isMobile, handleSend]
   )
 
+  const handleToggleWebsearch = useCallback(() => {
+    setWebsearchEnabled(prev => !prev)
+  }, [setWebsearchEnabled])
+
   return (
     <ComposerPrimitive.Root
       className={cx('u-w-100 u-maw-7 u-mh-auto', {
@@ -64,6 +69,8 @@ const ConversationComposer = () => {
         onKeyDown={handleKeyDown}
         onCancel={handleCancel}
         onSend={handleSend}
+        websearchEnabled={websearchEnabled}
+        onToggleWebsearch={handleToggleWebsearch}
       />
 
       <div className="u-flex u-flex-items-center u-flex-justify-between u-mt-1">

--- a/packages/cozy-search/src/components/Conversations/ConversationComposer.jsx
+++ b/packages/cozy-search/src/components/Conversations/ConversationComposer.jsx
@@ -51,8 +51,9 @@ const ConversationComposer = () => {
   )
 
   const handleToggleWebsearch = useCallback(() => {
+    if (isRunning) return
     setWebsearchEnabled(prev => !prev)
-  }, [setWebsearchEnabled])
+  }, [isRunning, setWebsearchEnabled])
 
   return (
     <ComposerPrimitive.Root

--- a/packages/cozy-search/src/components/Conversations/Sources/Sources.jsx
+++ b/packages/cozy-search/src/components/Conversations/Sources/Sources.jsx
@@ -11,9 +11,12 @@ import { useI18n } from 'twake-i18n'
 
 import EmailSourceItem from './EmailSourceItem'
 import FileSourcesItem from './FileSourcesItem'
+import WebSourceItem from './WebSourceItem'
 import { EMAIL_DOCTYPE, buildFilesByIds } from '../../queries'
 
-const Sources = ({ messageId, files, emails }) => {
+const WEB_SOURCE_TYPE = 'web'
+
+const Sources = ({ messageId, files, emails, urls }) => {
   const [showSources, setShowSources] = useState(false)
   const { t } = useI18n()
   const ref = useRef()
@@ -47,7 +50,10 @@ const Sources = ({ messageId, files, emails }) => {
       <Chip
         className="u-mb-1"
         icon={<Icon icon={MultiFilesIcon} className="u-ml-half" />}
-        label={t('assistant.sources', files.length + emails.length)}
+        label={t(
+          'assistant.sources',
+          files.length + emails.length + urls.length
+        )}
         deleteIcon={
           <Icon
             className="u-h-1"
@@ -72,6 +78,12 @@ const Sources = ({ messageId, files, emails }) => {
           {emails.map(email => (
             <EmailSourceItem key={`${messageId}-${email.id}`} email={email} />
           ))}
+          {urls?.map((url, index) => (
+            <WebSourceItem
+              key={`${messageId}-${url.url || index}`}
+              source={url}
+            />
+          ))}
         </div>
       </Grow>
     </Box>
@@ -81,11 +93,16 @@ const Sources = ({ messageId, files, emails }) => {
 const SourcesWithFilesQuery = ({ messageId, sources }) => {
   const fileIds = []
   const emails = []
+  const urls = []
   let files
   sources.map(source => {
-    source.doctype === EMAIL_DOCTYPE
-      ? emails.push(source)
-      : fileIds.push(source.id)
+    if (source.sourceType === WEB_SOURCE_TYPE) {
+      urls.push(source)
+    } else if (source.doctype === EMAIL_DOCTYPE) {
+      emails.push(source)
+    } else {
+      fileIds.push(source.id)
+    }
   })
   const enabled = fileIds && fileIds.length > 0
   const filesByIds = buildFilesByIds(fileIds, enabled)
@@ -97,10 +114,15 @@ const SourcesWithFilesQuery = ({ messageId, sources }) => {
   const isLoading = isQueryLoading(queryResult)
   files = fetchedFiles || []
 
-  if ((isLoading && enabled) || (files.length === 0 && emails.length === 0))
+  if (
+    (isLoading && enabled) ||
+    (files.length === 0 && emails.length === 0 && urls.length === 0)
+  )
     return null
 
-  return <Sources messageId={messageId} files={files} emails={emails} />
+  return (
+    <Sources messageId={messageId} files={files} emails={emails} urls={urls} />
+  )
 }
 
 export default SourcesWithFilesQuery

--- a/packages/cozy-search/src/components/Conversations/Sources/WebSourceItem.jsx
+++ b/packages/cozy-search/src/components/Conversations/Sources/WebSourceItem.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import GlobeIcon from 'cozy-ui/transpiled/react/Icons/Globe'
+import ListItem from 'cozy-ui/transpiled/react/ListItem'
+import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+
+import styles from './styles.styl'
+
+const isHttpUrl = url =>
+  typeof url === 'string' && /^https?:\/\//i.test(url.trim())
+
+const WebSourceItem = ({ source }) => {
+  const { url, title } = source
+
+  if (!isHttpUrl(url)) return null
+
+  const displayTitle = title || url
+
+  return (
+    <ListItem
+      className={styles['sourcesItem']}
+      component="a"
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      button
+    >
+      <ListItemIcon>
+        <Icon icon={GlobeIcon} size={32} color="var(--primaryColor)" />
+      </ListItemIcon>
+      <ListItemText primary={displayTitle} secondary={url} />
+    </ListItem>
+  )
+}
+
+export default WebSourceItem

--- a/packages/cozy-search/src/components/Conversations/WebsearchButton.jsx
+++ b/packages/cozy-search/src/components/Conversations/WebsearchButton.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+
+import flag from 'cozy-flags'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import IconButton from 'cozy-ui/transpiled/react/IconButton'
+import GlobeIcon from 'cozy-ui/transpiled/react/Icons/Globe'
+import { useI18n } from 'twake-i18n'
+
+const WebsearchButton = ({ websearchEnabled, onToggleWebsearch }) => {
+  const { t } = useI18n()
+
+  if (!flag('cozy.assistant.websearch.enabled')) {
+    return null
+  }
+
+  return (
+    <IconButton
+      className="u-p-0 u-mr-half"
+      aria-pressed={websearchEnabled}
+      aria-label={t('assistant.websearch.label')}
+      title={t('assistant.websearch.label')}
+      onClick={onToggleWebsearch}
+    >
+      <Button
+        size="small"
+        component="div"
+        className="u-miw-auto u-w-2 u-h-2 u-bdrs-circle"
+        classes={{ label: 'u-flex u-w-auto' }}
+        disabled={!websearchEnabled}
+        label={<Icon icon={GlobeIcon} size={12} />}
+      />
+    </IconButton>
+  )
+}
+
+export default WebsearchButton

--- a/packages/cozy-search/src/components/CozyAssistantRuntimeProvider.tsx
+++ b/packages/cozy-search/src/components/CozyAssistantRuntimeProvider.tsx
@@ -143,7 +143,7 @@ const CozyAssistantRuntimeProviderInner = ({
   const messagesIdRef = useRef<string[]>([])
   const cancelledMessageIdsRef = useRef<Set<string>>(new Set())
   const currentStreamingMessageIdRef = useRef<string | null>(null)
-  const { selectedAssistantId } = useAssistant()
+  const { selectedAssistantId, websearchEnabled } = useAssistant()
 
   useEffect(() => {
     messagesIdRef.current = initialMessages
@@ -293,13 +293,13 @@ const CozyAssistantRuntimeProviderInner = ({
             typeof createCozyRealtimeChatAdapter
           >[0]['client'],
           conversationId,
-          // eslint-disable-next-line react-hooks/refs
           streamBridge: streamBridgeRef.current,
-          assistantId: selectedAssistantId
+          assistantId: selectedAssistantId,
+          websearchEnabled
         },
         t
       ),
-    [client, conversationId, selectedAssistantId, t]
+    [client, conversationId, selectedAssistantId, websearchEnabled, t]
   )
 
   const runtime = useLocalRuntime(adapter, {

--- a/packages/cozy-search/src/components/CozyAssistantRuntimeProvider.tsx
+++ b/packages/cozy-search/src/components/CozyAssistantRuntimeProvider.tsx
@@ -46,7 +46,14 @@ interface ConversationMessage {
   id: string
   role: 'user' | 'assistant'
   content: string
-  sources?: Array<{ id: string; doctype?: string }>
+  sources?: Array<{
+    id?: string
+    doctype?: string
+    sourceType?: string
+    url?: string
+    title?: string
+    snippet?: string
+  }>
 }
 
 interface Conversation {
@@ -225,7 +232,14 @@ const CozyAssistantRuntimeProviderInner = ({
             | {
                 _id: string
                 object: 'sources'
-                content: Array<{ id: string; doctype?: string }>
+                content: Array<{
+                  id?: string
+                  doctype?: string
+                  sourceType?: string
+                  url?: string
+                  title?: string
+                  snippet?: string
+                }>
               }
             | { _id: string; object: 'error'; message: string }
         ) => {
@@ -293,11 +307,12 @@ const CozyAssistantRuntimeProviderInner = ({
             typeof createCozyRealtimeChatAdapter
           >[0]['client'],
           conversationId,
-          streamBridge: streamBridgeRef.current,
           assistantId: selectedAssistantId,
           websearchEnabled
         },
-        t
+        t,
+        // eslint-disable-next-line react-hooks/refs -- streamBridgeRef is stable and only read inside adapter.run(), not during render
+        streamBridgeRef
       ),
     [client, conversationId, selectedAssistantId, websearchEnabled, t]
   )

--- a/packages/cozy-search/src/components/adapters/CozyRealtimeChatAdapter.ts
+++ b/packages/cozy-search/src/components/adapters/CozyRealtimeChatAdapter.ts
@@ -32,6 +32,7 @@ export interface CozyRealtimeChatAdapterOptions {
   conversationId: string
   streamBridge: StreamBridge
   assistantId?: string
+  websearchEnabled?: boolean
 }
 
 /**
@@ -67,7 +68,13 @@ export const createCozyRealtimeChatAdapter = (
     messages,
     abortSignal
   }: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult> {
-    const { client, conversationId, streamBridge, assistantId } = options
+    const {
+      client,
+      conversationId,
+      streamBridge,
+      assistantId,
+      websearchEnabled
+    } = options
 
     const userQuery = findUserQuery(messages)
     if (!userQuery) {
@@ -86,7 +93,11 @@ export const createCozyRealtimeChatAdapter = (
       await client.stackClient.fetchJSON(
         'POST',
         `/ai/chat/conversations/${conversationId}`,
-        { q: userQuery, assistantID: assistantId }
+        {
+          q: userQuery,
+          assistantID: assistantId,
+          ...(websearchEnabled && { websearch: true })
+        }
       )
 
       let fullText = ''

--- a/packages/cozy-search/src/components/adapters/CozyRealtimeChatAdapter.ts
+++ b/packages/cozy-search/src/components/adapters/CozyRealtimeChatAdapter.ts
@@ -30,7 +30,6 @@ type CozyClient = {
 export interface CozyRealtimeChatAdapterOptions {
   client: CozyClient
   conversationId: string
-  streamBridge: StreamBridge
   assistantId?: string
   websearchEnabled?: boolean
 }
@@ -62,19 +61,15 @@ const findUserQuery = (
  */
 export const createCozyRealtimeChatAdapter = (
   options: CozyRealtimeChatAdapterOptions,
-  t: (key: string, options?: Record<string, unknown>) => string
+  t: (key: string, options?: Record<string, unknown>) => string,
+  streamBridgeRef: { current: StreamBridge }
 ): ChatModelAdapter => ({
   async *run({
     messages,
     abortSignal
   }: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult> {
-    const {
-      client,
-      conversationId,
-      streamBridge,
-      assistantId,
-      websearchEnabled
-    } = options
+    const { client, conversationId, assistantId, websearchEnabled } = options
+    const streamBridge = streamBridgeRef.current
 
     const userQuery = findUserQuery(messages)
     if (!userQuery) {
@@ -83,6 +78,11 @@ export const createCozyRealtimeChatAdapter = (
     }
 
     const stream = streamBridge.createStream(conversationId)
+
+    if (abortSignal?.aborted) {
+      streamBridge.cleanup(conversationId)
+      return
+    }
 
     try {
       // Note: For reload, this sends the same query again to regenerate

--- a/packages/cozy-search/src/components/adapters/StreamBridge.ts
+++ b/packages/cozy-search/src/components/adapters/StreamBridge.ts
@@ -20,7 +20,14 @@ export class StreamBridge {
   private nextPositions = new Map<string, number>()
   private sourcesMap = new Map<
     string,
-    Array<{ id: string; doctype?: string }>
+    Array<{
+      id?: string
+      doctype?: string
+      sourceType?: string
+      url?: string
+      title?: string
+      snippet?: string
+    }>
   >()
 
   /**
@@ -175,7 +182,14 @@ export class StreamBridge {
    */
   onSources(
     conversationId: string,
-    sources: Array<{ id: string; doctype?: string }>
+    sources: Array<{
+      id?: string
+      doctype?: string
+      sourceType?: string
+      url?: string
+      title?: string
+      snippet?: string
+    }>
   ): void {
     if (!this.streams.has(conversationId)) return
     this.sourcesMap.set(conversationId, sources)
@@ -184,9 +198,16 @@ export class StreamBridge {
   /**
    * Returns stored sources for a conversation.
    */
-  getSources(
-    conversationId: string
-  ): Array<{ id: string; doctype?: string }> | undefined {
+  getSources(conversationId: string):
+    | Array<{
+        id?: string
+        doctype?: string
+        sourceType?: string
+        url?: string
+        title?: string
+        snippet?: string
+      }>
+    | undefined {
     return this.sourcesMap.get(conversationId)
   }
 

--- a/packages/cozy-search/src/locales/en.json
+++ b/packages/cozy-search/src/locales/en.json
@@ -6,6 +6,9 @@
       "noItem": "No results",
       "notEnough": "Your query must contain at least 3 characters"
     },
+    "websearch": {
+      "label": "Web search"
+    },
     "dialog": {
       "close": "Close"
     },

--- a/packages/cozy-search/src/locales/en.json
+++ b/packages/cozy-search/src/locales/en.json
@@ -46,7 +46,7 @@
       "today": "Today",
       "yesterday": "Yesterday"
     },
-    "default_error": "There was an error, please try again",
+    "default_error": "An error occurred during response generation. Please try again",
     "hide": "Hide",
     "show": "Show",
     "search_conversation": {

--- a/packages/cozy-search/src/locales/fr.json
+++ b/packages/cozy-search/src/locales/fr.json
@@ -6,6 +6,9 @@
       "noItem": "Aucun résultat",
       "notEnough": "Votre recherche doit contenir au moins 3 caractères"
     },
+    "websearch": {
+      "label": "Recherche web"
+    },
     "dialog": {
       "close": "Fermer"
     },

--- a/packages/cozy-search/src/locales/fr.json
+++ b/packages/cozy-search/src/locales/fr.json
@@ -46,7 +46,7 @@
       "today": "Aujourd'hui",
       "yesterday": "Hier"
     },
-    "default_error": "Une erreur s'est produite, veuillez réessayer",
+    "default_error": "Une erreur est survenue lors de la génération de la réponse. Veuillez réessayer",
     "hide": "Masquer",
     "show": "Afficher",
     "search_conversation": {


### PR DESCRIPTION
Add an optional websearch feature to RAG search. 
When enabled, the search will leverage user document and perform web search to combine sources. 
This feature is hidden behind a `cozy.assistant.websearch.enabled` flag

See <img width="802" height="90" alt="image" src="https://github.com/user-attachments/assets/2b710153-67ac-43b6-8b4f-cc85b62b8d23" />

the sources look like this: 

<img width="876" height="727" alt="image" src="https://github.com/user-attachments/assets/a90fd622-0c45-46a5-9337-9325b020fb19" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a web search toggle to enable/disable web search in conversations
  * Web sources (URLs) are now shown alongside files and emails in message sources
  * New web source list items link to original pages and include title/URL

* **Bug Fixes / UX**
  * Improved error message wording during response generation

* **Localization**
  * Added "Web search" translation entries (en/fr)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->