### PR TITLE
feat: Add codemods for cozy-ui BC 140.0.0

### DIFF
--- a/packages/cozy-codemods/src/transforms/__testfixtures__/transform-ui-bc-140.input.js
+++ b/packages/cozy-codemods/src/transforms/__testfixtures__/transform-ui-bc-140.input.js
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import Sprite from 'cozy-ui/transpiled/react/Icon/Sprite'
+import Check from 'cozy-ui/transpiled/react/Icons/Check'
+import CrossCircleOutlineIcon from 'cozy-ui/transpiled/react/Icons/CrossCircleOutline'
+
+import IconButton from 'cozy-ui/transpiled/react/IconButton'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+
+const MyComponent = () => (
+  <div>
+    <Sprite />
+    <Icon icon={Check} />
+    <Icon icon={CrossCircleOutlineIcon} size={24} />
+    <IconButton icon="add" label="Add" />
+    <Button label="Hello" />
+  </div>
+)
+
+export default MyComponent

--- a/packages/cozy-codemods/src/transforms/__testfixtures__/transform-ui-bc-140.output.js
+++ b/packages/cozy-codemods/src/transforms/__testfixtures__/transform-ui-bc-140.output.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+import IconButton from 'cozy-ui/transpiled/react/IconButton'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+
+import { Icon, Sprite, Check, CrossCircleOutline } from "@linagora/twake-icons";
+
+const MyComponent = () => (
+  <div>
+    <Sprite />
+    <Icon icon={Check} />
+    <Icon icon={CrossCircleOutline} size={24} />
+    <IconButton icon="add" label="Add" />
+    <Button label="Hello" />
+  </div>
+)
+
+export default MyComponent

--- a/packages/cozy-codemods/src/transforms/__tests__/transform-ui-bc-140.spec.js
+++ b/packages/cozy-codemods/src/transforms/__tests__/transform-ui-bc-140.spec.js
@@ -1,0 +1,2 @@
+const defineTest = require('jscodeshift/dist/testUtils').defineTest
+defineTest(__dirname, 'transform-ui-bc-140')

--- a/packages/cozy-codemods/src/transforms/transform-ui-bc-140.js
+++ b/packages/cozy-codemods/src/transforms/transform-ui-bc-140.js
@@ -1,0 +1,70 @@
+const { imports } = require('..')
+
+module.exports = function transformUiBC140(file, api) {
+  const j = api.jscodeshift
+  const root = j(file.source)
+
+  // Match cozy-ui icon import patterns:
+  // - cozy-ui/transpiled/react/Icon (default import)
+  // - cozy-ui/transpiled/react/Icon/Sprite (default import)
+  // - cozy-ui/transpiled/react/Icons/Check (default import)
+  const iconImportRegex =
+    /^cozy-ui\/transpiled\/react\/(Icon(\/Sprite)?$|Icons\/[^/]+$)/
+
+  root.find(j.ImportDeclaration).forEach(path => {
+    const source = path.node.source.value
+    if (!iconImportRegex.test(source)) return
+
+    // Extract component name from the PATH, not the local name
+    let componentName
+    if (source.includes('/Icons/')) {
+      componentName = source.split('/').pop()
+    } else if (source.endsWith('/Icon/Sprite')) {
+      componentName = 'Sprite'
+    } else {
+      componentName = 'Icon'
+    }
+
+    const spec = path.node.specifiers[0]
+    const localName = spec.local?.name
+
+    // Rename all usages if local name differs from component name
+    if (localName && localName !== componentName) {
+      root.find(j.Identifier, { name: localName }).forEach(idPath => {
+        idPath.node.name = componentName
+      })
+    }
+
+    // Add new named import
+    imports.ensure(
+      root,
+      { [componentName]: componentName },
+      '@linagora/twake-icons'
+    )
+
+    // Remove old import
+    j(path).remove()
+  })
+
+  // Merge all @linagora/twake-icons imports into one
+  const twakeImports = root.find(j.ImportDeclaration, {
+    source: { value: '@linagora/twake-icons' }
+  })
+  if (twakeImports.length > 1) {
+    const allSpecifiers = []
+    twakeImports.forEach(path => {
+      allSpecifiers.push(...path.node.specifiers)
+    })
+    twakeImports
+      .at(0)
+      .replace(
+        j.importDeclaration(allSpecifiers, j.literal('@linagora/twake-icons'))
+      )
+    twakeImports.slice(1).forEach(path => j(path).remove())
+  }
+
+  return root.toSource()
+}
+
+module.exports.description =
+  'Replaces cozy-ui Icon, Sprite, and Icons imports with @linagora/twake-icons'


### PR DESCRIPTION
to deal with icons moved in `@linagora/twake-icons`

Usage example:
```
yarn add @linagora/twake-icons
yarn global add @cozy/codemods
yarn global add jscodeshift@0.13.1
jscodeshift babel --parser tsx --ignore-pattern=src/targets/ --extensions js,jsx,ts,tsx -t $(yarn global dir)/node_modules/@cozy/codemods/src/transforms/transform-ui-bc-140.js src
yarn lint --fix
```