### PR TITLE
feat: Add prop to disable sharing actions

### DIFF
--- a/packages/cozy-viewer/src/Footer/SharingButton.jsx
+++ b/packages/cozy-viewer/src/Footer/SharingButton.jsx
@@ -7,9 +7,13 @@ import IconButton from 'cozy-ui/transpiled/react/IconButton'
 import ShareIcon from 'cozy-ui/transpiled/react/Icons/Share'
 
 import { useShareModal } from '../providers/ShareModalProvider'
+import { useViewer } from '../providers/ViewerProvider'
 
 const SharingButton = ({ className, file, variant }) => {
+  const { componentsProps } = useViewer()
   const { setShowShareModal } = useShareModal()
+
+  if (componentsProps?.sharingActions?.disabled) return null
 
   if (variant === 'iconButton')
     return (

--- a/packages/cozy-viewer/src/Footer/SharingButton.spec.jsx
+++ b/packages/cozy-viewer/src/Footer/SharingButton.spec.jsx
@@ -1,0 +1,45 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+import SharingButton from './SharingButton'
+import ShareModalProvider from '../providers/ShareModalProvider'
+import ViewerProvider from '../providers/ViewerProvider'
+
+jest.mock('cozy-sharing', () => ({
+  ShareButton: ({ docId }) => <button>share {docId}</button>,
+  ShareModal: () => null
+}))
+
+const file = {
+  _id: 'file-1',
+  id: 'file-1',
+  name: 'Document'
+}
+
+const renderSharingButton = ({ componentsProps } = {}) =>
+  render(
+    <ViewerProvider file={file} componentsProps={componentsProps}>
+      <ShareModalProvider>
+        <SharingButton file={file} />
+      </ShareModalProvider>
+    </ViewerProvider>
+  )
+
+describe('SharingButton', () => {
+  it('renders by default', () => {
+    renderSharingButton()
+
+    expect(screen.getByText('share file-1')).toBeInTheDocument()
+  })
+
+  it('does not render when sharing actions are disabled', () => {
+    renderSharingButton({
+      componentsProps: {
+        sharingActions: { disabled: true }
+      }
+    })
+
+    expect(screen.queryByText('share file-1')).not.toBeInTheDocument()
+  })
+})

--- a/packages/cozy-viewer/src/Readme.md
+++ b/packages/cozy-viewer/src/Readme.md
@@ -29,6 +29,8 @@ The `Viewer` can display an **information panel** to show additional information
   - **OnlyOfficeViewer** : `<object>` – Used to open an Only Office file
     - **isEnabled** : `<boolean>` – Whether Only Office is enabled on the server
     - **opener** : `<function>` – To open the Only Office file
+  - **sharingActions** : `<object>` – Sharing action controls
+    - **disabled** : `<boolean>` – Whether sharing action buttons are disabled
   - **toolbarProps** : `<object>` – Toolbar properties
     - **toolbarRef** : `<object>` – React reference of the toolbar node
     - **showToolbar** : `<boolean>` – Whether to show the toolbar or not. Note that the built-in close button is in the toolbar

--- a/packages/cozy-viewer/src/Viewer.jsx
+++ b/packages/cozy-viewer/src/Viewer.jsx
@@ -126,6 +126,10 @@ Viewer.propTypes = {
       /** To open the Only Office file */
       opener: PropTypes.func
     }),
+    sharingActions: PropTypes.shape({
+      /** Whether sharing action buttons are disabled */
+      disabled: PropTypes.bool
+    }),
     toolbarProps: PropTypes.shape(toolbarPropsPropType)
   })
 }

--- a/packages/cozy-viewer/src/ViewerContainer.jsx
+++ b/packages/cozy-viewer/src/ViewerContainer.jsx
@@ -165,6 +165,10 @@ ViewerContainer.propTypes = {
       /** To open the Only Office file */
       opener: PropTypes.func
     }),
+    sharingActions: PropTypes.shape({
+      /** Whether sharing action buttons are disabled */
+      disabled: PropTypes.bool
+    }),
     /** Used to spread props to Panel components */
     panel: PropTypes.shape({
       qualifications: PropTypes.shape({

--- a/packages/cozy-viewer/src/components/Toolbar.jsx
+++ b/packages/cozy-viewer/src/components/Toolbar.jsx
@@ -45,7 +45,7 @@ const Toolbar = ({
   const client = useClient()
   const { t } = useI18n()
   const webviewIntent = useWebviewIntent()
-  const { file } = useViewer()
+  const { file, componentsProps } = useViewer()
   const { isSharingShortcutCreated, addSharingLink, loading } =
     useSharingInfos()
   const { isOwner } = useSharingContext()
@@ -54,6 +54,7 @@ const Toolbar = ({
 
   const isCozySharing = window.location.pathname === '/preview'
   const isShareNotAdded = !loading && !isSharingShortcutCreated
+  const areSharingActionsDisabled = componentsProps?.sharingActions?.disabled
   const ToolbarButtons = extractChildrenCompByName({
     children,
     file,
@@ -93,15 +94,17 @@ const Toolbar = ({
 
       {isDesktop && (
         <div className="u-flex u-flex-items-center">
-          {!isCozySharing && !isOwner(file._id) && (
-            <ShareButton
-              className="u-white"
-              fullWidth
-              useShortLabel
-              docId={file._id}
-              onClick={() => setShowShareModal(true)}
-            />
-          )}
+          {!areSharingActionsDisabled &&
+            !isCozySharing &&
+            !isOwner(file._id) && (
+              <ShareButton
+                className="u-white"
+                fullWidth
+                useShortLabel
+                docId={file._id}
+                onClick={() => setShowShareModal(true)}
+              />
+            )}
           {isCozySharing && isShareNotAdded && (
             <OpenSharingLinkButton
               link={addSharingLink}


### PR DESCRIPTION
## Summary

Adds a first-class `componentsProps.sharingActions.disabled` prop to `cozy-viewer`.

This lets consumer apps disable viewer sharing action buttons without relying on CSS selectors against `cozy-sharing` internals.

## Changes

- Add `componentsProps.sharingActions.disabled` support.
- Hide the toolbar share button when sharing actions are disabled.
- Make `Footer/SharingButton` render `null` when sharing actions are disabled.
- Add prop types for `Viewer` and `ViewerContainer`.
- Document the new prop in the viewer README.
- Add unit coverage for `SharingButton`.
