### PR TITLE
fix: Remove strange custom color on share by me button

### DIFF
--- a/packages/cozy-sharing/src/components/ShareButton.jsx
+++ b/packages/cozy-sharing/src/components/ShareButton.jsx
@@ -22,7 +22,7 @@ export const ShareButton = ({ label, onClick, className, ...props }) => (
 export const SharedByMeButton = ({ label, onClick, className, ...props }) => (
   <Button
     data-test-id="share-by-me-button"
-    className={classNames(styles['coz-btn-shared'], className)}
+    className={className}
     onClick={() => onClick()}
     icon={<Icon icon={ShareIcon} />}
     label={label}

--- a/packages/cozy-sharing/src/styles/button.styl
+++ b/packages/cozy-sharing/src/styles/button.styl
@@ -4,11 +4,6 @@
     color: var(--primaryContrastTextColor)
     transition all .2s ease-out
 
-    &:focus
-    &:not([disabled]):not([aria-disabled=true]):hover
-        border-color: var(--malachite)
-        background-color: var(--malachite)
-
 .coz-btn-sharedWithMe
     border-color: #B449E7
     background-color: #B449E7


### PR DESCRIPTION
From 
<img width="314" height="96" alt="image" src="https://github.com/user-attachments/assets/2ae7d5d0-2055-4977-8982-704c1e88fcc3" />

to

<img width="314" height="96" alt="image" src="https://github.com/user-attachments/assets/6438a3d2-39a2-4250-bc42-4119040d1fce" />

https://app.notion.com/p/linagora/Color-of-button-Shared-by-me-is-incorrect-36862718bad1801bb792ddfec38c00d2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the styling of shared button components by removing default styling classes and hover/focus color transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->