### PR TITLE
feat(cozy-sharing): Show progress icon on done button during share

### DIFF
--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
@@ -269,7 +269,7 @@ const FederatedFolderModalContent = ({
             <Button
               variant="primary"
               label={t('FederatedFolder.share')}
-              disabled={isSending}
+              busy={isSending}
               onClick={onSend}
             />
           )}

--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, waitFor } from '@testing-library/react'
 import React from 'react'
 
 import { createMockClient } from 'cozy-client'
@@ -255,6 +255,36 @@ describe('FederatedFolderModal', () => {
           variant: 'filled'
         })
         expect(mockOnClose).not.toHaveBeenCalled()
+      })
+    })
+
+    it('should show progress icon on Done button while share is in progress', async () => {
+      usePendingRecipients.mockReturnValue({
+        pendingRecipients: [pendingRecipient],
+        setPendingRecipients: jest.fn(),
+        selectedOption: 'readWrite',
+        setSelectedOption: jest.fn()
+      })
+      getOrCreateFromArray.mockResolvedValue([pendingRecipient])
+      let resolveShare
+      mockShare.mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveShare = resolve
+        })
+      )
+      const { findByText, getByRole, queryByRole } = setup()
+
+      const sendButton = await findByText('Done')
+
+      fireEvent.click(sendButton)
+
+      await waitFor(() => {
+        expect(getByRole('button', { name: 'Done' })).toBeDisabled()
+        expect(queryByRole('progressbar')).not.toBeNull()
+      })
+
+      await act(async () => {
+        resolveShare({})
       })
     })
   })


### PR DESCRIPTION
To know something is happening even with bad connection

<img width="679" height="425" alt="image" src="https://github.com/user-attachments/assets/1b6d5444-1a62-4db1-a7dd-24a6eabbd42d" />

https://app.notion.com/p/linagora/5d2f7429646042378356ecb072890d35?v=1c062718bad180d3847f000cd4c97139&p=36862718bad180fb947af16050416527&pm=s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * The share button now displays a loading state instead of being disabled while processing the share request, providing clearer visual feedback during the sharing process.

* **Tests**
  * Added test coverage to verify button behavior and progress indicator display during the sharing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->