### PR TITLE
fix(cozy-sharing): Handle structured name on share recipients

### DIFF
--- a/packages/cozy-sharing/src/DoctypeContact.js
+++ b/packages/cozy-sharing/src/DoctypeContact.js
@@ -2,29 +2,18 @@ import { models } from 'cozy-client'
 import { Contact as DoctypeContact } from 'cozy-doctypes'
 const ContactModel = models.contact
 
-const isContact = candidate => {
-  return candidate._type === 'io.cozy.contacts'
-}
 export const getInitials = (contactOrRecipient, defaultValue = '') => {
-  if (isContact(contactOrRecipient)) {
-    return ContactModel.getInitials(contactOrRecipient)
-  } else {
-    // @todo Extract to RecipientModel ?
-    const s =
-      contactOrRecipient.public_name ||
-      contactOrRecipient.name ||
-      contactOrRecipient.email
-    return (s && s[0].toUpperCase()) || defaultValue
+  if (contactOrRecipient.public_name) {
+    return contactOrRecipient.public_name[0].toUpperCase()
   }
+  return ContactModel.getInitials(contactOrRecipient) || defaultValue
 }
 
-export const getDisplayName = (contact, defaultValue = '') => {
-  if (isContact(contact)) {
-    return ContactModel.getDisplayName(contact)
-  } else {
-    // @todo Extract to RecipientModel ?
-    return contact.public_name || contact.name || contact.email || defaultValue
+export const getDisplayName = (contactOrRecipient, defaultValue = '') => {
+  if (contactOrRecipient.public_name) {
+    return contactOrRecipient.public_name
   }
+  return ContactModel.getDisplayName(contactOrRecipient) || defaultValue
 }
 
 export default DoctypeContact

--- a/packages/cozy-sharing/src/DoctypeContact.spec.js
+++ b/packages/cozy-sharing/src/DoctypeContact.spec.js
@@ -4,44 +4,51 @@ describe('Contact model', () => {
   describe('getInitials method', () => {
     it('should return the first letter of public_name if it is an owner recipient', () => {
       const recipient = {
-        name: 'whatever',
+        name: { givenName: 'Jane', familyName: 'Doe' },
         public_name: 'janedoe'
       }
       const result = getInitials(recipient)
       expect(result).toEqual('J')
     })
 
-    it('should return the first letter of name if it is a recipient', () => {
+    it('should build initials from the structured name object', () => {
       const recipient = {
-        name: 'janedoe'
+        name: { givenName: 'Jane', familyName: 'Doe' }
       }
       const result = getInitials(recipient)
-      expect(result).toEqual('J')
+      expect(result).toEqual('JD')
     })
 
-    it('should return the first letter of email if it is a recipient and name/public_name are not defined', () => {
+    it('should return the first letter of email when name and public_name are absent', () => {
       const recipient = {
-        name: undefined,
-        public_name: undefined,
         email: 'janedoe@example.com'
       }
       const result = getInitials(recipient)
       expect(result).toEqual('J')
     })
 
-    it('should return an empty string if name/public_name are undefined', () => {
+    it('should return the first letter of email when name is an empty object', () => {
+      const recipient = {
+        name: {},
+        email: 'janedoe@example.com'
+      }
+      const result = getInitials(recipient)
+      expect(result).toEqual('J')
+    })
+
+    it('should return an empty string when nothing is resolvable', () => {
       const recipient = {}
       const result = getInitials(recipient)
       expect(result).toEqual('')
     })
 
-    it('should use a default value if name/public_name are undefined', () => {
+    it('should use the default value when nothing is resolvable', () => {
       const recipient = {}
       const result = getInitials(recipient, 'A')
       expect(result).toEqual('A')
     })
 
-    it('should use the original implementation if a contact is given', () => {
+    it('should build initials for a full contact document', () => {
       const contact = {
         _id: '46b5d129-0296-4466-8c02-9a6a0c17c4cb',
         _type: 'io.cozy.contacts',
@@ -56,11 +63,11 @@ describe('Contact model', () => {
   })
 
   describe('getDisplayName method', () => {
-    it('should use the original implementation if a contact is given', () => {
+    it('should use displayName when a contact document is given', () => {
       const contact = {
         _id: '46b5d129-0296-4466-8c02-9a6a0c17c4cb',
         _type: 'io.cozy.contacts',
-        fullname: 'Arya Stark',
+        displayName: 'Arya Stark',
         name: {
           givenName: 'Arya',
           familyName: 'Stark'
@@ -70,25 +77,29 @@ describe('Contact model', () => {
       expect(result).toEqual('Arya Stark')
     })
 
-    it('should use public_name if available', () => {
-      const contact = {
+    it('should use public_name when available', () => {
+      const recipient = {
         email: 'arya@winterfell.westeros',
-        name: 'Arya Stark',
+        name: { givenName: 'Arya', familyName: 'Stark' },
         public_name: 'aryastark'
       }
-      const result = getDisplayName(contact)
+      const result = getDisplayName(recipient)
       expect(result).toEqual('aryastark')
     })
 
-    it('should use name if a recipient is given', () => {
-      const contact = {
-        name: 'Arya Stark'
+    it('should build the fullname from the structured name object', () => {
+      const recipient = {
+        name: {
+          namePrefix: 'Lady',
+          givenName: 'Arya',
+          familyName: 'Stark'
+        }
       }
-      const result = getDisplayName(contact)
-      expect(result).toEqual('Arya Stark')
+      const result = getDisplayName(recipient)
+      expect(result).toEqual('Lady Arya Stark')
     })
 
-    it('should use email if a recipient is given', () => {
+    it('should fall back to email when name is absent', () => {
       const recipient = {
         email: 'arya.stark@winterfell.westeros'
       }
@@ -96,13 +107,22 @@ describe('Contact model', () => {
       expect(result).toEqual('arya.stark@winterfell.westeros')
     })
 
-    it('should use an empty string as default value if nothing is available', () => {
+    it('should fall back to email when name is an empty object', () => {
+      const recipient = {
+        name: {},
+        email: 'arya.stark@winterfell.westeros'
+      }
+      const result = getDisplayName(recipient)
+      expect(result).toEqual('arya.stark@winterfell.westeros')
+    })
+
+    it('should return an empty string when nothing is resolvable', () => {
       const recipient = {}
       const result = getDisplayName(recipient)
       expect(result).toEqual('')
     })
 
-    it('should use a default value if nothing is available', () => {
+    it('should use the default value when nothing is resolvable', () => {
       const recipient = {}
       const result = getDisplayName(recipient, 'Anonymous')
       expect(result).toEqual('Anonymous')


### PR DESCRIPTION
## Context

The share modal is the entry point for sharing anything in Cozy. When it crashes, the whole sharing flow is unreachable.

## Problem

On certain instances, opening the share modal and selecting a recipient brings the whole page down. The `io.cozy.contacts` doctype defines a recipient's `name` as a structured object, but the modal's fallback path was reading it as a string. Any recipient arriving in its documented shape therefore took the modal down instead of rendering.

## Expected behavior

Selecting a recipient renders their initials and display name without error, whatever combination of `name`, `public_name`, and `email` the recipient carries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined contact display name resolution with enhanced fallback logic to ensure consistent display across various contact information structures.
  * Enhanced contact initial generation to work reliably with different types of contact data and formats.
  * Improved how contact information is displayed when certain standard fields are unavailable or incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->