### PR TITLE
fix(sharing): Update member permissions optimistically

### DIFF
--- a/packages/cozy-sharing/src/SharingProvider.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.jsx
@@ -383,7 +383,23 @@ export class SharingProvider extends Component {
         await this.sharingCol.setReadWrite(sharing, memberIndex)
       }
     } catch (error) {
-      this.dispatch(updateSharing(sharing))
+      const currentSharing = getSharingById(this.state, sharingId) || sharing
+      const rollbackSharing = {
+        ...currentSharing,
+        attributes: {
+          ...currentSharing.attributes,
+          members: currentSharing.attributes.members.map((member, index) =>
+            index === memberIndex
+              ? {
+                  ...member,
+                  read_only: !makeReadOnly
+                }
+              : member
+          )
+        }
+      }
+
+      this.dispatch(updateSharing(rollbackSharing))
       log.error(
         `Failed to change member ${member.email} permission type to ${newType}`,
         error

--- a/packages/cozy-sharing/src/SharingProvider.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.jsx
@@ -358,6 +358,24 @@ export class SharingProvider extends Component {
     if (newType !== 'one-way' && newType !== 'two-way') {
       throw new Error('Unsupported sharing type: ' + newType)
     }
+
+    const optimisticSharing = {
+      ...sharing,
+      attributes: {
+        ...sharing.attributes,
+        members: sharing.attributes.members.map((member, index) =>
+          index === memberIndex
+            ? {
+                ...member,
+                read_only: makeReadOnly
+              }
+            : member
+        )
+      }
+    }
+
+    this.dispatch(updateSharing(optimisticSharing))
+
     try {
       if (makeReadOnly) {
         await this.sharingCol.setReadOnly(sharing, memberIndex)
@@ -365,6 +383,7 @@ export class SharingProvider extends Component {
         await this.sharingCol.setReadWrite(sharing, memberIndex)
       }
     } catch (error) {
+      this.dispatch(updateSharing(sharing))
       log.error(
         `Failed to change member ${member.email} permission type to ${newType}`,
         error

--- a/packages/cozy-sharing/src/SharingProvider.spec.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.spec.jsx
@@ -524,7 +524,9 @@ describe('updateSharingMemberType', () => {
       setReadOnly: jest.fn().mockResolvedValue({}),
       setReadWrite: jest.fn().mockResolvedValue({})
     }
-    jest.spyOn(instance, 'setState')
+    instance.dispatch = jest.fn(action => {
+      instance.state = { ...instance.state, ...reducer(instance.state, action) }
+    })
   })
 
   it('should throw when sharing is not found', async () => {
@@ -556,16 +558,46 @@ describe('updateSharingMemberType', () => {
     expect(instance.sharingCol.setReadOnly).not.toHaveBeenCalled()
   })
 
-  it('should not dispatch a state update — realtime refreshes the store', async () => {
+  it('should optimistically dispatch a state update when switching to one-way', async () => {
     await instance.updateSharingMemberType('sharing-123', 1, 'one-way')
 
-    expect(instance.setState).not.toHaveBeenCalled()
+    expect(instance.dispatch).toHaveBeenCalledWith({
+      type: 'UPDATE_SHARING',
+      sharing: {
+        ...mockSharing,
+        attributes: {
+          ...mockSharing.attributes,
+          members: [
+            mockSharing.attributes.members[0],
+            {
+              ...mockSharing.attributes.members[1],
+              read_only: true
+            }
+          ]
+        }
+      }
+    })
   })
 
-  it('should not dispatch a state update for two-way — realtime refreshes the store', async () => {
+  it('should optimistically dispatch a state update when switching to two-way', async () => {
     await instance.updateSharingMemberType('sharing-123', 1, 'two-way')
 
-    expect(instance.setState).not.toHaveBeenCalled()
+    expect(instance.dispatch).toHaveBeenCalledWith({
+      type: 'UPDATE_SHARING',
+      sharing: {
+        ...mockSharing,
+        attributes: {
+          ...mockSharing.attributes,
+          members: [
+            mockSharing.attributes.members[0],
+            {
+              ...mockSharing.attributes.members[1],
+              read_only: false
+            }
+          ]
+        }
+      }
+    })
   })
 
   it('should rethrow error if setReadOnly fails', async () => {
@@ -588,7 +620,7 @@ describe('updateSharingMemberType', () => {
     ).rejects.toThrow('Network error')
   })
 
-  it('should not dispatch state update if API call fails', async () => {
+  it('should rollback optimistic state update if API call fails', async () => {
     instance.sharingCol.setReadOnly.mockRejectedValue(
       new Error('Network error')
     )
@@ -597,7 +629,26 @@ describe('updateSharingMemberType', () => {
       instance.updateSharingMemberType('sharing-123', 1, 'one-way')
     ).rejects.toThrow('Network error')
 
-    expect(instance.setState).not.toHaveBeenCalled()
+    expect(instance.dispatch).toHaveBeenNthCalledWith(1, {
+      type: 'UPDATE_SHARING',
+      sharing: {
+        ...mockSharing,
+        attributes: {
+          ...mockSharing.attributes,
+          members: [
+            mockSharing.attributes.members[0],
+            {
+              ...mockSharing.attributes.members[1],
+              read_only: true
+            }
+          ]
+        }
+      }
+    })
+    expect(instance.dispatch).toHaveBeenNthCalledWith(2, {
+      type: 'UPDATE_SHARING',
+      sharing: mockSharing
+    })
   })
 })
 

--- a/packages/cozy-sharing/src/SharingProvider.spec.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.spec.jsx
@@ -647,7 +647,70 @@ describe('updateSharingMemberType', () => {
     })
     expect(instance.dispatch).toHaveBeenNthCalledWith(2, {
       type: 'UPDATE_SHARING',
-      sharing: mockSharing
+      sharing: {
+        ...mockSharing,
+        attributes: {
+          ...mockSharing.attributes,
+          members: [
+            mockSharing.attributes.members[0],
+            {
+              ...mockSharing.attributes.members[1],
+              read_only: false
+            }
+          ]
+        }
+      }
+    })
+  })
+
+  it('should preserve realtime changes when rolling back an API failure', async () => {
+    const realtimeSharing = {
+      ...mockSharing,
+      attributes: {
+        ...mockSharing.attributes,
+        description: 'updated by realtime',
+        members: [
+          {
+            ...mockSharing.attributes.members[0],
+            status: 'seen'
+          },
+          {
+            ...mockSharing.attributes.members[1],
+            read_only: true
+          }
+        ]
+      }
+    }
+
+    instance.sharingCol.setReadOnly.mockImplementation(async () => {
+      instance.state = {
+        ...instance.state,
+        sharings: instance.state.sharings.map(sharing =>
+          sharing.id === realtimeSharing.id ? realtimeSharing : sharing
+        )
+      }
+      throw new Error('Network error')
+    })
+
+    await expect(
+      instance.updateSharingMemberType('sharing-123', 1, 'one-way')
+    ).rejects.toThrow('Network error')
+
+    expect(instance.dispatch).toHaveBeenNthCalledWith(2, {
+      type: 'UPDATE_SHARING',
+      sharing: {
+        ...realtimeSharing,
+        attributes: {
+          ...realtimeSharing.attributes,
+          members: [
+            realtimeSharing.attributes.members[0],
+            {
+              ...realtimeSharing.attributes.members[1],
+              read_only: false
+            }
+          ]
+        }
+      }
     })
   })
 })

--- a/packages/cozy-sharing/src/components/Recipient/MemberRecipientPermissions.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/MemberRecipientPermissions.jsx
@@ -74,6 +74,7 @@ const MemberRecipientPermissions = ({
         hideMenu()
         return
       }
+      hideMenu()
       try {
         await updateSharingMemberType(sharingId, memberIndex, newType)
       } catch (error) {
@@ -84,7 +85,6 @@ const MemberRecipientPermissions = ({
           variant: 'filled'
         })
       }
-      hideMenu()
     },
     [
       hideMenu,


### PR DESCRIPTION
Do not wait for realtime to update the change of rights on recipient. Do it optimistically. If any error occur, the state will be reverted by realtime update

https://app.notion.com/p/linagora/Recipient-Change-role-long-response-38162718bad18044b8dcd528c85b215f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Member permissions now update instantly in the UI while synchronizing with the backend, with automatic rollback if synchronization fails.

* **Bug Fixes**
  * Fixed the permission type selection menu so it closes reliably right when the permission type actually changes.

* **Tests**
  * Updated sharing permission change tests to verify optimistic UI updates and rollback behavior under failure and realtime update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->