### PR TITLE
feat(cozy-sharing): add props to tune link sharing flow

### DIFF
--- a/packages/cozy-sharing/src/components/FederatedFolder/DumbFederatedFolderModal.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/DumbFederatedFolderModal.jsx
@@ -20,7 +20,9 @@ export const DumbFederatedFolderModal = withLocales(
     onClose,
     onShare,
     sharingLink,
-    showShareByEmail
+    showShareByEmail,
+    autoOpenShareRestriction,
+    showGenerateLinkButton
   }) => {
     const { t } = useI18n()
     return (
@@ -42,6 +44,8 @@ export const DumbFederatedFolderModal = withLocales(
         addButtonLabel={t('FederatedFolder.add')}
         shareLabel={t('FederatedFolder.share')}
         showShareByEmail={showShareByEmail}
+        autoOpenShareRestriction={autoOpenShareRestriction}
+        showGenerateLinkButton={showGenerateLinkButton}
       />
     )
   }
@@ -60,7 +64,9 @@ DumbFederatedFolderModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   onShare: PropTypes.func.isRequired,
   sharingLink: PropTypes.string,
-  showShareByEmail: PropTypes.bool
+  showShareByEmail: PropTypes.bool,
+  autoOpenShareRestriction: PropTypes.bool,
+  showGenerateLinkButton: PropTypes.bool
 }
 
 export default DumbFederatedFolderModal

