### PR TITLE
fix(cozy-sharing): Preserve user gesture for Safari clipboard writes

### DIFF
--- a/packages/cozy-sharing/src/components/ShareByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareByLink.jsx
@@ -75,18 +75,29 @@ const ShareByLink = ({
   }
 
   const generateLinkAndCopyLinkToClipboard = async () => {
-    let linkToCopy = link
-    const wasNewlyGenerated = !linkToCopy
-    if (!linkToCopy) {
-      linkToCopy = await handleGenerateLink()
+    if (link) {
+      await copyToClipboard(link, { t, showAlert })
+      return
     }
-    if (linkToCopy) {
-      await copyToClipboard(linkToCopy, { t, showAlert })
-      if (wasNewlyGenerated && autoOpenShareRestriction) {
-        toggleEditDialogOpen()
-      }
-    } else {
+    // Safari: the clipboard API must be invoked synchronously within the
+    // click handler, so we pass the pending link to `copyToClipboard`.
+    // The resolved URL is captured here so we can branch on success after
+    // the copy has completed, without re-awaiting the promise.
+    let generatedLink = null
+    await copyToClipboard(
+      handleGenerateLink().then(generated => {
+        generatedLink = generated
+        if (!generated) throw new Error('link-generation-failed')
+        return generated
+      }),
+      { t, showAlert }
+    )
+    if (!generatedLink) {
       showGenericError()
+      return
+    }
+    if (autoOpenShareRestriction) {
+      toggleEditDialogOpen()
     }
   }
 

--- a/packages/cozy-sharing/src/components/ShareRestrictionModal/ShareRestrictionModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareRestrictionModal/ShareRestrictionModal.jsx
@@ -77,51 +77,55 @@ export const ShareRestrictionModal = ({ file, onClose }) => {
 
   const handleClick = async () => {
     setLoading(true)
-    // If the file is not shared, we create a new sharing link
-    if (!hasSharingLink) {
-      const ttl = makeTTL(dateToggle && selectedDate)
-      const { data: perms } = await createPermissions({
-        file,
-        t,
-        ttl,
-        password,
-        editingRights,
-        documentType,
-        shareByLink,
-        showAlert
-      })
-      const url = generateWebLink({
+    // The clipboard write must be initiated synchronously within the click
+    // handler for Safari to honor the user gesture; we pass a pending blob
+    // whose content resolves after the permission round-trip.
+    const permsPromise = hasSharingLink
+      ? updatePermissions({
+          file,
+          t,
+          dateToggle,
+          selectedDate,
+          passwordToggle,
+          password,
+          editingRights,
+          documentType,
+          updateDocumentPermissions,
+          showAlert
+        }).then(([{ data: perms }]) => perms)
+      : createPermissions({
+          file,
+          t,
+          ttl: makeTTL(dateToggle && selectedDate),
+          password,
+          editingRights,
+          documentType,
+          shareByLink,
+          showAlert
+        }).then(({ data: perms }) => perms)
+
+    const urlPromise = permsPromise.then(perms =>
+      generateWebLink({
         cozyUrl: client.getStackClient().uri,
         searchParams: [['sharecode', perms.attributes.shortcodes.code]],
         pathname: '/public',
         slug: getAppSlugFromDocumentType({ documentType }),
         subDomainType: client.capabilities.flat_subdomains ? 'flat' : 'nested'
       })
-      await copyToClipboard(url, { t, showAlert })
-      onClose()
-    } else {
-      const [{ data: perms }] = await updatePermissions({
-        file,
-        t,
-        dateToggle,
-        selectedDate,
-        passwordToggle,
-        password,
-        editingRights,
-        documentType,
-        updateDocumentPermissions,
-        showAlert
-      })
-      const url = generateWebLink({
-        cozyUrl: client.getStackClient().uri,
-        searchParams: [['sharecode', perms.attributes.shortcodes.code]],
-        pathname: '/public',
-        slug: getAppSlugFromDocumentType({ documentType }),
-        subDomainType: client.capabilities.flat_subdomains ? 'flat' : 'nested'
-      })
-      await copyToClipboard(url, { t, showAlert })
-      onClose()
+    )
+
+    await copyToClipboard(urlPromise, { t, showAlert })
+    try {
+      // Observe the permission result so we can keep the modal open (and
+      // preserve the user's date / password / editing-rights inputs) if
+      // the permission round-trip failed. copyToClipboard swallows its
+      // own errors so the await above always resolves.
+      await permsPromise
+    } catch {
+      setLoading(false)
+      return
     }
+    onClose()
   }
 
   const handleRevokeLink = async () => {

--- a/packages/cozy-sharing/src/components/ShareRestrictionModal/helpers.js
+++ b/packages/cozy-sharing/src/components/ShareRestrictionModal/helpers.js
@@ -96,17 +96,36 @@ export const generateShareLinkFromFile = ({
 }
 
 /**
- * Copy a string to the clipboard
+ * Copy a value to the clipboard.
  *
- * @param {string} value - The string saved to the clipboard
+ * Accepts a resolved string or a `Promise<string>`. The promise form is
+ * required when the value depends on a prior async step (e.g. creating a
+ * sharing link) from within a click handler: Safari drops the user-gesture
+ * context across any `await`, so `navigator.clipboard.writeText` called after
+ * an awaited call throws `NotAllowedError`. Passing a pending blob to
+ * `ClipboardItem` lets the clipboard API be invoked synchronously while the
+ * content is resolved later.
+ *
+ * @param {string | Promise<string>} value - Value to copy
  * @param {object} [options]
- * @param {number} options.t - Translation function
+ * @param {Function} options.t - Translation function
  * @param {Function} options.showAlert - Function to display an alert
  */
 export const copyToClipboard = async (value, { t, showAlert } = {}) => {
   if (!value) return false
   try {
-    await navigator.clipboard.writeText(value)
+    if (typeof value === 'string') {
+      await navigator.clipboard.writeText(value)
+    } else if (typeof ClipboardItem !== 'undefined') {
+      const blobPromise = Promise.resolve(value).then(
+        text => new Blob([text], { type: 'text/plain' })
+      )
+      await navigator.clipboard.write([
+        new ClipboardItem({ 'text/plain': blobPromise })
+      ])
+    } else {
+      await navigator.clipboard.writeText(await value)
+    }
     showAlert({
       message: t('copyReminderContent.success'),
       severity: 'success',


### PR DESCRIPTION
## Context

Copying a share link waits for an async permission round-trip before `navigator.clipboard` is called. Safari drops the user-gesture context across any `await`, which is stricter than Chrome or Firefox.

## Problem

On Safari, the first click on **Copy link** — or **Confirm** in the restriction modal — surfaces a red "copy failed" toast and logs `NotAllowedError`. A second click appears to work, but only because the link is now in state: the async step is skipped and the clipboard write runs in the same tick as the click.

Reported in linagora/twake-drive#3766.

## Expected behavior

The link is copied on the first click, no error toast.

---

Once this ships, linagora/twake-drive#3767 can close in favor of a dependency bump there.