### PR TITLE
feat(viewer): Add an Edit button to the PDF viewer

### DIFF
--- a/packages/cozy-viewer/src/Viewer.jsx
+++ b/packages/cozy-viewer/src/Viewer.jsx
@@ -126,6 +126,14 @@ Viewer.propTypes = {
       /** To open the Only Office file */
       opener: PropTypes.func
     }),
+    /** Used to open a PDF in an external editor */
+    PdfViewer: PropTypes.shape({
+      /** Whether PDF editing is enabled by the host app */
+      isPdfEditorEnabled: PropTypes.bool,
+      /** Opens the PDF in the editor; an "Edit" button is shown when editing is
+       * enabled, this is set and the user has write access */
+      opener: PropTypes.func
+    }),
     toolbarProps: PropTypes.shape(toolbarPropsPropType)
   })
 }

--- a/packages/cozy-viewer/src/ViewerContainer.jsx
+++ b/packages/cozy-viewer/src/ViewerContainer.jsx
@@ -165,6 +165,14 @@ ViewerContainer.propTypes = {
       /** To open the Only Office file */
       opener: PropTypes.func
     }),
+    /** Used to open a PDF in an external editor */
+    PdfViewer: PropTypes.shape({
+      /** Whether PDF editing is enabled by the host app */
+      isPdfEditorEnabled: PropTypes.bool,
+      /** Opens the PDF in the editor; an "Edit" button is shown when editing is
+       * enabled, this is set and the user has write access */
+      opener: PropTypes.func
+    }),
     /** Used to spread props to Panel components */
     panel: PropTypes.shape({
       qualifications: PropTypes.shape({

--- a/packages/cozy-viewer/src/ViewersByFile/PdfJsViewer.jsx
+++ b/packages/cozy-viewer/src/ViewersByFile/PdfJsViewer.jsx
@@ -5,6 +5,10 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { Document, Page } from 'react-pdf'
 
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import PenIcon from 'cozy-ui/transpiled/react/Icons/Pen'
+
 import styles from './styles.styl'
 import NoViewer from '../NoViewer'
 import ToolbarButton from '../components/PdfToolbarButton'
@@ -195,7 +199,15 @@ export class PdfJsViewer extends Component {
   }
 
   render() {
-    const { url, file, renderFallbackExtraContent, t } = this.props
+    const {
+      url,
+      file,
+      renderFallbackExtraContent,
+      t,
+      isReadOnly,
+      isPdfEditorEnabled,
+      editPdfOpener
+    } = this.props
     const {
       loaded,
       errored,
@@ -273,6 +285,17 @@ export class PdfJsViewer extends Component {
               this.setState({ keepToolbarDisplayed: false })
             }
           >
+            {isPdfEditorEnabled && editPdfOpener && !isReadOnly && (
+              <Button
+                variant="text"
+                color="secondary"
+                className="u-p-half u-m-half"
+                startIcon={<Icon icon={PenIcon} size={16} />}
+                label={t('Viewer.editPdf')}
+                onClick={() => editPdfOpener(file)}
+                data-testid="pdf-edit-button"
+              />
+            )}
             {!renderAllPages && (
               <span className="u-mh-half">
                 <ToolbarButton
@@ -329,8 +352,17 @@ export class PdfJsViewer extends Component {
 
 PdfJsViewer.propTypes = {
   url: PropTypes.string.isRequired,
+  file: PropTypes.object,
   gestures: PropTypes.object,
-  renderFallbackExtraContent: PropTypes.func
+  renderFallbackExtraContent: PropTypes.func,
+  /** Whether the user only has read access; hides the "Edit" button. */
+  isReadOnly: PropTypes.bool,
+  /** Whether PDF editing is enabled by the host app. The "Edit" button is only
+   * shown when this is true, an opener is provided and the user has write
+   * access. */
+  isPdfEditorEnabled: PropTypes.bool,
+  /** Opens the file in an external PDF editor. */
+  editPdfOpener: PropTypes.func
 }
 
 export default flow(withFileUrl, withViewerLocales)(PdfJsViewer)

--- a/packages/cozy-viewer/src/components/ViewerByFile.jsx
+++ b/packages/cozy-viewer/src/components/ViewerByFile.jsx
@@ -64,9 +64,11 @@ const ViewerByFile = withBreakpoints()(({
   breakpoints: { isDesktop },
   componentsProps
 }) => {
-  const { file } = useViewer()
+  const { file, isReadOnly } = useViewer()
   const isOnlyOfficeEnabled = componentsProps?.OnlyOfficeViewer?.isEnabled
   const onlyOfficeOpener = componentsProps?.OnlyOfficeViewer?.opener
+  const isPdfEditorEnabled = componentsProps?.PdfViewer?.isPdfEditorEnabled
+  const editPdfOpener = componentsProps?.PdfViewer?.opener
 
   const { url } = useEncrypted()
 
@@ -88,6 +90,9 @@ const ViewerByFile = withBreakpoints()(({
       gestures={gestures}
       gesturesRef={gesturesRef}
       onlyOfficeOpener={onlyOfficeOpener}
+      isReadOnly={isReadOnly}
+      isPdfEditorEnabled={isPdfEditorEnabled}
+      editPdfOpener={editPdfOpener}
       onSwipe={onSwipe}
       onClose={onClose}
     />

--- a/packages/cozy-viewer/src/locales/en.json
+++ b/packages/cozy-viewer/src/locales/en.json
@@ -26,6 +26,7 @@
     "next": "Next",
     "openWith": "Open with...",
     "openInOnlyOffice": "Open with Only Office",
+    "editPdf": "Edit",
     "panel": {
       "collapse": "Collapse",
       "header": "Details",

--- a/packages/cozy-viewer/src/locales/fr.json
+++ b/packages/cozy-viewer/src/locales/fr.json
@@ -26,6 +26,7 @@
     "next": "Suivante",
     "openWith": "Ouvrir avec...",
     "openInOnlyOffice": "Ouvrir avec Only Office",
+    "editPdf": "Éditer",
     "panel": {
       "collapse": "Réduire",
       "header": "Détails",

--- a/packages/cozy-viewer/src/locales/ru.json
+++ b/packages/cozy-viewer/src/locales/ru.json
@@ -26,6 +26,7 @@
     "next": "Следующий",
     "openWith": "Открыть с помощью...",
     "openInOnlyOffice": "Открыть в Only Office",
+    "editPdf": "Редактировать",
     "panel": {
       "collapse": "Свернуть",
       "header": "Сведения",

--- a/packages/cozy-viewer/src/locales/vi.json
+++ b/packages/cozy-viewer/src/locales/vi.json
@@ -26,6 +26,7 @@
     "next": "Tiếp theo",
     "openWith": "Mở bằng...",
     "openInOnlyOffice": "Mở bằng Only Office",
+    "editPdf": "Chỉnh sửa",
     "panel": {
       "collapse": "Thu gọn",
       "header": "Chi tiết",


### PR DESCRIPTION
## Summary

- Add an Edit button to the `PdfJsViewer` toolbar, shown when the host app enables PDF editing through `componentsProps.PdfViewer` (`isEnabled` together with an `opener`) and the user has write access.
- The button calls the opener with the file so the app can open the PDF in its own editor.
- Editing is toggled by the app via the `isEnabled` prop; the viewer keeps no feature-flag logic of its own, matching the existing `OnlyOfficeViewer` prop shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Edit" button for PDFs when enabled and user has write access; allows opening files in external editor.

* **Localization**
  * Added translations for the PDF edit action in English, French, Russian, and Vietnamese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->