### PR TITLE
fix(cozy-sharing): Fix lint issue in master

### DIFF
--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
@@ -31,6 +31,7 @@ const FederatedFolderModalContent = ({
   const { t } = useI18n()
   const {
     share,
+    getSharingById,
     getSharingLink,
     getFederatedShareLink,
     getRecipients,

--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
@@ -29,7 +29,6 @@ jest.mock('../../hooks/useSharingContext', () => ({
     getFederatedShareLink: mockGetFederatedShareLink,
     getDocumentPermissions: jest.fn().mockReturnValue([]),
     getOwner: jest.fn(),
-    getSharingById: jest.fn(),
     getRecipients: mockGetRecipients,
     getSharingById: mockGetSharingById,
     hasSharedChild: mockHasSharedChild,


### PR DESCRIPTION
This resulted from a merge of
https://github.com/linagora/cozy-libs/pull/3023 without rebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue with federated folder sharing where shared-drive information was not being properly retrieved, ensuring correct sharing resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->