### PR TITLE
fix: Forget owner-only shared drive sharings

### DIFF
--- a/packages/cozy-sharing/src/SharingProvider.spec.jsx
+++ b/packages/cozy-sharing/src/SharingProvider.spec.jsx
@@ -5,7 +5,12 @@ import { createMockClient } from 'cozy-client'
 
 import { SharingProvider } from './SharingProvider'
 import SharingContext from './context'
-import reducer, { addSharingLink, getDocumentPermissions } from './state'
+import reducer, {
+  addSharingLink,
+  getDocumentPermissions,
+  getDocumentSharing,
+  receiveSharings
+} from './state'
 import AppLike from '../test/AppLike'
 
 const AppWrapper = ({ children, client, isPublic }) => {
@@ -288,6 +293,115 @@ describe('updateDocumentPermissions', () => {
     })
 
     expect(mockAdd).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('shared drive recipient revocation', () => {
+  const SHARED_DRIVE = {
+    _id: 'sharing_123',
+    id: 'sharing_123',
+    type: 'io.cozy.sharings',
+    attributes: {
+      drive: true,
+      owner: true,
+      description: 'Shared folder',
+      rules: [
+        {
+          title: 'Shared folder',
+          doctype: 'io.cozy.files',
+          values: ['folder_123'],
+          add: 'none',
+          update: 'none',
+          remove: 'none'
+        }
+      ],
+      members: [
+        {
+          status: 'owner',
+          email: 'owner@cozy.local',
+          instance: 'http://cozy.local'
+        },
+        {
+          status: 'pending',
+          email: 'recipient@cozy.local',
+          instance: 'http://recipient.cozy.local'
+        }
+      ]
+    }
+  }
+  const NEW_SHARING = {
+    ...SHARED_DRIVE,
+    _id: 'sharing_456',
+    id: 'sharing_456'
+  }
+  const document = {
+    _id: 'folder_123',
+    id: 'folder_123',
+    path: '/Shared folder'
+  }
+  const recipient = {
+    _id: 'contact_123',
+    id: 'contact_123',
+    _type: 'io.cozy.contacts',
+    email: 'recipient@cozy.local'
+  }
+
+  let provider
+  let sharingCol
+
+  beforeEach(() => {
+    const mockClient = createMockClient({})
+    mockClient.getStackClient = () => ({ uri: 'http://cozy.local' })
+    mockClient.collection = jest.fn().mockReturnValue({})
+
+    provider = new SharingProvider({ client: mockClient })
+    provider.state = {
+      ...provider.state,
+      ...reducer(undefined, receiveSharings({ sharings: [SHARED_DRIVE] }))
+    }
+    provider.dispatch = jest.fn(action => {
+      provider.state = {
+        ...provider.state,
+        ...reducer(provider.state, action)
+      }
+    })
+    sharingCol = {
+      addRecipients: jest.fn(),
+      create: jest.fn().mockResolvedValue({ data: NEW_SHARING }),
+      revokeRecipient: jest.fn().mockResolvedValue({})
+    }
+    provider.sharingCol = sharingCol
+  })
+
+  it('forgets the shared drive when revoking its last recipient', async () => {
+    await provider.revoke(document, SHARED_DRIVE.id, 1)
+
+    expect(sharingCol.revokeRecipient).toHaveBeenCalledWith(SHARED_DRIVE, 1)
+    expect(getDocumentSharing(provider.state, document.id)).toBeNull()
+  })
+
+  it('creates a new sharing when re-adding after the last recipient was revoked', async () => {
+    await provider.revoke(document, SHARED_DRIVE.id, 1)
+
+    await provider.share({
+      document,
+      recipients: [recipient],
+      readOnlyRecipients: [],
+      description: 'Shared folder',
+      openSharing: true,
+      sharedDrive: true
+    })
+
+    expect(sharingCol.addRecipients).not.toHaveBeenCalled()
+    expect(sharingCol.create).toHaveBeenCalledWith({
+      document,
+      recipients: [recipient],
+      readOnlyRecipients: [],
+      description: 'Shared folder',
+      previewPath: '/preview',
+      openSharing: true,
+      sharedDrive: true
+    })
   })
 })
 

--- a/packages/cozy-sharing/src/state.js
+++ b/packages/cozy-sharing/src/state.js
@@ -184,10 +184,7 @@ const byDocId = (state = {}, action) => {
     case REVOKE_GROUP:
     case REVOKE_RECIPIENT:
     case UPDATE_SHARING:
-      if (
-        !isSharingADrive(action.sharing) &&
-        areAllRecipientsRevoked(action.sharing)
-      ) {
+      if (areAllRecipientsRevoked(action.sharing)) {
         return forgetSharing(state, action.sharing)
       }
       return state
@@ -258,10 +255,7 @@ const sharings = (state = [], action) => {
     case UPDATE_SHARING:
     case REVOKE_GROUP:
     case REVOKE_RECIPIENT:
-      if (
-        !isSharingADrive(action.sharing) &&
-        areAllRecipientsRevoked(action.sharing)
-      ) {
+      if (areAllRecipientsRevoked(action.sharing)) {
         return state.filter(s => s.id !== action.sharing.id)
       }
       return state.map(s => {
@@ -287,10 +281,8 @@ const sharedPaths = (state = [], action) => {
       return newState
     case REVOKE_GROUP:
     case REVOKE_RECIPIENT:
-      if (
-        !isSharingADrive(action.sharing) &&
-        areAllRecipientsRevoked(action.sharing)
-      ) {
+    case UPDATE_SHARING:
+      if (areAllRecipientsRevoked(action.sharing)) {
         return state.filter(p => p !== action.path)
       }
       return state

--- a/packages/cozy-sharing/src/state.spec.js
+++ b/packages/cozy-sharing/src/state.spec.js
@@ -6,6 +6,7 @@ import reducer, {
   revokeSharingLink,
   getRecipients,
   getRecipientsFromSharing,
+  revokeGroup,
   revokeRecipient,
   revokeSelf,
   updateSharing,
@@ -143,7 +144,7 @@ describe('Sharing state', () => {
     expect(state.sharings).toEqual([SHARING_1, SHARED_DRIVE_WITHOUT_RECIPIENTS])
   })
 
-  it('should not forget shared drives without recipients when updating', () => {
+  it('should forget shared drives without recipients when updating', () => {
     const SHARED_DRIVE_WITHOUT_RECIPIENTS = {
       ...SHARING_1,
       id: 'shared_drive_no_recipients',
@@ -184,16 +185,65 @@ describe('Sharing state', () => {
       }
     }
     const state = reducer(initialState, updateSharing(updatedSharing))
-    expect(state.byDocId).toEqual({
-      shared_drive_folder: {
-        sharings: [SHARED_DRIVE_WITHOUT_RECIPIENTS.id],
-        permissions: []
-      }
-    })
-    expect(state.sharings).toEqual([updatedSharing])
+
+    expect(state.byDocId).toEqual({})
+    expect(state.sharings).toEqual([])
   })
 
-  it('should not remove shared drive path when revoking last recipient', () => {
+  it('should forget a shared drive when revoking its last group', () => {
+    const SHARED_DRIVE_WITH_GROUP = {
+      ...SHARING_1,
+      id: 'shared_drive_group',
+      attributes: {
+        ...SHARING_1.attributes,
+        drive: true,
+        members: [
+          {
+            status: 'owner',
+            name: 'Jane Doe',
+            email: 'jane@doe.com',
+            instance: 'http://cozy.tools:8080'
+          }
+        ],
+        groups: [
+          {
+            name: 'Last group',
+            addedBy: 0
+          }
+        ],
+        rules: [
+          {
+            title: 'My Shared Drive',
+            doctype: 'io.cozy.files',
+            values: ['shared_drive_group_folder'],
+            add: 'sync',
+            update: 'sync',
+            remove: 'sync'
+          }
+        ]
+      }
+    }
+    const sharedDrivePath = '/shared_drive_group_folder'
+    const initialState = reducer(
+      reducer(
+        undefined,
+        receiveSharings({
+          sharings: [SHARED_DRIVE_WITH_GROUP]
+        })
+      ),
+      addSharing(SHARED_DRIVE_WITH_GROUP, sharedDrivePath)
+    )
+    const state = reducer(
+      initialState,
+      revokeGroup(SHARED_DRIVE_WITH_GROUP, 0, sharedDrivePath)
+    )
+
+    expect(state.byDocId).toEqual({})
+    expect(state.sharings).toEqual([])
+    expect(state.sharedPaths).toEqual([])
+  })
+
+  it('should forget a shared drive when revoking last recipient', () => {
     const SHARED_DRIVE_WITH_ONE_RECIPIENT = {
       ...SHARING_1,
       id: 'shared_drive_one_recipient',
@@ -236,30 +286,14 @@ describe('Sharing state', () => {
       ),
       addSharing(SHARED_DRIVE_WITH_ONE_RECIPIENT, sharedDrivePath)
     )
-    const sharingAfterRevoke = {
-      ...SHARED_DRIVE_WITH_ONE_RECIPIENT,
-      attributes: {
-        ...SHARED_DRIVE_WITH_ONE_RECIPIENT.attributes,
-        members: [
-          SHARED_DRIVE_WITH_ONE_RECIPIENT.attributes.members[0],
-          {
-            ...SHARED_DRIVE_WITH_ONE_RECIPIENT.attributes.members[1],
-            status: 'revoked'
-          }
-        ]
-      }
-    }
     const state = reducer(
       initialState,
-      revokeRecipient(sharingAfterRevoke, 1, sharedDrivePath)
+      revokeRecipient(SHARED_DRIVE_WITH_ONE_RECIPIENT, 1, sharedDrivePath)
     )
-    expect(state.sharedPaths).toContain(sharedDrivePath)
-    expect(state.byDocId).toEqual({
-      shared_drive_folder: {
-        sharings: [SHARED_DRIVE_WITH_ONE_RECIPIENT.id],
-        permissions: []
-      }
-    })
+
+    expect(state.byDocId).toEqual({})
+    expect(state.sharings).toEqual([])
+    expect(state.sharedPaths).toEqual([])
   })
 
   it('should index received permissions', () => {


### PR DESCRIPTION
## Summary

  Fix stale shared-drive sharing state after the last recipient/group is removed.

  When a shared-drive sharing becomes owner-only after `REVOKE_RECIPIENT`, `REVOKE_GROUP`, or `UPDATE_SHARING`, `cozy-sharing` now removes it from local sharing state. This
  prevents the UI from reusing a sharing id that the stack has already deleted, which caused re-adding a recipient to call `/sharings/{id}/recipients` and receive `404
  deleted`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shared drives now properly remove from the system when all recipients have been revoked, ensuring consistent behavior with other sharing types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->