### PR TITLE
fix(cozy-search): Align sidebar items and icons to 16px gutter

### DIFF
--- a/packages/cozy-search/src/components/Conversations/ConversationListItem.jsx
+++ b/packages/cozy-search/src/components/Conversations/ConversationListItem.jsx
@@ -29,7 +29,7 @@ const ConversationListItem = ({
       button
       onClick={() => onOpenConversation(conversation._id)}
       className={cx(
-        'u-ov-hidden u-flex-column',
+        'u-ov-hidden u-flex-column u-pv-half u-ph-1',
         styles['conversation-list-item'],
         {
           [styles[`conversation-list-item--selected--${theme}`]]: selected
@@ -54,7 +54,7 @@ const ConversationListItem = ({
         primary={
           <span
             className={cx(
-              'u-ellipsis u-db',
+              'u-ellipsis u-db u-pb-half',
               styles['conversation-list-item-title']
             )}
           >

--- a/packages/cozy-search/src/components/Conversations/ConversationListItemWider.jsx
+++ b/packages/cozy-search/src/components/Conversations/ConversationListItemWider.jsx
@@ -33,7 +33,7 @@ const ConversationListItemWider = ({
       button
       onClick={() => onOpenConversation(conversation._id)}
       className={cx(
-        'u-bdrs-0 u-ov-hidden u-flex u-flex-items-center u-flex-justify-between u-w-100',
+        'u-bdrs-0 u-ov-hidden u-flex u-flex-items-center u-flex-justify-between u-w-100 u-pv-half u-ph-1',
         styles['conversation-list-item'],
         styles['conversation-list-item--wider'],
         {

--- a/packages/cozy-search/src/components/Conversations/styles.styl
+++ b/packages/cozy-search/src/components/Conversations/styles.styl
@@ -105,7 +105,6 @@
   hyphens auto
 
 .conversation-list-item
-  padding 8px !important
   border-radius 8px !important
   align-items stretch !important
   // force 0 gap to override cozy-ui gap 16px on .MuiListItem-root
@@ -126,9 +125,9 @@
     align-items center !important
 
 .conversation-list-item-divider
-  // Counteract the item's 8px padding so the divider spans the full
-  // width and sits flush with the bottom edge of the selected highlight
-  margin 8px -8px -8px -8px !important
+  // Counteract the item's 16px horizontal padding so the divider spans the
+  // full width and sits flush with the bottom edge of the selected highlight
+  margin 8px -16px -8px -16px !important
 
 .conversation-list-item-action
   position absolute !important

--- a/packages/cozy-search/src/components/Sidebar/index.jsx
+++ b/packages/cozy-search/src/components/Sidebar/index.jsx
@@ -62,7 +62,7 @@ const Sidebar = ({ className }) => {
           'u-left-0 u-pos-absolute': isMobile
         })}
       >
-        <div className="u-flex u-flex-items-center u-flex-justify-between u-ph-half u-pv-1">
+        <div className="u-flex u-flex-items-center u-flex-justify-between u-ph-1 u-pv-1">
           <div
             className={cx('u-flex', {
               'u-bdrs-circle': isFloatingToggle,
@@ -71,6 +71,7 @@ const Sidebar = ({ className }) => {
           >
             <IconButton
               size="medium"
+              edge="start"
               className="u-bdrs-6"
               onClick={onToggleSidebar}
               aria-label={t('assistant.sidebar.toggle_sidebar')}
@@ -83,6 +84,7 @@ const Sidebar = ({ className }) => {
               flag('cozy.assistant.search-conversation.enabled') && (
                 <IconButton
                   size="medium"
+                  edge="end"
                   className="u-bdrs-6"
                   onClick={onToggleSearch}
                   aria-label={t('assistant.sidebar.toggle_search')}
@@ -102,7 +104,7 @@ const Sidebar = ({ className }) => {
             )}
           </div>
         </div>
-        <div className="u-ph-half u-pb-half">
+        <div className="u-ph-1 u-pb-half">
           {sidebarOpen ? (
             <Button
               className="u-w-100 u-bdrs-6"
@@ -126,7 +128,7 @@ const Sidebar = ({ className }) => {
 
         {sidebarOpen && (
           <>
-            <Typography variant="h6" className="u-ml-half u-p-half">
+            <Typography variant="h6" className="u-ph-1 u-pv-half">
               {t('assistant.sidebar.recent_chats')}
             </Typography>
             <PrettyScrollbar className="u-flex-auto u-ov-auto u-pb-half">


### PR DESCRIPTION
## Summary

Align conversation list items, the create button, the 'Recent' header and the toggle/search icons to a consistent 16px left/right gutter in the cozy-search sidebar.

- Item padding is now driven by `u-pv-half`/`u-ph-1` utilities on the `ListItem` instead of the styl module
- Header icons use the `edge` prop so their glyphs sit on the gutter

## Files

- `Conversations/ConversationListItem.jsx`
- `Conversations/ConversationListItemWider.jsx`
- `Conversations/styles.styl`
- `Sidebar/index.jsx`

https://claude.ai/code/session_01XddtLhR5ieHcr9MXAr15CR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing and alignment in the conversation list for a cleaner, more consistent view.
  * Fixed divider positioning so selected conversations now span edge-to-edge more reliably.
  * Adjusted sidebar button and section spacing to better match the overall layout and feel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->