### PR TITLE
feat(cozy-bar): Add twake-icons

### DIFF
--- a/packages/cozy-bar/jest.config.js
+++ b/packages/cozy-bar/jest.config.js
@@ -20,7 +20,8 @@ module.exports = {
     '^cozy-client$': '<rootDir>/node_modules/cozy-client/dist/index',
     '^cozy-client/dist/(.*)$': '<rootDir>/node_modules/cozy-client/dist/$1',
     '^react$': '<rootDir>/node_modules/react',
-    '^react-dom(.*)$': '<rootDir>/node_modules/react-dom$1'
+    '^react-dom(.*)$': '<rootDir>/node_modules/react-dom$1',
+    '^@linagora/twake-icons$': '<rootDir>/test/__mocks__/twake-icons.js'
   },
   transformIgnorePatterns: ['node_modules/(?!cozy-ui)']
 }

--- a/packages/cozy-bar/package.json
+++ b/packages/cozy-bar/package.json
@@ -31,6 +31,7 @@
     "@babel/cli": "7.16.8",
     "@babel/core": "7.16.12",
     "@cozy/minilog": "^1.0.0",
+    "@linagora/twake-icons": "^2.6.2",
     "@testing-library/jest-dom": "5.17.0",
     "@testing-library/react": "12.1.5",
     "babel-preset-cozy-app": "^2.8.4",
