### PR TITLE
fix(cozy-sharing): Prioritize email over instance URL

### DIFF
--- a/packages/cozy-sharing/src/components/Recipient/GroupRecipientDetailWithAccess.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/GroupRecipientDetailWithAccess.jsx
@@ -39,6 +39,7 @@ const GroupRecipientDetailWithAccess = ({ withAccess }) => {
                     isMe={isMe}
                     instance={recipient.instance}
                     email={recipient.email}
+                    name={recipient.name || recipient.public_name}
                   />
                 }
               />

--- a/packages/cozy-sharing/src/components/Recipient/GroupRecipientDetailWithAccess.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/GroupRecipientDetailWithAccess.jsx
@@ -38,6 +38,7 @@ const GroupRecipientDetailWithAccess = ({ withAccess }) => {
                     status={recipient.status}
                     isMe={isMe}
                     instance={recipient.instance}
+                    email={recipient.email}
                   />
                 }
               />

--- a/packages/cozy-sharing/src/components/Recipient/MemberRecipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/MemberRecipient.jsx
@@ -66,6 +66,7 @@ const MemberRecipient = props => {
               status={status}
               isMe={isMe}
               instance={instance}
+              email={rest.email}
             />
           }
         />

--- a/packages/cozy-sharing/src/components/Recipient/MemberRecipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/MemberRecipient.jsx
@@ -67,6 +67,7 @@ const MemberRecipient = props => {
               isMe={isMe}
               instance={instance}
               email={rest.email}
+              name={rest.name || rest.public_name}
             />
           }
         />

--- a/packages/cozy-sharing/src/components/Recipient/MemberRecipientLite.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/MemberRecipientLite.jsx
@@ -38,6 +38,7 @@ const MemberRecipientLite = ({ recipient, isOwner, ...props }) => {
             status={recipient.status}
             isMe={isMe}
             instance={recipient.instance}
+            email={recipient.email}
             typographyProps={{ noWrap: true }}
           />
         }

--- a/packages/cozy-sharing/src/components/Recipient/MemberRecipientLite.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/MemberRecipientLite.jsx
@@ -39,6 +39,7 @@ const MemberRecipientLite = ({ recipient, isOwner, ...props }) => {
             isMe={isMe}
             instance={recipient.instance}
             email={recipient.email}
+            name={recipient.name || recipient.public_name}
             typographyProps={{ noWrap: true }}
           />
         }

