### PR TITLE
fix(cozy-viewer): Show inherited sharing recipients

### DIFF
--- a/packages/cozy-viewer/src/Panel/Sharing.jsx
+++ b/packages/cozy-viewer/src/Panel/Sharing.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import { useClient } from 'cozy-client'
+import { useClient, useQuery } from 'cozy-client'
 import flag from 'cozy-flags'
 import {
   getRecipientsFromSharing,
@@ -21,6 +21,7 @@ import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import { withViewerLocales } from '../hoc/withViewerLocales'
 import { useShareModal } from '../providers/ShareModalProvider'
+import { buildFolderByPathQuery } from '../queries'
 
 const Sharing = ({ file, t }) => {
   const client = useClient()
@@ -31,19 +32,38 @@ const Sharing = ({ file, t }) => {
     getSharingLink,
     allLoaded,
     getRecipients,
+    getSharedParentPath,
+    hasSharedParent,
     isOwner
   } = useSharingContext()
 
   const sharedDriveSharing = file.driveId ? getSharingById(file.driveId) : null
+  const sharedParentPath =
+    !sharedDriveSharing && file.path && hasSharedParent(file.path)
+      ? getSharedParentPath(file.path)
+      : null
+  const sharedParentQuery = buildFolderByPathQuery(sharedParentPath)
+  const { data: sharedParentFolders, fetchStatus: sharedParentFetchStatus } =
+    useQuery(sharedParentQuery.definition, {
+      ...sharedParentQuery.options,
+      enabled: !!sharedParentPath
+    })
+  const sharingReferenceId =
+    !sharedDriveSharing && sharedParentPath && sharedParentFolders?.[0]?._id
+      ? sharedParentFolders[0]._id
+      : file._id
+
+  if (sharedParentPath && sharedParentFetchStatus !== 'loaded') return null
+
   const recipients = sharedDriveSharing
     ? getRecipientsFromSharing(sharedDriveSharing, file._id)
-    : getRecipients(file._id)
-  const permissions = getDocumentPermissions(file._id)
-  const link = getSharingLink(file._id)
+    : getRecipients(sharingReferenceId)
+  const permissions = getDocumentPermissions(sharingReferenceId)
+  const link = getSharingLink(sharingReferenceId)
   const owner = recipients.find(recipient => recipient.status === 'owner')
   const isCurrentUserOwner = file.driveId
     ? owner?.instance === client.options.uri
-    : isOwner(file._id)
+    : isOwner(sharingReferenceId)
 
   const showModal = () => {
     if (!flag('drive.new-file-viewer-ui.enabled')) {

--- a/packages/cozy-viewer/src/Panel/Sharing.spec.jsx
+++ b/packages/cozy-viewer/src/Panel/Sharing.spec.jsx
@@ -5,6 +5,7 @@ import Sharing from './Sharing'
 
 const mockGetRecipientsFromSharing = jest.fn()
 const mockUseClient = jest.fn()
+const mockUseQuery = jest.fn()
 const mockUseShareModal = jest.fn()
 const mockUseSharingContext = jest.fn()
 const mockMemberRecipientLite = jest.fn(({ recipient, isOwner }) => (
@@ -14,7 +15,16 @@ const mockMemberRecipientLite = jest.fn(({ recipient, isOwner }) => (
 ))
 
 jest.mock('cozy-client', () => ({
-  useClient: () => mockUseClient()
+  Q: () => ({
+    where: jest.fn().mockReturnThis(),
+    indexFields: jest.fn().mockReturnThis(),
+    limitBy: jest.fn().mockReturnThis()
+  }),
+  fetchPolicies: {
+    olderThan: jest.fn(() => 'fetch-policy')
+  },
+  useClient: () => mockUseClient(),
+  useQuery: (...args) => mockUseQuery(...args)
 }))
 
 jest.mock('cozy-flags', () => jest.fn(() => false))
@@ -40,6 +50,15 @@ jest.mock('../providers/ShareModalProvider', () => ({
 
 const file = { _id: 'file-id' }
 const sharedFile = { _id: 'shared-file-id' }
+const fileInSharedFolder = {
+  _id: 'file-in-shared-folder-id',
+  path: '/shared-folder/subfolder/file.pdf'
+}
+const sharedFolder = {
+  _id: 'shared-folder-id',
+  path: '/shared-folder',
+  type: 'directory'
+}
 const sharedDriveFile = { _id: 'file-id', driveId: 'drive-id' }
 const ownerRecipient = {
   index: 'recipient-0',
@@ -60,19 +79,33 @@ const sharedDriveSharing = {
   }
 }
 
-const setup = ({
-  clientUri = 'http://bob.localhost:8080/',
-  targetFile = file,
-  userIsOwner = true
-} = {}) => {
+const setup = (options = {}) => {
+  const {
+    clientUri = 'http://bob.localhost:8080/',
+    sharedParentFetchStatus = 'loaded',
+    targetFile = file,
+    userIsOwner = true
+  } = options
+  const sharedParentFolders = Object.prototype.hasOwnProperty.call(
+    options,
+    'sharedParentFolders'
+  )
+    ? options.sharedParentFolders
+    : [sharedFolder]
   const getDocumentPermissions = jest
     .fn()
-    .mockImplementation(docId => (docId === 'file-id' ? ['perm'] : []))
+    .mockImplementation(docId =>
+      docId === 'file-id' || docId === 'shared-folder-id' ? ['perm'] : []
+    )
   const getSharingById = jest
     .fn()
     .mockImplementation(id => (id === 'drive-id' ? sharedDriveSharing : null))
   const getRecipients = jest.fn().mockImplementation(docId => {
-    if (docId === 'file-id' || docId === 'shared-file-id') {
+    if (
+      docId === 'file-id' ||
+      docId === 'shared-file-id' ||
+      docId === 'shared-folder-id'
+    ) {
       return [ownerRecipient]
     }
 
@@ -81,12 +114,26 @@ const setup = ({
   const getSharingLink = jest
     .fn()
     .mockImplementation(docId =>
-      docId === 'file-id' ? 'http://share-link' : null
+      docId === 'file-id' || docId === 'shared-folder-id'
+        ? 'http://share-link'
+        : null
     )
 
+  mockUseQuery.mockReturnValue({
+    data: sharedParentFolders,
+    fetchStatus: sharedParentFetchStatus
+  })
   mockGetRecipientsFromSharing.mockReturnValue([ownerRecipient])
   mockUseClient.mockReturnValue({ options: { uri: clientUri } })
   const isOwner = jest.fn().mockReturnValue(userIsOwner)
+  const hasSharedParent = jest
+    .fn()
+    .mockImplementation(path => path === '/shared-folder/subfolder/file.pdf')
+  const getSharedParentPath = jest
+    .fn()
+    .mockImplementation(path =>
+      path === '/shared-folder/subfolder/file.pdf' ? '/shared-folder' : null
+    )
 
   mockUseShareModal.mockReturnValue({ setShowShareModal: jest.fn() })
   mockUseSharingContext.mockReturnValue({
@@ -95,6 +142,8 @@ const setup = ({
     getSharingById,
     getRecipients,
     getSharingLink,
+    getSharedParentPath,
+    hasSharedParent,
     isOwner
   })
 
@@ -143,6 +192,66 @@ describe('Sharing', () => {
         recipient: expect.objectContaining(expectedOwnerRecipient),
         isOwner: true
       })
+    )
+  })
+
+  it('should use shared parent recipients when a file is inside a shared folder without driveId', () => {
+    setup({ targetFile: fileInSharedFolder })
+
+    expect(mockUseSharingContext().getSharedParentPath).toHaveBeenCalledWith(
+      '/shared-folder/subfolder/file.pdf'
+    )
+    expect(mockUseSharingContext().getRecipients).toHaveBeenCalledWith(
+      'shared-folder-id'
+    )
+    expect(mockUseSharingContext().getDocumentPermissions).toHaveBeenCalledWith(
+      'shared-folder-id'
+    )
+    expect(mockUseSharingContext().getSharingLink).toHaveBeenCalledWith(
+      'shared-folder-id'
+    )
+    expect(mockUseSharingContext().isOwner).toHaveBeenCalledWith(
+      'shared-folder-id'
+    )
+  })
+
+  it('should not display sharing section while shared parent folder is loading', () => {
+    const { queryByText } = setup({
+      sharedParentFetchStatus: 'loading',
+      sharedParentFolders: undefined,
+      targetFile: fileInSharedFolder
+    })
+
+    expect(queryByText('Viewer.panel.sharing')).toBeNull()
+  })
+
+  it('should not display sharing section while shared parent folder is in pending state', () => {
+    const { queryByText } = setup({
+      sharedParentFetchStatus: 'pending',
+      sharedParentFolders: undefined,
+      targetFile: fileInSharedFolder
+    })
+
+    expect(queryByText('Viewer.panel.sharing')).toBeNull()
+  })
+
+  it('should fallback to file recipients when no shared parent folder is found', () => {
+    setup({
+      sharedParentFolders: [],
+      targetFile: fileInSharedFolder
+    })
+
+    expect(mockUseSharingContext().getRecipients).toHaveBeenCalledWith(
+      'file-in-shared-folder-id'
+    )
+    expect(mockUseSharingContext().getDocumentPermissions).toHaveBeenCalledWith(
+      'file-in-shared-folder-id'
+    )
+    expect(mockUseSharingContext().getSharingLink).toHaveBeenCalledWith(
+      'file-in-shared-folder-id'
+    )
+    expect(mockUseSharingContext().isOwner).toHaveBeenCalledWith(
+      'file-in-shared-folder-id'
     )
   })
 

--- a/packages/cozy-viewer/src/queries.js
+++ b/packages/cozy-viewer/src/queries.js
@@ -18,3 +18,19 @@ export const buildFileByIdQuery = fileId => ({
     singleDocData: true
   }
 })
+
+export const buildFolderByPathQuery = path => {
+  const folderPath = path || ''
+
+  return {
+    definition: () =>
+      Q('io.cozy.files')
+        .where({ type: 'directory', path: folderPath })
+        .indexFields(['type', 'path'])
+        .limitBy(1),
+    options: {
+      as: `io.cozy.files/path/${encodeURIComponent(folderPath)}`,
+      fetchPolicy: defaultFetchPolicy
+    }
+  }
+}


### PR DESCRIPTION
Files inside shared folder but fetched with regular file api don't have a driveId attribute

When a shared parent path is known, fetch the corresponding folder by path and use its id as the sharing reference for recipients, permissions, links, and ownership.

https://app.notion.com/p/linagora/Who-has-access-seciton-in-viewer-is-wrong-36862718bad1807b9145c6714ab3f0ba?source=copy_link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sharing panel to correctly display permissions and recipients for files located within shared folders, improving reliability for nested file sharing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->