### PR TITLE
fix(cozy-sharing): Allow sharing shared drive folder root by email

### DIFF
--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
@@ -128,9 +128,27 @@ const FederatedFolderModalContent = ({
 
   const folderName = existingDocument?.name || ''
   const documentPath = existingDocument?.path
-  const hasParentRestriction = Boolean(
-    existingDocument?.driveId || (documentPath && hasSharedParent(documentPath))
+  const sharedDriveSharing = existingDocument?.driveId
+    ? getSharingById(existingDocument.driveId)
+    : null
+  const sharedDriveRootIds =
+    sharedDriveSharing?.attributes?.rules?.reduce(
+      (ids, rule) => ids.concat(rule.values || []),
+      []
+    ) || []
+  const isSharedDriveRoot = Boolean(
+    existingDocument?.driveId &&
+    sharedDriveRootIds.some(
+      id => id === existingDocument?._id || id === existingDocument?.id
+    )
   )
+  const isInsideSharedDrive = Boolean(
+    existingDocument?.driveId && !isSharedDriveRoot
+  )
+  const hasSharedParentByPath = Boolean(
+    documentPath && hasSharedParent(documentPath)
+  )
+  const hasParentRestriction = isInsideSharedDrive || hasSharedParentByPath
   const hasChildRestriction = Boolean(
     documentPath && hasSharedChild(documentPath)
   )

--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
@@ -13,6 +13,7 @@ const mockRevoke = jest.fn()
 const mockGetSharingLink = jest.fn()
 const mockGetFederatedShareLink = jest.fn()
 const mockGetRecipients = jest.fn().mockReturnValue([])
+const mockGetSharingById = jest.fn()
 const mockHasSharedChild = jest.fn()
 const mockHasSharedParent = jest.fn()
 const mockShowAlert = jest.fn()
@@ -26,6 +27,7 @@ jest.mock('../../hooks/useSharingContext', () => ({
     getFederatedShareLink: mockGetFederatedShareLink,
     getDocumentPermissions: jest.fn().mockReturnValue([]),
     getRecipients: mockGetRecipients,
+    getSharingById: mockGetSharingById,
     hasSharedChild: mockHasSharedChild,
     hasSharedParent: mockHasSharedParent
   })
@@ -94,6 +96,7 @@ describe('FederatedFolderModal', () => {
       'https://example.com/share/federated-abc123'
     )
     mockGetRecipients.mockReturnValue([])
+    mockGetSharingById.mockReturnValue(null)
     mockHasSharedChild.mockReturnValue(false)
     mockHasSharedParent.mockReturnValue(false)
     client = createTestClient()
@@ -161,6 +164,32 @@ describe('FederatedFolderModal', () => {
 
       await findByText('This folder can only be shared by link, because')
       await findByText('it has a shared parent')
+    })
+
+    it('should allow share by email when document is the federated shared folder root', async () => {
+      mockGetSharingById.mockReturnValue({
+        attributes: {
+          rules: [
+            { values: ['another-folder-id'] },
+            { values: ['yet-another-folder-id', mockDocument._id] }
+          ]
+        }
+      })
+
+      const { findByText, queryByText } = setup({
+        document: {
+          ...mockDocument,
+          driveId: 'federated-folder-id',
+          type: 'directory'
+        }
+      })
+
+      await findByText('Add users')
+
+      expect(
+        queryByText('This folder can only be shared by link, because')
+      ).toBe(null)
+      expect(queryByText('it has a shared parent')).toBe(null)
     })
   })
 


### PR DESCRIPTION
Get the associated sharing to know if a folder is the root of the sharing or not

This was a regression from https://github.com/linagora/cozy-libs/pull/3017

https://app.notion.com/p/linagora/5d2f7429646042378356ecb072890d35?v=1c062718bad180d3847f000cd4c97139&p=37a62718bad180ab88bbf091063ce599&pm=s