### PR TITLE
fix(cozy-dataproxy-lib): index a shared drive received over realtime

### DIFF
--- a/packages/cozy-dataproxy-lib/src/search/SearchEngine.spec.js
+++ b/packages/cozy-dataproxy-lib/src/search/SearchEngine.spec.js
@@ -736,7 +736,9 @@ describe('Realtime features', () => {
     })
 
     describe('addSharedDrive method', () => {
-      it('should add shared drive realtime and trigger replication', () => {
+      it('should seed an index, add shared drive realtime and trigger replication', () => {
+        const { initSearchIndex } = require('./indexDocs')
+        initSearchIndex.mockReturnValue({ search: jest.fn() })
         const addSharedDriveRealtimeSpy = jest.spyOn(
           searchEngine,
           'addSharedDriveRealtime'
@@ -745,11 +747,23 @@ describe('Realtime features', () => {
           searchEngine,
           'debouncedReplication'
         )
+        const indexDocsForSearchSpy = jest
+          .spyOn(searchEngine, 'indexDocsForSearch')
+          .mockResolvedValue(undefined)
 
         searchEngine.addSharedDrive('drive1')
 
+        // The index is seeded immediately so realtime events are not dropped
+        // while the first replication is still running.
+        expect(
+          searchEngine.searchIndexes['io.cozy.files.shareddrives-drive1']
+        ).toBeDefined()
         expect(addSharedDriveRealtimeSpy).toHaveBeenCalledWith('drive1')
         expect(debouncedReplicationSpy).toHaveBeenCalled()
+        // Existing replicated documents are indexed without waiting for a refresh.
+        expect(indexDocsForSearchSpy).toHaveBeenCalledWith(
+          'io.cozy.files.shareddrives-drive1'
+        )
       })
 
       it('should not trigger replication for non-local search', () => {

--- a/packages/cozy-dataproxy-lib/src/search/SearchEngine.ts
+++ b/packages/cozy-dataproxy-lib/src/search/SearchEngine.ts
@@ -226,9 +226,32 @@ export class SearchEngine {
   }
 
   addSharedDrive(driveId: string): void {
+    const doctype = `${SHARED_DRIVE_FILES_DOCTYPE}-${driveId}`
+    // Seed an index right away so realtime events for this drive's files are
+    // not dropped while its first replication is still running. Without this,
+    // a drive received over realtime stays unsearchable until the next full
+    // init (a page refresh), because the replication event that would build
+    // its index does not fire for a dynamically-added doctype.
+    if (!this.searchIndexes[doctype]) {
+      this.searchIndexes[doctype] = {
+        index: initSearchIndex(doctype),
+        lastSeq: 0,
+        lastUpdated: new Date().toISOString()
+      }
+    }
     this.addSharedDriveRealtime(driveId)
     if (this.isLocalSearch) {
       this.debouncedReplication()
+    }
+    // Index the documents already replicated for this drive (existing files
+    // predate the realtime subscription) instead of waiting for a refresh.
+    void this.indexSharedDriveDocs(doctype)
+  }
+
+  private async indexSharedDriveDocs(doctype: string): Promise<void> {
+    const searchIndex = await this.indexDocsForSearch(doctype)
+    if (searchIndex) {
+      this.searchIndexes[doctype] = searchIndex
     }
   }
 


### PR DESCRIPTION
## Context
When a shared drive arrives while the data proxy worker is already running, its files do not show up in search until the page is refreshed. The realtime onboarding path sets up replication but never builds the per-drive search index; it relies on a replication event that does not fire for a dynamically added doctype, and incoming file events are dropped because no index exists yet.

## Solution
`addSharedDrive` now seeds the index for the drive immediately, so realtime file events are no longer dropped, and indexes the documents already replicated for the drive. The drive becomes searchable once it replicates, with no refresh needed.