### PR TITLE
test(cozy-harvest-lib): Now avoid iconRef spread in DOM for icon mock

### DIFF
--- a/packages/cozy-harvest-lib/src/__mocks__/twake-icons.js
+++ b/packages/cozy-harvest-lib/src/__mocks__/twake-icons.js
@@ -1,6 +1,6 @@
 const React = require('react')
 
-const Icon = ({ icon, ...props }) =>
+const Icon = ({ icon, iconRef, ...props }) =>
   React.createElement('span', { 'data-icon': true, ...props })
 
 const Sprite = () => null
@@ -14,7 +14,7 @@ const proxyHandler = {
   get: function (target, prop) {
     if (prop in target) return target[prop]
     if (prop === 'default') return target.Icon
-    return function IconMock(props) {
+    return function IconMock({ iconRef, ...props }) {
       return React.createElement('svg', { 'data-mock-icon': prop, ...props })
     }
   }


### PR DESCRIPTION
to avoid react warning, and so test crashes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved icon mock compatibility so icon references are handled consistently during development and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->