### PR TITLE
feat(cozy-sharing): Add twake-icons

### DIFF
--- a/packages/cozy-sharing/jest.config.js
+++ b/packages/cozy-sharing/jest.config.js
@@ -26,10 +26,11 @@ module.exports = {
     '^cozy-client$': '<rootDir>/node_modules/cozy-client/dist/index.js',
     '^cozy-client/dist/types$':
       '<rootDir>/node_modules/cozy-client/dist/types.js',
-    '^twake-i18n$': '<rootDir>/../twake-i18n/dist/index.js'
+    '^twake-i18n$': '<rootDir>/../twake-i18n/dist/index.js',
+    '^@linagora/twake-icons$': '<rootDir>/jestHelpers/mocks/twake-icons.js'
   },
   transformIgnorePatterns: [
-    '<rootDir>/node_modules/(?!(cozy-ui|cozy-harvest-lib))'
+    '<rootDir>/node_modules/(?!(cozy-ui|cozy-harvest-lib|cozy-ui-plus))'
   ],
   setupFilesAfterEnv: ['<rootDir>/jestHelpers/setup.js']
 }

--- a/packages/cozy-sharing/jestHelpers/mocks/twake-icons.js
+++ b/packages/cozy-sharing/jestHelpers/mocks/twake-icons.js
@@ -1,0 +1,23 @@
+const React = require('react')
+
+const Icon = ({ icon, ...props }) =>
+  React.createElement('span', { 'data-icon': true, ...props })
+
+const Sprite = () => null
+
+const getFileTypeIcon = () =>
+  function FileTypeIcon() {
+    return React.createElement('svg', { 'data-filetypeicon': true })
+  }
+
+const proxyHandler = {
+  get: function (target, prop) {
+    if (prop in target) return target[prop]
+    if (prop === 'default') return target.Icon
+    return function IconMock(props) {
+      return React.createElement('svg', { 'data-mock-icon': prop, ...props })
+    }
+  }
+}
+
+module.exports = new Proxy({ Icon, Sprite, getFileTypeIcon }, proxyHandler)

--- a/packages/cozy-sharing/package.json
+++ b/packages/cozy-sharing/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@babel/cli": "7.16.8",
     "@babel/core": "7.16.12",
+    "@linagora/twake-icons": "^2.6.2",
     "@storybook/addon-essentials": "7.6.0",
     "@storybook/addon-interactions": "7.6.0",
     "@storybook/addon-links": "7.6.0",
