### PR TITLE
feat(cozy-sharing): Show shared drive links

### DIFF
--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -53,7 +53,7 @@
     "babel-jest": "30.3.0",
     "babel-plugin-css-modules-transform": "1.6.2",
     "babel-plugin-inline-react-svg": "1.1.2",
-    "cozy-client": "^60.27.0",
+    "cozy-client": "^60.28.0",
     "cozy-device-helper": "^4.0.0",
     "cozy-intent": "^2.31.1",
     "cozy-minilog": "^3.10.1",
@@ -68,7 +68,7 @@
     "twake-i18n": "^0.4.1"
   },
   "peerDependencies": {
-    "cozy-client": ">=60.27.0",
+    "cozy-client": ">=60.28.0",
     "cozy-device-helper": ">=4.0.0",
     "cozy-flags": ">=4.8.1",
     "cozy-intent": ">=2.29.1",

--- a/packages/cozy-sharing/src/SharingProvider.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.jsx
@@ -440,8 +440,16 @@ export class SharingProvider extends Component {
     const resp = await drivePermissionCollection.findLinksByIds([documentId])
     const permissions = resp.data || []
 
-    if (permissions.length > 0) {
-      this.dispatch(addSharingLink(permissions))
+    const existingPermissions = getDocumentPermissions(this.state, documentId)
+    const existingPermissionIds = existingPermissions.map(
+      permission => permission.id
+    )
+    const newPermissions = permissions.filter(
+      permission => !existingPermissionIds.includes(permission.id)
+    )
+
+    if (newPermissions.length > 0) {
+      this.dispatch(addSharingLink(newPermissions))
     }
 
     return permissions

--- a/packages/cozy-sharing/src/SharingProvider.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.jsx
@@ -87,6 +87,7 @@ export class SharingProvider extends Component {
       revokeSelf: this.revokeSelf,
       shareByLink: this.shareByLink,
       getFederatedShareLink: this.getFederatedShareLink,
+      fetchSharedDriveSharingLinks: this.fetchSharedDriveSharingLinks,
       updateDocumentPermissions: this.updateDocumentPermissions,
       revokeSharingLink: this.revokeSharingLink,
       hasLoadedAtLeastOnePage: false,
@@ -373,17 +374,30 @@ export class SharingProvider extends Component {
   }
 
   shareByLink = async (document, options) => {
-    const resp = document.driveId
-      ? await this.createSharedDriveSharingLink(document, options)
-      : await this.permissionCol.createSharingLink(document, options)
-    this.dispatch(addSharingLink(resp.data))
-    return resp
+    try {
+      const resp = document.driveId
+        ? await this.createSharedDriveSharingLink(document, options)
+        : await this.permissionCol.createSharingLink(document, options)
+      this.dispatch(addSharingLink(resp.data))
+      return resp
+    } catch (error) {
+      if (document.driveId && error && error.status === 409) {
+        const permissions = await this.fetchSharedDriveSharingLinks(document)
+        if (permissions && permissions.length > 0) {
+          return { data: permissions[0] }
+        }
+      }
+      throw error
+    }
   }
 
   getFederatedShareLink = document => {
-    if (!document.driveId) return null
+    if (!document?.driveId) return null
 
-    const permissions = getDocumentPermissions(this.state, document._id)
+    const documentId = document._id || document.id
+    if (!documentId) return null
+
+    const permissions = getDocumentPermissions(this.state, documentId)
     const perm = permissions.find(p => getShortcode(p))
     if (!perm) return null
 
@@ -411,6 +425,26 @@ export class SharingProvider extends Component {
       options
     )
     return resp
+  }
+
+  fetchSharedDriveSharingLinks = async document => {
+    if (!document || !document.driveId) return []
+
+    const { client } = this.props
+    const drivePermissionCollection = client.collection('io.cozy.permissions', {
+      driveId: document.driveId
+    })
+    const documentId = document._id || document.id
+    if (!documentId) return []
+
+    const resp = await drivePermissionCollection.findLinksByIds([documentId])
+    const permissions = resp.data || []
+
+    if (permissions.length > 0) {
+      this.dispatch(addSharingLink(permissions))
+    }
+
+    return permissions
   }
 
   updateSharedDrivePermissions = async (

--- a/packages/cozy-sharing/src/SharingProvider.spec.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.spec.jsx
@@ -449,6 +449,32 @@ describe('shareByLink shared drive 409 recovery', () => {
     expect(resp.data.id).toBe(PERM_DRIVE_FILE.id)
   })
 
+  it('does not duplicate existing links when 409 recovery refetches them', async () => {
+    const conflict = Object.assign(new Error('Conflict'), { status: 409 })
+    const mockCreateSharingLink = jest.fn().mockRejectedValue(conflict)
+    const mockFindLinksByIds = jest
+      .fn()
+      .mockResolvedValue({ data: [PERM_DRIVE_FILE] })
+    const mockClient = createMockClient({})
+    mockClient.collection = jest.fn().mockReturnValue({
+      createSharingLink: mockCreateSharingLink,
+      findLinksByIds: mockFindLinksByIds
+    })
+
+    const provider = new SharingProvider({ client: mockClient })
+    provider.state = reducer(undefined, addSharingLink(PERM_DRIVE_FILE))
+    provider.dispatch = jest.fn(action => {
+      provider.state = reducer(provider.state, action)
+    })
+
+    const resp = await provider.shareByLink(driveFile, { verbs: ['GET'] })
+
+    const permissions = getDocumentPermissions(provider.state, 'file_in_drive')
+    expect(resp.data.id).toBe(PERM_DRIVE_FILE.id)
+    expect(provider.dispatch).not.toHaveBeenCalled()
+    expect(permissions).toHaveLength(1)
+  })
+
   it('rethrows the original error when 409 happens and no link is found', async () => {
     const conflict = Object.assign(new Error('Conflict'), { status: 409 })
     const mockCreateSharingLink = jest.fn().mockRejectedValue(conflict)

--- a/packages/cozy-sharing/src/SharingProvider.spec.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.spec.jsx
@@ -291,6 +291,184 @@ describe('updateDocumentPermissions', () => {
   })
 })
 
+describe('fetchSharedDriveSharingLinks', () => {
+  const PERM_DRIVE_FILE = {
+    type: 'io.cozy.permissions',
+    id: 'perm_drive_file',
+    attributes: {
+      type: 'share',
+      permissions: {
+        rule0: {
+          type: 'io.cozy.files',
+          verbs: ['GET'],
+          values: ['file_in_drive']
+        }
+      },
+      shortcodes: { code: 'shortcode123' }
+    }
+  }
+
+  const driveFile = {
+    _id: 'file_in_drive',
+    id: 'file_in_drive',
+    driveId: 'drive_123'
+  }
+
+  it('fetches shared drive sharing links by file id', async () => {
+    const mockFindLinksByIds = jest
+      .fn()
+      .mockResolvedValue({ data: [PERM_DRIVE_FILE] })
+    const mockClient = createMockClient({})
+    mockClient.collection = jest.fn().mockReturnValue({
+      findLinksByIds: mockFindLinksByIds
+    })
+
+    const provider = new SharingProvider({ client: mockClient })
+    provider.state = reducer()
+    provider.dispatch = jest.fn(action => {
+      provider.state = reducer(provider.state, action)
+    })
+
+    const result = await provider.fetchSharedDriveSharingLinks(driveFile)
+
+    expect(mockClient.collection).toHaveBeenCalledWith('io.cozy.permissions', {
+      driveId: 'drive_123'
+    })
+    expect(mockFindLinksByIds).toHaveBeenCalledWith(['file_in_drive'])
+    expect(provider.dispatch).toHaveBeenCalled()
+    const permissions = getDocumentPermissions(provider.state, 'file_in_drive')
+    expect(permissions).toHaveLength(1)
+    expect(permissions[0].id).toBe(PERM_DRIVE_FILE.id)
+    expect(result).toEqual([PERM_DRIVE_FILE])
+  })
+
+  it('returns an empty array and skips the API call for non-shared-drive documents', async () => {
+    const mockClient = createMockClient({})
+    const findLinksByIds = jest.fn()
+    mockClient.collection = jest.fn().mockReturnValue({
+      findLinksByIds
+    })
+
+    const provider = new SharingProvider({ client: mockClient })
+    provider.dispatch = jest.fn()
+
+    const result = await provider.fetchSharedDriveSharingLinks({
+      _id: 'regular_file'
+    })
+
+    expect(result).toEqual([])
+    expect(findLinksByIds).not.toHaveBeenCalled()
+    expect(provider.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('uses document.id as a fallback when _id is missing', async () => {
+    const mockFindLinksByIds = jest
+      .fn()
+      .mockResolvedValue({ data: [PERM_DRIVE_FILE] })
+    const mockClient = createMockClient({})
+    mockClient.collection = jest.fn().mockReturnValue({
+      findLinksByIds: mockFindLinksByIds
+    })
+
+    const provider = new SharingProvider({ client: mockClient })
+    provider.state = reducer()
+    provider.dispatch = jest.fn(action => {
+      provider.state = reducer(provider.state, action)
+    })
+
+    await provider.fetchSharedDriveSharingLinks({
+      id: 'file_in_drive',
+      driveId: 'drive_123'
+    })
+
+    expect(mockFindLinksByIds).toHaveBeenCalledWith(['file_in_drive'])
+  })
+
+  it('does not dispatch when the response has no data', async () => {
+    const mockFindLinksByIds = jest.fn().mockResolvedValue({ data: [] })
+    const mockClient = createMockClient({})
+    mockClient.collection = jest.fn().mockReturnValue({
+      findLinksByIds: mockFindLinksByIds
+    })
+
+    const provider = new SharingProvider({ client: mockClient })
+    provider.dispatch = jest.fn()
+
+    const result = await provider.fetchSharedDriveSharingLinks(driveFile)
+
+    expect(result).toEqual([])
+    expect(provider.dispatch).not.toHaveBeenCalled()
+  })
+})
+
+describe('shareByLink shared drive 409 recovery', () => {
+  const PERM_DRIVE_FILE = {
+    type: 'io.cozy.permissions',
+    id: 'perm_drive_file',
+    attributes: {
+      type: 'share',
+      permissions: {
+        rule0: {
+          type: 'io.cozy.files',
+          verbs: ['GET'],
+          values: ['file_in_drive']
+        }
+      },
+      shortcodes: { code: 'shortcode123' }
+    }
+  }
+
+  const driveFile = {
+    _id: 'file_in_drive',
+    id: 'file_in_drive',
+    driveId: 'drive_123'
+  }
+
+  it('falls back to fetching existing links when create returns 409', async () => {
+    const conflict = Object.assign(new Error('Conflict'), { status: 409 })
+    const mockCreateSharingLink = jest.fn().mockRejectedValue(conflict)
+    const mockFindLinksByIds = jest
+      .fn()
+      .mockResolvedValue({ data: [PERM_DRIVE_FILE] })
+    const mockClient = createMockClient({})
+    mockClient.collection = jest.fn().mockReturnValue({
+      createSharingLink: mockCreateSharingLink,
+      findLinksByIds: mockFindLinksByIds
+    })
+
+    const provider = new SharingProvider({ client: mockClient })
+    provider.state = reducer()
+    provider.dispatch = jest.fn(action => {
+      provider.state = reducer(provider.state, action)
+    })
+
+    const resp = await provider.shareByLink(driveFile, { verbs: ['GET'] })
+
+    expect(mockCreateSharingLink).toHaveBeenCalled()
+    expect(mockFindLinksByIds).toHaveBeenCalledWith(['file_in_drive'])
+    expect(resp.data.id).toBe(PERM_DRIVE_FILE.id)
+  })
+
+  it('rethrows the original error when 409 happens and no link is found', async () => {
+    const conflict = Object.assign(new Error('Conflict'), { status: 409 })
+    const mockCreateSharingLink = jest.fn().mockRejectedValue(conflict)
+    const mockFindLinksByIds = jest.fn().mockResolvedValue({ data: [] })
+    const mockClient = createMockClient({})
+    mockClient.collection = jest.fn().mockReturnValue({
+      createSharingLink: mockCreateSharingLink,
+      findLinksByIds: mockFindLinksByIds
+    })
+
+    const provider = new SharingProvider({ client: mockClient })
+    provider.state = reducer()
+    provider.dispatch = jest.fn()
+
+    await expect(
+      provider.shareByLink(driveFile, { verbs: ['GET'] })
+    ).rejects.toBe(conflict)
+  })
+})
+
 describe('updateSharingMemberType', () => {
   const mockSharing = {
     id: 'sharing-123',

--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 
 import { useClient } from 'cozy-client'
+import minilog from 'cozy-minilog'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import { FixedDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Typography from 'cozy-ui/transpiled/react/Typography'
@@ -21,6 +22,8 @@ import { default as DumbShareByEmail } from '../ShareByEmail'
 import ShareByLink from '../ShareByLink'
 import WhoHasAccess from '../WhoHasAccess'
 
+const log = minilog('FederatedFolderModal')
+
 const FederatedFolderModalContent = ({
   onClose,
   document: existingDocument,
@@ -34,6 +37,8 @@ const FederatedFolderModalContent = ({
     getSharingById,
     getSharingLink,
     getFederatedShareLink,
+    getDocumentPermissions,
+    fetchSharedDriveSharingLinks,
     getRecipients,
     hasSharedChild,
     hasSharedParent,
@@ -169,12 +174,36 @@ const FederatedFolderModalContent = ({
     }
   }
 
-  const existingRecipients = existingDocument
-    ? getRecipients(existingDocument._id)
+  const documentId = existingDocument?._id || existingDocument?.id
+  const existingRecipients = documentId ? getRecipients(documentId) : []
+  const documentPermissions = documentId
+    ? getDocumentPermissions(documentId)
     : []
   const displayedLink = existingDocument?.driveId
     ? getFederatedShareLink(existingDocument)
     : getSharingLink(existingDocument?._id)
+
+  useEffect(() => {
+    if (!existingDocument?.driveId) return
+    if (!documentId) return
+    if (!fetchSharedDriveSharingLinks) return
+    if (documentPermissions.length > 0) return
+
+    const fetchSharingLinks = async () => {
+      try {
+        await fetchSharedDriveSharingLinks(existingDocument)
+      } catch (error) {
+        log.error('Failed to fetch shared drive sharing links', error)
+      }
+    }
+
+    fetchSharingLinks()
+  }, [
+    documentId,
+    existingDocument,
+    documentPermissions.length,
+    fetchSharedDriveSharingLinks
+  ])
 
   const modalTitle = t('FederatedFolder.shareTitle', { name: folderName })
 

--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
@@ -61,6 +61,9 @@ const FederatedFolderModalContent = ({
   // in members before the modal closes. That's why when clicking on "Share"
   // we do not use the reactive existingDocument and existingRecipients.
   const [isSending, setIsSending] = useState(false)
+  const [isFetchingSharingLinks, setIsFetchingSharingLinks] = useState(false)
+  const [fetchedSharingLinksDocumentId, setFetchedSharingLinksDocumentId] =
+    useState(null)
   const [frozenDoc, setFrozenDoc] = useState(null)
   const [frozenRecipients, setFrozenRecipients] = useState(null)
 
@@ -188,12 +191,19 @@ const FederatedFolderModalContent = ({
     if (!documentId) return
     if (!fetchSharedDriveSharingLinks) return
     if (documentPermissions.length > 0) return
+    if (isFetchingSharingLinks) return
+    if (fetchedSharingLinksDocumentId === documentId) return
 
     const fetchSharingLinks = async () => {
+      setIsFetchingSharingLinks(true)
+
       try {
         await fetchSharedDriveSharingLinks(existingDocument)
       } catch (error) {
         log.error('Failed to fetch shared drive sharing links', error)
+      } finally {
+        setFetchedSharingLinksDocumentId(documentId)
+        setIsFetchingSharingLinks(false)
       }
     }
 
@@ -202,7 +212,9 @@ const FederatedFolderModalContent = ({
     documentId,
     existingDocument,
     documentPermissions.length,
-    fetchSharedDriveSharingLinks
+    fetchedSharingLinksDocumentId,
+    fetchSharedDriveSharingLinks,
+    isFetchingSharingLinks
   ])
 
   const modalTitle = t('FederatedFolder.shareTitle', { name: folderName })

--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
@@ -17,6 +17,8 @@ const mockGetRecipients = jest.fn().mockReturnValue([])
 const mockGetSharingById = jest.fn()
 const mockHasSharedChild = jest.fn()
 const mockHasSharedParent = jest.fn()
+const mockFetchSharedDriveSharingLinks = jest.fn()
+const mockGetDocumentPermissions = jest.fn().mockReturnValue([])
 const mockShowAlert = jest.fn()
 const mockOnClose = jest.fn()
 
@@ -27,7 +29,8 @@ jest.mock('../../hooks/useSharingContext', () => ({
     revoke: mockRevoke,
     getSharingLink: mockGetSharingLink,
     getFederatedShareLink: mockGetFederatedShareLink,
-    getDocumentPermissions: jest.fn().mockReturnValue([]),
+    getDocumentPermissions: mockGetDocumentPermissions,
+    fetchSharedDriveSharingLinks: mockFetchSharedDriveSharingLinks,
     getOwner: jest.fn(),
     getRecipients: mockGetRecipients,
     getSharingById: mockGetSharingById,
@@ -65,7 +68,8 @@ const createSharingContextValue = () => ({
   hasWriteAccess: jest.fn(),
   getRecipients: jest.fn(),
   getSharingLink: mockGetSharingLink,
-  getDocumentPermissions: jest.fn().mockReturnValue([]),
+  getDocumentPermissions: mockGetDocumentPermissions,
+  fetchSharedDriveSharingLinks: mockFetchSharedDriveSharingLinks,
   share: mockShare
 })
 
@@ -96,6 +100,8 @@ describe('FederatedFolderModal', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockGetDocumentPermissions.mockReturnValue([])
+    mockFetchSharedDriveSharingLinks.mockResolvedValue([])
     mockGetSharingLink.mockReturnValue('https://example.com/share/abc123')
     mockGetFederatedShareLink.mockReturnValue(
       'https://example.com/share/federated-abc123'
@@ -224,6 +230,68 @@ describe('FederatedFolderModal', () => {
         queryByText('This folder can only be shared by link, because')
       ).toBe(null)
       expect(queryByText('it has a shared parent')).toBe(null)
+    })
+  })
+
+  describe('shared drive link fetch on mount', () => {
+    it('should fetch shared drive sharing links when document has a driveId and no permissions yet', async () => {
+      mockGetDocumentPermissions.mockReturnValue([])
+
+      setup({
+        document: { ...mockDocument, driveId: 'federated-folder-id' }
+      })
+
+      await waitFor(() => {
+        expect(mockFetchSharedDriveSharingLinks).toHaveBeenCalledTimes(1)
+      })
+      expect(mockFetchSharedDriveSharingLinks).toHaveBeenCalledWith(
+        expect.objectContaining({
+          _id: mockDocument._id,
+          driveId: 'federated-folder-id'
+        })
+      )
+    })
+
+    it('should use document.id when _id is missing', async () => {
+      const document = {
+        id: 'folder-id-only',
+        name: 'My Test Folder',
+        path: '/test/folder',
+        driveId: 'federated-folder-id'
+      }
+
+      setup({ document })
+
+      await waitFor(() => {
+        expect(mockFetchSharedDriveSharingLinks).toHaveBeenCalledWith(document)
+      })
+      expect(mockGetDocumentPermissions).toHaveBeenCalledWith('folder-id-only')
+    })
+
+    it('should not fetch shared drive sharing links when document has no driveId', async () => {
+      const { findByText } = setup({ document: mockDocument })
+
+      await findByText('Copy link')
+
+      expect(mockFetchSharedDriveSharingLinks).not.toHaveBeenCalled()
+    })
+
+    it('should not fetch shared drive sharing links when permissions are already loaded', async () => {
+      mockGetDocumentPermissions.mockReturnValue([
+        {
+          id: 'perm-1',
+          type: 'io.cozy.permissions',
+          attributes: { shortcodes: { code: 'abc' } }
+        }
+      ])
+
+      const { findByText } = setup({
+        document: { ...mockDocument, driveId: 'federated-folder-id' }
+      })
+
+      await findByText('Copy link')
+
+      expect(mockFetchSharedDriveSharingLinks).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
@@ -276,6 +276,23 @@ describe('FederatedFolderModal', () => {
       expect(mockFetchSharedDriveSharingLinks).not.toHaveBeenCalled()
     })
 
+    it('should not refetch after one attempt when permissions stay empty', async () => {
+      const document = { ...mockDocument, driveId: 'federated-folder-id' }
+      const { rerender } = setup({ document })
+
+      await waitFor(() => {
+        expect(mockFetchSharedDriveSharingLinks).toHaveBeenCalledTimes(1)
+      })
+
+      rerender(
+        <AppLike client={client} sharingContextValue={sharingContextValue}>
+          <FederatedFolderModal document={document} onClose={mockOnClose} />
+        </AppLike>
+      )
+
+      expect(mockFetchSharedDriveSharingLinks).toHaveBeenCalledTimes(1)
+    })
+
     it('should not fetch shared drive sharing links when permissions are already loaded', async () => {
       mockGetDocumentPermissions.mockReturnValue([
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17305,16 +17305,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cozy-client@npm:^60.27.0":
-  version: 60.27.0
-  resolution: "cozy-client@npm:60.27.0"
+"cozy-client@npm:^60.28.0":
+  version: 60.28.0
+  resolution: "cozy-client@npm:60.28.0"
   dependencies:
     "@cozy/minilog": "npm:1.0.0"
     "@fastify/deepmerge": "npm:^2.0.2"
     "@types/jest": "npm:^26.0.20"
     "@types/lodash": "npm:^4.14.170"
     btoa: "npm:^1.2.1"
-    cozy-stack-client: "npm:^60.27.0"
+    cozy-stack-client: "npm:^60.28.0"
     date-fns: "npm:^2.30.0"
     fast-deep-equal: "npm:^3.1.3"
     json-stable-stringify: "npm:^1.0.1"
@@ -17340,7 +17340,7 @@ __metadata:
     react-native-google-play-integrity: ^1.1.0
     react-native-inappbrowser-reborn: ^3.5.1
     react-native-ios11-devicecheck: ^0.0.3
-  checksum: 10c0/c362cbb0a56a19c26d6fdb76454f3135a0721e76c09ecf60c3621b42a6a640a4c94864e25693808d170e0af2b44c915cd2e6cdab55207b8d12afc2b3d687f0d4
+  checksum: 10c0/f4ac08062b053e96bd9e20f1b308933e394341c638abb49a8847dc4f9a0dcbd56b75f3a5f0545f34494646185c1222573100fb3a99684e4d6a643124039ce738
   languageName: node
   linkType: hard
 
@@ -18002,7 +18002,7 @@ __metadata:
     babel-plugin-css-modules-transform: "npm:1.6.2"
     babel-plugin-inline-react-svg: "npm:1.1.2"
     classnames: "npm:^2.5.1"
-    cozy-client: "npm:^60.27.0"
+    cozy-client: "npm:^60.28.0"
     cozy-device-helper: "npm:^4.0.0"
     cozy-doctypes: "npm:^1.99.1"
     cozy-intent: "npm:^2.31.1"
@@ -18022,7 +18022,7 @@ __metadata:
     storybook: "npm:7.6.0"
     twake-i18n: "npm:^0.4.1"
   peerDependencies:
-    cozy-client: ">=60.27.0"
+    cozy-client: ">=60.28.0"
     cozy-device-helper: ">=4.0.0"
     cozy-flags: ">=4.8.1"
     cozy-intent: ">=2.29.1"
@@ -18203,16 +18203,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cozy-stack-client@npm:^60.27.0":
-  version: 60.27.0
-  resolution: "cozy-stack-client@npm:60.27.0"
+"cozy-stack-client@npm:^60.28.0":
+  version: 60.28.0
+  resolution: "cozy-stack-client@npm:60.28.0"
   dependencies:
     detect-node: "npm:^2.0.4"
     mime: "npm:^2.4.0"
     qs: "npm:^6.7.0"
   peerDependencies:
     cozy-flags: ">2.8.6"
-  checksum: 10c0/53bd1200f3f812073782f994d4cdf3a6ac5771a6cec52f1ef239cc543d6e0b0e0acfb6171d944f6aef7231b1423a87ce7684bb92ce9d82fd6f4507aaf5764300
+  checksum: 10c0/e34fcb9bdeb36e7053528b925c9a432cf3015000d555adbb39a5ff8121d823e74603576ec634b39d7489c3f8f7cfd440cc0ba997508d60dfe6be5ffc9e0809df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://app.notion.com/p/linagora/LINKS-on-reciver-side-doen-t-work-37c62718bad1801c8041e23d64eae181

Needs next cozy-stack-client with https://github.com/linagora/cozy-client/pull/1689

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic link prefetching for shared drives to improve responsiveness when opening sharing dialogs.

* **Bug Fixes**
  * Improved shared drive link creation to automatically recover from conflicts by fetching and reusing existing sharing links instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->