### PR TITLE
fix: show shared drive recipients in viewer panel

### DIFF
--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -31,6 +31,7 @@ export { useSharingInfos } from './components/SharingBanner/hooks/useSharingInfo
 export { ConfirmTrustedRecipientsDialog } from './ConfirmTrustedRecipientsDialog'
 export { ShareButtonWithRecipients } from './ShareButtonWithRecipients'
 export { DOCUMENT_TYPE } from './helpers/documentType'
+export { getRecipientsFromSharing } from './state'
 export { default as OpenSharingLinkButton } from './OpenSharingLinkButton'
 export { default as OpenSharingLinkFabButton } from './OpenSharingLinkFabButton'
 export {

--- a/packages/cozy-sharing/src/state.js
+++ b/packages/cozy-sharing/src/state.js
@@ -338,6 +338,18 @@ export const getOwner = (state, docId) =>
 
 export const getRecipients = (state, docId) => {
   const sharings = getDocumentSharings(state, docId)
+  return getRecipientsFromSharings(sharings, docId)
+}
+
+export const getRecipientsFromSharing = (sharing, docId) => {
+  if (!sharing) {
+    return []
+  }
+
+  return getRecipientsFromSharings([sharing], docId)
+}
+
+const getRecipientsFromSharings = (sharings, docId) => {
   if (flag('sharing.show-recipient-groups')) {
     return getRecipientsWithGroups(sharings, docId)
   }

--- a/packages/cozy-sharing/src/state.spec.js
+++ b/packages/cozy-sharing/src/state.spec.js
@@ -5,6 +5,7 @@ import reducer, {
   updateSharingLink,
   revokeSharingLink,
   getRecipients,
+  getRecipientsFromSharing,
   revokeRecipient,
   revokeSelf,
   updateSharing,
@@ -537,6 +538,63 @@ describe('Sharing state', () => {
           status: 'pending',
           type: 'one-way',
           avatarPath: '/sharings/sharing_5/recipients/1/avatar'
+        }
+      ])
+    })
+
+    it('should list recipients from a shared drive sharing', () => {
+      const sharing = {
+        id: 'shared_drive_id',
+        drive: true,
+        attributes: {
+          members: [
+            {
+              email: 'jane@doe.com',
+              instance: 'http://cozy.tools:8080',
+              name: 'Jane Doe',
+              status: 'owner'
+            },
+            {
+              email: 'john@doe.com',
+              instance: 'http://cozy.local:8080',
+              name: 'John Doe',
+              status: 'ready'
+            }
+          ],
+          rules: [
+            {
+              doctype: 'io.cozy.files',
+              values: ['shared_drive_root'],
+              add: 'sync',
+              update: 'sync',
+              remove: 'sync'
+            }
+          ]
+        }
+      }
+
+      expect(getRecipientsFromSharing(sharing, 'child_file_id')).toEqual([
+        {
+          email: 'jane@doe.com',
+          instance: 'http://cozy.tools:8080',
+          name: 'Jane Doe',
+          sharingId: 'shared_drive_id',
+          index: 'sharing-shared_drive_id-member-0',
+          memberIndex: 0,
+          status: 'owner',
+          type: 'two-way',
+          avatarPath: '/sharings/shared_drive_id/recipients/0/avatar'
+        },
+        {
+          email: 'john@doe.com',
+          instance: 'http://cozy.local:8080',
+          name: 'John Doe',
+          sharingId: 'shared_drive_id',
+          index: 'sharing-shared_drive_id-member-1',
+          memberIndex: 1,
+          status: 'ready',
+          type: 'two-way',
+          avatarPath: '/sharings/shared_drive_id/recipients/1/avatar'
         }
       ])
     })

--- a/packages/cozy-viewer/src/Panel/Sharing.jsx
+++ b/packages/cozy-viewer/src/Panel/Sharing.jsx
@@ -1,12 +1,14 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import { useClient } from 'cozy-client'
 import flag from 'cozy-flags'
 import {
-  useSharingContext,
+  getRecipientsFromSharing,
+  LinkRecipientLite,
   MemberRecipientLite,
   OwnerRecipientDefaultLite,
-  LinkRecipientLite
+  useSharingContext
 } from 'cozy-sharing'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import Icon from 'cozy-ui/transpiled/react/Icon'
