### PR TITLE
fix: Disable new contact creation for shared drives forms

### DIFF
--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
@@ -206,6 +206,7 @@ const FederatedFolderModalContent = ({
               onPendingRecipientsChange={setPendingRecipients}
               selectedOption={selectedOption}
               onSelectedOptionChange={setSelectedOption}
+              enableCreateContact
             />
           </div>
           <WhoHasAccess

--- a/packages/cozy-sharing/src/components/ShareAutosuggest.jsx
+++ b/packages/cozy-sharing/src/components/ShareAutosuggest.jsx
@@ -8,6 +8,7 @@ import { Spinner } from 'cozy-ui/transpiled/react/Spinner'
 
 import { GroupAvatar } from './Avatar/GroupAvatar'
 import ContactSuggestion from './ContactSuggestion'
+import { isContactToBeCreated } from '../helpers/contacts'
 import { extractEmails, validateEmail } from '../helpers/email'
 import { getDisplayName, getInitials, Contact, Group } from '../models'
 import styles from '../styles/autosuggest.styl'
@@ -25,6 +26,7 @@ const ShareAutocomplete = ({
   recipients,
   onPick,
   onRemove,
+  enableCreateContact,
   placeholder,
   endAdornment
 }) => {
@@ -53,17 +55,18 @@ const ShareAutocomplete = ({
   const onSuggestionsFetchRequested = ({ value }) => {
     const computedSuggestions = computeSuggestions(value)
 
-    const newSuggestions =
-      computedSuggestions.length === 0 && validateEmail(value)
-        ? [
-            {
-              email: value,
-              _type: Contact.doctype
-            }
-          ]
-        : computedSuggestions
-
-    setSuggestions(newSuggestions)
+    if (computedSuggestions.length > 0) {
+      setSuggestions(computedSuggestions)
+    } else if (enableCreateContact && validateEmail(value)) {
+      setSuggestions([
+        {
+          email: value,
+          _type: Contact.doctype
+        }
+      ])
+    } else {
+      setSuggestions([])
+    }
   }
 
   const onSuggestionsClearRequested = () => {
@@ -130,6 +133,8 @@ const ShareAutocomplete = ({
   }
 
   const onAutosuggestPick = value => {
+    if (isContactToBeCreated(value) && !enableCreateContact) return
+
     onPick(value)
     setInputValue('')
     autosuggestRef?.current?.input?.focus()
@@ -228,6 +233,7 @@ ShareAutocomplete.propTypes = {
   recipients: PropTypes.array.isRequired,
   onPick: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
+  enableCreateContact: PropTypes.bool,
   placeholder: PropTypes.string,
   endAdornment: PropTypes.node
 }

--- a/packages/cozy-sharing/src/components/ShareAutosuggest.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareAutosuggest.spec.jsx
@@ -9,7 +9,12 @@ jest.mock('cozy-ui/transpiled/react/Spinner', () => ({
 }))
 
 describe('ShareAutosuggest', () => {
-  const setup = ({ onPick, onRemove, loading = false }) => {
+  const setup = ({
+    onPick,
+    onRemove,
+    loading = false,
+    enableCreateContact = true
+  }) => {
     render(
       <AppLike>
         <ShareAutosuggest
@@ -19,6 +24,7 @@ describe('ShareAutosuggest', () => {
           onPick={onPick}
           recipients={[]}
           onRemove={onRemove}
+          enableCreateContact={enableCreateContact}
         />
       </AppLike>
     )
@@ -49,6 +55,19 @@ describe('ShareAutosuggest', () => {
     expect(onPick).toHaveBeenCalledWith({
       email: 'quentin.valmori@cozycloud.cc'
     })
+  })
+
+  it('should not call onPick for new contacts when enableCreateContact is false', () => {
+    const onPick = jest.fn()
+    const onRemove = jest.fn()
+
+    setup({ onPick, onRemove, enableCreateContact: false })
+
+    const inputNode = screen.getByPlaceholderText('myPlaceHolder')
+
+    fireEvent.change(inputNode, { target: { value: 'new@cozycloud.cc' } })
+    fireEvent.keyPress(inputNode, { key: 'Enter', keyCode: 13, charCode: 13 })
+    expect(onPick).not.toHaveBeenCalled()
   })
 
   it('should show loading indicator when loading prop is true (autoFocus triggers onFocus on mount)', () => {

--- a/packages/cozy-sharing/src/components/ShareByEmail.jsx
+++ b/packages/cozy-sharing/src/components/ShareByEmail.jsx
@@ -21,6 +21,7 @@ export const ShareByEmail = ({
   onPendingRecipientsChange,
   selectedOption,
   onSelectedOptionChange,
+  enableCreateContact,
   sharing
 }) => {
   const { t } = useI18n()
@@ -66,6 +67,7 @@ export const ShareByEmail = ({
           }
           onPick={onRecipientPick}
           onRemove={onRecipientRemove}
+          enableCreateContact={enableCreateContact}
           currentRecipients={currentRecipients}
           recipients={pendingRecipients}
           endAdornment={
@@ -89,6 +91,7 @@ ShareByEmail.propTypes = {
   onPendingRecipientsChange: PropTypes.func.isRequired,
   selectedOption: PropTypes.oneOf(['readWrite', 'readOnly']).isRequired,
   onSelectedOptionChange: PropTypes.func.isRequired,
+  enableCreateContact: PropTypes.bool,
   sharing: PropTypes.object
 }
 

--- a/packages/cozy-sharing/src/components/ShareByEmail.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareByEmail.spec.jsx
@@ -17,6 +17,7 @@ describe('ShareByEmail (controlled)', () => {
       onPendingRecipientsChange,
       selectedOption: 'readWrite',
       onSelectedOptionChange,
+      enableCreateContact: true,
       ...overrides
     }
     const utils = render(

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
@@ -79,6 +79,7 @@ const SharingContent = ({
             onPendingRecipientsChange={onPendingRecipientsChange}
             selectedOption={selectedOption}
             onSelectedOptionChange={onSelectedOptionChange}
+            enableCreateContact
           />
         )}
       </div>

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
@@ -21,6 +21,7 @@ jest.mock('../hooks/useSharingContext', () => ({
 }))
 
 jest.mock('../helpers/contacts', () => ({
+  ...jest.requireActual('../helpers/contacts'),
   getOrCreateFromArray: jest.fn((client, recipients) =>
     Promise.resolve(recipients)
   )

--- a/packages/cozy-sharing/src/components/ShareRecipientsInput.jsx
+++ b/packages/cozy-sharing/src/components/ShareRecipientsInput.jsx
@@ -25,6 +25,7 @@ const ShareRecipientsInput = ({
   placeholder,
   onPick,
   onRemove,
+  enableCreateContact,
   disabled,
   endAdornment
 }) => {
@@ -114,6 +115,7 @@ const ShareRecipientsInput = ({
       recipients={recipients}
       onPick={onPick}
       onRemove={onRemove}
+      enableCreateContact={enableCreateContact}
       placeholder={placeholder}
       endAdornment={endAdornment}
     />
@@ -126,6 +128,7 @@ ShareRecipientsInput.propTypes = {
   placeholder: PropTypes.string,
   onPick: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
+  enableCreateContact: PropTypes.bool,
   disabled: PropTypes.bool,
   endAdornment: PropTypes.node
 }

--- a/packages/cozy-sharing/src/helpers/contacts.js
+++ b/packages/cozy-sharing/src/helpers/contacts.js
@@ -47,3 +47,15 @@ export const getContactsFromGroupId = (contacts = [], groupId) => {
     )
   })
 }
+
+/**
+ * Returns true when a contact does not exist. A contact without
+ * an `_id` is always a placeholder that must be created before sharing.
+ *
+ * Used to decide whether the autosuggest input should allow creating
+ * a new contact on the fly or should block the pick (depending on the
+ * `enableCreateContact` flag).
+ */
+export const isContactToBeCreated = contact => {
+  return !contact._id
+}


### PR DESCRIPTION
For now, shared drives are meant to be used only inside an organization, so with existing contacts of the organization. So we disable the ability to create new contact for these forms. In the future, we may enable it again when we will introduce guest user for organization

**What is not possible anymore in shared drives forms**

=> when typing a valid email, suggest it and it will create a new contact

<img width="300" alt="image" src="https://github.com/user-attachments/assets/211a5696-9486-4886-a8a1-3a9e54e967ec" />
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to control whether users can create new contacts during the sharing process.

* **Tests**
  * Added and updated test coverage for the new contact creation control feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->