--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
@@ -17,7 +17,12 @@ import {
 } from '../SharedDrive/helpers'
 
 export const FederatedFolderModal = withLocales(
-  ({ onClose, document: existingDocument }) => {
+  ({
+    onClose,
+    document: existingDocument,
+    autoOpenShareRestriction,
+    showGenerateLinkButton
+  }) => {
     const client = useClient()
     const { t } = useI18n()
     const {
@@ -159,6 +164,8 @@ export const FederatedFolderModal = withLocales(
         onShare={onShare}
         sharingLink={sharingLink}
         showShareByEmail={!isSharedDrive}
+        autoOpenShareRestriction={autoOpenShareRestriction}
+        showGenerateLinkButton={showGenerateLinkButton}
       />
     )
   }
@@ -166,7 +173,9 @@ export const FederatedFolderModal = withLocales(
 
 FederatedFolderModal.propTypes = {
   onClose: PropTypes.func.isRequired,
-  document: PropTypes.object.isRequired
+  document: PropTypes.object.isRequired,
+  autoOpenShareRestriction: PropTypes.bool,
+  showGenerateLinkButton: PropTypes.bool
 }
 
 export default FederatedFolderModal

--- a/packages/cozy-sharing/src/components/ShareByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareByLink.jsx
@@ -18,7 +18,13 @@ import {
 } from './ShareRestrictionModal/helpers'
 import { useSharingContext } from '../hooks/useSharingContext'
 
-const ShareByLink = ({ link, document, documentType }) => {
+const ShareByLink = ({
+  link,
+  document,
+  documentType,
+  showGenerateLinkButton = false,
+  autoOpenShareRestriction = false
+}) => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const { showAlert } = useAlert()
@@ -27,14 +33,23 @@ const ShareByLink = ({ link, document, documentType }) => {
   const [isGenerating, setIsGenerating] = useState(false)
 
   const canShare = typeof navigator?.share === 'function'
-  const showCopyAndSendButtons = isMobile && canShare
-  const showOnlyCopyButton = !isMobile || !canShare
+  const showGenerateButton = showGenerateLinkButton && !link
+  const showCopyAndSendButtons = !showGenerateButton && isMobile && canShare
+  const showOnlyCopyButton = !showGenerateButton && (!isMobile || !canShare)
   const isFederated = flag('drive.federated-shared-folder.enabled')
 
   const [isEditDialogOpen, toggleEditDialogOpen] = useReducer(
     state => !state,
     false
   )
+
+  const showGenericError = () => {
+    showAlert({
+      message: t(`${documentType}.share.error.generic`),
+      severity: 'error',
+      variant: 'filled'
+    })
+  }
 
   const handleGenerateLink = async () => {
     setIsGenerating(true)
@@ -61,17 +76,28 @@ const ShareByLink = ({ link, document, documentType }) => {
 
   const generateLinkAndCopyLinkToClipboard = async () => {
     let linkToCopy = link
+    const wasNewlyGenerated = !linkToCopy
     if (!linkToCopy) {
       linkToCopy = await handleGenerateLink()
     }
     if (linkToCopy) {
       await copyToClipboard(linkToCopy, { t, showAlert })
+      if (wasNewlyGenerated && autoOpenShareRestriction) {
+        toggleEditDialogOpen()
+      }
     } else {
-      showAlert({
-        message: t(`${documentType}.share.error.generic`),
-        severity: 'error',
-        variant: 'filled'
-      })
+      showGenericError()
+    }
+  }
+
+  const generateLinkSilently = async () => {
+    const generated = await handleGenerateLink()
+    if (!generated) {
+      showGenericError()
+      return
+    }
+    if (autoOpenShareRestriction) {
+      toggleEditDialogOpen()
     }
   }
 
@@ -81,11 +107,7 @@ const ShareByLink = ({ link, document, documentType }) => {
       linkToShare = await handleGenerateLink()
     }
     if (!linkToShare) {
-      showAlert({
-        message: t(`${documentType}.share.error.generic`),
-        severity: 'error',
-        variant: 'filled'
-      })
+      showGenericError()
       return
     }
 
@@ -100,11 +122,7 @@ const ShareByLink = ({ link, document, documentType }) => {
     } catch (error) {
       // Don't show error when user cancels the share dialog
       if (error.name !== 'AbortError') {
-        showAlert({
-          message: t(`${documentType}.share.error.generic`),
-          severity: 'error',
-          variant: 'filled'
-        })
+        showGenericError()
       }
     }
   }
@@ -144,6 +162,16 @@ const ShareByLink = ({ link, document, documentType }) => {
           busy={isGenerating}
         />
       )}
+      {showGenerateButton && (
+        <Button
+          label={t(`${documentType}.share.shareByLink.create`)}
+          variant="secondary"
+          size="medium"
+          startIcon={<Icon icon={LinkIcon} />}
+          onClick={generateLinkSilently}
+          busy={isGenerating}
+        />
+      )}
       {isEditDialogOpen && (
         <ShareRestrictionModal file={document} onClose={toggleEditDialogOpen} />
       )}
@@ -154,7 +182,9 @@ const ShareByLink = ({ link, document, documentType }) => {
 ShareByLink.propTypes = {
   link: PropTypes.string,
   document: PropTypes.object.isRequired,
-  documentType: PropTypes.string.isRequired
+  documentType: PropTypes.string.isRequired,
+  showGenerateLinkButton: PropTypes.bool,
+  autoOpenShareRestriction: PropTypes.bool
 }
 
 export default ShareByLink

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
@@ -111,17 +111,32 @@ const SharingTitleFunction = ({ documentType, document }) =>
  */
 const ShareDialogCozyToCozy = ({
   showShareByLink,
+  showGenerateLinkButton,
+  autoOpenShareRestriction,
   documentType,
   document,
   ...props
 }) => {
+  const dialogActionsOnShare = useMemo(() => {
+    if (!showShareByLink) return null
+    const BoundShareByLink = dialogActionProps => (
+      <DumbShareByLink
+        {...dialogActionProps}
+        showGenerateLinkButton={showGenerateLinkButton}
+        autoOpenShareRestriction={autoOpenShareRestriction}
+      />
+    )
+    BoundShareByLink.displayName = 'BoundShareByLink'
+    return BoundShareByLink
+  }, [showShareByLink, showGenerateLinkButton, autoOpenShareRestriction])
+
   return (
     <ShareDialogTwoStepsConfirmationContainer
       {...props}
       documentType={documentType}
       document={document}
       dialogContentOnShare={SharingContent}
-      dialogActionsOnShare={showShareByLink ? DumbShareByLink : null}
+      dialogActionsOnShare={dialogActionsOnShare}
       dialogTitleOnShare={SharingTitleFunction({ documentType, document })}
       disableGutters
     />

--- a/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.jsx
@@ -19,7 +19,9 @@ const ShareDialogOnlyByLink = ({
   documentType,
   link,
   onClose,
-  permissions
+  permissions,
+  showGenerateLinkButton,
+  autoOpenShareRestriction
 }) => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
@@ -62,6 +64,8 @@ const ShareDialogOnlyByLink = ({
               link={link}
               document={document}
               documentType={documentType}
+              showGenerateLinkButton={showGenerateLinkButton}
+              autoOpenShareRestriction={autoOpenShareRestriction}
             />
           </div>
         </>

--- a/packages/cozy-sharing/src/components/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal.jsx
@@ -8,6 +8,7 @@ import ShareDialogOnlyByLink from './ShareDialogOnlyByLink'
 import { SharedDriveEditModal } from './SharedDrive/SharedDriveEditModal'
 
 export const ShareModal = ({
+  autoOpenShareRestriction,
   createContact,
   document,
   documentType = 'Document',
@@ -24,6 +25,7 @@ export const ShareModal = ({
   recipients,
   sharing,
   sharingDesc,
+  showGenerateLinkButton,
   twoStepsConfirmationMethods
 }) => {
   if (isSharedDrive && !flag('drive.federated-shared-folder.enabled')) {
@@ -35,6 +37,8 @@ export const ShareModal = ({
         onShare={onShare}
         onRevoke={onRevoke}
         onClose={onClose}
+        autoOpenShareRestriction={autoOpenShareRestriction}
+        showGenerateLinkButton={showGenerateLinkButton}
       />
     )
   }
@@ -58,6 +62,8 @@ export const ShareModal = ({
       link={link}
       onClose={onClose}
       permissions={permissions}
+      showGenerateLinkButton={showGenerateLinkButton}
+      autoOpenShareRestriction={autoOpenShareRestriction}
     />
   ) : (
     <ShareDialogCozyToCozy
@@ -79,6 +85,8 @@ export const ShareModal = ({
       showShareByLink={showShareByLink}
       showShareOnlyByLink={showShareOnlyByLink}
       showWhoHasAccess={showWhoHasAccess}
+      showGenerateLinkButton={showGenerateLinkButton}
+      autoOpenShareRestriction={autoOpenShareRestriction}
       twoStepsConfirmationMethods={twoStepsConfirmationMethods}
     />
   )
@@ -87,6 +95,7 @@ export const ShareModal = ({
 export default ShareModal
 
 ShareModal.propTypes = {
+  autoOpenShareRestriction: PropTypes.bool,
   createContact: PropTypes.func.isRequired,
   document: PropTypes.object.isRequired,
   documentType: PropTypes.string,
@@ -100,6 +109,7 @@ ShareModal.propTypes = {
   permissions: PropTypes.array.isRequired,
   recipients: PropTypes.array.isRequired,
   sharingDesc: PropTypes.string,
+  showGenerateLinkButton: PropTypes.bool,
   twoStepsConfirmationMethods: PropTypes.shape({
     getRecipientsToBeConfirmed: PropTypes.func,
     confirmRecipient: PropTypes.func,

--- a/packages/cozy-sharing/src/components/ShareModal.spec.js
+++ b/packages/cozy-sharing/src/components/ShareModal.spec.js
@@ -6,8 +6,12 @@ import flag from 'cozy-flags'
 import { ShareModal } from './ShareModal'
 import AppLike from '../../test/AppLike'
 
-jest.mock('./ShareDialogCozyToCozy', () => () => <>ShareDialogCozyToCozy</>)
-jest.mock('./ShareDialogOnlyByLink', () => () => <>ShareDialogOnlyByLink</>)
+jest.mock('./ShareDialogCozyToCozy', () => () => (
+  <div>ShareDialogCozyToCozy</div>
+))
+jest.mock('./ShareDialogOnlyByLink', () => () => (
+  <div>ShareDialogOnlyByLink</div>
+))
 
 jest.mock('cozy-flags')
 
@@ -43,7 +47,7 @@ describe('ShareModal component', () => {
   })
 
   it('should render ShareDialogOnlyByLink if flag cozy.hide-sharing-cozy-to-cozy is true', () => {
-    flag.mockImplementation(() => true)
+    flag.mockImplementation(name => name === 'cozy.hide-sharing-cozy-to-cozy')
 
     const root = setup({ documentType: 'Document' })
 

--- a/packages/cozy-sharing/src/components/ShareModal/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal/ShareModal.jsx
@@ -36,7 +36,7 @@ export const ShareModal = withLocales(props => {
 
   const isFederatedMode = flag('drive.federated-shared-folder.enabled')
   if (isFederatedMode && allLoaded) {
-    return <FederatedFolderModal document={document} onClose={rest.onClose} />
+    return <FederatedFolderModal document={document} {...rest} />
   }
 
   const isEditable =
@@ -61,6 +61,8 @@ export const ShareModal = withLocales(props => {
 })
 
 ShareModal.propTypes = {
+  autoOpenShareRestriction: PropTypes.bool,
   document: PropTypes.object.isRequired,
-  onRevokeSuccess: PropTypes.func
+  onRevokeSuccess: PropTypes.func,
+  showGenerateLinkButton: PropTypes.bool
 }

--- a/packages/cozy-sharing/src/components/SharedDrive/DumbSharedDriveModal.jsx
+++ b/packages/cozy-sharing/src/components/SharedDrive/DumbSharedDriveModal.jsx
@@ -23,7 +23,9 @@ export const DumbSharedDriveModal = withLocales(
     onShare,
     onRename,
     showNameField = true,
-    sharingLink
+    sharingLink,
+    autoOpenShareRestriction,
+    showGenerateLinkButton
   }) => {
     const { t } = useI18n()
     return (
@@ -51,6 +53,8 @@ export const DumbSharedDriveModal = withLocales(
         createLabel={t('SharedDrive.sharedDriveModal.create')}
         shareLabel={t('FederatedFolder.share')}
         saveLabel={t('SharedDrive.sharedDriveModal.save')}
+        autoOpenShareRestriction={autoOpenShareRestriction}
+        showGenerateLinkButton={showGenerateLinkButton}
       />
     )
   }
@@ -72,7 +76,9 @@ DumbSharedDriveModal.propTypes = {
   onShare: PropTypes.func.isRequired,
   onRename: PropTypes.func,
   showNameField: PropTypes.bool,
-  sharingLink: PropTypes.string
+  sharingLink: PropTypes.string,
+  autoOpenShareRestriction: PropTypes.bool,
+  showGenerateLinkButton: PropTypes.bool
 }
 
 export default DumbSharedDriveModal

--- a/packages/cozy-sharing/src/components/SharedDrive/SharedDriveEditModal.jsx
+++ b/packages/cozy-sharing/src/components/SharedDrive/SharedDriveEditModal.jsx
@@ -11,7 +11,16 @@ import { useSharingContext } from '../../hooks/useSharingContext'
 import { Contact } from '../../models'
 
 export const SharedDriveEditModal = withLocales(
-  ({ document, sharing, recipients, onShare, onRevoke, onClose }) => {
+  ({
+    document,
+    sharing,
+    recipients,
+    onShare,
+    onRevoke,
+    onClose,
+    autoOpenShareRestriction,
+    showGenerateLinkButton
+  }) => {
     const client = useClient()
     const { t } = useI18n()
     const { showAlert } = useAlert()
@@ -51,11 +60,20 @@ export const SharedDriveEditModal = withLocales(
         sharedDriveName={name}
         handleSharedDriveNameChange={handleNameChange}
         onRename={onRename}
+        autoOpenShareRestriction={autoOpenShareRestriction}
+        showGenerateLinkButton={showGenerateLinkButton}
       />
     )
   }
 )
 
 SharedDriveEditModal.propTypes = {
-  onClose: PropTypes.func.isRequired
+  document: PropTypes.object,
+  sharing: PropTypes.object,
+  recipients: PropTypes.array,
+  onShare: PropTypes.func.isRequired,
+  onRevoke: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+  autoOpenShareRestriction: PropTypes.bool,
+  showGenerateLinkButton: PropTypes.bool
 }

--- a/packages/cozy-sharing/src/components/SharedFolder/DumbBatchSharedFolderModal.jsx
+++ b/packages/cozy-sharing/src/components/SharedFolder/DumbBatchSharedFolderModal.jsx
@@ -38,7 +38,9 @@ export const DumbBatchSharedFolderModal = withLocales(
     shareLabel,
     saveLabel,
     sharingDesc,
-    showShareByEmail = true
+    showShareByEmail = true,
+    autoOpenShareRestriction,
+    showGenerateLinkButton
   }) => {
     const hasRecipients = Boolean(recipients?.length)
 
@@ -59,6 +61,8 @@ export const DumbBatchSharedFolderModal = withLocales(
             link={sharingLink}
             document={document}
             documentType="Files"
+            showGenerateLinkButton={showGenerateLinkButton}
+            autoOpenShareRestriction={autoOpenShareRestriction}
           />
         )
       }
@@ -70,6 +74,8 @@ export const DumbBatchSharedFolderModal = withLocales(
               link={sharingLink}
               document={document}
               documentType="Files"
+              showGenerateLinkButton={showGenerateLinkButton}
+              autoOpenShareRestriction={autoOpenShareRestriction}
             />
             <Button
               variant="primary"
@@ -182,7 +188,9 @@ DumbBatchSharedFolderModal.propTypes = {
   shareLabel: PropTypes.string,
   saveLabel: PropTypes.string,
   sharingDesc: PropTypes.string,
-  showShareByEmail: PropTypes.bool
+  showShareByEmail: PropTypes.bool,
+  autoOpenShareRestriction: PropTypes.bool,
+  showGenerateLinkButton: PropTypes.bool
 }
 
 DumbBatchSharedFolderModal.defaultProps = {


### PR DESCRIPTION
### changes

Two independent, opt-in props let the app tune the link sharing UX without affecting the default behavior:

- `showGenerateLinkButton`: the initial button only creates the link. Copying becomes a deliberate second action once the link exists.
- `autoOpenShareRestriction`: surfaces the password / expiry / edit-rights popup right after a link is generated, so the user configures permissions immediately.

**_Both default to false — the current behavior is preserved._**

### demo

#### only `showGenerateLinkButton` is active

https://github.com/user-attachments/assets/300d3b73-83d0-4f99-bf5a-25e56d5da87e

#### both props active
https://github.com/user-attachments/assets/90a7da97-0e6e-4e6b-b88f-d8fe584e0033

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional controls to display link generation buttons and automatically open share restriction settings across sharing dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->