@@ -59,6 +60,7 @@
   },
   "peerDependencies": {
     "@cozy/minilog": ">=1.0.0",
+    "@linagora/twake-icons": ">=2.6.2",
     "cozy-client": ">=60.21.0",
     "cozy-dataproxy-lib": ">=4.1.0",
     "cozy-device-helper": ">=2.6.0",

--- a/packages/cozy-bar/src/components/AppsMenu/index.jsx
+++ b/packages/cozy-bar/src/components/AppsMenu/index.jsx
@@ -1,10 +1,9 @@
+import { Icon, Mosaic } from '@linagora/twake-icons'
 import AppsMenuContent from 'components/AppsMenu/AppsMenuContent'
 import React, { useRef, useState } from 'react'
 
 import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
-import Icon from 'cozy-ui/transpiled/react/Icon'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
-import MosaicIcon from 'cozy-ui/transpiled/react/Icons/Mosaic'
 import Menu from 'cozy-ui/transpiled/react/Menu'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { makeStyles } from 'cozy-ui/transpiled/react/styles'
@@ -35,7 +34,7 @@ const AppsMenu = ({ shortcuts, apps, homeApp, isFetchingApps }) => {
   return (
     <nav ref={containerRef}>
       <IconButton ref={buttonRef} onClick={toggleMenu} className="u-p-half">
-        <Icon icon={MosaicIcon} size="18" />
+        <Icon icon={Mosaic} size="18" />
       </IconButton>
       {isMobile ? (
         <ConfirmDialog

--- a/packages/cozy-bar/src/components/UserMenu/UserMenuContent.jsx
+++ b/packages/cozy-bar/src/components/UserMenu/UserMenuContent.jsx
@@ -1,3 +1,11 @@
+import {
+  Icon,
+  CloudRainbow,
+  Company,
+  FromUser,
+  Logout,
+  Right
+} from '@linagora/twake-icons'
 import cx from 'classnames'
 import useI18n from 'components/useI18n'
 import React from 'react'
@@ -8,12 +16,6 @@ import { makeDiskInfos } from 'cozy-client/dist/models/instance'
 import flag from 'cozy-flags'
 import { useWebviewIntent } from 'cozy-intent'
 import Divider from 'cozy-ui/transpiled/react/Divider'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import CloudRainbowIcon from 'cozy-ui/transpiled/react/Icons/CloudRainbow'
-import CompanyIcon from 'cozy-ui/transpiled/react/Icons/Company'
-import FromUserIcon from 'cozy-ui/transpiled/react/Icons/FromUser'
-import LogoutIcon from 'cozy-ui/transpiled/react/Icons/Logout'
-import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
 import List from 'cozy-ui/transpiled/react/List'
 import ListItem from 'cozy-ui/transpiled/react/ListItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
@@ -72,7 +74,7 @@ const UserMenuContent = ({
             onClick={closeMenu}
           >
             <ListItemIcon>
-              <Icon icon={FromUserIcon} />
+              <Icon icon={FromUser} />
             </ListItemIcon>
             <ListItemText primary={t('userMenu.manageProfile')} />
           </ListItem>
@@ -87,7 +89,7 @@ const UserMenuContent = ({
             onClick={closeMenu}
           >
             <ListItemIcon>
-              <Icon icon={CompanyIcon} />
+              <Icon icon={Company} />
             </ListItemIcon>
             <ListItemText primary={t('userMenu.createBusinessAccount')} />
           </ListItem>
@@ -102,7 +104,7 @@ const UserMenuContent = ({
             onClick={closeMenu}
           >
             <ListItemIcon>
-              <Icon icon={CloudRainbowIcon} />
+              <Icon icon={CloudRainbow} />
             </ListItemIcon>
             <ListItemText
               primary={t('userMenu.storage')}
@@ -112,7 +114,7 @@ const UserMenuContent = ({
               )}
             />
             <ListItemIcon>
-              <Icon icon={RightIcon} />
+              <Icon icon={Right} />
             </ListItemIcon>
           </ListItem>
         )}
@@ -126,7 +128,7 @@ const UserMenuContent = ({
           onClick={() => logOut({ client, webviewIntent, onLogOut })}
         >
           <ListItemIcon>
-            <Icon icon={LogoutIcon} />
+            <Icon icon={Logout} />
           </ListItemIcon>
           <ListItemText primary={t('userMenu.logOut')} />
         </ListItem>

--- a/packages/cozy-bar/src/components/utils/HelpLink.jsx
+++ b/packages/cozy-bar/src/components/utils/HelpLink.jsx
@@ -1,9 +1,8 @@
+import { Icon, HelpOutlined } from '@linagora/twake-icons'
 import React from 'react'
 
 import { useInstanceInfo } from 'cozy-client'
-import Icon from 'cozy-ui/transpiled/react/Icon'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
-import HelpOutlinedIcon from 'cozy-ui/transpiled/react/Icons/HelpOutlined'
 
 const HelpLink = () => {
   const { context } = useInstanceInfo()
@@ -19,7 +18,7 @@ const HelpLink = () => {
       rel="noopener, noreferrer"
       className="u-p-half"
     >
-      <Icon icon={HelpOutlinedIcon} size="18" />
+      <Icon icon={HelpOutlined} size="18" />
     </IconButton>
   )
 }

--- a/packages/cozy-bar/src/components/utils/IconCozyHome.jsx
+++ b/packages/cozy-bar/src/components/utils/IconCozyHome.jsx
@@ -1,7 +1,7 @@
+import { TwakeWorkplace } from '@linagora/twake-icons'
 import React from 'react'
 
 import { useClient } from 'cozy-client'
-import TwakeWorkplaceIcon from 'cozy-ui/transpiled/react/Icons/TwakeWorkplace'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import AppIcon from 'cozy-ui-plus/dist/AppIcon'
 
@@ -16,7 +16,7 @@ const IconCozyHome = () => {
   return (
     <AppIcon
       fetchIcon={fetchIcon}
-      fallbackIcon={TwakeWorkplaceIcon}
+      fallbackIcon={TwakeWorkplace}
       className={isMobile ? 'u-ml-half' : undefined}
     />
   )

--- a/packages/cozy-bar/src/components/utils/SearchButton.jsx
+++ b/packages/cozy-bar/src/components/utils/SearchButton.jsx
@@ -1,9 +1,8 @@
+import { Icon, Magnifier } from '@linagora/twake-icons'
 import React, { useCallback } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
-import Icon from 'cozy-ui/transpiled/react/Icon'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
-import Magnifier from 'cozy-ui/transpiled/react/Icons/Magnifier'
 
 const SearchButton = () => {
   const navigate = useNavigate()

--- a/packages/cozy-bar/test/__mocks__/twake-icons.js
+++ b/packages/cozy-bar/test/__mocks__/twake-icons.js
@@ -1,0 +1,23 @@
+const React = require('react')
+
+const Icon = ({ icon, ...props }) =>
+  React.createElement('span', { 'data-icon': true, ...props })
+
+const Sprite = () => null
+
+const getFileTypeIcon = () =>
+  function FileTypeIcon() {
+    return React.createElement('svg', { 'data-filetypeicon': true })
+  }
+
+const proxyHandler = {
+  get: function (target, prop) {
+    if (prop in target) return target[prop]
+    if (prop === 'default') return target.Icon
+    return function IconMock(props) {
+      return React.createElement('svg', { 'data-mock-icon': prop, ...props })
+    }
+  }
+}
+
+module.exports = new Proxy({ Icon, Sprite, getFileTypeIcon }, proxyHandler)

--- a/yarn.lock
+++ b/yarn.lock
@@ -16763,6 +16763,7 @@ __metadata:
     "@babel/cli": "npm:7.16.8"
     "@babel/core": "npm:7.16.12"
     "@cozy/minilog": "npm:^1.0.0"
+    "@linagora/twake-icons": "npm:^2.6.2"
     "@testing-library/jest-dom": "npm:5.17.0"
     "@testing-library/react": "npm:12.1.5"
     babel-preset-cozy-app: "npm:^2.8.4"
@@ -16788,6 +16789,7 @@ __metadata:
     twake-i18n: "npm:^0.3.0"
   peerDependencies:
     "@cozy/minilog": ">=1.0.0"
+    "@linagora/twake-icons": ">=2.6.2"
     cozy-client: ">=60.21.0"
     cozy-dataproxy-lib: ">=4.1.0"
     cozy-device-helper: ">=2.6.0"


### PR DESCRIPTION
BREAKING CHANGE: You must add `@linagora/twake-icons >= 2.6.2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated app bar, user menu, help, home, and search controls to use a refreshed shared icon set for a more consistent interface.

* **Bug Fixes**
  * Improved test support for icon rendering so the app’s menus and buttons display correctly in development and automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->