### PR TITLE
feat: Remove email sharing in recipient side

### DIFF
--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
@@ -15,6 +15,7 @@ import { getOrCreateFromArray } from '../../helpers/contacts'
 import withLocales from '../../hoc/withLocales'
 import { usePendingRecipients } from '../../hooks/usePendingRecipients'
 import { useSharingContext } from '../../hooks/useSharingContext'
+import styles from '../../styles/share.styl'
 import AntivirusAlert from '../AntivirusAlert'
 import { default as DumbShareByEmail } from '../ShareByEmail'
 import ShareByLink from '../ShareByLink'
@@ -36,6 +37,8 @@ const FederatedFolderModalContent = ({
     getOwner,
     getSharingById,
     getRecipients,
+    hasSharedChild,
+    hasSharedParent,
     revoke
   } = useSharingContext()
   const { showAlert } = useAlert()
@@ -124,6 +127,14 @@ const FederatedFolderModalContent = ({
   ])
 
   const folderName = existingDocument?.name || ''
+  const documentPath = existingDocument?.path
+  const hasParentRestriction = Boolean(
+    existingDocument?.driveId || (documentPath && hasSharedParent(documentPath))
+  )
+  const hasChildRestriction = Boolean(
+    documentPath && hasSharedChild(documentPath)
+  )
+  const canShareByEmail = !hasParentRestriction && !hasChildRestriction
 
   const onSend = async () => {
     if (isSending || pendingRecipients.length === 0) {
@@ -193,21 +204,45 @@ const FederatedFolderModalContent = ({
             <AntivirusAlert
               document={isSending ? frozenDoc : existingDocument}
             />
-            <Typography variant="h6" className="u-mt-1-half u-mb-half">
-              {t('Share.contacts.addUsers')}
-            </Typography>
-            <DumbShareByEmail
-              currentRecipients={
-                isSending ? frozenRecipients : existingRecipients
-              }
-              document={isSending ? frozenDoc : existingDocument}
-              documentType="Files"
-              pendingRecipients={pendingRecipients}
-              onPendingRecipientsChange={setPendingRecipients}
-              selectedOption={selectedOption}
-              onSelectedOptionChange={setSelectedOption}
-              enableCreateContact
-            />
+            {!canShareByEmail && (
+              <div className={styles['share-byemail-onlybylink']}>
+                {t('Files.share.shareByEmail.onlyByLink', {
+                  type: t(
+                    `Files.share.shareByEmail.type.${
+                      existingDocument?.type === 'file' ? 'file' : 'folder'
+                    }`
+                  )
+                })}{' '}
+                <strong>
+                  {t(
+                    `Files.share.shareByEmail.${
+                      hasParentRestriction
+                        ? 'hasSharedParent'
+                        : 'hasSharedChild'
+                    }`
+                  )}
+                </strong>
+              </div>
+            )}
+            {canShareByEmail && (
+              <>
+                <Typography variant="h6" className="u-mt-1-half u-mb-half">
+                  {t('Share.contacts.addUsers')}
+                </Typography>
+                <DumbShareByEmail
+                  currentRecipients={
+                    isSending ? frozenRecipients : existingRecipients
+                  }
+                  document={isSending ? frozenDoc : existingDocument}
+                  documentType="Files"
+                  pendingRecipients={pendingRecipients}
+                  onPendingRecipientsChange={setPendingRecipients}
+                  selectedOption={selectedOption}
+                  onSelectedOptionChange={setSelectedOption}
+                  enableCreateContact
+                />
+              </>
+            )}
           </div>
           <WhoHasAccess
             isOwner
@@ -230,12 +265,14 @@ const FederatedFolderModalContent = ({
             showGenerateLinkButton={showGenerateLinkButton}
             autoOpenShareRestriction={autoOpenShareRestriction}
           />
-          <Button
-            variant="primary"
-            label={t('FederatedFolder.share')}
-            disabled={isSending}
-            onClick={onSend}
-          />
+          {canShareByEmail && (
+            <Button
+              variant="primary"
+              label={t('FederatedFolder.share')}
+              disabled={isSending}
+              onClick={onSend}
+            />
+          )}
         </>
       }
     />

--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
@@ -11,7 +11,10 @@ import AppLike from '../SharingBanner/test/AppLike'
 const mockShare = jest.fn()
 const mockRevoke = jest.fn()
 const mockGetSharingLink = jest.fn()
+const mockGetFederatedShareLink = jest.fn()
 const mockGetRecipients = jest.fn().mockReturnValue([])
+const mockHasSharedChild = jest.fn()
+const mockHasSharedParent = jest.fn()
 const mockShowAlert = jest.fn()
 const mockOnClose = jest.fn()
 
@@ -20,8 +23,11 @@ jest.mock('../../hooks/useSharingContext', () => ({
     share: mockShare,
     revoke: mockRevoke,
     getSharingLink: mockGetSharingLink,
+    getFederatedShareLink: mockGetFederatedShareLink,
     getDocumentPermissions: jest.fn().mockReturnValue([]),
-    getRecipients: mockGetRecipients
+    getRecipients: mockGetRecipients,
+    hasSharedChild: mockHasSharedChild,
+    hasSharedParent: mockHasSharedParent
   })
 }))
 
@@ -84,7 +90,12 @@ describe('FederatedFolderModal', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockGetSharingLink.mockReturnValue('https://example.com/share/abc123')
+    mockGetFederatedShareLink.mockResolvedValue(
+      'https://example.com/share/federated-abc123'
+    )
     mockGetRecipients.mockReturnValue([])
+    mockHasSharedChild.mockReturnValue(false)
+    mockHasSharedParent.mockReturnValue(false)
     client = createTestClient()
     sharingContextValue = createSharingContextValue()
     usePendingRecipients.mockReturnValue({
@@ -126,6 +137,30 @@ describe('FederatedFolderModal', () => {
       const { findByText } = setup()
 
       await findByText('Copy link')
+    })
+
+    it('should hide share by email when document is in federated shared folder received by current user', async () => {
+      const { findByText, queryByText } = setup({
+        document: { ...mockDocument, driveId: 'federated-folder-id' }
+      })
+
+      await findByText('Copy link')
+
+      expect(queryByText('Add users')).toBe(null)
+      expect(queryByText('Done')).toBe(null)
+    })
+
+    it('should show only by link message when document is in federated shared folder received by current user', async () => {
+      const { findByText } = setup({
+        document: {
+          ...mockDocument,
+          driveId: 'federated-folder-id',
+          type: 'directory'
+        }
+      })
+
+      await findByText('This folder can only be shared by link, because')
+      await findByText('it has a shared parent')
     })
   })
 


### PR DESCRIPTION
Since we cannot share files inside federated shared folder as a recipient, let's remove the UI to do it.

Also display information to user on why we do not display, as for synchronized sharings

https://app.notion.com/p/linagora/5d2f7429646042378356ecb072890d35?v=1c062718bad180d3847f000cd4c97139&p=37362718bad180df85cfe0896fa9bf19&pm=s
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email-based sharing is disabled for folders that must be shared only by link; the primary share action is hidden in those cases while link-sharing remains available.
  * UI shows an “only by link” notice when email sharing is not permitted.

* **Tests**
  * Added initialization tests verifying modal behavior for federated/shared folders: link copy visible, email add-users and Done button hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->