### PR TITLE
feat(cozy-ui-plus): Add 'unreadable' UploadQueue error status

### DIFF
--- a/packages/cozy-ui-plus/src/UploadQueue/index.jsx
+++ b/packages/cozy-ui-plus/src/UploadQueue/index.jsx
@@ -33,8 +33,9 @@ const FAILED = 'failed'
 const CONFLICT = 'conflict'
 const QUOTA = 'quota'
 const NETWORK = 'network'
+const UNREADABLE = 'unreadable'
 const DONE_STATUSES = [CREATED, UPDATED]
-const ERROR_STATUSES = [CONFLICT, NETWORK, QUOTA, FAILED]
+const ERROR_STATUSES = [CONFLICT, NETWORK, QUOTA, FAILED, UNREADABLE]
 
 export const uploadStatus = {
   CANCEL,
@@ -46,6 +47,7 @@ export const uploadStatus = {
   CONFLICT,
   QUOTA,
   NETWORK,
+  UNREADABLE,
   DONE_STATUSES,
   ERROR_STATUSES
 }


### PR DESCRIPTION
## Summary

- The UploadQueue renders an item's row and icon from its \`status\` field, treating any value in \`ERROR_STATUSES\` as an error (red bar, warning triangle). Consumers that classify uploads failing with a browser \`NotFoundError\` (long path, folder modified mid-transfer) under an \`'unreadable'\` status currently fall through to the default loading look because the value isn't recognized.
- Adds \`UNREADABLE = 'unreadable'\` to \`ERROR_STATUSES\` and exposes it on the \`uploadStatus\` export. \`Item.jsx\` and \`useStatusIcon.js\` read the set via \`uploadStatus.ERROR_STATUSES\`, so no other changes are needed there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "unreadable" upload status, classified as an error condition to improve handling of uploads that cannot be properly read. This enhances error categorization and user feedback throughout the upload process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->