### PR TITLE
fix(cozy-sharing): flatten contact name object in formatRecipients

### DIFF
--- a/packages/cozy-sharing/src/components/SharedDrive/helpers.js
+++ b/packages/cozy-sharing/src/components/SharedDrive/helpers.js
@@ -73,7 +73,7 @@ export const formatRecipients = sharedDriveRecipients => {
     recipients.push({
       index: `${RECIPIENT_INDEX_PREFIX}${r._id}`,
       email: ContactModel.getPrimaryEmail(r),
-      public_name: r.displayName || r.name,
+      public_name: ContactModel.getDisplayName(r),
       memberIndex: r._id,
       type: 'two-way',
       members: r.members
@@ -84,7 +84,7 @@ export const formatRecipients = sharedDriveRecipients => {
     recipients.push({
       index: `${RECIPIENT_INDEX_PREFIX}${r._id}`,
       email: ContactModel.getPrimaryEmail(r),
-      public_name: r.displayName || r.name,
+      public_name: ContactModel.getDisplayName(r),
       memberIndex: r._id,
       type: 'one-way',
       members: r.members

--- a/packages/cozy-sharing/src/components/SharedDrive/helpers.spec.js
+++ b/packages/cozy-sharing/src/components/SharedDrive/helpers.spec.js
@@ -138,6 +138,22 @@ describe('formatRecipients', () => {
     })
   })
 
+  it('should flatten an object-shaped contact name into a string public_name', () => {
+    const input = {
+      recipients: [
+        {
+          _id: '3',
+          name: { givenName: 'Arya', familyName: 'Stark' },
+          email: [{ address: 'arya@example.com', primary: true }]
+        }
+      ],
+      readOnlyRecipients: []
+    }
+    const result = formatRecipients(input)
+    expect(typeof result[0].public_name).toBe('string')
+    expect(result[0].public_name).toBe('Arya Stark')
+  })
+
   it('should sort recipients by public_name', () => {
     const input = {
       recipients: [


### PR DESCRIPTION
## What breaks

Selecting a contact in the folder share modal crashes the whole page. The user just sees the modal die; under the hood it's a `TypeError` on `.toUpperCase()` plus React complaining that `{familyName, givenName}` isn't a valid child.

## Why it's weird

Same cozy-drive, same flags, two instances: one crashes every time, the other never does. That's not a version bug — it's data-shape bug.

## What's actually happening

`formatRecipients` builds `public_name` as `r.displayName || r.name`. It assumes `r.name` is a string. For an `io.cozy.contacts` doc it isn't, it's `{ givenName, familyName }`.

If the contact has no `displayName`, the object leaks into `public_name` and blows up the first component that tries to show initials or render the name.

Contacts with `displayName` go through fine. Contacts without it crash.

## Why some instances have `displayName` and others don't

Depends on how the contact was written to CouchDB:

- Contacts app / cozy-client save paths → stack hooks populate `displayName`.
- Raw CouchDB write (early LDAP sync used this) → `displayName` is never set.

Production instances with LDAP-synced contacts hit the second case. Instances where every contact happens to have `displayName` never see the bug.

## Where it came from

Introduced in [`9aba0371d9`](https://github.com/linagora/cozy-libs/commit/9aba0371d9), first shipped in `cozy-sharing@21.3.0`, dormant since February 2025.

## Fix

`r.displayName || r.name` → `ContactModel.getDisplayName(r)`. That always returns a string, uses `displayName` when present, falls back to a flattened fullname otherwise. One-line change, regression test included.