### PR TITLE
fix(cozy-sharing): Make matching diacritic-insensitive

### DIFF
--- a/packages/cozy-sharing/src/suggestionMatchers.js
+++ b/packages/cozy-sharing/src/suggestionMatchers.js
@@ -2,36 +2,48 @@ import escapeRegExp from 'lodash/escapeRegExp'
 
 import { Group } from 'cozy-doctypes'
 
+let removeDiacritics
+try {
+  new RegExp('\\p{Diacritic}', 'gu')
+  removeDiacritics = str => str.replace(/\p{Diacritic}/gu, '')
+} catch {
+  removeDiacritics = str => str.replace(/[̀-ͯ]/g, '')
+}
+
+const normalize = str => removeDiacritics(str.normalize('NFD'))
+
 // TODO: sadly we have different versions of contacts' doctype to handle...
 // A migration tool on the stack side is needed here
 const emailMatch = (input, contact) => {
   if (!contact.email) return false
-  const emailInput = new RegExp(escapeRegExp(input), 'i')
+  const emailInput = new RegExp(normalize(input), 'i')
   if (Array.isArray(contact.email)) {
-    return contact.email.some(email => emailInput.test(email.address))
+    return contact.email.some(email =>
+      emailInput.test(normalize(email.address))
+    )
   }
-  return emailInput.test(contact.email)
+  return emailInput.test(normalize(contact.email))
 }
 
 const cozyUrlMatch = (input, contact) => {
   if (!contact.cozy && !contact.url) return false
-  const urlInput = new RegExp(escapeRegExp(input), 'i')
+  const urlInput = new RegExp(normalize(input), 'i')
   if (contact.cozy && Array.isArray(contact.cozy)) {
-    return contact.cozy.some(cozy => urlInput.test(cozy.url))
+    return contact.cozy.some(cozy => urlInput.test(normalize(cozy.url)))
   }
-  return urlInput.test(contact.url)
+  return urlInput.test(normalize(contact.url))
 }
 
 const groupNameMatch = (input, contactOrGroup) => {
   if (contactOrGroup._type !== Group.doctype) return false
-  const nameInput = new RegExp(escapeRegExp(input), 'i')
-  return nameInput.test(contactOrGroup.name)
+  const nameInput = new RegExp(normalize(input), 'i')
+  return nameInput.test(normalize(contactOrGroup.name))
 }
 
 const fullnameMatch = (input, contact) => {
   if (!contact.fullname) return false
-  const fullnameInput = new RegExp(escapeRegExp(input), 'i')
-  return fullnameInput.test(contact.fullname)
+  const fullnameInput = new RegExp(normalize(input), 'i')
+  return fullnameInput.test(normalize(contact.fullname))
 }
 
 export { emailMatch, cozyUrlMatch, groupNameMatch, fullnameMatch }

--- a/packages/cozy-sharing/src/suggestionMatchers.js
+++ b/packages/cozy-sharing/src/suggestionMatchers.js
@@ -1,5 +1,3 @@
-import escapeRegExp from 'lodash/escapeRegExp'
-
 import { Group } from 'cozy-doctypes'
 
 let removeDiacritics

--- a/packages/cozy-sharing/src/suggestionMatchers.js
+++ b/packages/cozy-sharing/src/suggestionMatchers.js
@@ -11,39 +11,42 @@ try {
 }
 
 const normalize = str => removeDiacritics(str.normalize('NFD'))
