### PR TITLE
fix(cozy-dataproxy-lib): require cozy-realtime with background option

### DIFF
--- a/packages/cozy-dataproxy-lib/package.json
+++ b/packages/cozy-dataproxy-lib/package.json
@@ -59,7 +59,7 @@
     "cozy-logger": ">=1.10.4",
     "cozy-minilog": ">=3.3.1",
     "cozy-pouch-link": "60.10.1",
-    "cozy-realtime": ">=5.6.4",
+    "cozy-realtime": ">=5.9.2",
     "cozy-ui": ">=111.19.0",
     "react": ">=16.12.0",
     "react-dom": ">=16.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17380,7 +17380,7 @@ __metadata:
     cozy-logger: ">=1.10.4"
     cozy-minilog: ">=3.3.1"
     cozy-pouch-link: 60.10.1
-    cozy-realtime: ">=5.6.4"
+    cozy-realtime: ">=5.9.2"
     cozy-ui: ">=111.19.0"
     react: ">=16.12.0"
     react-dom: ">=16.12.0"


### PR DESCRIPTION
## Context
The published cozy-dataproxy-lib already ships the search indexer that passes a `background` option when connecting to drive realtime, which keeps auto-accepted drive sharings unseen. That option only exists in cozy-realtime 5.9.2, but the peer range still allowed anything from 5.6.4 up, so a consumer could install the lib against a realtime that silently ignores the option.

## Solution
Bump the cozy-realtime peer range to >=5.9.2 so the lib is only satisfied by a version that actually supports the background connection.