### PR TITLE
fix(federated): Show correct recipients for files inside shared folder

### DIFF
--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
@@ -16,6 +16,7 @@ import { getOrCreateFromArray } from '../../helpers/contacts'
 import withLocales from '../../hoc/withLocales'
 import { usePendingRecipients } from '../../hooks/usePendingRecipients'
 import { useSharingContext } from '../../hooks/useSharingContext'
+import { getRecipientsFromSharing } from '../../state'
 import styles from '../../styles/share.styl'
 import AntivirusAlert from '../AntivirusAlert'
 import { default as DumbShareByEmail } from '../ShareByEmail'
@@ -40,6 +41,7 @@ const FederatedFolderModalContent = ({
     getDocumentPermissions,
     fetchSharedDriveSharingLinks,
     getRecipients,
+    getSharedParentPath,
     hasSharedChild,
     hasSharedParent,
     revoke
@@ -178,7 +180,40 @@ const FederatedFolderModalContent = ({
   }
 
   const documentId = existingDocument?._id || existingDocument?.id
-  const existingRecipients = documentId ? getRecipients(documentId) : []
+  // Owner case: when document is inside a shared folder (via path) but has no driveId,
+  // find the parent shared folder to use its _id for recipient/permission lookups.
+  const sharedParentPath =
+    !sharedDriveSharing && hasSharedParentByPath && documentPath
+      ? getSharedParentPath(documentPath)
+      : null
+  const [sharedParentFolder, setSharedParentFolder] = useState(null)
+
+  useEffect(() => {
+    if (!sharedParentPath) return
+    const fetchParentFolder = async () => {
+      try {
+        const res = await client
+          .collection('io.cozy.files')
+          .statByPath(sharedParentPath)
+        if (res.data) setSharedParentFolder(res.data)
+      } catch (err) {
+        log.error('Failed to fetch shared parent folder', err)
+      }
+    }
+    fetchParentFolder()
+  }, [sharedParentPath, client])
+
+  const sharingReferenceId =
+    !sharedDriveSharing && sharedParentFolder?._id
+      ? sharedParentFolder._id
+      : documentId
+
+  const existingRecipients =
+    sharedDriveSharing?.attributes?.members && documentId
+      ? getRecipientsFromSharing(sharedDriveSharing, documentId)
+      : sharingReferenceId
+        ? getRecipients(sharingReferenceId)
+        : []
   const documentPermissions = documentId
     ? getDocumentPermissions(documentId)
     : []

--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
@@ -33,6 +33,7 @@ jest.mock('../../hooks/useSharingContext', () => ({
     fetchSharedDriveSharingLinks: mockFetchSharedDriveSharingLinks,
     getOwner: jest.fn(),
     getRecipients: mockGetRecipients,
+    getSharedParentPath: jest.fn().mockReturnValue(null),
     getSharingById: mockGetSharingById,
     hasSharedChild: mockHasSharedChild,
     hasSharedParent: mockHasSharedParent


### PR DESCRIPTION
For the recipient case (document has driveId), use getRecipientsFromSharing on the shared drive sharing directly.

For the owner case (file inside shared folder but no driveId), fetch the parent folder via statByPath from its path, then use its _id for getRecipients.

https://app.notion.com/p/linagora/Recipient-Share-subfolder-or-file-in-the-shared-foder-Wrong-role-38862718bad180e091cfd1593883e184?source=copy_link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shared folder recipient handling so sharing details are now shown correctly even when the drive context is unavailable.
  * Existing recipients are now derived more reliably based on the folder path or sharing context, reducing incorrect recipient lists in the sharing modal.

* **Tests**
  * Updated coverage to match the latest sharing-context behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->