### PR TITLE
Fix revoked sharing reuse

### DIFF
--- a/packages/cozy-sharing/src/state.js
+++ b/packages/cozy-sharing/src/state.js
@@ -258,6 +258,12 @@ const sharings = (state = [], action) => {
     case UPDATE_SHARING:
     case REVOKE_GROUP:
     case REVOKE_RECIPIENT:
+      if (
+        !isSharingADrive(action.sharing) &&
+        areAllRecipientsRevoked(action.sharing)
+      ) {
+        return state.filter(s => s.id !== action.sharing.id)
+      }
       return state.map(s => {
         return s.id !== action.sharing.id ? s : action.sharing
       })

--- a/packages/cozy-sharing/src/state.spec.js
+++ b/packages/cozy-sharing/src/state.spec.js
@@ -343,6 +343,22 @@ describe('Sharing state', () => {
     )
   })
 
+  it('should forget a sharing when revoking the last recipient', () => {
+    const state = reducer(
+      reducer(
+        undefined,
+        receiveSharings({
+          sharings: [SHARING_1, SHARING_2]
+        })
+      ),
+      revokeRecipient(SHARING_2, 1)
+    )
+    expect(state.byDocId).toEqual({
+      folder_1: { sharings: [SHARING_1.id], permissions: [] }
+    })
+    expect(state.sharings).toEqual([SHARING_1])
+  })
+
   it('should revoke self', () => {
     const state = reducer(
       reducer(


### PR DESCRIPTION
## Summary

Fixes `cozy-sharing` state after the last recipient is revoked from a non-shared-drive sharing.

The reducer already removed the document index for fully revoked non-drive sharings, but it kept the stale sharing object in `state.sharings`. That could let later share flows reuse the deleted sharing and call `POST /sharings/{old_id}/recipients`, which fails when adding the same recipient again.

## Changes

- Remove fully revoked non-drive sharings from `state.sharings` on revoke/update.
- Keep existing shared-drive behavior unchanged.
- Add a regression test for revoking the last recipient.

## Validation

- `corepack yarn workspace cozy-sharing test --runTestsByPath src/state.spec.js --moduleNameMapper '{"^cozy-flags$":"<rootDir>/../cozy-flags/src/index.js"}'`
- `corepack yarn workspace cozy-sharing lint` passed with existing unrelated warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sharing cleanup logic to properly handle revoked recipients. When all recipients of a sharing are revoked, the sharing record is now removed from the system, maintaining data consistency.

* **Tests**
  * Added test coverage for sharing removal when the last recipient is revoked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->