### PR TITLE
fix(cozy-sharing): keep the owner avatar visible in the share modal

### DIFF
--- a/packages/cozy-sharing/src/components/Avatar/MemberAvatar.jsx
+++ b/packages/cozy-sharing/src/components/Avatar/MemberAvatar.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import { useClient } from 'cozy-client'
 import Avatar from 'cozy-ui/transpiled/react/Avatar'
@@ -8,6 +8,10 @@ import { getInitials } from '../../models'
 
 const MemberAvatar = ({ recipient, ...rest }) => {
   const client = useClient()
+  // Remember which image url failed to load so we can fall back to the
+  // initials. Storing the url (instead of a boolean) means a new url is
+  // retried automatically, without an effect to reset the error state.
+  const [erroredSrc, setErroredSrc] = useState(null)
 
   // There are cases when due to apparent memory leaks, the recipient does not exist
   // This will trigger an unhanded error in the Avatar component and crash the app
@@ -31,13 +35,24 @@ const MemberAvatar = ({ recipient, ...rest }) => {
    */
   const image =
     recipient.avatarPath && recipient.status
-      ? `${client.options.uri}${recipient.avatarPath}?v=${recipient.status}`
+      ? `${client.options.uri}${recipient.avatarPath}${
+          recipient.avatarPath.includes('?') ? '&' : '?'
+        }v=${recipient.status}`
       : null
 
+  // The avatar can become unreachable (eg. the related sharing is revoked
+  // while its members are still rendered), in which case the image request
+  // fails. Without a fallback the browser shows a broken-image icon, so we
+  // render the initials instead.
   return (
     <Avatar {...rest}>
-      {image ? (
-        <img width="100%" height="100%" src={image} />
+      {image && erroredSrc !== image ? (
+        <img
+          width="100%"
+          height="100%"
+          src={image}
+          onError={() => setErroredSrc(image)}
+        />
       ) : (
         getInitials(recipient)
       )}

--- a/packages/cozy-sharing/src/components/Avatar/MemberAvatar.spec.jsx
+++ b/packages/cozy-sharing/src/components/Avatar/MemberAvatar.spec.jsx
@@ -1,0 +1,80 @@
+import { render, fireEvent } from '@testing-library/react'
+import React from 'react'
+
+import { createMockClient } from 'cozy-client'
+
+import { MemberAvatar } from './MemberAvatar'
+import AppLike from '../../../test/AppLike'
+
+describe('MemberAvatar', () => {
+  const client = createMockClient({})
+  client.options = { uri: 'http://cozy.example.com' }
+
+  const setup = recipient =>
+    render(
+      <AppLike client={client}>
+        <MemberAvatar recipient={recipient} />
+      </AppLike>
+    )
+
+  it('renders nothing when the recipient is missing', () => {
+    const { container } = setup(undefined)
+
+    // The component returns null; only the provider wrappers remain, with no
+    // avatar rendered inside.
+    expect(container.querySelector('[class*="MuiAvatar-root"]')).toBeNull()
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('renders the avatar image when the recipient has an avatarPath and a status', () => {
+    const { container } = setup({
+      public_name: 'Bob',
+      status: 'owner',
+      avatarPath: '/sharings/123/recipients/0/avatar'
+    })
+
+    const img = container.querySelector('img')
+    expect(img).toBeTruthy()
+    expect(img.getAttribute('src')).toBe(
+      'http://cozy.example.com/sharings/123/recipients/0/avatar?v=owner'
+    )
+  })
+
+  it('appends the cache-busting param with & when avatarPath already has a query string', () => {
+    const { container } = setup({
+      public_name: 'Bob',
+      status: 'owner',
+      avatarPath: '/public/avatar?fallback=initials'
+    })
+
+    expect(container.querySelector('img').getAttribute('src')).toBe(
+      'http://cozy.example.com/public/avatar?fallback=initials&v=owner'
+    )
+  })
+
+  it('renders the initials when there is no avatarPath', () => {
+    const { container, getByText } = setup({
+      public_name: 'Bob',
+      status: 'owner'
+    })
+
+    expect(container.querySelector('img')).toBeNull()
+    expect(getByText('B')).toBeTruthy()
+  })
+
+  it('falls back to the initials when the avatar image fails to load', () => {
+    const { container, getByText } = setup({
+      public_name: 'Bob',
+      status: 'owner',
+      avatarPath: '/sharings/123/recipients/0/avatar'
+    })
+
+    const img = container.querySelector('img')
+    expect(img).toBeTruthy()
+
+    fireEvent.error(img)
+
+    expect(container.querySelector('img')).toBeNull()
+    expect(getByText('B')).toBeTruthy()
+  })
+})

--- a/packages/cozy-sharing/src/components/Recipient/OwnerRecipientDefault.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/OwnerRecipientDefault.jsx
@@ -5,6 +5,13 @@ import { useClient, useQuery, hasQueryBeenLoaded } from 'cozy-client'
 import MemberRecipient from './MemberRecipient'
 import { buildInstanceSettingsQuery } from '../../queries/queries'
 
+// When the owner is not part of a sharing's members (eg. the folder only has
+// a link), there is no per-sharing avatar to reference. The instance's public
+// avatar still holds the owner's picture. fallback=initials makes the stack
+// serve a generated initials avatar (instead of the app icon) when no picture
+// has been uploaded, matching how avatars are rendered everywhere else.
+const OWNER_PUBLIC_AVATAR_PATH = '/public/avatar?fallback=initials'
+
 const OwnerRecipientDefault = () => {
   const client = useClient()
 
@@ -20,6 +27,7 @@ const OwnerRecipientDefault = () => {
         isOwner={true}
         status="owner"
         instance={client.options.uri}
+        avatarPath={OWNER_PUBLIC_AVATAR_PATH}
         public_name={instanceSettingsResult?.data?.attributes?.public_name}
       />
     )

--- a/packages/cozy-sharing/src/components/Recipient/OwnerRecipientDefaultLite.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/OwnerRecipientDefaultLite.jsx
@@ -6,6 +6,10 @@ import MemberRecipientLite from './MemberRecipientLite'
 import withLocales from '../../hoc/withLocales'
 import { buildInstanceSettingsQuery } from '../../queries/queries'
 
+// See OwnerRecipientDefault: show the instance public avatar (with an initials
+// fallback) when the owner has no per-sharing avatar to reference.
+const OWNER_PUBLIC_AVATAR_PATH = '/public/avatar?fallback=initials'
+
 const OwnerRecipientDefaultLite = () => {
   const client = useClient()
 
@@ -21,6 +25,7 @@ const OwnerRecipientDefaultLite = () => {
         recipient={{
           status: 'owner',
           instance: client.options.uri,
+          avatarPath: OWNER_PUBLIC_AVATAR_PATH,
           public_name: instanceSettingsResult?.data?.attributes?.public_name
         }}
         isOwner={true}


### PR DESCRIPTION
## Context
In the share modal the owner avatar is a plain image with no error handling, so when its request fails (for example the sharing is torn down right after the last recipient is removed) the browser paints a broken-image icon. And when the owner is not part of a sharing's members (a link-only share) the owner row fell back to plain initials, or even the app icon, instead of the real picture.

## Solution
Fall back to the initials when the avatar image fails to load, and point the member-less owner at the instance public avatar (with an initials fallback) so the real picture shows wherever it is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar image reliability with fallback to initials when images fail to load.
  * Fixed cache-busting for avatar URLs to properly handle existing query parameters.

* **Tests**
  * Added comprehensive test coverage for avatar component behavior and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->