### PR TITLE
fix(cozy-sharing): scroll members list in federated share dialogs

### DIFF
--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
@@ -186,10 +186,12 @@ const FederatedFolderModalContent = ({
       title={modalTitle}
       classes={{ paper: 'u-ov-visible' }}
       componentsProps={{
-        dialogContent: { className: 'u-ov-visible' }
+        dialogContent: {
+          className: styles['share-dialog-scrollable-content']
+        }
       }}
       content={
-        <div>
+        <div className={styles['share-dialog-scrollable-body']}>
           <div className="u-ph-2">
             <AntivirusAlert
               document={isSending ? frozenDoc : existingDocument}
@@ -240,7 +242,7 @@ const FederatedFolderModalContent = ({
             recipients={isSending ? frozenRecipients : existingRecipients}
             document={isSending ? frozenDoc : existingDocument}
             documentType="Files"
-            className="u-w-100"
+            className={styles['share-dialog-members']}
             onRevoke={revoke}
             link={displayedLink}
           />

--- a/packages/cozy-sharing/src/components/SharedDrive/EditSharedDriveModal.jsx
+++ b/packages/cozy-sharing/src/components/SharedDrive/EditSharedDriveModal.jsx
@@ -14,6 +14,7 @@ import { getOrCreateFromArray } from '../../helpers/contacts'
 import withLocales from '../../hoc/withLocales'
 import { usePendingRecipients } from '../../hooks/usePendingRecipients'
 import { useSharingContext } from '../../hooks/useSharingContext'
+import styles from '../../styles/share.styl'
 import { default as DumbShareByEmail } from '../ShareByEmail'
 import WhoHasAccess from '../WhoHasAccess'
 
@@ -68,10 +69,12 @@ export const EditSharedDriveModal = withLocales(({ onClose, document }) => {
       onClose={onClose}
       classes={{ paper: 'u-ov-visible' }}
       componentsProps={{
-        dialogContent: { className: 'u-ov-visible' }
+        dialogContent: {
+          className: styles['share-dialog-scrollable-content']
+        }
       }}
       content={
-        <div>
+        <div className={styles['share-dialog-scrollable-body']}>
           <div className="u-ph-2 u-pt-2">
             <SharedDriveHeader
               title={t('SharedDrive.editSharedDriveModal.title')}
@@ -104,7 +107,7 @@ export const EditSharedDriveModal = withLocales(({ onClose, document }) => {
             recipients={existingRecipients}
             document={document}
             documentType="Files"
-            className="u-w-100"
+            className={styles['share-dialog-members']}
             onRevoke={revoke}
           />
           <div className="u-flex u-ph-2 u-pv-1">

--- a/packages/cozy-sharing/src/styles/share.styl
+++ b/packages/cozy-sharing/src/styles/share.styl
@@ -2,6 +2,39 @@
 @require 'components/popover.styl'
 @require 'settings/breakpoints.styl'
 
+// The federated share dialogs keep overflow visible so the contact
+// suggestions dropdown can pop over the dialog, which disables the dialog's
+// native scrolling. These classes pass the height constraint down through
+// the flex chain so only the members list scrolls.
+.share-dialog-scrollable-content
+    display flex
+    flex-direction column
+    min-height 0
+    // keep the contact suggestions dropdown visible over the dialog;
+    // !important to win over MUI's DialogContent overflow-y auto
+    overflow visible !important // @stylint ignore
+
+    // cozy-ui dialogs expose no componentsProps hook for their
+    // .dialogContentInner wrapper, but the classname is a stable contract:
+    // cozy-ui's own MUI theme overrides style it by name
+    > :global(.dialogContentInner) // @stylint ignore Naming imposed by cozy-ui
+        display flex
+        flex-direction column
+        flex 1 1 auto
+        min-height 0
+
+.share-dialog-scrollable-body
+    display flex
+    flex-direction column
+    flex 1 1 auto
+    min-height 0
+
+.share-dialog-members
+    flex 1 1 auto
+    min-height 0
+    overflow-y auto
+    width 100%
+
 .share-byemail-onlybylink
     background var(--defaultBackgroundColor)
     padding 1rem 2rem


### PR DESCRIPTION
## Problem
The federated share dialogs keep overflow visible so the contact suggestions dropdown can pop over the dialog, which disables the dialog's native content scrolling. With many members the list grows past the viewport and pushes the Copy link and Share buttons off screen, with no way to reach them.

## Solution
Keep overflow visible for the dropdown, and pass the height constraint down the flex chain instead: the dialog content, its inner wrapper and the body become flex columns with min-height 0, and only the members list scrolls.

## demo
<img width="683" height="908" alt="image" src="https://github.com/user-attachments/assets/2b430760-a392-4c50-adac-7e04c9aa2543" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Members list in sharing dialogs now scrolls independently while suggestion dropdowns and overlays remain visible, improving usability.

* **Style**
  * Dialog layout and styling updated for consistent sizing and overflow behavior, resulting in a cleaner presentation and more reliable access-management interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->