### PR TITLE
fix(cozy-sharing): Filter out the owner from the list of suggested users

### DIFF
--- a/packages/cozy-sharing/src/components/ShareRecipientsInput.jsx
+++ b/packages/cozy-sharing/src/components/ShareRecipientsInput.jsx
@@ -17,6 +17,8 @@ import {
  * We retrieve all the contacts that are reachable and the groups they belong to.
  * In order to display the total number of members in each group, we also retrieve the contacts that are not reachable.
  */
+const isCurrentUser = contact => contact.me === true
+
 const ShareRecipientsInput = ({
   currentRecipients,
   recipients,
@@ -57,6 +59,12 @@ const ShareRecipientsInput = ({
       (isQueryLoading(unreachableContactsWithGroupsResult) ||
         unreachableContactsWithGroupsResult.hasMore))
 
+  const reachableContacts = (reachableContactsResult.data || []).filter(
+    contact => !isCurrentUser(contact)
+  )
+  const unreachableContactsWithGroups = (
+    unreachableContactsWithGroupsResult.data || []
+  ).filter(contact => !isCurrentUser(contact))
   const currentRecipientGroups = currentRecipients
     .map(({ id }) => id)
     .filter(Boolean)
@@ -68,7 +76,7 @@ const ShareRecipientsInput = ({
     )
     .map(contactGroup => {
       const reachableMembers = getContactsFromGroupId(
-        reachableContactsResult.data,
+        reachableContacts,
         contactGroup.id
       ).map(contact => ({
         ...contact,
@@ -83,7 +91,7 @@ const ShareRecipientsInput = ({
       }
 
       const unreachableMembers = getContactsFromGroupId(
-        unreachableContactsWithGroupsResult.data,
+        unreachableContactsWithGroups,
         contactGroup.id
       ).map(contact => ({
         ...contact,
@@ -96,10 +104,7 @@ const ShareRecipientsInput = ({
       }
     })
 
-  const contactsAndGroups = [
-    ...(reachableContactsResult.data || []),
-    ...contactGroups
-  ]
+  const contactsAndGroups = [...reachableContacts, ...contactGroups]
 
   return (
     <ShareAutosuggest

--- a/packages/cozy-sharing/src/components/ShareRecipientsInput.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareRecipientsInput.spec.jsx
@@ -116,6 +116,65 @@ describe('ShareRecipientsInput component', () => {
     ).toBeInTheDocument()
   })
 
+  it('should exclude current user from suggestions when me is true', async () => {
+    const contacts = [
+      {
+        id: 'df563cc4-6440',
+        _id: 'df563cc4-6440',
+        _type: 'io.cozy.contacts',
+        me: true,
+        name: {
+          givenName: 'My',
+          familyName: 'Self'
+        },
+        relationships: {
+          groups: {
+            data: [
+              {
+                _id: 'group-id',
+                _type: 'io.cozy.contacts.groups'
+              }
+            ]
+          }
+        }
+      },
+      {
+        id: '5a3b4ccf-c257',
+        _id: '5a3b4ccf-c257',
+        _type: 'io.cozy.contacts',
+        name: {
+          givenName: 'Teagan',
+          familyName: 'Wolf'
+        },
+        relationships: {
+          groups: {
+            data: [
+              {
+                _id: 'group-id',
+                _type: 'io.cozy.contacts.groups'
+              }
+            ]
+          }
+        }
+      }
+    ]
+
+    const contactGroups = [
+      {
+        id: 'group-id',
+        name: 'Friends',
+        _id: 'group-id',
+        _type: 'io.cozy.contacts.groups'
+      }
+    ]
+
+    setup({ contacts, contactGroups })
+
+    expect(screen.queryByText('My Self')).not.toBeInTheDocument()
+    expect(screen.getByText('Teagan Wolf')).toBeInTheDocument()
+    expect(screen.getByText('Friends - 1 members')).toBeInTheDocument()
+  })
+
   it('should include unreachable members when flag sharing.show-recipient-groups is activated', async () => {
     flag.mockReturnValue(true)
 


### PR DESCRIPTION
Do not display the user's own instance in the list of users to share with

https://www.notion.so/linagora/sharing-modal-polishing-36662718bad18012a393cd5103f03a3e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The sharing recipients input now excludes the current user from recipient suggestions.

* **Tests**
  * Added a test to verify the current user is not shown among recipient suggestions while other contacts and groups remain available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/cozy-libs/pull/3006?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->