+const normalizeLowercase = str => normalize(str).toLowerCase()
 
 // TODO: sadly we have different versions of contacts' doctype to handle...
 // A migration tool on the stack side is needed here
 const emailMatch = (input, contact) => {
   if (!contact.email) return false
-  const emailInput = new RegExp(normalize(input), 'i')
+  const normalizedInput = normalizeLowercase(input)
   if (Array.isArray(contact.email)) {
     return contact.email.some(email =>
-      emailInput.test(normalize(email.address))
+      normalizeLowercase(email.address).includes(normalizedInput)
     )
   }
-  return emailInput.test(normalize(contact.email))
+  return normalizeLowercase(contact.email).includes(normalizedInput)
 }
 
 const cozyUrlMatch = (input, contact) => {
   if (!contact.cozy && !contact.url) return false
-  const urlInput = new RegExp(normalize(input), 'i')
+  const normalizedInput = normalizeLowercase(input)
   if (contact.cozy && Array.isArray(contact.cozy)) {
-    return contact.cozy.some(cozy => urlInput.test(normalize(cozy.url)))
+    return contact.cozy.some(cozy =>
+      normalizeLowercase(cozy.url).includes(normalizedInput)
+    )
   }
-  return urlInput.test(normalize(contact.url))
+  return normalizeLowercase(contact.url).includes(normalizedInput)
 }
 
 const groupNameMatch = (input, contactOrGroup) => {
   if (contactOrGroup._type !== Group.doctype) return false
-  const nameInput = new RegExp(normalize(input), 'i')
-  return nameInput.test(normalize(contactOrGroup.name))
+  const normalizedInput = normalizeLowercase(input)
+  return normalizeLowercase(contactOrGroup.name).includes(normalizedInput)
 }
 
 const fullnameMatch = (input, contact) => {
   if (!contact.fullname) return false
-  const fullnameInput = new RegExp(normalize(input), 'i')
-  return fullnameInput.test(normalize(contact.fullname))
+  const normalizedInput = normalizeLowercase(input)
+  return normalizeLowercase(contact.fullname).includes(normalizedInput)
 }
 
 export { emailMatch, cozyUrlMatch, groupNameMatch, fullnameMatch }

--- a/packages/cozy-sharing/src/suggestionMatchers.spec.js
+++ b/packages/cozy-sharing/src/suggestionMatchers.spec.js
@@ -164,6 +164,17 @@ describe('Suggestion matchers', () => {
         matchers.fullnameMatch('zoé', { fullname: 'Zoe Dupont' })
       ).toBeTruthy()
     })
+
+    it('should treat regex metacharacters as plain text', () => {
+      expect(() =>
+        matchers.fullnameMatch('(', { fullname: 'Jon Snow' })
+      ).not.toThrow()
+      expect(matchers.fullnameMatch('(', { fullname: 'Jon Snow' })).toBeFalsy()
+      expect(matchers.fullnameMatch('.', { fullname: 'Jon Snow' })).toBeFalsy()
+      expect(
+        matchers.fullnameMatch('.', { fullname: 'Dr. House' })
+      ).toBeTruthy()
+    })
   })
 
   describe('groupNameMatch', () => {

--- a/packages/cozy-sharing/src/suggestionMatchers.spec.js
+++ b/packages/cozy-sharing/src/suggestionMatchers.spec.js
@@ -146,5 +146,33 @@ describe('Suggestion matchers', () => {
       expect(matchers.fullnameMatch('snow', contact)).toBeTruthy()
       expect(matchers.fullnameMatch('MARG', contact)).toBeTruthy()
     })
+
+    it('should match accented fullname with unaccented input', () => {
+      expect(
+        matchers.fullnameMatch('zoe', { fullname: 'Zoé Dupont' })
+      ).toBeTruthy()
+      expect(
+        matchers.fullnameMatch('elodie', { fullname: 'Élodie Martin' })
+      ).toBeTruthy()
+      expect(
+        matchers.fullnameMatch('celine', { fullname: 'Céline' })
+      ).toBeTruthy()
+    })
+
+    it('should match unaccented fullname with accented input', () => {
+      expect(
+        matchers.fullnameMatch('zoé', { fullname: 'Zoe Dupont' })
+      ).toBeTruthy()
+    })
+  })
+
+  describe('groupNameMatch', () => {
+    it('should match accented group name with unaccented input', () => {
+      const group = {
+        _type: 'io.cozy.contacts.groups',
+        name: 'Équipe'
+      }
+      expect(matchers.groupNameMatch('equipe', group)).toBeTruthy()
+    })
   })
 })

--- a/packages/cozy-sharing/src/suggestionMatchers.spec.js
+++ b/packages/cozy-sharing/src/suggestionMatchers.spec.js
@@ -186,4 +186,72 @@ describe('Suggestion matchers', () => {
       expect(matchers.groupNameMatch('equipe', group)).toBeTruthy()
     })
   })