@@ -21,19 +23,27 @@ import { withViewerLocales } from '../hoc/withViewerLocales'
 import { useShareModal } from '../providers/ShareModalProvider'
 
 const Sharing = ({ file, t }) => {
+  const client = useClient()
   const { setShowShareModal } = useShareModal()
   const {
-    isOwner,
     getDocumentPermissions,
+    getSharingById,
     getSharingLink,
     allLoaded,
-    getRecipients
+    getRecipients,
+    isOwner
   } = useSharingContext()
 
-  const recipients = getRecipients(file._id)
+  const sharedDriveSharing = file.driveId ? getSharingById(file.driveId) : null
+  const recipients = sharedDriveSharing
+    ? getRecipientsFromSharing(sharedDriveSharing, file._id)
+    : getRecipients(file._id)
   const permissions = getDocumentPermissions(file._id)
   const link = getSharingLink(file._id)
-  const _isOwner = isOwner(file._id)
+  const owner = recipients.find(recipient => recipient.status === 'owner')
+  const isCurrentUserOwner = file.driveId
+    ? owner?.instance === client.options.uri
+    : isOwner(file._id)
 
   const showModal = () => {
     if (!flag('drive.new-file-viewer-ui.enabled')) {
@@ -71,7 +81,7 @@ const Sharing = ({ file, t }) => {
             <MemberRecipientLite
               key={recipient.index}
               recipient={recipient}
-              isOwner={_isOwner}
+              isOwner={isCurrentUserOwner}
             />
           ))
         ) : (

--- a/packages/cozy-viewer/src/Panel/Sharing.spec.jsx
+++ b/packages/cozy-viewer/src/Panel/Sharing.spec.jsx
@@ -1,0 +1,170 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import Sharing from './Sharing'
+
+const mockGetRecipientsFromSharing = jest.fn()
+const mockUseClient = jest.fn()
+const mockUseShareModal = jest.fn()
+const mockUseSharingContext = jest.fn()
+const mockMemberRecipientLite = jest.fn(({ recipient, isOwner }) => (
+  <div data-testid="member-recipient" data-is-owner={String(isOwner)}>
+    {recipient.name}
+  </div>
+))
+
+jest.mock('cozy-client', () => ({
+  useClient: () => mockUseClient()
+}))
+
+jest.mock('cozy-flags', () => jest.fn(() => false))
+jest.mock('cozy-sharing', () => ({
+  getRecipientsFromSharing: (...args) => mockGetRecipientsFromSharing(...args),
+  LinkRecipientLite: () => <div data-testid="link-recipient" />,
+  MemberRecipientLite: props => mockMemberRecipientLite(props),
+  OwnerRecipientDefaultLite: () => (
+    <div data-testid="owner-recipient-default" />
+  ),
+  useSharingContext: () => mockUseSharingContext()
+}))
+
+jest.mock('../hoc/withViewerLocales', () => ({
+  withViewerLocales: Component => props => (
+    <Component {...props} t={key => key} />
+  )
+}))
+
+jest.mock('../providers/ShareModalProvider', () => ({
+  useShareModal: () => mockUseShareModal()
+}))
+
+const file = { _id: 'file-id' }
+const sharedFile = { _id: 'shared-file-id' }
+const sharedDriveFile = { _id: 'file-id', driveId: 'drive-id' }
+const ownerRecipient = {
+  index: 'recipient-0',
+  name: 'Alice',
+  status: 'owner',
+  instance: 'http://alice.localhost:8080/'
+}
+const expectedOwnerRecipient = {
+  name: ownerRecipient.name,
+  status: ownerRecipient.status,
+  instance: ownerRecipient.instance
+}
+const sharedDriveSharing = {
+  id: 'drive-id',
+  attributes: {
+    drive: true,
+    members: [ownerRecipient]
+  }
+}
+
+const setup = ({
+  clientUri = 'http://bob.localhost:8080/',
+  targetFile = file,
+  userIsOwner = true
+} = {}) => {
+  const getDocumentPermissions = jest
+    .fn()
+    .mockImplementation(docId => (docId === 'file-id' ? ['perm'] : []))
+  const getSharingById = jest
+    .fn()
+    .mockImplementation(id => (id === 'drive-id' ? sharedDriveSharing : null))
+  const getRecipients = jest.fn().mockImplementation(docId => {
+    if (docId === 'file-id' || docId === 'shared-file-id') {
+      return [ownerRecipient]
+    }
+
+    return []
+  })
+  const getSharingLink = jest
+    .fn()
+    .mockImplementation(docId =>
+      docId === 'file-id' ? 'http://share-link' : null
+    )
+
+  mockGetRecipientsFromSharing.mockReturnValue([ownerRecipient])
+  mockUseClient.mockReturnValue({ options: { uri: clientUri } })
+  const isOwner = jest.fn().mockReturnValue(userIsOwner)
+
+  mockUseShareModal.mockReturnValue({ setShowShareModal: jest.fn() })
+  mockUseSharingContext.mockReturnValue({
+    allLoaded: true,
+    getDocumentPermissions,
+    getSharingById,
+    getRecipients,
+    getSharingLink,
+    isOwner
+  })
+
+  return render(<Sharing file={targetFile} />)
+}
+
+describe('Sharing', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should use shared drive recipients when the file belongs to a shared drive', () => {
+    setup({ targetFile: sharedDriveFile })
+
+    expect(mockUseSharingContext().getSharingById).toHaveBeenCalledWith(
+      'drive-id'
+    )
+    expect(mockGetRecipientsFromSharing).toHaveBeenCalledWith(
+      sharedDriveSharing,
+      'file-id'
+    )
+    expect(mockUseSharingContext().getRecipients).not.toHaveBeenCalled()
+    expect(mockUseSharingContext().getDocumentPermissions).toHaveBeenCalledWith(
+      'file-id'
+    )
+    expect(mockUseSharingContext().getSharingLink).toHaveBeenCalledWith(
+      'file-id'
+    )
+    expect(mockUseSharingContext().isOwner).not.toHaveBeenCalled()
+    expect(mockMemberRecipientLite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipient: expect.objectContaining(expectedOwnerRecipient),
+        isOwner: false
+      })
+    )
+  })
+
+  it('should use isOwner for a regular sharing', () => {
+    setup({ targetFile: sharedFile, userIsOwner: true })
+
+    expect(mockUseSharingContext().isOwner).toHaveBeenCalledWith(
+      'shared-file-id'
+    )
+    expect(mockMemberRecipientLite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipient: expect.objectContaining(expectedOwnerRecipient),
+        isOwner: true
+      })
+    )
+  })
+
+  it('should not mark the owner as current user when the owner is remote', () => {
+    setup({ targetFile: sharedDriveFile })
+
+    expect(mockMemberRecipientLite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipient: expect.objectContaining(expectedOwnerRecipient),
+        isOwner: false
+      })
+    )
+  })
+
+  it('should mark the owner as current user when the owner matches the current instance', () => {
+    setup({ clientUri: ownerRecipient.instance, targetFile: sharedDriveFile })
+
+    expect(mockMemberRecipientLite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipient: expect.objectContaining(expectedOwnerRecipient),
+        isOwner: true
+      })
+    )
+  })
+})


### PR DESCRIPTION
- Add a cozy-sharing helper to derive recipients from an existing sharing.
- Use shared drive recipients in the viewer sharing panel.
- Add tests for shared drive recipients in cozy-sharing and cozy-viewer.

https://app.notion.com/p/linagora/5d2f7429646042378356ecb072890d35?v=1c062718bad180d3847f000cd4c97139&p=36862718bad1807b9145c6714ab3f0ba&pm=s
