### PR TITLE
fix: Avoid uncapped home icon size on flagship

### DIFF
--- a/packages/cozy-bar/src/components/utils/ButtonCozyHome.jsx
+++ b/packages/cozy-bar/src/components/utils/ButtonCozyHome.jsx
@@ -15,10 +15,10 @@ const ButtonCozyHome = ({ homeHref }) => {
         onClick={() => {
           webviewIntent.call('backToHome')
         }}
-        className="coz-nav-apps-btns-home coz-nav-apps-btns-home--is-flagship"
+        className="coz-nav-apps-btns-home"
         data-testid="buttonCozyHome"
       >
-        <IconCozyHome className="coz-nav-apps-btns-home-svg" />
+        <IconCozyHome />
       </a>
     )
 
@@ -29,14 +29,14 @@ const ButtonCozyHome = ({ homeHref }) => {
         className="coz-nav-apps-btns-home"
         data-testid="buttonCozyHome"
       >
-        <IconCozyHome className="coz-nav-apps-btns-home-svg" />
+        <IconCozyHome />
       </a>
     )
   }
 
   return (
     <span className="coz-nav-apps-btns-home" data-testid="buttonCozyHome">
-      <IconCozyHome className="coz-nav-apps-btns-home-svg" />
+      <IconCozyHome />
     </span>
   )
 }

--- a/packages/cozy-bar/src/styles/apps.css
+++ b/packages/cozy-bar/src/styles/apps.css
@@ -50,22 +50,6 @@
   margin-right: .75rem;
 }
 
-[role=banner] .coz-nav-apps-btns-home--is-flagship {
-  align-items: center;
-  display: flex;
-  flex-shrink: 0;
-  height: 100%;
-  justify-content: center;
-  margin-right: .25rem;
-  width: 3rem;
-}
-
-
-[role=banner] .coz-nav-apps-btns-home-svg {
-  max-width: 2rem;
-  max-height: 2rem;
-}
-
 [role=banner] .coz-nav-apps-btns-home,
 [role=banner] .coz-nav-apps-btns-home[href]:visited {
   color: var(--actionColorFocus);


### PR DESCRIPTION
By removing old CSS that break the `height: 2rem;` from `coz-nav-apps-btns-home` class.

This bug appears since we use again the home icon served by the stack

## Screenshot of the bug

<img width="200" alt="Screenshot_1779788790" src="https://github.com/user-attachments/assets/90a2f9d1-ef16-407a-8161-5c0c8ce9f6c8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Unified the home button markup so it renders consistently across variants.
  * Removed a special-case styling variant, simplifying appearance and behavior.
  * Adjusted SVG/icon sizing rules so the home icon displays uniformly in the navigation bar.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/cozy-libs/pull/3010?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->