+
+  describe('Vietnamese diacritics support', () => {
+    const vietnameseContacts = [
+      { fullname: 'Nguyễn Văn Minh', email: 'minh.nguyen@email.com' },
+      { fullname: 'Trần Thị Hương', email: 'huong.tran@email.com' },
+      { fullname: 'Lê Hoàng Nam', email: 'nam.hoang@email.com' },
+      {
+        fullname: 'Phạm Đức Anh',
+        email: 'anh.pham@email.com',
+        cozy: [{ url: 'https://anh.mycozy.cloud' }]
+      }
+    ]
+
+    it('should match Vietnamese accented name with unaccented input', () => {
+      expect(
+        matchers.fullnameMatch('nguyen', vietnameseContacts[0])
+      ).toBeTruthy()
+      expect(matchers.fullnameMatch('van', vietnameseContacts[0])).toBeTruthy()
+      expect(matchers.fullnameMatch('minh', vietnameseContacts[0])).toBeTruthy()
+      expect(matchers.fullnameMatch('tran', vietnameseContacts[1])).toBeTruthy()
+      expect(
+        matchers.fullnameMatch('huong', vietnameseContacts[1])
+      ).toBeTruthy()
+      expect(matchers.fullnameMatch('le', vietnameseContacts[2])).toBeTruthy()
+      expect(matchers.fullnameMatch('nam', vietnameseContacts[2])).toBeTruthy()
+      expect(matchers.fullnameMatch('pham', vietnameseContacts[3])).toBeTruthy()
+      expect(matchers.fullnameMatch('anh', vietnameseContacts[3])).toBeTruthy()
+    })
+
+    it('should match unaccented input with Vietnamese accented name', () => {
+      expect(
+        matchers.fullnameMatch('nguyễn', vietnameseContacts[0])
+      ).toBeTruthy()
+      expect(matchers.fullnameMatch('văn', vietnameseContacts[0])).toBeTruthy()
+      expect(matchers.fullnameMatch('trần', vietnameseContacts[1])).toBeTruthy()
+      expect(
+        matchers.fullnameMatch('hương', vietnameseContacts[1])
+      ).toBeTruthy()
+      expect(matchers.fullnameMatch('lê', vietnameseContacts[2])).toBeTruthy()
+      expect(matchers.fullnameMatch('phạm', vietnameseContacts[3])).toBeTruthy()
+    })
+
+    it('should match Vietnamese email with partial unaccented input', () => {
+      expect(matchers.emailMatch('minh', vietnameseContacts[0])).toBeTruthy()
+      expect(matchers.emailMatch('nguyen', vietnameseContacts[0])).toBeTruthy()
+      expect(matchers.emailMatch('huong', vietnameseContacts[1])).toBeTruthy()
+      expect(matchers.emailMatch('tran', vietnameseContacts[1])).toBeTruthy()
+    })
+
+    it('should match Vietnamese cozy URL with unaccented input', () => {
+      const contact = {
+        fullname: 'Đặng Minh Đức',
+        cozy: [{ url: 'https://duc.mycozy.cloud' }]
+      }
+      expect(matchers.cozyUrlMatch('duc', contact)).toBeTruthy()
+      expect(matchers.cozyUrlMatch('mycozy', contact)).toBeTruthy()
+    })
+
+    it('should match Vietnamese group names with diacritics', () => {
+      const vietGroup = {
+        _type: 'io.cozy.contacts.groups',
+        name: 'Nhóm Việt'
+      }
+      expect(matchers.groupNameMatch('nhom', vietGroup)).toBeTruthy()
+      expect(matchers.groupNameMatch('viet', vietGroup)).toBeTruthy()
+      expect(matchers.groupNameMatch('nhóm', vietGroup)).toBeTruthy()
+    })
+  })
 })


### PR DESCRIPTION
Allow users to search contacts and groups using accented or unaccented versions interchangeably (e.g., 'Zoe' matches 'Zoé' and vice versa). This improves UX for international users who may not remember exact accentuation.

Uses Unicode normalization with diacritic removal, with fallback for older browsers that don't support the Diacritic property in regex.

[Capture vidéo du 2026-04-23 17-12-14.webm](https://github.com/user-attachments/assets/dd5ea160-5b98-4d0e-aba6-ecfe495340d0)

https://www.notion.so/linagora/2d162718bad180a0a68ad0738dbf9ebe?v=2d162718bad180ea8a91000c4ea30ddd&p=34b62718bad180d0a4b4f9af4ca70a78&pm=s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Matching is now diacritic-insensitive across names, group labels, URLs and emails so accented and unaccented queries match interchangeably (e.g., "José" ↔ "Jose").
  * Queries containing regex metacharacters are treated as literal text, preventing unintended regex behavior and crashes.

* **Tests**
  * Added and expanded tests covering diacritic scenarios and regression cases to ensure stable matching behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/cozy-libs/pull/2994?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->