### PR TITLE
feat(cozy-sharing): Add autoFocus to the share recipient input

### DIFF
--- a/packages/cozy-sharing/src/components/ShareAutosuggest.jsx
+++ b/packages/cozy-sharing/src/components/ShareAutosuggest.jsx
@@ -205,6 +205,7 @@ const ShareAutocomplete = ({
         renderInputComponent={renderInput}
         highlightFirstSuggestion
         inputProps={{
+          autoFocus: true,
           onFocus: onAutosuggestFocus,
           onChange: onAutosuggestChange,
           onPaste: onAutosuggestPaste,

--- a/packages/cozy-sharing/src/components/ShareAutosuggest.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareAutosuggest.spec.jsx
@@ -51,17 +51,22 @@ describe('ShareAutosuggest', () => {
     })
   })
 
-  it('should show loading only after user focus input', () => {
+  it('should show loading indicator when loading prop is true (autoFocus triggers onFocus on mount)', () => {
     const onPick = jest.fn()
     const onRemove = jest.fn()
 
     setup({ onPick, onRemove, loading: true })
 
-    const inputNode = screen.getByPlaceholderText('myPlaceHolder')
+    // autoFocus triggers onFocus on mount, which sets isLoadingDisplayed
+    expect(screen.getByText('loading')).toBeInTheDocument()
+  })
+
+  it('should not show loading indicator when loading prop is false', () => {
+    const onPick = jest.fn()
+    const onRemove = jest.fn()
+
+    setup({ onPick, onRemove, loading: false })
 
     expect(screen.queryByText('loading')).toBeNull()
-    fireEvent.focus(inputNode)
-
-    expect(screen.getByText('loading')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
<img width="571" height="287" alt="image" src="https://github.com/user-attachments/assets/00ec7fd4-809e-4c98-9182-088cd28364ca" />


https://www.notion.so/linagora/sharing-modal-polishing-36662718bad18012a393cd5103f03a3e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The sharing suggestion input now receives focus automatically when shown, so you can start typing right away to find and select contacts more quickly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/cozy-libs/pull/3005?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->