### PR TITLE
Avoid double add in sharing modals

### DIFF
--- a/packages/cozy-sharing/src/components/ShareAutosuggest.jsx
+++ b/packages/cozy-sharing/src/components/ShareAutosuggest.jsx
@@ -12,12 +12,7 @@ import { isContactToBeCreated } from '../helpers/contacts'
 import { extractEmails, validateEmail } from '../helpers/email'
 import { getDisplayName, getInitials, Contact, Group } from '../models'
 import styles from '../styles/autosuggest.styl'
-import {
-  cozyUrlMatch,
-  emailMatch,
-  groupNameMatch,
-  fullnameMatch
-} from '../suggestionMatchers'
+import { contactOrGroupMatch } from '../suggestionMatchers'
 
 const ShareAutocomplete = ({
   loading,
@@ -43,12 +38,8 @@ const ShareAutocomplete = ({
 
     return inputValue.length === 0
       ? []
-      : contactsAndGroups.filter(
-          contactOrGroup =>
-            groupNameMatch(inputValue, contactOrGroup) ||
-            fullnameMatch(inputValue, contactOrGroup) ||
-            emailMatch(inputValue, contactOrGroup) ||
-            cozyUrlMatch(inputValue, contactOrGroup)
+      : contactsAndGroups.filter(contactOrGroup =>
+          contactOrGroupMatch(inputValue, contactOrGroup)
         )
   }
 

--- a/packages/cozy-sharing/src/components/ShareAutosuggest.jsx
+++ b/packages/cozy-sharing/src/components/ShareAutosuggest.jsx
@@ -14,7 +14,7 @@ import { getDisplayName, getInitials, Contact, Group } from '../models'
 import styles from '../styles/autosuggest.styl'
 import { contactOrGroupMatch } from '../suggestionMatchers'
 
-const ShareAutocomplete = ({
+const ShareAutosuggest = ({
   loading,
   disabled,
   contactsAndGroups,
@@ -217,7 +217,7 @@ const ShareAutocomplete = ({
   )
 }
 
-ShareAutocomplete.propTypes = {
+ShareAutosuggest.propTypes = {
   loading: PropTypes.bool,
   disabled: PropTypes.bool,
   contactsAndGroups: PropTypes.array,
@@ -229,4 +229,4 @@ ShareAutocomplete.propTypes = {
   endAdornment: PropTypes.node
 }
 
-export default ShareAutocomplete
+export default ShareAutosuggest

--- a/packages/cozy-sharing/src/components/ShareRecipientsInput.jsx
+++ b/packages/cozy-sharing/src/components/ShareRecipientsInput.jsx
@@ -61,8 +61,14 @@ const ShareRecipientsInput = ({
         unreachableContactsWithGroupsResult.hasMore))
 
   const reachableContacts = (reachableContactsResult.data || []).filter(
-    contact => !isCurrentUser(contact)
+    contact =>
+      !isCurrentUser(contact) &&
+      // We do not want contact already in the sharing
+      !currentRecipients.find(r => r.email === contact?.email?.[0]?.address) &&
+      // We do not want contact currently in pending contacts (in chips)
+      !recipients.find(r => r._id === contact._id)
   )
+
   const unreachableContactsWithGroups = (
     unreachableContactsWithGroupsResult.data || []
   ).filter(contact => !isCurrentUser(contact))

--- a/packages/cozy-sharing/src/components/ShareRecipientsInput.jsx
+++ b/packages/cozy-sharing/src/components/ShareRecipientsInput.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import { useQueryAll, isQueryLoading } from 'cozy-client'
+import { models } from 'cozy-client'
 import flag from 'cozy-flags'
 
 import ShareAutosuggest from './ShareAutosuggest'
@@ -11,6 +12,8 @@ import {
   buildContactGroupsQuery,
   buildUnreachableContactsWithGroupsQuery
 } from '../queries/queries'
+
+const ContactModel = models.contact
 
 /**
  * ShareRecipientsInput is responsible for fetching contacts and groups.
@@ -64,7 +67,9 @@ const ShareRecipientsInput = ({
     contact =>
       !isCurrentUser(contact) &&
       // We do not want contact already in the sharing
-      !currentRecipients.find(r => r.email === contact?.email?.[0]?.address) &&
+      !currentRecipients.find(
+        r => r.email === ContactModel.getPrimaryEmail(contact)
+      ) &&
       // We do not want contact currently in pending contacts (in chips)
       !recipients.find(r => r._id === contact._id)
   )

--- a/packages/cozy-sharing/src/components/ShareRecipientsInput.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareRecipientsInput.spec.jsx
@@ -38,7 +38,10 @@ jest.mock('./ShareAutosuggest', () => ({
 }))
 
 describe('ShareRecipientsInput component', () => {
-  const setup = ({ contacts, contactGroups, unreachableContact }) => {
+  const setup = (
+    { contacts, contactGroups, unreachableContact },
+    { currentRecipients, recipients } = {}
+  ) => {
     const mockClient = createMockClient({
       queries: {
         'io.cozy.contacts/reachable': {
@@ -61,6 +64,8 @@ describe('ShareRecipientsInput component', () => {
           onPick={() => {}}
           onRemove={() => {}}
           placeholder="Enter recipients here"
+          currentRecipients={currentRecipients}
+          recipients={recipients}
         />
       </AppLike>
     )
@@ -173,6 +178,44 @@ describe('ShareRecipientsInput component', () => {
     expect(screen.queryByText('My Self')).not.toBeInTheDocument()
     expect(screen.getByText('Teagan Wolf')).toBeInTheDocument()
     expect(screen.getByText('Friends - 1 members')).toBeInTheDocument()
+  })
+
+  it('should exclude already added recipients from suggestions', async () => {
+    const contacts = [
+      {
+        id: 'df563cc4-6440',
+        _id: 'df563cc4-6440',
+        _type: 'io.cozy.contacts',
+        name: {
+          givenName: 'Michale',
+          familyName: 'Russel'
+        },
+        email: [{ address: 'michale@example.com', primary: true }]
+      },
+      {
+        id: '5a3b4ccf-c257',
+        _id: '5a3b4ccf-c257',
+        _type: 'io.cozy.contacts',
+        name: {
+          givenName: 'Teagan',
+          familyName: 'Wolf'
+        },
+        email: [{ address: 'teagan@example.com', primary: true }]
+      }
+    ]
+
+    const contactGroups = []
+    const currentRecipients = [
+      { id: 'recipient-1', email: 'michale@example.com' }
+    ]
+    const recipients = [{ _id: '5a3b4ccf-c257' }]
+
+    setup({ contacts, contactGroups }, { currentRecipients, recipients })
+
+    // Michale is in currentRecipients by email, should be filtered out
+    expect(screen.queryByText('Michale Russel')).not.toBeInTheDocument()
+    // Teagan is in recipients by _id, should be filtered out
+    expect(screen.queryByText('Teagan Wolf')).not.toBeInTheDocument()
   })
 
   it('should include unreachable members when flag sharing.show-recipient-groups is activated', async () => {

--- a/packages/cozy-sharing/src/suggestionMatchers.js
+++ b/packages/cozy-sharing/src/suggestionMatchers.js
@@ -34,4 +34,19 @@ const fullnameMatch = (input, contact) => {
   return fullnameInput.test(contact.fullname)
 }
 
-export { emailMatch, cozyUrlMatch, groupNameMatch, fullnameMatch }
+const contactOrGroupMatch = (input, contact) => {
+  return (
+    groupNameMatch(input, contact) ||
+    fullnameMatch(input, contact) ||
+    emailMatch(input, contact) ||
+    cozyUrlMatch(input, contact)
+  )
+}
+
+export {
+  emailMatch,
+  cozyUrlMatch,
+  groupNameMatch,
+  fullnameMatch,
+  contactOrGroupMatch
+}


### PR DESCRIPTION
**Before**

https://github.com/user-attachments/assets/03101477-31c9-4936-9b6f-71afcfb0471b

**After**

https://github.com/user-attachments/assets/c784f3e3-187e-4626-9026-7dcfe911b45d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined contact filtering during sharing to exclude duplicate contacts already in recipient list
  * Enhanced robustness when handling contact email information

* **Refactor**
  * Consolidated suggestion matching logic for improved maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->