### PR TITLE
fix(sharing): Call self revoke for federated recipients

### DIFF
--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
@@ -26,6 +26,7 @@ const log = minilog('FederatedFolderModal')
 
 const FederatedFolderModalContent = ({
   onClose,
+  onRevokeSuccess,
   document: existingDocument,
   autoOpenShareRestriction,
   showGenerateLinkButton
@@ -42,7 +43,9 @@ const FederatedFolderModalContent = ({
     getRecipients,
     hasSharedChild,
     hasSharedParent,
-    revoke
+    isOwner,
+    revoke,
+    revokeSelf
   } = useSharingContext()
   const { showAlert } = useAlert()
   const { showConfirmDialog, closeConfirmDialog } = useConfirmDialog()
@@ -185,6 +188,12 @@ const FederatedFolderModalContent = ({
   const displayedLink = existingDocument?.driveId
     ? getFederatedShareLink(existingDocument)
     : getSharingLink(existingDocument?._id)
+  const isCurrentUserOwner = documentId ? isOwner(documentId) : false
+
+  const handleRevokeSelf = async document => {
+    await revokeSelf(document)
+    onRevokeSuccess?.(document)
+  }
 
   useEffect(() => {
     if (!existingDocument?.driveId) return
@@ -278,13 +287,14 @@ const FederatedFolderModalContent = ({
             )}
           </div>
           <WhoHasAccess
-            isOwner
+            isOwner={isCurrentUserOwner}
             isSharedDrive
             recipients={isSending ? frozenRecipients : existingRecipients}
             document={isSending ? frozenDoc : existingDocument}
             documentType="Files"
             className={styles['share-dialog-members']}
             onRevoke={revoke}
+            onRevokeSelf={handleRevokeSelf}
             link={displayedLink}
           />
         </div>
@@ -320,6 +330,7 @@ export const FederatedFolderModal = withLocales(props => (
 
 FederatedFolderModal.propTypes = {
   onClose: PropTypes.func.isRequired,
+  onRevokeSuccess: PropTypes.func,
   document: PropTypes.object.isRequired,
   autoOpenShareRestriction: PropTypes.bool,
   showGenerateLinkButton: PropTypes.bool

--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
@@ -11,6 +11,8 @@ import AppLike from '../SharingBanner/test/AppLike'
 const mockShare = jest.fn()
 const mockShareByLink = jest.fn()
 const mockRevoke = jest.fn()
+const mockRevokeSelf = jest.fn()
+const mockIsOwner = jest.fn()
 const mockGetSharingLink = jest.fn()
 const mockGetFederatedShareLink = jest.fn()
 const mockGetRecipients = jest.fn().mockReturnValue([])
@@ -27,6 +29,8 @@ jest.mock('../../hooks/useSharingContext', () => ({
     share: mockShare,
     shareByLink: mockShareByLink,
     revoke: mockRevoke,
+    revokeSelf: mockRevokeSelf,
+    isOwner: mockIsOwner,
     getSharingLink: mockGetSharingLink,
     getFederatedShareLink: mockGetFederatedShareLink,
     getDocumentPermissions: mockGetDocumentPermissions,
@@ -100,6 +104,9 @@ describe('FederatedFolderModal', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockRevoke.mockResolvedValue()
+    mockRevokeSelf.mockResolvedValue()
+    mockIsOwner.mockReturnValue(false)
     mockGetDocumentPermissions.mockReturnValue([])
     mockFetchSharedDriveSharingLinks.mockResolvedValue([])
     mockGetSharingLink.mockReturnValue('https://example.com/share/abc123')
@@ -124,6 +131,10 @@ describe('FederatedFolderModal', () => {
       }
     })
     client = createTestClient()
+    client.options = {
+      ...client.options,
+      uri: 'https://me.mycozy.cloud'
+    }
     sharingContextValue = createSharingContextValue()
     usePendingRecipients.mockReturnValue({
       pendingRecipients: [],
@@ -433,6 +444,30 @@ describe('FederatedFolderModal', () => {
 
       await act(async () => {
         resolveShare({})
+      })
+    })
+  })
+
+  describe('onRevoke callback', () => {
+    const currentUserRecipient = {
+      instance: 'https://me.mycozy.cloud',
+      memberIndex: 1,
+      sharingId: 'sharing-id',
+      type: 'two-way'
+    }
+
+    it('should call onRevokeSelf and onRevokeSuccess when the current user is revoked', async () => {
+      const onRevokeSuccess = jest.fn()
+      mockGetRecipients.mockReturnValue([currentUserRecipient])
+
+      const { findByLabelText } = setup({ onRevokeSuccess })
+
+      fireEvent.click(await findByLabelText('Remove from sharing'))
+
+      await waitFor(() => {
+        expect(mockRevokeSelf).toHaveBeenCalledWith(mockDocument)
+        expect(mockRevoke).not.toHaveBeenCalled()
+        expect(onRevokeSuccess).toHaveBeenCalledWith(mockDocument)
       })
     })
   })

--- a/packages/cozy-sharing/src/components/Recipient/MemberRecipientPermissions.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/MemberRecipientPermissions.jsx
@@ -20,6 +20,7 @@ const log = minilog('MemberRecipientPermissions')
 
 const MemberRecipientPermissions = ({
   isOwner,
+  canManageSharing = isOwner,
   isReadOnly,
   status,
   instance,
@@ -46,7 +47,7 @@ const MemberRecipientPermissions = ({
     !isReadOnly &&
     !revoking &&
     !contactIsOwner &&
-    ((instanceMatchesClient && !isOwner) || isOwner)
+    ((instanceMatchesClient && !isOwner) || canManageSharing)
 
   const toggleMenu = useCallback(() => {
     setMenuDisplayed(displayed => !displayed)
@@ -58,15 +59,23 @@ const MemberRecipientPermissions = ({
   const handleRevocation = useCallback(async () => {
     setRevoking(true)
     try {
-      if (isOwner) {
-        await onRevoke(document, sharingId, memberIndex)
-      } else {
+      if (instanceMatchesClient && !isOwner) {
         await onRevokeSelf(document)
+      } else {
+        await onRevoke(document, sharingId, memberIndex)
       }
     } finally {
       setRevoking(false)
     }
-  }, [isOwner, onRevoke, onRevokeSelf, document, sharingId, memberIndex])
+  }, [
+    document,
+    instanceMatchesClient,
+    isOwner,
+    memberIndex,
+    onRevoke,
+    onRevokeSelf,
+    sharingId
+  ])
 
   const setType = useCallback(
     async newType => {

--- a/packages/cozy-sharing/src/components/Recipient/RecipientList.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/RecipientList.jsx
@@ -9,6 +9,7 @@ const RecipientList = ({
   recipients,
   recipientsToBeConfirmed,
   isOwner,
+  canManageSharing,
   isSharedDrive,
   isReadOnly,
   document,
@@ -49,6 +50,7 @@ const RecipientList = ({
         {...recipient}
         key={recipient.index}
         isOwner={isOwner}
+        canManageSharing={canManageSharing}
         isSharedDrive={isSharedDrive}
         isReadOnly={isReadOnly}
         document={document}

--- a/packages/cozy-sharing/src/components/ShareModal/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal/ShareModal.jsx
@@ -38,7 +38,13 @@ export const ShareModal = withLocales(props => {
   if (isEditable) {
     const isFederatedMode = flag('drive.federated-shared-folder.enabled')
     if (isFederatedMode && allLoaded) {
-      return <FederatedFolderModal document={document} {...rest} />
+      return (
+        <FederatedFolderModal
+          document={document}
+          onRevokeSuccess={onRevokeSuccess}
+          {...rest}
+        />
+      )
     }
 
     return <EditableSharingModal document={document} {...rest} />

--- a/packages/cozy-sharing/src/components/WhoHasAccess.jsx
+++ b/packages/cozy-sharing/src/components/WhoHasAccess.jsx
@@ -28,6 +28,7 @@ const RecipientWaitingForConfirmationAlert = ({ recipientsToBeConfirmed }) => {
 
 const WhoHasAccess = ({
   isOwner = false,
+  canManageSharing = isOwner,
   isSharedDrive = false,
   isReadOnly = false,
   showOwner = true,
@@ -70,6 +71,7 @@ const WhoHasAccess = ({
           recipients={recipients}
           recipientsToBeConfirmed={recipientsToBeConfirmed}
           isOwner={isOwner}
+          canManageSharing={canManageSharing}
           isSharedDrive={isSharedDrive}
           isReadOnly={isReadOnly}
           document={document}
@@ -86,6 +88,7 @@ const WhoHasAccess = ({
 
 WhoHasAccess.propTypes = {
   isOwner: PropTypes.bool,
+  canManageSharing: PropTypes.bool,
   showOwner: PropTypes.bool,
   recipients: PropTypes.array.isRequired,
   recipientsToBeConfirmed: PropTypes.arrayOf(


### PR DESCRIPTION
This will allow to redirect to a proper page in the application especially when the user is revoking himself

https://app.notion.com/p/linagora/Recipient-When-remove-myself-from-folder-still-see-folder-content-but-can-t-interact-with-content-38862718bad180f0844fd6ff0d13e24d?source=copy_link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional post-revoke success callback to the federated folder revoke flow.
  * Improved sharing management by introducing permission-based controls so sharing options can appear when you can manage sharing (not only when you’re the owner).

* **Bug Fixes**
  * Correctly revoke “self” when the current user is the target; otherwise revoke the specific member.
  * Updated recipient menu visibility and revoke routing to align with the right permission state.
  * Extended tests to cover the current-user revoke path and callback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->