### PR TITLE
fix(sharing): guard shared-path helpers against undefined path

### DIFF
--- a/packages/cozy-sharing/src/state.js
+++ b/packages/cozy-sharing/src/state.js
@@ -506,14 +506,14 @@ const getPermissionById = (state, id) =>
 const getApps = state => state.apps
 
 export const hasSharedParent = (state, documentPath) => {
-  if (!state.sharedPaths) {
+  if (!state.sharedPaths || !documentPath) {
     return false // hasSharedParent should not occur
   }
   return state.sharedPaths.some(path => documentPath.indexOf(`${path}/`) === 0)
 }
 
 export const hasSharedChild = (state, documentPath) => {
-  if (!state.sharedPaths) {
+  if (!state.sharedPaths || !documentPath) {
     return false // hasSharedChild should not occur
   }
   const ret = state.sharedPaths.some(

--- a/packages/cozy-sharing/src/state.spec.js
+++ b/packages/cozy-sharing/src/state.spec.js
@@ -739,6 +739,13 @@ describe('hasSharedParent helper', () => {
     const result = hasSharedParent(state, documentPath)
     expect(result).toBe(false)
   })
+
+  it('should return false when documentPath is undefined', () => {
+    const state = {
+      sharedPaths: ['/dir0/doc0', '/dir1', '/dir2/doc1']
+    }
+    expect(hasSharedParent(state, undefined)).toBe(false)
+  })
 })
 
 describe('hasSharedChild helper', () => {
@@ -758,6 +765,13 @@ describe('hasSharedChild helper', () => {
     const documentPath = '/dir3'
     const result = hasSharedChild(state, documentPath)
     expect(result).toBe(false)
+  })
+
+  it('should return false when documentPath is undefined', () => {
+    const state = {
+      sharedPaths: ['/dir0/doc0', '/dir1', '/dir2/doc1']
+    }
+    expect(hasSharedChild(state, undefined)).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Problem
`hasSharedParent` dereferenced `documentPath` without checking it, so a document with no path (such as a shared-drive proxied doc) threw `TypeError: Cannot read properties of undefined (reading 'indexOf')`. On shared-drive file routes this surfaced as an unhandled promise rejection.

## Solution
Return false when `documentPath` is missing, the same way both helpers already bail out when `sharedPaths` is absent. `getSharedParentPath` is covered transitively.