--- a/packages/cozy-sharing/src/components/Recipient/MemberRecipientStatus.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/MemberRecipientStatus.jsx
@@ -9,6 +9,7 @@ const MemberRecipientStatus = ({
   isMe,
   instance,
   email,
+  name,
   typographyProps
 }) => {
   const { t } = useI18n()
@@ -17,7 +18,11 @@ const MemberRecipientStatus = ({
   const isReady = isMe || status === 'ready' || status === 'owner'
   let text
   if (isReady) {
-    text = email || instance
+    // Hide the email when the parent already uses it as the primary text
+    // (getDisplayName falls back to email when the recipient has no name).
+    // Keep the instance visible when there is no email at all, so the user
+    // can still tell the recipient lives on a different Cozy instance.
+    text = isMe || name || !email ? email || instance : ''
   } else if (isSendingEmail) {
     text = t('Share.status.mail-not-sent')
   } else {
@@ -39,6 +44,7 @@ MemberRecipientStatus.propTypes = {
   isMe: PropTypes.bool,
   instance: PropTypes.string,
   email: PropTypes.string,
+  name: PropTypes.string,
   typographyProps: PropTypes.object
 }
 

--- a/packages/cozy-sharing/src/components/Recipient/MemberRecipientStatus.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/MemberRecipientStatus.jsx
@@ -1,42 +1,45 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import EyeIcon from 'cozy-ui/transpiled/react/Icons/Eye'
-import PaperplaneIcon from 'cozy-ui/transpiled/react/Icons/Paperplane'
-import ToTheCloudIcon from 'cozy-ui/transpiled/react/Icons/ToTheCloud'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import { useI18n } from 'twake-i18n'
 
-const MemberRecipientStatus = ({ status, isMe, instance, typographyProps }) => {
+const MemberRecipientStatus = ({
+  status,
+  isMe,
+  instance,
+  email,
+  typographyProps
+}) => {
   const { t } = useI18n()
 
   const isSendingEmail = !isMe && status === 'mail-not-sent'
   const isReady = isMe || status === 'ready' || status === 'owner'
-  let text, icon
+  let text
   if (isReady) {
-    text = instance
-    icon = ToTheCloudIcon
+    text = email || instance
   } else if (isSendingEmail) {
     text = t('Share.status.mail-not-sent')
-    icon = PaperplaneIcon
   } else {
     const supportedStatus = ['pending', 'seen']
     text = supportedStatus.includes(status)
       ? t(`Share.status.${status}`)
       : t('Share.status.pending')
-
-    icon = status === 'seen' ? EyeIcon : PaperplaneIcon
   }
 
   return (
-    <div className="u-flex u-flex-items-center">
-      <Icon icon={icon} size={10} />
-      &nbsp;
-      <Typography variant="caption" color="textSecondary" {...typographyProps}>
-        {text}
-      </Typography>
-    </div>
+    <Typography variant="caption" color="textSecondary" {...typographyProps}>
+      {text}
+    </Typography>
   )
+}
+
+MemberRecipientStatus.propTypes = {
+  status: PropTypes.string,
+  isMe: PropTypes.bool,
+  instance: PropTypes.string,
+  email: PropTypes.string,
+  typographyProps: PropTypes.object
 }
 
 export default MemberRecipientStatus

--- a/packages/cozy-sharing/src/components/Recipient/MemberRecipientStatus.spec.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/MemberRecipientStatus.spec.jsx
@@ -1,0 +1,97 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import MemberRecipientStatus from './MemberRecipientStatus'
+import AppLike from '../../../test/AppLike'
+
+describe('MemberRecipientStatus component', () => {
+  const setup = props =>
+    render(
+      <AppLike>
+        <MemberRecipientStatus {...props} />
+      </AppLike>
+    )
+
+  it('should show email when status is ready and recipient has a name', () => {
+    const { getByText } = setup({
+      status: 'ready',
+      isMe: false,
+      email: 'other@example.com',
+      instance: 'foo.mycozy.cloud',
+      name: 'Other Person'
+    })
+    expect(getByText('other@example.com')).toBeTruthy()
+  })
+
+  it('should render nothing when recipient has no name and status is ready', () => {
+    const { queryByText } = setup({
+      status: 'ready',
+      isMe: false,
+      email: 'other@example.com',
+      instance: 'foo.mycozy.cloud'
+    })
+    expect(queryByText('other@example.com')).toBe(null)
+    expect(queryByText('foo.mycozy.cloud')).toBe(null)
+  })
+
+  it('should show email when isMe is true regardless of status', () => {
+    const { getByText } = setup({
+      status: 'pending',
+      isMe: true,
+      email: 'me@example.com'
+    })
+    expect(getByText('me@example.com')).toBeTruthy()
+  })
+
+  it('should fallback to instance when email is missing and status is ready', () => {
+    const { getByText } = setup({
+      status: 'ready',
+      isMe: false,
+      instance: 'foo.mycozy.cloud'
+    })
+    expect(getByText('foo.mycozy.cloud')).toBeTruthy()
+  })
+
+  it('should show email when status is owner, not isMe, and recipient has a name', () => {
+    const { getByText } = setup({
+      status: 'owner',
+      isMe: false,
+      email: 'owner@example.com',
+      instance: 'foo.mycozy.cloud',
+      name: 'Owner Person'
+    })
+    expect(getByText('owner@example.com')).toBeTruthy()
+  })
+
+  it('should show "Sending invitation mail..." when status is mail-not-sent and not isMe', () => {
+    const { getByText } = setup({
+      status: 'mail-not-sent',
+      isMe: false
+    })
+    expect(getByText('Sending invitation mail...')).toBeTruthy()
+  })
+
+  it('should show "Invitation sent" when status is pending', () => {
+    const { getByText } = setup({
+      status: 'pending',
+      isMe: false
+    })
+    expect(getByText('Invitation sent')).toBeTruthy()
+  })
+
+  it('should show "Invitation seen" when status is seen', () => {
+    const { getByText } = setup({
+      status: 'seen',
+      isMe: false
+    })
+    expect(getByText('Invitation seen')).toBeTruthy()
+  })
+
+  it('should fallback to "Invitation sent" for unknown status', () => {
+    const { getByText } = setup({
+      status: 'unknown-status',
+      isMe: false
+    })
+    expect(getByText('Invitation sent')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Remove all icons from MemberRecipientStatus and display email instead of instance URL for sharing recipients

https://app.notion.com/p/linagora/Sharing-modal-Don-t-display-cloud-icon-and-display-email-38162718bad180d6a979cb34bc56c313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sharing recipient lists now show recipient email and name details in their status text.

* **Bug Fixes**
  * Recipient email addresses now display correctly across recipient list views.

* **Refactor**
  * Simplified recipient status rendering to a single text element.
  * Updated recipient status logic to localize invitation states more consistently and handle missing identity fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->