### PR TITLE
feat: Show text and not menu if forced readonly for groups 

### DIFF
--- a/packages/cozy-sharing/src/components/Recipient/GroupRecipientPermissions.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/GroupRecipientPermissions.jsx
@@ -21,7 +21,7 @@ const GroupRecipientPermissions = ({
   isOwner,
   sharingId,
   groupIndex,
-  read_only: isReadOnly = false,
+  read_only = false,
   className,
   isUserInsideMembers,
   document
@@ -48,7 +48,7 @@ const GroupRecipientPermissions = ({
     setRevoking(false)
   }
 
-  const type = isReadOnly ? 'one-way' : 'two-way'
+  const type = read_only ? 'one-way' : 'two-way'
 
   const actions = makeActions([permission], {
     t,

--- a/packages/cozy-sharing/src/components/Recipient/GroupRecipientPermissions.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/GroupRecipientPermissions.jsx
@@ -10,6 +10,7 @@ import CrossCircleOutlineIcon from 'cozy-ui/transpiled/react/Icons/CrossCircleOu
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
+import Typography from 'cozy-ui/transpiled/react/Typography'
 import { useI18n } from 'twake-i18n'
 
 import { permission } from './actions/permission'
@@ -19,6 +20,7 @@ import { GroupAvatar } from '../Avatar/GroupAvatar'
 const GroupRecipientPermissions = ({
   name,
   isOwner,
+  isReadOnly,
   sharingId,
   groupIndex,
   read_only = false,
@@ -33,7 +35,8 @@ const GroupRecipientPermissions = ({
   const [isMenuDisplayed, setMenuDisplayed] = useState(false)
   const [revoking, setRevoking] = useState(false)
 
-  const shouldShowMenu = !revoking && (isOwner || isUserInsideMembers)
+  const shouldShowMenu =
+    !isReadOnly && !revoking && (isOwner || isUserInsideMembers)
 
   const toggleMenu = () => setMenuDisplayed(!isMenuDisplayed)
   const hideMenu = () => setMenuDisplayed(false)
@@ -58,6 +61,9 @@ const GroupRecipientPermissions = ({
   return (
     <div className={className}>
       {revoking && <Spinner />}
+      {!shouldShowMenu && (
+        <Typography variant="body2">{t(`Share.type.${type}`)}</Typography>
+      )}
       {shouldShowMenu && (
         <>
           <DropdownButton

--- a/packages/cozy-sharing/src/components/Recipient/RecipientList.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/RecipientList.jsx
@@ -34,6 +34,7 @@ const RecipientList = ({
         <GroupRecipient
           {...recipient}
           isOwner={isOwner}
+          isReadOnly={isReadOnly}
           key={recipient.index}
           document={document}
           documentType={documentType}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sharing permissions display for group recipients.
  * When actions aren’t available, the interface now shows a clear permission label instead of an empty or dropdown-style control.
  * Read-only sharing states are now handled more consistently in recipient lists and permission menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->