### PR TITLE
fix(cozy-sharing): Refresh link state in share modal

### DIFF
--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 
 import { useClient } from 'cozy-client'
 import Button from 'cozy-ui/transpiled/react/Buttons'
@@ -33,9 +33,6 @@ const FederatedFolderModalContent = ({
     share,
     getSharingLink,
     getFederatedShareLink,
-    getDocumentPermissions,
-    getOwner,
-    getSharingById,
     getRecipients,
     hasSharedChild,
     hasSharedParent,
@@ -44,7 +41,6 @@ const FederatedFolderModalContent = ({
   const { showAlert } = useAlert()
   const { showConfirmDialog, closeConfirmDialog } = useConfirmDialog()
 
-  const [sharingLink, setSharingLink] = useState(null)
   const {
     pendingRecipients,
     setPendingRecipients,
@@ -96,34 +92,6 @@ const FederatedFolderModalContent = ({
     pendingRecipients.length,
     showConfirmDialog,
     t
-  ])
-
-  const documentPermissions = useMemo(
-    () =>
-      existingDocument ? getDocumentPermissions(existingDocument._id) : [],
-    [existingDocument, getDocumentPermissions]
-  )
-
-  useEffect(() => {
-    const fetchSharingLink = async () => {
-      if (!existingDocument) return
-
-      if (existingDocument.driveId) {
-        const link = await getFederatedShareLink(existingDocument)
-        setSharingLink(link)
-      } else {
-        setSharingLink(getSharingLink(existingDocument._id))
-      }
-    }
-
-    fetchSharingLink()
-  }, [
-    existingDocument,
-    documentPermissions,
-    getFederatedShareLink,
-    getSharingLink,
-    getOwner,
-    getSharingById
   ])
 
   const folderName = existingDocument?.name || ''
@@ -185,6 +153,9 @@ const FederatedFolderModalContent = ({
   const existingRecipients = existingDocument
     ? getRecipients(existingDocument._id)
     : []
+  const displayedLink = existingDocument?.driveId
+    ? getFederatedShareLink(existingDocument)
+    : getSharingLink(existingDocument?._id)
 
   const modalTitle = t('FederatedFolder.shareTitle', { name: folderName })
 
@@ -252,14 +223,14 @@ const FederatedFolderModalContent = ({
             documentType="Files"
             className="u-w-100"
             onRevoke={revoke}
-            link={sharingLink}
+            link={displayedLink}
           />
         </div>
       }
       actions={
         <>
           <ShareByLink
-            link={sharingLink}
+            link={displayedLink}
             document={isSending ? frozenDoc : existingDocument}
             documentType="Files"
             showGenerateLinkButton={showGenerateLinkButton}

--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
@@ -9,6 +9,7 @@ import { usePendingRecipients } from '../../hooks/usePendingRecipients'
 import AppLike from '../SharingBanner/test/AppLike'
 
 const mockShare = jest.fn()
+const mockShareByLink = jest.fn()
 const mockRevoke = jest.fn()
 const mockGetSharingLink = jest.fn()
 const mockGetFederatedShareLink = jest.fn()
@@ -21,10 +22,13 @@ const mockOnClose = jest.fn()
 jest.mock('../../hooks/useSharingContext', () => ({
   useSharingContext: () => ({
     share: mockShare,
+    shareByLink: mockShareByLink,
     revoke: mockRevoke,
     getSharingLink: mockGetSharingLink,
     getFederatedShareLink: mockGetFederatedShareLink,
     getDocumentPermissions: jest.fn().mockReturnValue([]),
+    getOwner: jest.fn(),
+    getSharingById: jest.fn(),
     getRecipients: mockGetRecipients,
     hasSharedChild: mockHasSharedChild,
     hasSharedParent: mockHasSharedParent
@@ -46,6 +50,8 @@ jest.mock('../../helpers/contacts', () => ({
 jest.mock('../../hooks/usePendingRecipients', () => ({
   usePendingRecipients: jest.fn()
 }))
+
+jest.mock('../ShareByLink', () => () => <button>Copy link</button>)
 
 const mockDocument = {
   _id: 'folder-123',
@@ -90,12 +96,25 @@ describe('FederatedFolderModal', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockGetSharingLink.mockReturnValue('https://example.com/share/abc123')
-    mockGetFederatedShareLink.mockResolvedValue(
+    mockGetFederatedShareLink.mockReturnValue(
       'https://example.com/share/federated-abc123'
     )
     mockGetRecipients.mockReturnValue([])
     mockHasSharedChild.mockReturnValue(false)
     mockHasSharedParent.mockReturnValue(false)
+    mockShareByLink.mockResolvedValue({
+      data: {
+        _id: 'permission-id',
+        attributes: {
+          shortcodes: { code: 'abc123' }
+        }
+      }
+    })
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: jest.fn()
+      }
+    })
     client = createTestClient()
     sharingContextValue = createSharingContextValue()
     usePendingRecipients.mockReturnValue({
@@ -137,6 +156,22 @@ describe('FederatedFolderModal', () => {
       const { findByText } = setup()
 
       await findByText('Copy link')
+    })
+
+    it('should show link access as soon as a link is generated', async () => {
+      mockGetSharingLink.mockReturnValue(null)
+      const { findByText, queryByText, rerender } = setup()
+
+      expect(queryByText('Anyone with the link')).toBe(null)
+
+      mockGetSharingLink.mockReturnValue('https://example.com/share/abc123')
+      rerender(
+        <AppLike client={client} sharingContextValue={sharingContextValue}>
+          <FederatedFolderModal document={mockDocument} onClose={mockOnClose} />
+        </AppLike>
+      )
+
+      await findByText('Anyone with the link')
     })
 
     it('should hide share by email when document is in federated shared folder received by current user', async () => {

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.jsx
@@ -19,6 +19,7 @@ import { getOrCreateFromArray } from '../helpers/contacts'
 import { hasReachRecipientsLimit } from '../helpers/recipients'
 import { getErrorMessage, getSuccessMessage } from '../helpers/share'
 import { usePendingRecipients } from '../hooks/usePendingRecipients'
+import { useSharingContext } from '../hooks/useSharingContext'
 import styles from '../styles/share.styl'
 
 const SharingContent = ({
@@ -126,6 +127,7 @@ const ShareDialogCozyToCozy = ({
   const { t } = useI18n()
   const client = useClient()
   const { showAlert } = useAlert()
+  const { getSharingLink } = useSharingContext()
 
   const {
     pendingRecipients,
@@ -136,6 +138,7 @@ const ShareDialogCozyToCozy = ({
 
   const [submitting, setSubmitting] = useState(false)
   const [showRecipientsLimit, setShowRecipientsLimit] = useState(false)
+  const displayedLink = getSharingLink(document._id || document.id)
 
   const handleShare = useCallback(async () => {
     if (pendingRecipients.length === 0) {
@@ -238,6 +241,7 @@ const ShareDialogCozyToCozy = ({
     <>
       <ShareDialogTwoStepsConfirmationContainer
         {...props}
+        link={displayedLink}
         documentType={documentType}
         document={document}
         recipients={recipients}

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
@@ -16,6 +16,7 @@ jest.mock('cozy-client', () => ({
 
 jest.mock('../hooks/useSharingContext', () => ({
   useSharingContext: () => ({
+    getSharingLink: jest.fn(() => null),
     updateSharingMemberType: jest.fn()
   })
 }))

--- a/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.jsx
@@ -9,6 +9,7 @@ import { useI18n } from 'twake-i18n'
 import AntivirusAlert from './AntivirusAlert'
 import { default as DumbShareByLink } from './ShareByLink'
 import WhoHasAccess from './WhoHasAccess'
+import { useSharingContext } from '../hooks/useSharingContext'
 
 const ShareDialogOnlyByLink = ({
   isOwner,
@@ -17,7 +18,6 @@ const ShareDialogOnlyByLink = ({
   recipients,
   document,
   documentType,
-  link,
   onClose,
   permissions,
   showGenerateLinkButton,
@@ -25,6 +25,8 @@ const ShareDialogOnlyByLink = ({
 }) => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
+  const { getSharingLink } = useSharingContext()
+  const displayedLink = getSharingLink(document._id || document.id)
 
   return (
     <Dialog
@@ -51,7 +53,7 @@ const ShareDialogOnlyByLink = ({
             onRevoke={onRevoke}
             onRevokeSelf={onRevokeSelf}
             recipients={recipients}
-            link={link}
+            link={displayedLink}
             permissions={permissions}
           />
           <div
@@ -61,7 +63,7 @@ const ShareDialogOnlyByLink = ({
             )}
           >
             <DumbShareByLink
-              link={link}
+              link={displayedLink}
               document={document}
               documentType={documentType}
               showGenerateLinkButton={showGenerateLinkButton}

--- a/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.spec.jsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+import ShareDialogOnlyByLink from './ShareDialogOnlyByLink'
+import AppLike from '../../test/AppLike'
+
+let mockSharingLink = null
+
+jest.mock('./ShareByLink', () => () => <button>Copy link</button>)
+
+jest.mock('../hooks/useSharingContext', () => ({
+  useSharingContext: () => ({
+    documentType: 'Files',
+    getDocumentPermissions: () => [],
+    getSharingLink: () => mockSharingLink,
+    revokeSharingLink: jest.fn(),
+    updateDocumentPermissions: jest.fn()
+  })
+}))
+
+describe('ShareDialogOnlyByLink', () => {
+  beforeEach(() => {
+    mockSharingLink = null
+  })
+
+  const renderModal = () => (
+    <AppLike>
+      <ShareDialogOnlyByLink
+        document={{ _id: 'file-id', attributes: { name: 'file.txt' } }}
+        documentType="Files"
+        isOwner
+        onClose={jest.fn()}
+        onRevoke={jest.fn()}
+        onRevokeSelf={jest.fn()}
+        permissions={[]}
+        recipients={[]}
+      />
+    </AppLike>
+  )
+
+  const setup = () => render(renderModal())
+
+  it('shows link access as soon as a link is generated', () => {
+    const { rerender } = setup()
+
+    expect(screen.queryByText('Anyone with the link')).toBe(null)
+
+    mockSharingLink = 'https://example.com/public'
+    rerender(renderModal())
+
+    expect(screen.queryByText('Anyone with the link')).toBeInTheDocument()
+  })
+
+  it('hides link access as soon as a link is revoked', () => {
+    mockSharingLink = 'https://example.com/public'
+    const { rerender } = setup()
+
+    expect(screen.queryByText('Anyone with the link')).toBeInTheDocument()
+
+    mockSharingLink = null
+    rerender(renderModal())
+
+    expect(screen.queryByText('Anyone with the link')).toBe(null)
+  })
+})


### PR DESCRIPTION
https://app.notion.com/p/linagora/5d2f7429646042378356ecb072890d35?v=1c062718bad180d3847f000cd4c97139&p=37462718bad18075bab2e83c56b23d26&pm=s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated sharing link handling in sharing dialogs and federated folder modals to use a centralized context source

* **Tests**
  * Added tests to verify "Anyone with the link" access message displays correctly when sharing links are available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->