### PR TITLE
fix(cozy-sharing): Use readonly endpoint in updateSharingMemberType

### DIFF
--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -53,7 +53,7 @@
     "babel-jest": "30.3.0",
     "babel-plugin-css-modules-transform": "1.6.2",
     "babel-plugin-inline-react-svg": "1.1.2",
-    "cozy-client": "^60.24.0",
+    "cozy-client": "^60.27.0",
     "cozy-device-helper": "^4.0.0",
     "cozy-intent": "^2.31.1",
     "cozy-minilog": "^3.10.1",
@@ -68,7 +68,7 @@
     "twake-i18n": "^0.4.1"
   },
   "peerDependencies": {
-    "cozy-client": ">=60.24.0",
+    "cozy-client": ">=60.27.0",
     "cozy-device-helper": ">=4.0.0",
     "cozy-flags": ">=4.8.1",
     "cozy-intent": ">=2.29.1",

--- a/packages/cozy-sharing/src/SharingProvider.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.jsx
@@ -143,7 +143,7 @@ export class SharingProvider extends Component {
     this.fetchAllSharings()
     if (!client.plugins.realtime) {
       // eslint-disable-next-line
-      console.warn(
+         console.warn(
         `You should register the realtime plugin to your CozyClient instance see https://docs.cozy.io/en/cozy-realtime/#example`
       )
     } else {
@@ -353,36 +353,19 @@ export class SharingProvider extends Component {
     const member = sharing.attributes.members[memberIndex]
     if (!member) throw new Error('Member not found')
 
-    // Find the contact by email (same pattern as helpers/contacts.js)
-    const matchedContacts = await this.props.client
-      .collection('io.cozy.contacts')
-      .find(
-        {
-          email: { $elemMatch: { address: member.email } },
-          _id: { $gt: null }
-        },
-        { indexedFields: ['_id'] }
-      )
-
-    if (!matchedContacts.data.length) {
-      throw new Error(`Contact not found for member ${member.email}`)
+    const makeReadOnly = newType === 'one-way'
+    if (newType !== 'one-way' && newType !== 'two-way') {
+      throw new Error('Unsupported sharing type: ' + newType)
     }
-    const contact = matchedContacts.data[0]
-
-    // Revoke (API call only, no state dispatch to avoid UI flickering)
-    await this.sharingCol.revokeRecipient(sharing, memberIndex)
-
-    // Re-add with the new permission type
-    const readOnly = newType === 'one-way'
     try {
-      await this.addRecipients({
-        document: sharing,
-        recipients: readOnly ? [] : [contact],
-        readOnlyRecipients: readOnly ? [contact] : []
-      })
+      if (makeReadOnly) {
+        await this.sharingCol.setReadOnly(sharing, memberIndex)
+      } else {
+        await this.sharingCol.setReadWrite(sharing, memberIndex)
+      }
     } catch (error) {
       log.error(
-        `Failed to re-add member ${member.email} after revocation. The member has been revoked but could not be re-added with the new permission type.`,
+        `Failed to change member ${member.email} permission type to ${newType}`,
         error
       )
       throw error

--- a/packages/cozy-sharing/src/SharingProvider.spec.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.spec.jsx
@@ -292,7 +292,6 @@ describe('updateDocumentPermissions', () => {
 })
 
 describe('updateSharingMemberType', () => {
-  const mockContact = { _id: 'contact-1', email: [{ address: 'bob@bob.cozy' }] }
   const mockSharing = {
     id: 'sharing-123',
     type: 'io.cozy.sharings',
@@ -305,16 +304,11 @@ describe('updateSharingMemberType', () => {
   }
 
   let instance
-  let mockContactsCollection
 
   beforeEach(() => {
-    mockContactsCollection = {
-      find: jest.fn().mockResolvedValue({ data: [mockContact] })
-    }
-
     const mockClient = {
       getStackClient: () => ({ uri: 'http://cozy.local' }),
-      collection: jest.fn().mockReturnValue(mockContactsCollection)
+      collection: jest.fn().mockReturnValue({})
     }
 
     instance = new SharingProvider({ client: mockClient })
@@ -323,9 +317,10 @@ describe('updateSharingMemberType', () => {
       sharings: [mockSharing]
     }
     instance.sharingCol = {
-      revokeRecipient: jest.fn().mockResolvedValue({})
+      setReadOnly: jest.fn().mockResolvedValue({}),
+      setReadWrite: jest.fn().mockResolvedValue({})
     }
-    jest.spyOn(instance, 'addRecipients').mockResolvedValue({})
+    jest.spyOn(instance, 'setState')
   })
 
   it('should throw when sharing is not found', async () => {
@@ -340,48 +335,65 @@ describe('updateSharingMemberType', () => {
     ).rejects.toThrow('Member not found')
   })
 
-  it('should throw when contact is not found', async () => {
-    mockContactsCollection.find.mockResolvedValue({ data: [] })
-
-    await expect(
-      instance.updateSharingMemberType('sharing-123', 1, 'one-way')
-    ).rejects.toThrow('Contact not found')
-  })
-
-  it('should revoke and re-add with readOnly when switching to one-way', async () => {
+  it('should call setReadOnly when switching to one-way', async () => {
     await instance.updateSharingMemberType('sharing-123', 1, 'one-way')
 
-    expect(instance.sharingCol.revokeRecipient).toHaveBeenCalledWith(
-      mockSharing,
-      1
-    )
-    expect(instance.addRecipients).toHaveBeenCalledWith({
-      document: mockSharing,
-      recipients: [],
-      readOnlyRecipients: [mockContact]
-    })
+    expect(instance.sharingCol.setReadOnly).toHaveBeenCalledWith(mockSharing, 1)
+    expect(instance.sharingCol.setReadWrite).not.toHaveBeenCalled()
   })
 
-  it('should revoke and re-add as read-write when switching to two-way', async () => {
+  it('should call setReadWrite when switching to two-way', async () => {
     await instance.updateSharingMemberType('sharing-123', 1, 'two-way')
 
-    expect(instance.sharingCol.revokeRecipient).toHaveBeenCalledWith(
+    expect(instance.sharingCol.setReadWrite).toHaveBeenCalledWith(
       mockSharing,
       1
     )
-    expect(instance.addRecipients).toHaveBeenCalledWith({
-      document: mockSharing,
-      recipients: [mockContact],
-      readOnlyRecipients: []
-    })
+    expect(instance.sharingCol.setReadOnly).not.toHaveBeenCalled()
   })
 
-  it('should rethrow error if addRecipients fails after revocation', async () => {
-    instance.addRecipients.mockRejectedValue(new Error('Network error'))
+  it('should not dispatch a state update — realtime refreshes the store', async () => {
+    await instance.updateSharingMemberType('sharing-123', 1, 'one-way')
+
+    expect(instance.setState).not.toHaveBeenCalled()
+  })
+
+  it('should not dispatch a state update for two-way — realtime refreshes the store', async () => {
+    await instance.updateSharingMemberType('sharing-123', 1, 'two-way')
+
+    expect(instance.setState).not.toHaveBeenCalled()
+  })
+
+  it('should rethrow error if setReadOnly fails', async () => {
+    instance.sharingCol.setReadOnly.mockRejectedValue(
+      new Error('Network error')
+    )
 
     await expect(
       instance.updateSharingMemberType('sharing-123', 1, 'one-way')
     ).rejects.toThrow('Network error')
+  })
+
+  it('should rethrow error if setReadWrite fails', async () => {
+    instance.sharingCol.setReadWrite.mockRejectedValue(
+      new Error('Network error')
+    )
+
+    await expect(
+      instance.updateSharingMemberType('sharing-123', 1, 'two-way')
+    ).rejects.toThrow('Network error')
+  })
+
+  it('should not dispatch state update if API call fails', async () => {
+    instance.sharingCol.setReadOnly.mockRejectedValue(
+      new Error('Network error')
+    )
+
+    await expect(
+      instance.updateSharingMemberType('sharing-123', 1, 'one-way')
+    ).rejects.toThrow('Network error')
+
+    expect(instance.setState).not.toHaveBeenCalled()
   })
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17305,16 +17305,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cozy-client@npm:^60.24.0":
-  version: 60.24.0
-  resolution: "cozy-client@npm:60.24.0"
+"cozy-client@npm:^60.27.0":
+  version: 60.27.0
+  resolution: "cozy-client@npm:60.27.0"
   dependencies:
     "@cozy/minilog": "npm:1.0.0"
     "@fastify/deepmerge": "npm:^2.0.2"
     "@types/jest": "npm:^26.0.20"
     "@types/lodash": "npm:^4.14.170"
     btoa: "npm:^1.2.1"
-    cozy-stack-client: "npm:^60.24.0"
+    cozy-stack-client: "npm:^60.27.0"
     date-fns: "npm:^2.30.0"
     fast-deep-equal: "npm:^3.1.3"
     json-stable-stringify: "npm:^1.0.1"
@@ -17340,7 +17340,7 @@ __metadata:
     react-native-google-play-integrity: ^1.1.0
     react-native-inappbrowser-reborn: ^3.5.1
     react-native-ios11-devicecheck: ^0.0.3
-  checksum: 10c0/2acf530daed69875c78a117a3c4fc11c020509dd4e25a2df0070c402cfba284bf6b0942753dc5d8863ad419f067da6e4967e42099411b95f1cd35db114ac8c5f
+  checksum: 10c0/c362cbb0a56a19c26d6fdb76454f3135a0721e76c09ecf60c3621b42a6a640a4c94864e25693808d170e0af2b44c915cd2e6cdab55207b8d12afc2b3d687f0d4
   languageName: node
   linkType: hard
 
@@ -18002,7 +18002,7 @@ __metadata:
     babel-plugin-css-modules-transform: "npm:1.6.2"
     babel-plugin-inline-react-svg: "npm:1.1.2"
     classnames: "npm:^2.5.1"
-    cozy-client: "npm:^60.24.0"
+    cozy-client: "npm:^60.27.0"
     cozy-device-helper: "npm:^4.0.0"
     cozy-doctypes: "npm:^1.99.1"
     cozy-intent: "npm:^2.31.1"
@@ -18022,7 +18022,7 @@ __metadata:
     storybook: "npm:7.6.0"
     twake-i18n: "npm:^0.4.1"
   peerDependencies:
-    cozy-client: ">=60.24.0"
+    cozy-client: ">=60.27.0"
     cozy-device-helper: ">=4.0.0"
     cozy-flags: ">=4.8.1"
     cozy-intent: ">=2.29.1"
@@ -18200,6 +18200,19 @@ __metadata:
   peerDependencies:
     cozy-flags: ">2.8.6"
   checksum: 10c0/62f70b9ee944b50b1246634a797a1050acd044ef244da4d5b2a5ca0a809b6496840ffac55f865eac705999c117bd106f8134c865aa232188b9736a4447415b2c
+  languageName: node
+  linkType: hard
+
+"cozy-stack-client@npm:^60.27.0":
+  version: 60.27.0
+  resolution: "cozy-stack-client@npm:60.27.0"
+  dependencies:
+    detect-node: "npm:^2.0.4"
+    mime: "npm:^2.4.0"
+    qs: "npm:^6.7.0"
+  peerDependencies:
+    cozy-flags: ">2.8.6"
+  checksum: 10c0/53bd1200f3f812073782f994d4cdf3a6ac5771a6cec52f1ef239cc543d6e0b0e0acfb6171d944f6aef7231b1423a87ce7684bb92ce9d82fd6f4507aaf5764300
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replace the revoke + re-add pattern with the dedicated read-only endpoints (POST and DELETE /sharings/:id/recipients/:index/readonly) exposed by the stack to flip a member's read_only flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cozy-client dependency requirements to version 60.27.0 minimum across development and peer dependency configurations

* **Bug Fixes**
  * Enhanced error handling and logging for member permission modification operations to provide clearer feedback when permission changes encounter issues

* **Tests**
  * Expanded test suite coverage to validate member permission update workflows and error handling scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->