### PR TITLE
fix(cozy-sharing): escape user input in suggestion matchers

### DIFF
--- a/packages/cozy-sharing/src/suggestionMatchers.js
+++ b/packages/cozy-sharing/src/suggestionMatchers.js
@@ -1,10 +1,12 @@
+import escapeRegExp from 'lodash/escapeRegExp'
+
 import { Group } from 'cozy-doctypes'
 
 // TODO: sadly we have different versions of contacts' doctype to handle...
 // A migration tool on the stack side is needed here
 const emailMatch = (input, contact) => {
   if (!contact.email) return false
-  const emailInput = new RegExp(input, 'i')
+  const emailInput = new RegExp(escapeRegExp(input), 'i')
   if (Array.isArray(contact.email)) {
     return contact.email.some(email => emailInput.test(email.address))
   }
@@ -13,7 +15,7 @@ const emailMatch = (input, contact) => {
 
 const cozyUrlMatch = (input, contact) => {
   if (!contact.cozy && !contact.url) return false
-  const urlInput = new RegExp(input, 'i')
+  const urlInput = new RegExp(escapeRegExp(input), 'i')
   if (contact.cozy && Array.isArray(contact.cozy)) {
     return contact.cozy.some(cozy => urlInput.test(cozy.url))
   }
@@ -22,13 +24,13 @@ const cozyUrlMatch = (input, contact) => {
 
 const groupNameMatch = (input, contactOrGroup) => {
   if (contactOrGroup._type !== Group.doctype) return false
-  const nameInput = new RegExp(input, 'i')
+  const nameInput = new RegExp(escapeRegExp(input), 'i')
   return nameInput.test(contactOrGroup.name)
 }
 
 const fullnameMatch = (input, contact) => {
   if (!contact.fullname) return false
-  const fullnameInput = new RegExp(input, 'i')
+  const fullnameInput = new RegExp(escapeRegExp(input), 'i')
   return fullnameInput.test(contact.fullname)
 }
 

--- a/packages/cozy-sharing/src/suggestionMatchers.spec.js
+++ b/packages/cozy-sharing/src/suggestionMatchers.spec.js
@@ -95,6 +95,36 @@ describe('Suggestion matchers', () => {
     })
   })
 
+  describe('with regex special characters in input', () => {
+    const contact = {
+      fullname: 'Jon (the) Snow*',
+      email: [{ address: 'jon+snow@winterfell.westeros' }],
+      cozy: [{ url: 'https://jon.mycozy.cloud' }]
+    }
+    const group = {
+      _type: 'io.cozy.contacts.groups',
+      name: 'House (Stark)'
+    }
+
+    it('should not throw on unbalanced parentheses', () => {
+      expect(() => matchers.emailMatch('foo (bar', contact)).not.toThrow()
+      expect(() => matchers.cozyUrlMatch('foo (bar', contact)).not.toThrow()
+      expect(() => matchers.fullnameMatch('foo (bar', contact)).not.toThrow()
+      expect(() => matchers.groupNameMatch('foo (bar', group)).not.toThrow()
+    })
+
+    it('should match special chars literally instead of as regex', () => {
+      expect(matchers.fullnameMatch('(the)', contact)).toBe(true)
+      expect(matchers.fullnameMatch('Snow*', contact)).toBe(true)
+      expect(matchers.emailMatch('jon+snow', contact)).toBe(true)
+      expect(matchers.groupNameMatch('(Stark)', group)).toBe(true)
+    })
+
+    it('should not let . match any character', () => {
+      expect(matchers.fullnameMatch('J.n', contact)).toBe(false)
+    })
+  })
+
   describe('fullnameMatch', () => {
     it('should return false if no fullname or no match', () => {
       const contact = {}


### PR DESCRIPTION
## Summary

- Typing or pasting text with regex metacharacters into the ShareAutosuggest input crashes with `SyntaxError: Invalid regular expression`. The four `*Match` helpers in `suggestionMatchers.js` build a `new RegExp(input, 'i')` from raw user input.
- Escape the input so special characters are matched literally. Existing matching behavior is preserved for plain inputs.
- Adds regression tests covering unbalanced parentheses, literal special chars, and the `.` no longer matching any character.

Fixes DRIVE-10ZR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of special characters in suggestion matchers to ensure they are treated as literal text rather than regex operators.

* **Tests**
  * Added test coverage for suggestion matchers with regex special characters, including unbalanced parentheses and wildcard characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->