### PR TITLE
fix: expire share links at the end of the selected day

### DIFF
--- a/packages/cozy-sharing/src/components/ShareRestrictionModal/helpers.js
+++ b/packages/cozy-sharing/src/components/ShareRestrictionModal/helpers.js
@@ -1,3 +1,5 @@
+import { endOfDay } from 'date-fns'
+
 import { generateWebLink } from 'cozy-client'
 import minilog from 'cozy-minilog'
 
@@ -8,6 +10,21 @@ const log = minilog('ShareRestrictionModal/helpers')
 
 export const WRITE_PERMS = ['GET', 'POST', 'PUT', 'PATCH']
 export const READ_ONLY_PERMS = ['GET']
+
+/**
+ * A share link expires at the END of the selected day, so picking today keeps
+ * the link reachable for the rest of today and expires it the next day.
+ * Without this, the picked day defaults to its midnight (start of day), which
+ * is already in the past and makes the link unreachable as soon as it is set.
+ * @param {Date|string|null|undefined} date - The picked expiration day
+ * @returns {Date|null|undefined} - The same value normalized to end of day
+ */
+export const toExpirationDate = date => {
+  if (!date) return date
+  const parsed = date instanceof Date ? date : new Date(date)
+  if (parsed.toString() === 'Invalid Date') return date
+  return endOfDay(parsed)
+}
 
 /**
  * Create a sharing link for a file with specified options
@@ -161,9 +178,10 @@ export const makeTTL = selectedDate => {
     }
     if (selectedDateConverted instanceof Date) {
       const now = new Date()
+      const expiration = toExpirationDate(selectedDateConverted)
       const ttl =
-        selectedDateConverted > now
-          ? `${Math.round((selectedDateConverted - now) / 1000)}s`
+        expiration > now
+          ? `${Math.round((expiration - now) / 1000)}s`
           : undefined
       return ttl
     }
@@ -239,7 +257,9 @@ export const updatePermissions = async ({
   showAlert
 }) => {
   try {
-    const expiresAt = dateToggle ? selectedDate?.toISOString() || undefined : ''
+    const expiresAt = dateToggle
+      ? toExpirationDate(selectedDate)?.toISOString() || undefined
+      : ''
     const ensurePassword = passwordToggle ? password || undefined : ''
     const verbs = editingRights === 'readOnly' ? READ_ONLY_PERMS : WRITE_PERMS
     return updateDocumentPermissions(file, {

--- a/packages/cozy-sharing/src/components/ShareRestrictionModal/helpers.spec.js
+++ b/packages/cozy-sharing/src/components/ShareRestrictionModal/helpers.spec.js
@@ -1,6 +1,29 @@
-import { makeTTL, revokePermissions, updatePermissions } from './helpers'
+import { endOfDay } from 'date-fns'
+
+import {
+  makeTTL,
+  revokePermissions,
+  toExpirationDate,
+  updatePermissions
+} from './helpers'
 
 describe('ShareRestrictionModal/helpers', () => {
+  describe('toExpirationDate', () => {
+    it('returns falsy values unchanged', () => {
+      expect(toExpirationDate(null)).toBeNull()
+      expect(toExpirationDate(undefined)).toBeUndefined()
+      expect(toExpirationDate('')).toBe('')
+    })
+    it('normalizes a Date to the end of its day', () => {
+      const date = new Date(2100, 0, 1, 9, 30)
+      expect(toExpirationDate(date)).toEqual(endOfDay(date))
+    })
+    it('accepts an ISO string', () => {
+      const iso = '2100-01-01T09:30:00.000Z'
+      expect(toExpirationDate(iso)).toEqual(endOfDay(new Date(iso)))
+    })
+  })
+
   describe('makeTTL', () => {
     it('sould return undefined', () => {
       expect(makeTTL()).toBeUndefined()
@@ -13,6 +36,17 @@ describe('ShareRestrictionModal/helpers', () => {
     it('sould return TTL in seconds', () => {
       expect(makeTTL(new Date('2100-01-01T00:00:00.000Z'))).toBeDefined()
       expect(makeTTL('2100-01-01T00:00:00.000Z')).toBeDefined()
+    })
+    it('keeps a link picked for today valid until the end of the day', () => {
+      // Regression: picking "today" used to resolve to midnight (already past),
+      // which dropped the TTL and the link never expired or was unreachable.
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date('2100-01-01T12:00:00.000Z'))
+      try {
+        expect(makeTTL(new Date())).toBeDefined()
+      } finally {
+        jest.useRealTimers()
+      }
     })
   })
 
@@ -118,11 +152,12 @@ describe('ShareRestrictionModal/helpers', () => {
       const updateDocumentPermissions = jest.fn()
       const file = { _id: '123' }
 
+      const selectedDate = new Date('2100-01-01T00:00:00.000Z')
       await updatePermissions({
         file,
         t: jest.fn(),
         dateToggle: true,
-        selectedDate: new Date('2100-01-01T00:00:00.000Z'),
+        selectedDate,
         passwordToggle: true,
         password: '1234',
         editingRights: 'readOnly',
@@ -132,10 +167,41 @@ describe('ShareRestrictionModal/helpers', () => {
       })
 
       expect(updateDocumentPermissions).toHaveBeenCalledWith(file, {
-        expiresAt: '2100-01-01T00:00:00.000Z',
+        expiresAt: endOfDay(selectedDate).toISOString(),
         password: '1234',
         verbs: ['GET']
       })
+    })
+
+    it('sets expiration to the end of the selected day so picking today stays valid', async () => {
+      // Freeze time so the "expires in the future" assertion can't flake near
+      // midnight or under slow CI.
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date('2100-01-01T12:00:00.000Z'))
+      try {
+        const updateDocumentPermissions = jest.fn()
+        const file = { _id: '123' }
+        const today = new Date()
+
+        await updatePermissions({
+          file,
+          t: jest.fn(),
+          dateToggle: true,
+          selectedDate: today,
+          passwordToggle: false,
+          password: '',
+          editingRights: 'readOnly',
+          documentType,
+          updateDocumentPermissions,
+          showAlert: jest.fn()
+        })
+
+        const { expiresAt } = updateDocumentPermissions.mock.calls[0][1]
+        expect(expiresAt).toBe(endOfDay(today).toISOString())
+        expect(new Date(expiresAt).getTime()).toBeGreaterThan(Date.now())
+      } finally {
+        jest.useRealTimers()
+      }
     })
   })
 


### PR DESCRIPTION
## Problem

Setting a share link's expiration to today made the link immediately unreachable for recipients. The date picker returns the chosen calendar day at local midnight (start of day), which is already in the past, and the timezone offset pushes it back further. So picking today wrote an `expires_at` in the past and the link expired the moment it was set.

## Solution

Treat a picked expiration day as the end of that day. A small helper normalizes the date with `endOfDay` and both the create path (`makeTTL`) and the edit path (`expires_at`) go through it. Picking today now keeps the link valid until tonight and expires it the next day.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Share links with expiration dates now correctly expire at the end of the selected day, ensuring the full day of access before expiration takes effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->