### PR TITLE
test: Harmonize test and svg mock render now an svg

### DIFF
--- a/packages/cozy-bar/test/__mocks__/twake-icons.js
+++ b/packages/cozy-bar/test/__mocks__/twake-icons.js
@@ -1,7 +1,7 @@
 const React = require('react')
 
-const Icon = ({ icon, ...props }) =>
-  React.createElement('span', { 'data-icon': true, ...props })
+const Icon = ({ icon, iconRef, ...props }) =>
+  React.createElement('svg', { 'data-icon': true, ...props })
 
 const Sprite = () => null
 
@@ -14,7 +14,7 @@ const proxyHandler = {
   get: function (target, prop) {
     if (prop in target) return target[prop]
     if (prop === 'default') return target.Icon
-    return function IconMock(props) {
+    return function IconMock({ iconRef, ...props }) {
       return React.createElement('svg', { 'data-mock-icon': prop, ...props })
     }
   }

--- a/packages/cozy-harvest-lib/src/__mocks__/twake-icons.js
+++ b/packages/cozy-harvest-lib/src/__mocks__/twake-icons.js
@@ -1,7 +1,7 @@
 const React = require('react')
 
 const Icon = ({ icon, iconRef, ...props }) =>
-  React.createElement('span', { 'data-icon': true, ...props })
+  React.createElement('svg', { 'data-icon': true, ...props })
 
 const Sprite = () => null
 

--- a/packages/cozy-sharing/jestHelpers/mocks/twake-icons.js
+++ b/packages/cozy-sharing/jestHelpers/mocks/twake-icons.js
@@ -1,7 +1,7 @@
 const React = require('react')
 
-const Icon = ({ icon, ...props }) =>
-  React.createElement('span', { 'data-icon': true, ...props })
+const Icon = ({ icon, iconRef, ...props }) =>
+  React.createElement('svg', { 'data-icon': true, ...props })
 
 const Sprite = () => null
 
@@ -14,7 +14,7 @@ const proxyHandler = {
   get: function (target, prop) {
     if (prop in target) return target[prop]
     if (prop === 'default') return target.Icon
-    return function IconMock(props) {
+    return function IconMock({ iconRef, ...props }) {
       return React.createElement('svg', { 'data-mock-icon': prop, ...props })
     }
   }

--- a/packages/cozy-viewer/src/NoViewer/__snapshots__/NoViewer.spec.jsx.snap
+++ b/packages/cozy-viewer/src/NoViewer/__snapshots__/NoViewer.spec.jsx.snap
@@ -6,7 +6,7 @@ exports[`NoViewer should render the viewer 1`] = `
     class="viewer-noviewer"
     data-testid="no-viewer"
   >
-    <span
+    <svg
       data-icon="true"
       height="140"
       width="160"
@@ -36,7 +36,7 @@ exports[`NoViewer should render the viewer with specific extra content 1`] = `
     class="viewer-noviewer"
     data-testid="no-viewer"
   >
-    <span
+    <svg
       data-icon="true"
       height="140"
       width="160"

--- a/packages/cozy-viewer/src/ViewersByFile/__snapshots__/AudioViewer.spec.jsx.snap
+++ b/packages/cozy-viewer/src/ViewersByFile/__snapshots__/AudioViewer.spec.jsx.snap
@@ -5,7 +5,7 @@ exports[`AudioViewer should render a spinner then the audio viewer 1`] = `
   <div
     class="viewer-audioviewer"
   >
-    <span
+    <svg
       data-icon="true"
       height="140"
       width="160"

--- a/packages/cozy-viewer/src/ViewersByFile/__snapshots__/ShortcutViewer.spec.jsx.snap
+++ b/packages/cozy-viewer/src/ViewersByFile/__snapshots__/ShortcutViewer.spec.jsx.snap
@@ -6,7 +6,7 @@ exports[`Shortcutviewer renders the component 1`] = `
     class="viewer-noviewer"
     data-testid="no-viewer"
   >
-    <span
+    <svg
       data-icon="true"
       height="140"
       width="160"

--- a/packages/cozy-viewer/test/__mocks__/twake-icons.js
+++ b/packages/cozy-viewer/test/__mocks__/twake-icons.js
@@ -1,7 +1,7 @@
 const React = require('react')
 
-const Icon = ({ icon, ...props }) =>
-  React.createElement('span', { 'data-icon': true, ...props })
+const Icon = ({ icon, iconRef, ...props }) =>
+  React.createElement('svg', { 'data-icon': true, ...props })
 
 const Sprite = () => null
 
@@ -14,7 +14,7 @@ const proxyHandler = {
   get: function (target, prop) {
     if (prop in target) return target[prop]
     if (prop === 'default') return target.Icon
-    return function IconMock(props) {
+    return function IconMock({ iconRef, ...props }) {
       return React.createElement('svg', { 'data-mock-icon': prop, ...props })
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated icon mocks to render SVG elements and accept the newer icon reference prop.
  * This improves compatibility with icon-related components in test environments and helps keep icon behavior consistent across apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->