### PR TITLE
fix(cozy-sharing): Memoize ShareByEmail section in SharedDriveForm

### DIFF
--- a/packages/cozy-sharing/src/components/SharedDrive/SharedDriveForm.jsx
+++ b/packages/cozy-sharing/src/components/SharedDrive/SharedDriveForm.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { memo } from 'react'
 
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import TextField from 'cozy-ui/transpiled/react/TextField'
@@ -11,6 +11,24 @@ import withLocales from '../../hoc/withLocales'
 import { default as DumbShareByEmail } from '../ShareByEmail'
 import SharedDriveHeader from './SharedDriveHeader'
 import { useSharedDrive } from './useSharedDrive'
+
+const ShareByEmailSection = memo(function ShareByEmailSection({
+  pendingRecipients,
+  setPendingRecipients,
+  selectedOption,
+  setSelectedOption
+}) {
+  return (
+    <DumbShareByEmail
+      currentRecipients={[]}
+      documentType="Files"
+      pendingRecipients={pendingRecipients}
+      onPendingRecipientsChange={setPendingRecipients}
+      selectedOption={selectedOption}
+      onSelectedOptionChange={setSelectedOption}
+    />
+  )
+})
 
 export const SharedDriveForm = withLocales(({ onSuccess, onCancel }) => {
   const { t } = useI18n()
@@ -41,13 +59,11 @@ export const SharedDriveForm = withLocales(({ onSuccess, onCancel }) => {
         <Typography variant="h6" className="u-mb-half">
           {t('Share.contacts.addUsers')}
         </Typography>
-        <DumbShareByEmail
-          currentRecipients={[]}
-          documentType="Files"
+        <ShareByEmailSection
           pendingRecipients={pendingRecipients}
-          onPendingRecipientsChange={setPendingRecipients}
+          setPendingRecipients={setPendingRecipients}
           selectedOption={selectedOption}
-          onSelectedOptionChange={setSelectedOption}
+          setSelectedOption={setSelectedOption}
         />
       </div>
       <div className="u-flex u-ph-2 u-pv-1">


### PR DESCRIPTION
Prevents ShareByEmail, ShareAutosuggest, ShareTypeSelect, and Radios from re-rendering on every keystroke in the drive name input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization within the sharing form component to enhance maintainability and component performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->