### PR TITLE
feat(sharing): Update sharing dialog close actions

### DIFF
--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -128,7 +128,7 @@
       "shareByEmail": {
         "subtitle": "By email",
         "emailPlaceholder": "Add contacts",
-        "send": "Share",
+        "send": "Done",
         "singleContactSuccess": "You sent an invite to %{email}.",
         "contactSuccess": "You sent an invite to %{smart_count} contact. |||| You sent an invite to %{smart_count} contacts.",
         "singleGroupSuccess": "You sent an invite to the members of the %{groupName} group.",
@@ -196,7 +196,7 @@
         "subtitle": "By email",
         "email": "To:",
         "emailPlaceholder": "Enter the email address or name of the recipient",
-        "send": "Share",
+        "send": "Done",
         "singleContactSuccess": "You sent an invite to %{email}.",
         "contactSuccess": "You sent an invite to %{smart_count} contact. |||| You sent an invite to %{smart_count} contacts.",
         "singleGroupSuccess": "You sent an invite to the members of the %{groupName} group.",
@@ -265,7 +265,7 @@
         "subtitle": "By email",
         "email": "email",
         "emailPlaceholder": "Enter the email address or name of the recipient",
-        "send": "Share",
+        "send": "Done",
         "singleContactSuccess": "You sent an invite to %{email}.",
         "contactSuccess": "You sent an invite to %{smart_count} contact. |||| You sent an invite to %{smart_count} contacts.",
         "singleGroupSuccess": "You sent an invite to the members of the %{groupName} group.",
@@ -329,7 +329,7 @@
         "subtitle": "By email",
         "email": "Send to:",
         "emailPlaceholder": "Enter the email address or name of the recipient",
-        "send": "Share",
+        "send": "Done",
         "error": {
           "addingRecipient": "An error occurred while adding the recipient. Please try again."
         },
@@ -381,6 +381,11 @@
     "title": "Problem with your sharing",
     "content": "You cannot share %{documentName} with more than %{limit} members.",
     "confirm": "I understand"
+  },
+  "ShareDiscardChangesModal": {
+    "title": "Discard the changes you haven't saved?",
+    "cancel": "Cancel",
+    "discard": "Discard"
   },
   "GroupRecipient": {
     "secondary": "%{memberCount} member |||| %{memberCount} members",
@@ -436,7 +441,7 @@
   },
   "FederatedFolder": {
     "title": "Shared folder",
-    "share": "Share",
+    "share": "Done",
     "shareTitle": "Share \"%{name}\"",
     "successNotification": "Folder has been shared",
     "errorNotification": "Error while sharing folder",

--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -125,7 +125,7 @@
       "shareByEmail": {
         "subtitle": "Par email",
         "emailPlaceholder": "Ajouter des contacts",
-        "send": "Partager",
+        "send": "Terminé",
         "singleContactSuccess": "Vous avez envoyé une invitation à %{email}.",
         "contactSuccess": "Vous avez invité %{smart_count} contact. |||| Vous avez invité %{smart_count} contacts.",
         "singleGroupSuccess": "Vous avez invité les membres du groupe %{groupName}.",
@@ -193,7 +193,7 @@
         "subtitle": "Par email",
         "email": "À :",
         "emailPlaceholder": "Saisissez le courriel ou le nom du destinataire.",
-        "send": "Partager",
+        "send": "Terminé",
         "singleContactSuccess": "Vous avez envoyé une invitation à %{email}.",
         "contactSuccess": "Vous avez invité %{smart_count} contact. |||| Vous avez invité %{smart_count} contacts.",
         "singleGroupSuccess": "Vous avez invité les membres du groupe %{groupName}.",
@@ -263,7 +263,7 @@
         "subtitle": "Par email",
         "email": "e-mail",
         "emailPlaceholder": "Saisissez l'email ou le nom du destinataire.",
-        "send": "Partager",
+        "send": "Terminé",
         "singleContactSuccess": "Vous avez envoyé une invitation à %{email}.",
         "contactSuccess": "Vous avez invité %{smart_count} contact. |||| Vous avez invité %{smart_count} contacts.",
         "singleGroupSuccess": "Vous avez invité les membres du groupe %{groupName}.",
@@ -327,7 +327,7 @@
         "subtitle": "Par email",
         "email": "Envoyer à :",
         "emailPlaceholder": "Saisissez le courriel ou le nom du destinataire.",
-        "send": "Partager",
+        "send": "Terminé",
         "error": {
           "addingRecipient": "Une erreur s'est produite lors de l'ajout du destinataire. Veuillez réessayer."
         },
@@ -379,6 +379,11 @@
     "title": "Problème au niveau de votre partage",
     "content": "Vous ne pouvez pas partager %{documentName} à plus de %{limit} membres.",
     "confirm": "J'ai compris"
+  },
+  "ShareDiscardChangesModal": {
+    "title": "Abandonner les modifications non enregistrées ?",
+    "cancel": "Annuler",
+    "discard": "Abandonner"
   },
   "GroupRecipient": {
     "secondary": "%{memberCount} membre |||| %{memberCount} membres",
@@ -434,7 +439,7 @@
   },
   "FederatedFolder": {
     "title": "Dossier partagé",
-    "share": "Partager",
+    "share": "Terminé",
     "shareTitle": "Partager \"%{name}\"",
     "successNotification": "Le dossier a été partagé",
     "errorNotification": "Erreur lors du partage du dossier",

--- a/packages/cozy-sharing/locales/ru.json
+++ b/packages/cozy-sharing/locales/ru.json
@@ -128,7 +128,7 @@
       "shareByEmail": {
         "subtitle": "По электронной почте",
         "emailPlaceholder": "Добавить контакты",
-        "send": "Поделиться",
+        "send": "Готово",
         "singleContactSuccess": "Вы отправили приглашение на %{email}.",
         "contactSuccess": "Вы отправили приглашение %{smart_count} контакту. |||| Вы отправили приглашение %{smart_count} контактам.",
         "singleGroupSuccess": "Вы отправили приглашение участникам группы %{groupName}.",
@@ -196,7 +196,7 @@
         "subtitle": "По электронной почте",
         "email": "Кому:",
         "emailPlaceholder": "Введите адрес электронной почты или имя получателя",
-        "send": "Поделиться",
+        "send": "Готово",
         "singleContactSuccess": "Вы отправили приглашение на %{email}.",
         "contactSuccess": "Вы отправили приглашение %{smart_count} контакту. |||| Вы отправили приглашение %{smart_count} контактам.",
         "singleGroupSuccess": "Вы отправили приглашение участникам группы %{groupName}.",
@@ -265,7 +265,7 @@
         "subtitle": "По электронной почте",
         "email": "эл. почта",
         "emailPlaceholder": "Введите адрес электронной почты или имя получателя",
-        "send": "Поделиться",
+        "send": "Готово",
         "singleContactSuccess": "Вы отправили приглашение на %{email}.",
         "contactSuccess": "Вы отправили приглашение %{smart_count} контакту. |||| Вы отправили приглашение %{smart_count} контактам.",
         "singleGroupSuccess": "Вы отправили приглашение участникам группы %{groupName}.",
@@ -329,7 +329,7 @@
         "subtitle": "По электронной почте",
         "email": "Отправить:",
         "emailPlaceholder": "Введите адрес электронной почты или имя получателя",
-        "send": "Поделиться",
+        "send": "Готово",
         "error": {
           "addingRecipient": "Произошла ошибка при добавлении получателя. Пожалуйста, попробуйте еще раз."
         },
@@ -381,6 +381,11 @@
     "title": "Проблема с вашим общим доступом",
     "content": "Вы не можете предоставить общий доступ к %{documentName} более чем %{limit} участникам.",
     "confirm": "Понятно"
+  },
+  "ShareDiscardChangesModal": {
+    "title": "Отменить несохраненные изменения?",
+    "cancel": "Отмена",
+    "discard": "Отменить"
   },
   "GroupRecipient": {
     "secondary": "%{memberCount} участник |||| %{memberCount} участников",
@@ -436,7 +441,7 @@
   },
   "FederatedFolder": {
     "title": "Общая папка",
-    "share": "Поделиться",
+    "share": "Готово",
     "shareTitle": "Поделиться \"%{name}\"",
     "successNotification": "Папка была расшарена",
     "errorNotification": "Ошибка при расшаривании папки",

--- a/packages/cozy-sharing/locales/vi.json
+++ b/packages/cozy-sharing/locales/vi.json
@@ -128,7 +128,7 @@
       "shareByEmail": {
         "subtitle": "Bằng email",
         "emailPlaceholder": "Thêm liên hệ",
-        "send": "Chia sẻ",
+        "send": "Xong",
         "singleContactSuccess": "Bạn đã gửi lời mời đến %{email}.",
         "contactSuccess": "Bạn đã gửi lời mời đến %{smart_count} liên hệ. |||| Bạn đã gửi lời mời đến %{smart_count} liên hệ.",
         "singleGroupSuccess": "Bạn đã gửi lời mời đến các thành viên của nhóm %{groupName}.",
@@ -196,7 +196,7 @@
         "subtitle": "Bằng email",
         "email": "Đến:",
         "emailPlaceholder": "Nhập địa chỉ email hoặc tên người nhận",
-        "send": "Chia sẻ",
+        "send": "Xong",
         "singleContactSuccess": "Bạn đã gửi lời mời đến %{email}.",
         "contactSuccess": "Bạn đã gửi lời mời đến %{smart_count} liên hệ. |||| Bạn đã gửi lời mời đến %{smart_count} liên hệ.",
         "singleGroupSuccess": "Bạn đã gửi lời mời đến các thành viên của nhóm %{groupName}.",
@@ -265,7 +265,7 @@
         "subtitle": "Bằng email",
         "email": "email",
         "emailPlaceholder": "Nhập địa chỉ email hoặc tên người nhận",
-        "send": "Chia sẻ",
+        "send": "Xong",
         "singleContactSuccess": "Bạn đã gửi lời mời đến %{email}.",
         "contactSuccess": "Bạn đã gửi lời mời đến %{smart_count} liên hệ. |||| Bạn đã gửi lời mời đến %{smart_count} liên hệ.",
         "singleGroupSuccess": "Bạn đã gửi lời mời đến các thành viên của nhóm %{groupName}.",
@@ -329,7 +329,7 @@
         "subtitle": "Bằng email",
         "email": "Gửi đến:",
         "emailPlaceholder": "Nhập địa chỉ email hoặc tên người nhận",
-        "send": "Chia sẻ",
+        "send": "Xong",
         "error": {
           "addingRecipient": "Đã xảy ra lỗi khi thêm người nhận. Vui lòng thử lại."
         },
@@ -381,6 +381,11 @@
     "title": "Sự cố với chia sẻ của bạn",
     "content": "Bạn không thể chia sẻ %{documentName} với nhiều hơn %{limit} thành viên.",
     "confirm": "Tôi hiểu rồi"
+  },
+  "ShareDiscardChangesModal": {
+    "title": "Bạn có muốn bỏ các thay đổi chưa lưu?",
+    "cancel": "Hủy",
+    "discard": "Bỏ"
   },
   "GroupRecipient": {
     "secondary": "%{memberCount} thành viên |||| %{memberCount} thành viên",
@@ -436,7 +441,7 @@
   },
   "FederatedFolder": {
     "title": "Thư mục chia sẻ",
-    "share": "Chia sẻ",
+    "share": "Xong",
     "shareTitle": "Chia sẻ \"%{name}\"",
     "successNotification": "Thư mục đã được chia sẻ",
     "errorNotification": "Lỗi khi chia sẻ thư mục",

--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
@@ -1,8 +1,12 @@
 import PropTypes from 'prop-types'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { useClient } from 'cozy-client'
+import Button from 'cozy-ui/transpiled/react/Buttons'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
+import ConfirmDialogProvider, {
+  useConfirmDialog
+} from 'cozy-ui/transpiled/react/providers/ConfirmDialog'
 import { useI18n } from 'twake-i18n'
 
 import { getOrCreateFromArray } from '../../helpers/contacts'
@@ -11,149 +15,191 @@ import { usePendingRecipients } from '../../hooks/usePendingRecipients'
 import { useSharingContext } from '../../hooks/useSharingContext'
 import { DumbBatchSharedFolderModal } from '../SharedFolder/DumbBatchSharedFolderModal'
 
-export const FederatedFolderModal = withLocales(
-  ({
+const FederatedFolderModalContent = ({
+  onClose,
+  document: existingDocument,
+  autoOpenShareRestriction,
+  showGenerateLinkButton
+}) => {
+  const client = useClient()
+  const { t } = useI18n()
+  const {
+    share,
+    getSharingLink,
+    getFederatedShareLink,
+    getDocumentPermissions,
+    getOwner,
+    getSharingById,
+    getRecipients,
+    revoke
+  } = useSharingContext()
+  const { showAlert } = useAlert()
+  const { showConfirmDialog, closeConfirmDialog } = useConfirmDialog()
+
+  const [sharingLink, setSharingLink] = useState(null)
+  const {
+    pendingRecipients,
+    setPendingRecipients,
+    selectedOption,
+    setSelectedOption
+  } = usePendingRecipients()
+
+  // share from CozyProvider is wired to callbacks and realtime that
+  // makes existingDocument and existingRecipients reactive to changes.
+  // But we want it to be reactive only when we revoke a member. When we add member
+  // we close the popup and we do not want to see briefly the new contacts added
+  // in members before the modal closes. That's why when clicking on "Share"
+  // we do not use the reactive existingDocument and existingRecipients.
+  const [isSending, setIsSending] = useState(false)
+  const [frozenDoc, setFrozenDoc] = useState(null)
+  const [frozenRecipients, setFrozenRecipients] = useState(null)
+
+  const handleCloseRequest = useCallback(() => {
+    if (pendingRecipients.length === 0) {
+      onClose()
+      return
+    }
+
+    showConfirmDialog({
+      title: t('ShareDiscardChangesModal.title'),
+      actions: (
+        <>
+          <Button
+            variant="secondary"
+            label={t('ShareDiscardChangesModal.cancel')}
+            className="u-fz-small"
+            onClick={closeConfirmDialog}
+          />
+          <Button
+            variant="primary"
+            label={t('ShareDiscardChangesModal.discard')}
+            className="u-fz-small"
+            onClick={() => {
+              closeConfirmDialog()
+              onClose()
+            }}
+          />
+        </>
+      )
+    })
+  }, [
+    closeConfirmDialog,
     onClose,
-    document: existingDocument,
-    autoOpenShareRestriction,
-    showGenerateLinkButton
-  }) => {
-    const client = useClient()
-    const { t } = useI18n()
-    const {
-      share,
-      getSharingLink,
-      getFederatedShareLink,
-      getDocumentPermissions,
-      getOwner,
-      getSharingById,
-      getRecipients,
-      revoke
-    } = useSharingContext()
-    const { showAlert } = useAlert()
+    pendingRecipients.length,
+    showConfirmDialog,
+    t
+  ])
 
-    const [sharingLink, setSharingLink] = useState(null)
-    const {
-      pendingRecipients,
-      setPendingRecipients,
-      selectedOption,
-      setSelectedOption
-    } = usePendingRecipients()
+  const documentPermissions = useMemo(
+    () =>
+      existingDocument ? getDocumentPermissions(existingDocument._id) : [],
+    [existingDocument, getDocumentPermissions]
+  )
 
-    // share from CozyProvider is wired to callbacks and realtime that
-    // makes existingDocument and existingRecipients reactive to changes.
-    // But we want it to be reactive only when we revoke a member. When we add member
-    // we close the popup and we do not want to see briefly the new contacts added
-    // in members before the modal closes. That's why when clicking on "Share"
-    // we do not use the reactive existingDocument and existingRecipients.
-    const [isSending, setIsSending] = useState(false)
-    const [frozenDoc, setFrozenDoc] = useState(null)
-    const [frozenRecipients, setFrozenRecipients] = useState(null)
+  useEffect(() => {
+    const fetchSharingLink = async () => {
+      if (!existingDocument) return
 
-    const documentPermissions = existingDocument
-      ? getDocumentPermissions(existingDocument._id)
-      : []
-
-    useEffect(() => {
-      const fetchSharingLink = async () => {
-        if (!existingDocument) return
-
-        if (existingDocument.driveId) {
-          const link = await getFederatedShareLink(existingDocument)
-          setSharingLink(link)
-        } else {
-          setSharingLink(getSharingLink(existingDocument._id))
-        }
-      }
-
-      fetchSharingLink()
-    }, [
-      existingDocument,
-      documentPermissions,
-      getFederatedShareLink,
-      getSharingLink,
-      getOwner,
-      getSharingById
-    ])
-
-    const folderName = existingDocument?.name || ''
-
-    const onSend = async () => {
-      if (pendingRecipients.length === 0) {
-        onClose()
-        return
-      }
-
-      setIsSending(true)
-      setFrozenDoc(existingDocument)
-      setFrozenRecipients(existingRecipients)
-
-      try {
-        const contacts = await getOrCreateFromArray(
-          client,
-          pendingRecipients,
-          contact => client.create('io.cozy.contacts', contact)
-        )
-        const readWriteRecipients =
-          selectedOption === 'readOnly' ? [] : contacts
-        const readOnlyRecipients = selectedOption === 'readOnly' ? contacts : []
-
-        await share({
-          description: folderName,
-          document: existingDocument,
-          recipients: readWriteRecipients,
-          readOnlyRecipients,
-          sharedDrive: true,
-          openSharing: false
-        })
-
-        showAlert({
-          message: t('FederatedFolder.successNotification'),
-          severity: 'success',
-          variant: 'filled'
-        })
-
-        onClose()
-      } catch (_err) {
-        showAlert({
-          message: t('FederatedFolder.errorNotification'),
-          severity: 'error',
-          variant: 'filled'
-        })
-      } finally {
-        setIsSending(false)
+      if (existingDocument.driveId) {
+        const link = await getFederatedShareLink(existingDocument)
+        setSharingLink(link)
+      } else {
+        setSharingLink(getSharingLink(existingDocument._id))
       }
     }
 
-    const existingRecipients = existingDocument
-      ? getRecipients(existingDocument._id)
-      : []
+    fetchSharingLink()
+  }, [
+    existingDocument,
+    documentPermissions,
+    getFederatedShareLink,
+    getSharingLink,
+    getOwner,
+    getSharingById
+  ])
 
-    const modalTitle = t('FederatedFolder.shareTitle', { name: folderName })
-    const isSharedDrive = Boolean(existingDocument?.driveId)
+  const folderName = existingDocument?.name || ''
 
-    return (
-      <DumbBatchSharedFolderModal
-        title={modalTitle}
-        document={isSending ? frozenDoc : existingDocument}
-        recipients={isSending ? frozenRecipients : existingRecipients}
-        currentRecipients={isSending ? frozenRecipients : existingRecipients}
-        onRevoke={revoke}
-        onSend={onSend}
-        onClose={onClose}
-        sharingLink={sharingLink}
-        shareLabel={t('FederatedFolder.share')}
-        showShareByEmail={!isSharedDrive}
-        autoOpenShareRestriction={autoOpenShareRestriction}
-        showGenerateLinkButton={showGenerateLinkButton}
-        pendingRecipients={pendingRecipients}
-        onPendingRecipientsChange={setPendingRecipients}
-        selectedOption={selectedOption}
-        onSelectedOptionChange={setSelectedOption}
-      />
-    )
+  const onSend = async () => {
+    if (pendingRecipients.length === 0) {
+      onClose()
+      return
+    }
+
+    setIsSending(true)
+    setFrozenDoc(existingDocument)
+    setFrozenRecipients(existingRecipients)
+
+    try {
+      const contacts = await getOrCreateFromArray(
+        client,
+        pendingRecipients,
+        contact => client.create('io.cozy.contacts', contact)
+      )
+      const readWriteRecipients = selectedOption === 'readOnly' ? [] : contacts
+      const readOnlyRecipients = selectedOption === 'readOnly' ? contacts : []
+
+      await share({
+        description: folderName,
+        document: existingDocument,
+        recipients: readWriteRecipients,
+        readOnlyRecipients,
+        sharedDrive: true,
+        openSharing: false
+      })
+
+      showAlert({
+        message: t('FederatedFolder.successNotification'),
+        severity: 'success',
+        variant: 'filled'
+      })
+
+      onClose()
+    } catch (_err) {
+      showAlert({
+        message: t('FederatedFolder.errorNotification'),
+        severity: 'error',
+        variant: 'filled'
+      })
+    } finally {
+      setIsSending(false)
+    }
   }
-)
+
+  const existingRecipients = existingDocument
+    ? getRecipients(existingDocument._id)
+    : []
+
+  const modalTitle = t('FederatedFolder.shareTitle', { name: folderName })
+  const isSharedDrive = Boolean(existingDocument?.driveId)
+
+  return (
+    <DumbBatchSharedFolderModal
+      title={modalTitle}
+      document={isSending ? frozenDoc : existingDocument}
+      recipients={isSending ? frozenRecipients : existingRecipients}
+      currentRecipients={isSending ? frozenRecipients : existingRecipients}
+      onRevoke={revoke}
+      onSend={onSend}
+      onClose={handleCloseRequest}
+      sharingLink={sharingLink}
+      shareLabel={t('FederatedFolder.share')}
+      showShareByEmail={!isSharedDrive}
+      autoOpenShareRestriction={autoOpenShareRestriction}
+      showGenerateLinkButton={showGenerateLinkButton}
+      pendingRecipients={pendingRecipients}
+      onPendingRecipientsChange={setPendingRecipients}
+      selectedOption={selectedOption}
+      onSelectedOptionChange={setSelectedOption}
+    />
+  )
+}
+
+export const FederatedFolderModal = withLocales(props => (
+  <ConfirmDialogProvider>
+    <FederatedFolderModalContent {...props} />
+  </ConfirmDialogProvider>
+))
 
 FederatedFolderModal.propTypes = {
   onClose: PropTypes.func.isRequired,

--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
@@ -320,6 +320,53 @@ describe('FederatedFolderModal', () => {
 
       expect(mockOnClose).toHaveBeenCalled()
     })
+
+    it('should ask confirmation when close button is clicked with pending recipients', async () => {
+      usePendingRecipients.mockReturnValue({
+        pendingRecipients: [{ name: 'Alice', email: 'alice@example.com' }],
+        setPendingRecipients: jest.fn(),
+        selectedOption: 'readWrite',
+        setSelectedOption: jest.fn()
+      })
+
+      const { getByRole, getByTestId, getByText } = setup()
+
+      await waitFor(() => {
+        expect(getByTestId('btn-close')).toBeTruthy()
+      })
+
+      fireEvent.click(getByTestId('btn-close'))
+
+      expect(getByText("Discard the changes you haven't saved?")).toBeTruthy()
+      expect(mockOnClose).not.toHaveBeenCalled()
+
+      fireEvent.click(getByRole('button', { name: 'Cancel' }))
+
+      expect(mockOnClose).not.toHaveBeenCalled()
+    })
+
+    it('should close after discard confirmation', async () => {
+      usePendingRecipients.mockReturnValue({
+        pendingRecipients: [{ name: 'Alice', email: 'alice@example.com' }],
+        setPendingRecipients: jest.fn(),
+        selectedOption: 'readWrite',
+        setSelectedOption: jest.fn()
+      })
+
+      const { getByRole, getByTestId, getByText } = setup()
+
+      await waitFor(() => {
+        expect(getByTestId('btn-close')).toBeTruthy()
+      })
+
+      fireEvent.click(getByTestId('btn-close'))
+
+      expect(getByText("Discard the changes you haven't saved?")).toBeTruthy()
+
+      fireEvent.click(getByRole('button', { name: 'Discard' }))
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('existing recipients', () => {

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
@@ -169,20 +169,66 @@ describe('ShareDialogCozyToCozy', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('main Share button calls onClose when there are no pending chips', () => {
+  it('main Done button calls onClose when there are no pending chips', () => {
     const onClose = jest.fn()
     const onShare = jest.fn()
     const props = { ...getMockProps(), onClose, onShare }
 
     const { getByRole } = setup(props)
 
-    fireEvent.click(getByRole('button', { name: 'Share' }))
+    fireEvent.click(getByRole('button', { name: 'Done' }))
 
     expect(onShare).not.toHaveBeenCalled()
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  it('main Share button calls onShare with chips then closes', async () => {
+  it('close action closes dialog when there are no pending chips', () => {
+    const onClose = jest.fn()
+    const props = { ...getMockProps(), onClose }
+
+    const { getByRole } = setup(props)
+
+    fireEvent.click(getByRole('button', { name: 'Close' }))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('close action closes dialog when there are pending chips', () => {
+    const onClose = jest.fn()
+    const props = { ...getMockProps(), onClose }
+
+    const { getByPlaceholderText, getByRole, queryByText } = setup(props)
+
+    act(() => {
+      fireEvent.change(
+        getByPlaceholderText(
+          'Enter the email address or name of the recipient'
+        ),
+        {
+          target: { value: 'new@cozycloud.cc' }
+        }
+      )
+    })
+    act(() => {
+      fireEvent.keyPress(
+        getByPlaceholderText(
+          'Enter the email address or name of the recipient'
+        ),
+        {
+          key: 'Enter',
+          code: 'Enter',
+          charCode: 13
+        }
+      )
+    })
+
+    fireEvent.click(getByRole('button', { name: 'Close' }))
+
+    expect(queryByText("Discard the changes you haven't saved?")).toBe(null)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('main Done button calls onShare with chips then closes', async () => {
     const onClose = jest.fn()
     const onShare = jest.fn().mockResolvedValue(undefined)
     const props = { ...getMockProps(), onClose, onShare }
@@ -213,7 +259,7 @@ describe('ShareDialogCozyToCozy', () => {
     })
 
     await act(async () => {
-      fireEvent.click(getByRole('button', { name: 'Share' }))
+      fireEvent.click(getByRole('button', { name: 'Done' }))
     })
 
     expect(onShare).toHaveBeenCalledWith(

--- a/packages/cozy-sharing/src/components/ShareDiscardChangesModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareDiscardChangesModal.jsx
@@ -1,0 +1,40 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import { useI18n } from 'twake-i18n'
+
+const ShareDiscardChangesModal = ({ onCancel, onConfirm }) => {
+  const { t } = useI18n()
+
+  return (
+    <ConfirmDialog
+      open
+      title={t('ShareDiscardChangesModal.title')}
+      actions={
+        <>
+          <Button
+            variant="secondary"
+            label={t('ShareDiscardChangesModal.cancel')}
+            className="u-fz-small"
+            onClick={onCancel}
+          />
+          <Button
+            variant="primary"
+            label={t('ShareDiscardChangesModal.discard')}
+            className="u-fz-small"
+            onClick={onConfirm}
+          />
+        </>
+      }
+    />
+  )
+}
+
+ShareDiscardChangesModal.propTypes = {
+  onCancel: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired
+}
+
+export { ShareDiscardChangesModal }


### PR DESCRIPTION
Show a discard confirmation when closing the federated folder modal with pending recipients. Rename share-email action labels to Done

[Capture vidéo du 2026-05-21 12-28-36.webm](https://github.com/user-attachments/assets/f3ab7a3a-0af1-46ba-b682-fcfa0861125f)

https://www.notion.so/linagora/Drive-Board-20062718bad180d687d1f517b2ed7dda?p=36662718bad18012a393cd5103f03a3e&pm=s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A new confirmation dialog now displays when you attempt to close share dialogs that contain unsaved pending recipients awaiting further action.

* **UI Updates**
  * The email-sharing action button label has been changed from "Share" to "Done" across Files, Notes, Albums, and Organizations (with support for English, French, Russian, and Vietnamese locales).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/cozy-libs/pull/3007?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->