@@ -68,6 +69,7 @@
     "twake-i18n": "^0.4.1"
   },
   "peerDependencies": {
+    "@linagora/twake-icons": ">=2.6.2",
     "cozy-client": ">=60.28.0",
     "cozy-device-helper": ">=4.0.0",
     "cozy-flags": ">=4.8.1",

--- a/packages/cozy-sharing/src/OpenSharingLinkButton.jsx
+++ b/packages/cozy-sharing/src/OpenSharingLinkButton.jsx
@@ -1,8 +1,8 @@
+import { Icon } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React from 'react'
 
 import Button from 'cozy-ui/transpiled/react/Buttons'
-import Icon from 'cozy-ui/transpiled/react/Icon'
 import { useI18n } from 'twake-i18n'
 
 import { getIconWithlabel, openExternalLink } from './helpers/sharings'

--- a/packages/cozy-sharing/src/actions/addToCozySharingLink.js
+++ b/packages/cozy-sharing/src/actions/addToCozySharingLink.js
@@ -1,8 +1,7 @@
+import { Icon, CloudPlusOutlined } from '@linagora/twake-icons'
 import React, { forwardRef } from 'react'
 
 import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import CloudPlusOutlinedIcon from 'cozy-ui/transpiled/react/Icons/CloudPlusOutlined'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 
@@ -35,7 +34,7 @@ export const addToCozySharingLink = ({
   const label = t('Share.banner.add_to_mine', {
     smart_count: isShortLabel ? 1 : 2
   })
-  const icon = CloudPlusOutlinedIcon
+  const icon = CloudPlusOutlined
 
   return {
     name: 'addToCozySharingLink',

--- a/packages/cozy-sharing/src/actions/createCozySharingLink.js
+++ b/packages/cozy-sharing/src/actions/createCozySharingLink.js
@@ -1,8 +1,7 @@
+import { Icon, ToTheCloud } from '@linagora/twake-icons'
 import React, { forwardRef } from 'react'
 
 import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import ToTheCloudIcon from 'cozy-ui/transpiled/react/Icons/ToTheCloud'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 
@@ -32,7 +31,7 @@ export const createCozySharingLink = ({
 }) => {
   const { t } = getActionsI18n()
   const label = t('Share.create-cozy', { smart_count: isShortLabel ? 1 : 2 })
-  const icon = ToTheCloudIcon
+  const icon = ToTheCloud
 
   return {
     name: 'createCozySharingLink',

--- a/packages/cozy-sharing/src/actions/shareNative.js
+++ b/packages/cozy-sharing/src/actions/shareNative.js
@@ -1,8 +1,7 @@
+import { Icon, Reply } from '@linagora/twake-icons'
 import React, { forwardRef } from 'react'
 
 import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import ReplyIcon from 'cozy-ui/transpiled/react/Icons/Reply'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 
@@ -31,7 +30,7 @@ export const shareNative = ({
   const { t } = getActionsI18n()
 
   const label = t('Share.send')
-  const icon = ReplyIcon
+  const icon = Reply
 
   return {
     name: 'shareNative',

--- a/packages/cozy-sharing/src/actions/syncToCozySharingLink.js
+++ b/packages/cozy-sharing/src/actions/syncToCozySharingLink.js
@@ -1,8 +1,7 @@
+import { Icon, Sync } from '@linagora/twake-icons'
 import React, { forwardRef } from 'react'
 
 import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import SyncIcon from 'cozy-ui/transpiled/react/Icons/Sync'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 
@@ -34,7 +33,7 @@ export const syncToCozySharingLink = ({
   const label = t('Share.banner.sync_to_mine', {
     smart_count: isShortLabel ? 1 : 2
   })
-  const icon = SyncIcon
+  const icon = Sync
 
   return {
     name: 'syncToCozySharingLink',

--- a/packages/cozy-sharing/src/components/Avatar/AvatarList.jsx
+++ b/packages/cozy-sharing/src/components/Avatar/AvatarList.jsx
@@ -1,10 +1,9 @@
+import { Icon, Link } from '@linagora/twake-icons'
 import cx from 'classnames'
 import React from 'react'
 
 import { useClient } from 'cozy-client'
 import Avatar from 'cozy-ui/transpiled/react/Avatar'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import LinkIcon from 'cozy-ui/transpiled/react/Icons/Link'
 
 import { ExtraAvatar } from './ExtraAvatar'
 import { GroupAvatar } from './GroupAvatar'
@@ -75,7 +74,7 @@ const AvatarList = ({
       {link && (
         <span data-testid="AvatarList-link">
           <Avatar color="none" border innerBorder size={size}>
-            <Icon icon={LinkIcon} />
+            <Icon icon={Link} />
           </Avatar>
         </span>
       )}

--- a/packages/cozy-sharing/src/components/Avatar/GroupAvatar.jsx
+++ b/packages/cozy-sharing/src/components/Avatar/GroupAvatar.jsx
@@ -1,13 +1,12 @@
+import { Icon, Team } from '@linagora/twake-icons'
 import React from 'react'
 
 import Avatar from 'cozy-ui/transpiled/react/Avatar'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import TeamIcon from 'cozy-ui/transpiled/react/Icons/Team'
 
 const GroupAvatar = ({ size, className }) => {
   return (
     <Avatar size={size} className={className} border>
-      <Icon icon={TeamIcon} />
+      <Icon icon={Team} />
     </Avatar>
   )
 }

--- a/packages/cozy-sharing/src/components/Recipient/GroupRecipientDetailWithoutAccess.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/GroupRecipientDetailWithoutAccess.jsx
@@ -1,8 +1,7 @@
+import { Icon, Forbidden } from '@linagora/twake-icons'
 import React from 'react'
 
 import Avatar from 'cozy-ui/transpiled/react/Avatar'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import ForbiddenIcon from 'cozy-ui/transpiled/react/Icons/Forbidden'
 import List from 'cozy-ui/transpiled/react/List'
 import ListItem from 'cozy-ui/transpiled/react/ListItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
@@ -23,7 +22,7 @@ const GroupRecipientDetailWithoutAccess = ({ withoutAccess, isOwner }) => {
       </Typography>
       <List>
         {withoutAccess.map(recipient => {
-          const icon = recipient.status === 'revoked' ? ForbiddenIcon : null
+          const icon = recipient.status === 'revoked' ? Forbidden : null
           const defaultDisplayName = t(DEFAULT_DISPLAY_NAME)
           const name = getDisplayName(recipient, defaultDisplayName)
 

--- a/packages/cozy-sharing/src/components/Recipient/GroupRecipientPermissions.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/GroupRecipientPermissions.jsx
@@ -1,12 +1,11 @@
+import { Icon, CrossCircleOutline } from '@linagora/twake-icons'
 import React, { useState, useRef } from 'react'
 
 import ActionsMenu from 'cozy-ui/transpiled/react/ActionsMenu'
 import { makeActions } from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
 import ActionsMenuMobileHeader from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuMobileHeader'
 import DropdownButton from 'cozy-ui/transpiled/react/DropdownButton'
-import Icon from 'cozy-ui/transpiled/react/Icon'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
-import CrossCircleOutlineIcon from 'cozy-ui/transpiled/react/Icons/CrossCircleOutline'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
@@ -92,7 +91,7 @@ const GroupRecipientPermissions = ({
             className="u-ml-half"
             aria-label={t('Share.members.revoke')}
           >
-            <Icon icon={CrossCircleOutlineIcon} />
+            <Icon icon={CrossCircleOutline} />
           </IconButton>
         </>
       )}

--- a/packages/cozy-sharing/src/components/Recipient/LinkRecipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/LinkRecipient.jsx
@@ -1,12 +1,10 @@
+import { Icon, Gear, Link } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 
 import Avatar from 'cozy-ui/transpiled/react/Avatar'
 import Fade from 'cozy-ui/transpiled/react/Fade'
-import Icon from 'cozy-ui/transpiled/react/Icon'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
-import Gear from 'cozy-ui/transpiled/react/Icons/Gear'
-import LinkIcon from 'cozy-ui/transpiled/react/Icons/Link'
 import ListItem from 'cozy-ui/transpiled/react/ListItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
@@ -100,7 +98,7 @@ const LinkRecipient = props => {
       <ListItem gutters={isMobile ? 'default' : 'double'} size="small">
         <ListItemIcon>
           <Avatar size="m" color="none" border innerBorder>
-            <Icon icon={LinkIcon} />
+            <Icon icon={Link} />
           </Avatar>
         </ListItemIcon>
         {isReadOnly ? (

--- a/packages/cozy-sharing/src/components/Recipient/LinkRecipientLite.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/LinkRecipientLite.jsx
@@ -1,9 +1,8 @@
+import { Icon, Link } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React from 'react'
 
 import Avatar from 'cozy-ui/transpiled/react/Avatar'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import LinkIcon from 'cozy-ui/transpiled/react/Icons/Link'
 import ListItem from 'cozy-ui/transpiled/react/ListItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
@@ -24,7 +23,7 @@ const LinkRecipientLite = ({ permissions, link }) => {
     <ListItem size="small" ellipsis>
       <ListItemIcon>
         <Avatar size="m" color="none" border innerBorder>
-          <Icon icon={LinkIcon} />
+          <Icon icon={Link} />
         </Avatar>
       </ListItemIcon>
       <ListItemText

--- a/packages/cozy-sharing/src/components/Recipient/MemberRecipientPermissions.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/MemberRecipientPermissions.jsx
@@ -1,3 +1,4 @@
+import { Icon, CrossCircleOutline } from '@linagora/twake-icons'
 import React, { useState, useRef, useCallback } from 'react'
 
 import { useClient } from 'cozy-client'
@@ -5,9 +6,7 @@ import minilog from 'cozy-minilog'
 import ActionsMenu from 'cozy-ui/transpiled/react/ActionsMenu'
 import { makeActions } from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
 import DropdownButton from 'cozy-ui/transpiled/react/DropdownButton'
-import Icon from 'cozy-ui/transpiled/react/Icon'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
-import CrossCircleOutlineIcon from 'cozy-ui/transpiled/react/Icons/CrossCircleOutline'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
@@ -141,7 +140,7 @@ const MemberRecipientPermissions = ({
             className="u-ml-half"
             aria-label={t('Share.members.revoke')}
           >
-            <Icon icon={CrossCircleOutlineIcon} />
+            <Icon icon={CrossCircleOutline} />
           </IconButton>
         </>
       )}

--- a/packages/cozy-sharing/src/components/Recipient/actions/revokeLink.js
+++ b/packages/cozy-sharing/src/components/Recipient/actions/revokeLink.js
@@ -1,8 +1,7 @@
+import { Icon, Trash } from '@linagora/twake-icons'
 import React, { forwardRef } from 'react'
 
 import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import Typography from 'cozy-ui/transpiled/react/Typography'
@@ -13,13 +12,13 @@ const revokeLink = ({ t, handleRevocation }) => {
   return {
     name: 'revokeLink',
     label: title,
-    icon: TrashIcon,
+    icon: Trash,
     action: handleRevocation,
     Component: forwardRef(function RevokeLinkItem(props, ref) {
       return (
         <ActionsMenuItem {...props} ref={ref}>
           <ListItemIcon>
-            <Icon icon={TrashIcon} color="var(--errorColor)" />
+            <Icon icon={Trash} color="var(--errorColor)" />
           </ListItemIcon>
           <ListItemText
             primary={<Typography color="error">{title}</Typography>}

--- a/packages/cozy-sharing/src/components/ShareButton.jsx
+++ b/packages/cozy-sharing/src/components/ShareButton.jsx
@@ -1,9 +1,8 @@
+import { Icon, Share } from '@linagora/twake-icons'
 import classNames from 'classnames'
 import React from 'react'
 
 import Button from 'cozy-ui/transpiled/react/Buttons'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import ShareIcon from 'cozy-ui/transpiled/react/Icons/Share'
 
 import styles from '../styles/button.styl'
 
@@ -13,7 +12,7 @@ export const ShareButton = ({ label, onClick, className, ...props }) => (
     variant="secondary"
     className={className}
     onClick={() => onClick()}
-    startIcon={<Icon icon={ShareIcon} />}
+    startIcon={<Icon icon={Share} />}
     label={label}
     {...props}
   />
@@ -24,7 +23,7 @@ export const SharedByMeButton = ({ label, onClick, className, ...props }) => (
     data-test-id="share-by-me-button"
     className={className}
     onClick={() => onClick()}
-    icon={<Icon icon={ShareIcon} />}
+    icon={<Icon icon={Share} />}
     label={label}
     {...props}
   />
@@ -34,7 +33,7 @@ export const SharedWithMeButton = ({ label, onClick, className, ...props }) => (
   <Button
     className={classNames(styles['coz-btn-sharedWithMe'], className)}
     onClick={() => onClick()}
-    startIcon={<Icon icon={ShareIcon} />}
+    startIcon={<Icon icon={Share} />}
     label={label}
     {...props}
   />

--- a/packages/cozy-sharing/src/components/ShareByLink.jsx
+++ b/packages/cozy-sharing/src/components/ShareByLink.jsx
@@ -1,11 +1,9 @@
+import { Icon, Copy, Link } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React, { useReducer, useState } from 'react'
 
 import { useClient } from 'cozy-client'
 import Button from 'cozy-ui/transpiled/react/Buttons'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import CopyIcon from 'cozy-ui/transpiled/react/Icons/Copy'
-import LinkIcon from 'cozy-ui/transpiled/react/Icons/Link'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'twake-i18n'
@@ -144,12 +142,12 @@ const ShareByLink = ({
             label={t(`${documentType}.share.shareByLink.send`)}
             variant="secondary"
             size="medium"
-            startIcon={<Icon icon={LinkIcon} />}
+            startIcon={<Icon icon={Link} />}
             onClick={shareLink}
             busy={isGenerating}
           />
           <Button
-            label={<Icon icon={CopyIcon} />}
+            label={<Icon icon={Copy} />}
             variant="secondary"
             size="medium"
             onClick={generateLinkAndCopyLinkToClipboard}
@@ -162,7 +160,7 @@ const ShareByLink = ({
           label={t(`${documentType}.share.shareByLink.copy`)}
           variant="secondary"
           size="medium"
-          startIcon={<Icon icon={LinkIcon} />}
+          startIcon={<Icon icon={Link} />}
           onClick={generateLinkAndCopyLinkToClipboard}
           busy={isGenerating}
         />
@@ -172,7 +170,7 @@ const ShareByLink = ({
           label={t(`${documentType}.share.shareByLink.create`)}
           variant="secondary"
           size="medium"
-          startIcon={<Icon icon={LinkIcon} />}
+          startIcon={<Icon icon={Link} />}
           onClick={generateLinkSilently}
           busy={isGenerating}
         />

--- a/packages/cozy-sharing/src/components/ShareRestrictionModal/BoxDate.jsx
+++ b/packages/cozy-sharing/src/components/ShareRestrictionModal/BoxDate.jsx
@@ -1,11 +1,10 @@
+import { Icon, Calendar } from '@linagora/twake-icons'
 import { format } from 'date-fns'
 import PropTypes from 'prop-types'
 import React from 'react'
 
 import Box from 'cozy-ui/transpiled/react/Box'
 import DatePicker from 'cozy-ui/transpiled/react/DatePicker'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import CalendarIcon from 'cozy-ui/transpiled/react/Icons/Calendar'
 import List from 'cozy-ui/transpiled/react/List'
 import ListItem from 'cozy-ui/transpiled/react/ListItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
@@ -33,7 +32,7 @@ export const BoxDate = ({ onChange, date, toggle, onToggle }) => {
           onClick={() => handleDateToggle(!toggle)}
         >
           <ListItemIcon>
-            <Icon icon={CalendarIcon} />
+            <Icon icon={Calendar} />
           </ListItemIcon>
           <ListItemText primary={t('BoxDate.text')} />
           <ListItemSecondaryAction>

--- a/packages/cozy-sharing/src/components/ShareRestrictionModal/BoxEditingRights.jsx
+++ b/packages/cozy-sharing/src/components/ShareRestrictionModal/BoxEditingRights.jsx
@@ -1,3 +1,4 @@
+import { Icon, Bottom, People } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React, { useReducer, useRef } from 'react'
 
@@ -7,9 +8,6 @@ import flag from 'cozy-flags'
 import ActionsMenu from 'cozy-ui/transpiled/react/ActionsMenu'
 import { makeActions } from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
 import Box from 'cozy-ui/transpiled/react/Box'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import BottomIcon from 'cozy-ui/transpiled/react/Icons/Bottom'
-import PeopleIcon from 'cozy-ui/transpiled/react/Icons/People'
 import List from 'cozy-ui/transpiled/react/List'
 import ListItem from 'cozy-ui/transpiled/react/ListItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
@@ -67,11 +65,11 @@ export const BoxEditingRights = ({ file, editingRights, setEditingRights }) => {
               onClick={toggleMenuDisplayed}
             >
               <ListItemIcon>
-                <Icon icon={PeopleIcon} />
+                <Icon icon={People} />
               </ListItemIcon>
               <ListItemText primary={textPrimary} secondary={textSecondary} />
               <ListItemIcon className="u-mr-half">
-                <Icon icon={BottomIcon} />
+                <Icon icon={Bottom} />
               </ListItemIcon>
             </ListItem>
           </List>

--- a/packages/cozy-sharing/src/components/ShareRestrictionModal/BoxPassword.jsx
+++ b/packages/cozy-sharing/src/components/ShareRestrictionModal/BoxPassword.jsx
@@ -1,11 +1,9 @@
+import { Icon, Copy, Password } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 
 import Box from 'cozy-ui/transpiled/react/Box'
-import Icon from 'cozy-ui/transpiled/react/Icon'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
-import CopyIcon from 'cozy-ui/transpiled/react/Icons/Copy'
-import PasswordIcon from 'cozy-ui/transpiled/react/Icons/Password'
 import List from 'cozy-ui/transpiled/react/List'
 import ListItem from 'cozy-ui/transpiled/react/ListItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
@@ -69,7 +67,7 @@ export const BoxPassword = ({
           onClick={() => handlePasswordToggle(!toggle)}
         >
           <ListItemIcon>
-            <Icon icon={PasswordIcon} />
+            <Icon icon={Password} />
           </ListItemIcon>
           <ListItemText primary={t('BoxPassword.text')} />
           <ListItemSecondaryAction>
@@ -106,7 +104,7 @@ export const BoxPassword = ({
             InputProps={{
               endAdornment: (
                 <IconButton onClick={handleCopy}>
-                  <Icon icon={CopyIcon} />
+                  <Icon icon={Copy} />
                 </IconButton>
               )
             }}

--- a/packages/cozy-sharing/src/components/ShareRestrictionModal/ShareRestrictionModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareRestrictionModal/ShareRestrictionModal.jsx
@@ -1,3 +1,4 @@
+import { Icon, Trash } from '@linagora/twake-icons'
 import { addDays } from 'date-fns'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
@@ -6,8 +7,6 @@ import { generateWebLink, useClient } from 'cozy-client'
 import flag from 'cozy-flags'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 import { useI18n } from 'twake-i18n'
 
@@ -172,7 +171,7 @@ export const ShareRestrictionModal = ({ file, onClose }) => {
               label={t('Share.permissionLink.deactivate')}
               variant="secondary"
               color="error"
-              startIcon={<Icon icon={TrashIcon} />}
+              startIcon={<Icon icon={Trash} />}
               onClick={handleRevokeLink}
               busy={loading}
             />

--- a/packages/cozy-sharing/src/components/SharedBadge.jsx
+++ b/packages/cozy-sharing/src/components/SharedBadge.jsx
@@ -1,8 +1,6 @@
+import { Icon, Share } from '@linagora/twake-icons'
 import classNames from 'classnames'
 import React from 'react'
-
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import ShareIcon from 'cozy-ui/transpiled/react/Icons/Share'
 
 import styles from '../styles/badge.styl'
 
@@ -17,7 +15,7 @@ const SharedBadge = ({ byMe, className, small, xsmall }) => (
     )}
   >
     <Icon
-      icon={ShareIcon}
+      icon={Share}
       color="var(--primaryContrastTextColor)"
       className={styles['shared-badge-icon']}
     />

--- a/packages/cozy-sharing/src/components/SharedDrive/SharedDriveHeader.jsx
+++ b/packages/cozy-sharing/src/components/SharedDrive/SharedDriveHeader.jsx
@@ -1,6 +1,6 @@
+import { Icon } from '@linagora/twake-icons'
 import React from 'react'
 
-import Icon from 'cozy-ui/transpiled/react/Icon'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
 import SharedDriveIcon from '../../assets/icons/shared-drive.svg'

--- a/packages/cozy-sharing/src/helpers/sharings.js
+++ b/packages/cozy-sharing/src/helpers/sharings.js
@@ -1,7 +1,6 @@
+import { CloudPlusOutlined, Sync, ToTheCloud } from '@linagora/twake-icons'
+
 import { Q } from 'cozy-client'
-import CloudPlusOutlinedIcon from 'cozy-ui/transpiled/react/Icons/CloudPlusOutlined'
-import SyncIcon from 'cozy-ui/transpiled/react/Icons/Sync'
-import ToTheCloudIcon from 'cozy-ui/transpiled/react/Icons/ToTheCloud'
 
 import { fetchFilesPaths } from './files'
 import {
@@ -78,20 +77,20 @@ export const getIconWithlabel = ({
 }) => {
   if (link === CREATE_COZY_HREF) {
     return {
-      icon: ToTheCloudIcon,
+      icon: ToTheCloud,
       label: t('Share.create-cozy', { smart_count: isShortLabel ? 1 : 2 })
     }
   }
   if (!isSharingShortcutCreated) {
     return {
-      icon: CloudPlusOutlinedIcon,
+      icon: CloudPlusOutlined,
       label: t('Share.banner.add_to_mine', {
         smart_count: isShortLabel ? 1 : 2
       })
     }
   }
   return {
-    icon: SyncIcon,
+    icon: Sync,
     label: t('Share.banner.sync_to_mine', { smart_count: isShortLabel ? 1 : 2 })
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18001,6 +18001,7 @@ __metadata:
     "@babel/cli": "npm:7.16.8"
     "@babel/core": "npm:7.16.12"
     "@cozy/minilog": "npm:^1.0.0"
+    "@linagora/twake-icons": "npm:^2.6.2"
     "@storybook/addon-essentials": "npm:7.6.0"
     "@storybook/addon-interactions": "npm:7.6.0"
     "@storybook/addon-links": "npm:7.6.0"
@@ -18035,6 +18036,7 @@ __metadata:
     storybook: "npm:7.6.0"
     twake-i18n: "npm:^0.4.1"
   peerDependencies:
+    "@linagora/twake-icons": ">=2.6.2"
     cozy-client: ">=60.28.0"
     cozy-device-helper: ">=4.0.0"
     cozy-flags: ">=4.8.1"


### PR DESCRIPTION
BREAKING CHANGE: You must add `@linagora/twake-icons >= 2.6.2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated many sharing-related screens and actions to display consistent, correct icons across buttons, menus, avatars, badges, and restriction dialogs.
  * Improved icon rendering in sharing workflows, including link sharing, revoking access, and permission controls.

* **Tests**
  * Expanded test support so the sharing package can run with additional UI icon packages mocked and transformed properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->