### PR TITLE
fix(cozy-dataproxy-lib): exclude shared-drive shortcuts from search

### DIFF
--- a/packages/cozy-dataproxy-lib/src/search/helpers/normalizeFile.spec.ts
+++ b/packages/cozy-dataproxy-lib/src/search/helpers/normalizeFile.spec.ts
@@ -1,0 +1,62 @@
+import { IOCozyFile } from 'cozy-client/types/types'
+
+import { ROOT_DIR_ID, SHARED_DRIVES_DIR_ID } from '../consts'
+import { shouldKeepFile } from './normalizeFile'
+
+describe('shouldKeepFile', () => {
+  it('keeps a regular file', () => {
+    const file = {
+      _id: 'abc',
+      dir_id: 'some-folder',
+      path: '/some-folder/doc.txt',
+      trashed: false
+    } as unknown as IOCozyFile
+    expect(shouldKeepFile(file)).toBe(true)
+  })
+
+  it('keeps a real file inside a shared drive', () => {
+    // Files within a shared drive live under their own folder, not directly
+    // under the Shared Drives directory, so they must remain searchable.
+    const file = {
+      _id: 'drive-file',
+      dir_id: 'drive-folder',
+      path: '/Drives/Team Drive/doc.txt',
+      trashed: false
+    } as unknown as IOCozyFile
+    expect(shouldKeepFile(file)).toBe(true)
+  })
+
+  it('drops the Shared Drives directory itself', () => {
+    const dir = {
+      _id: SHARED_DRIVES_DIR_ID,
+      dir_id: ROOT_DIR_ID,
+      trashed: false
+    } as unknown as IOCozyFile
+    expect(shouldKeepFile(dir)).toBe(false)
+  })
+
+  it('drops the .url shortcut placeholder of a shared drive', () => {
+    // When a shared drive is received, the stack drops a `<DriveName>.url`
+    // shortcut directly under the Shared Drives directory. It must not pollute
+    // search results.
+    const shortcut = {
+      _id: 'shortcut-id',
+      dir_id: SHARED_DRIVES_DIR_ID,
+      class: 'shortcut',
+      path: '/Drives/Team Drive.url',
+      trashed: false
+    } as unknown as IOCozyFile
+    expect(shouldKeepFile(shortcut)).toBe(false)
+  })
+
+  it('keeps a non-shortcut file sitting under the Shared Drives directory', () => {
+    const file = {
+      _id: 'some-file',
+      dir_id: SHARED_DRIVES_DIR_ID,
+      class: 'text',
+      path: '/Drives/doc.txt',
+      trashed: false
+    } as unknown as IOCozyFile
+    expect(shouldKeepFile(file)).toBe(true)
+  })
+})

--- a/packages/cozy-dataproxy-lib/src/search/helpers/normalizeFile.ts
+++ b/packages/cozy-dataproxy-lib/src/search/helpers/normalizeFile.ts
@@ -36,6 +36,14 @@ export const shouldKeepFile = (file: IOCozyFile): boolean => {
   // Shared drives folder to be hidden in search.
   // The files inside it though must appear. Thus only the file with the folder ID is filtered out.
   const notSharedDrivesDir = file._id !== SHARED_DRIVES_DIR_ID
+  // The shortcut placeholders sitting directly under the Shared Drives
+  // directory represent the drive itself, not its content; they must not appear
+  // in search.
+  const notSharedDriveShortcut = !(
+    file.dir_id === SHARED_DRIVES_DIR_ID && file.class === 'shortcut'
+  )
 
-  return notInTrash && notRootDir && notSharedDrivesDir
+  return (
+    notInTrash && notRootDir && notSharedDrivesDir && notSharedDriveShortcut
+  )
 }


### PR DESCRIPTION
## Context
When a recipient receives a shared drive, the stack drops a `<DriveName>.url` shortcut directly under the Shared Drives directory. These placeholders were indexed into global search, so searching a drive name returned `<DriveName>.url` junk instead of (or alongside) the drive content.

## Solution
`shouldKeepFile` only excluded the Shared Drives folder itself (by `_id`), not the shortcuts inside it. It now also drops any file whose `dir_id` is the Shared Drives directory. Real drive files are unaffected since they live under their own folders, never directly in that directory.