### PR TITLE
fix(cozy-realtime): keep drive sharings new on background connections

### DIFF
--- a/packages/cozy-dataproxy-lib/src/search/@types/cozy-realtime.d.ts
+++ b/packages/cozy-dataproxy-lib/src/search/@types/cozy-realtime.d.ts
@@ -11,7 +11,11 @@ declare module 'cozy-realtime' {
   export const RealtimePlugin: RealtimePluginType
 
   export default class CozyRealtime {
-    constructor(options: { client: CozyClient; sharedDriveId?: string })
+    constructor(options: {
+      client: CozyClient
+      sharedDriveId?: string
+      background?: boolean
+    })
     subscribe(
       event: string,
       doctype: string,

--- a/packages/cozy-dataproxy-lib/src/search/SearchEngine.spec.js
+++ b/packages/cozy-dataproxy-lib/src/search/SearchEngine.spec.js
@@ -582,11 +582,13 @@ describe('Realtime features', () => {
 
       expect(mockCozyRealtime).toHaveBeenCalledWith({
         client: mockClient,
-        sharedDriveId: 'drive1'
+        sharedDriveId: 'drive1',
+        background: true
       })
       expect(mockCozyRealtime).toHaveBeenCalledWith({
         client: mockClient,
-        sharedDriveId: 'drive2'
+        sharedDriveId: 'drive2',
+        background: true
       })
     })
   })
@@ -814,7 +816,8 @@ describe('Realtime features', () => {
 
         expect(mockCozyRealtime).toHaveBeenCalledWith({
           client: mockClient,
-          sharedDriveId: 'drive1'
+          sharedDriveId: 'drive1',
+          background: true
         })
         expect(mockRealtimeInstance.subscribe).toHaveBeenCalledWith(
           'created',

--- a/packages/cozy-dataproxy-lib/src/search/SearchEngine.ts
+++ b/packages/cozy-dataproxy-lib/src/search/SearchEngine.ts
@@ -245,9 +245,12 @@ export class SearchEngine {
   }
 
   private addSharedDriveRealtime(sharedDriveId: string): void {
+    // background: the indexer watches the drive without the user looking at
+    // it, so the stack must not mark the sharing as seen
     const realtime = new CozyRealtime({
       client: this.client,
-      sharedDriveId
+      sharedDriveId,
+      background: true
     })
     this.subscribeDoctype(this.client, FILES_DOCTYPE, realtime, sharedDriveId)
     this.sharedDrivesRealtimes[sharedDriveId] = realtime

--- a/packages/cozy-realtime/src/CozyRealtime.js
+++ b/packages/cozy-realtime/src/CozyRealtime.js
@@ -35,9 +35,11 @@ class CozyRealtime {
    * @param {Function} [options.createWebSocket] The function used to create WebSocket instances
    * @param {object} [options.logger] A custom logger
    * @param {string} [options.sharedDriveId] - The ID of the shared drive to connect to
+   * @param {boolean} [options.background] - Whether the shared drive connection is made by a background service rather than the user viewing the drive, so the stack does not mark the sharing as seen
    */
   constructor(options) {
     this.sharedDriveId = options.sharedDriveId
+    this.background = options.background
     this.client = getCozyClientFromOptions(options)
     this.createWebSocket = options.createWebSocket || createWebSocket
     this.logger = options.logger || defaultLogger
@@ -85,7 +87,7 @@ class CozyRealtime {
       this.revokeWebSocket()
     }
     this.logger.info('creating a new websocket…')
-    const url = getUrl(this.client, this.sharedDriveId)
+    const url = getUrl(this.client, this.sharedDriveId, this.background)
     try {
       this.websocket = this.createWebSocket(url, protocol)
       this.websocket.authenticated = false

--- a/packages/cozy-realtime/src/CozyRealtime.spec.js
+++ b/packages/cozy-realtime/src/CozyRealtime.spec.js
@@ -549,6 +549,28 @@ describe('CozyRealtime', () => {
         expect(createWebSocket).toHaveBeenCalledWith(sharedDriveWsURI, protocol)
       )
     })
+
+    it('appends background=true to the shared drive URL for background connections', async () => {
+      const createWebSocket = jest.fn()
+      const sharedDriveId = 'drive-123'
+      const sharedDriveWsURI =
+        defaultClientUri.replace(/^http/, 'ws') +
+        `sharings/drives/${sharedDriveId}/realtime?background=true`
+
+      createSocketServer({ wsuri: sharedDriveWsURI })
+      const realtime = createRealtime({
+        createWebSocket,
+        sharedDriveId,
+        background: true
+      })
+
+      const handler = jest.fn()
+      realtime.subscribe(event, type, handler)
+
+      await waitFor(() =>
+        expect(createWebSocket).toHaveBeenCalledWith(sharedDriveWsURI, protocol)
+      )
+    })
   })
 
   describe('cozy-client events', () => {

--- a/packages/cozy-realtime/src/utils.js
+++ b/packages/cozy-realtime/src/utils.js
@@ -51,15 +51,21 @@ function getInstanceUri(client) {
  * Return websocket url from cozyClient
  *
  * @param {CozyClient} client - CozyClient instance
+ * @param {string} [sharedDriveId] - The ID of the shared drive to connect to
+ * @param {boolean} [background] - Whether the connection is made by a
+ * background service rather than the user viewing the drive, so the stack
+ * does not mark the sharing as seen
  * @return {string} WebSocket url
  */
-export function getUrl(client, sharedDriveId) {
+export function getUrl(client, sharedDriveId, background) {
   const url = getInstanceUri(client)
   const protocol = isSecureUrl(url) ? 'wss:' : 'ws:'
   const host = new URL(url).host
-  return sharedDriveId
-    ? `${protocol}//${host}/sharings/drives/${sharedDriveId}/realtime`
-    : `${protocol}//${host}/realtime/`
+  if (!sharedDriveId) {
+    return `${protocol}//${host}/realtime/`
+  }
+  const driveUrl = `${protocol}//${host}/sharings/drives/${sharedDriveId}/realtime`
+  return background ? `${driveUrl}?background=true` : driveUrl
 }
 
 /**


### PR DESCRIPTION
## Problem
The stack marks a drive sharing as seen whenever a recipient connects to its realtime websocket, which was meant for the user opening the drive view. The dataproxy search indexer connects to every accepted drive within seconds, so auto-accepted sharings lose their new status before the user ever sees the sharings counter in Drive.

## Solution
cozy-realtime gains a `background` option that appends `background=true` to the drive realtime URL, and the search indexer in cozy-dataproxy-lib passes it so the stack keeps the sharing unseen (stack side: cozy/cozy-stack#4793). Connections without the option behave as before, so the drive folder view still clears the counter when the user opens the drive.

## Worth knowing
cozy-dataproxy-lib needs the cozy-realtime release containing this option; its peer range should be bumped to that version when it is published.