### PR TITLE
Feat/decouple chat views

### DIFF
--- a/packages/cozy-search/babel.config.js
+++ b/packages/cozy-search/babel.config.js
@@ -11,7 +11,7 @@ module.exports = {
       'css-modules-transform',
       {
         extensions: ['.styl'],
-        preprocessCss: './preprocess',
+        preprocessCss: require.resolve('./preprocess'),
         extractCss: './dist/stylesheet.css',
         generateScopedName:
           process.env['NODE_ENV'] == 'test'

--- a/packages/cozy-search/package.json
+++ b/packages/cozy-search/package.json
@@ -58,6 +58,10 @@
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",
+    "./ai-chat-ui": {
+      "types": "./dist/ai-chat-ui.d.ts",
+      "default": "./dist/ai-chat-ui.js"
+    },
     "./dist/stylesheet.css": "./dist/stylesheet.css"
   },
   "peerDependencies": {

--- a/packages/cozy-search/src/ai-chat-ui.ts
+++ b/packages/cozy-search/src/ai-chat-ui.ts
@@ -1,0 +1,29 @@
+// Sidebar requires an AssistantProvider + ConversationStoreProvider +
+// ChatComponentsProvider above it (and a router context for useConversation);
+// it pulls in no Cozy backend.
+export { default as Sidebar } from './components/Sidebar'
+// AssistantProvider is cozy-free (pure React state); Sidebar and
+// useConversation read it via useAssistant(), so consumers must mount it.
+export { default as AssistantProvider } from './components/AssistantProvider'
+export { default as Conversation } from './components/Conversations/Conversation'
+export { default as CozyComposer } from './components/Conversations/ConversationComposer'
+export { default as ConversationList } from './components/Conversations/ConversationList'
+export { default as AssistantMessage } from './components/Messages/AssistantMessage'
+export { default as UserMessage } from './components/Messages/UserMessage'
+export {
+  ConversationStoreProvider,
+  useConversationStore
+} from './contexts/ConversationStoreContext'
+export type {
+  ConversationStore,
+  ConversationSummary,
+  StoredMessage,
+  StoredSource,
+  UseConversationsResult
+} from './contexts/ConversationStore'
+export {
+  ChatComponentsProvider,
+  useChatComponents
+} from './contexts/ChatComponentsContext'
+export type { ChatComponents } from './contexts/ChatComponents'
+export { locales } from './locales'

--- a/packages/cozy-search/src/components/Conversations/ConversationComposer.jsx
+++ b/packages/cozy-search/src/components/Conversations/ConversationComposer.jsx
@@ -8,23 +8,19 @@ import { Icon, Paperplane, Stop } from '@linagora/twake-icons'
 import cx from 'classnames'
 import React, { useCallback } from 'react'
 
-import flag from 'cozy-flags'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import ConversationBar from './ConversationBar'
 import styles from './styles.styl'
-import AssistantSelection from '../Assistant/AssistantSelection'
-import { useAssistant } from '../AssistantProvider'
-import TwakeKnowledgeSelector from '../TwakeKnowledges/TwakeKnowledgeSelector'
+import { useChatComponents } from '../../contexts/ChatComponentsContext'
 
 const ConversationComposer = () => {
   const { isMobile } = useBreakpoints()
   const composerRuntime = useComposerRuntime()
   const isRunning = useThread(state => state.isRunning)
   const isThreadEmpty = useThread(state => state.messages.length === 0)
-  const { setOpenedKnowledgePanel, websearchEnabled, setWebsearchEnabled } =
-    useAssistant()
+  const { ComposerExtras } = useChatComponents()
 
   const value = useComposer(state => state.text)
   const isEmpty = useComposer(state => state.isEmpty)
@@ -52,11 +48,6 @@ const ConversationComposer = () => {
     },
     [isMobile, handleSend]
   )
-
-  const handleToggleWebsearch = useCallback(() => {
-    if (isRunning) return
-    setWebsearchEnabled(prev => !prev)
-  }, [isRunning, setWebsearchEnabled])
 
   return (
     <ComposerPrimitive.Root
@@ -96,15 +87,7 @@ const ConversationComposer = () => {
           styles['composerActions']
         )}
       >
-        {flag('cozy.assistant.create-assistant.enabled') && (
-          <AssistantSelection disabled={!isThreadEmpty} />
-        )}
-        <TwakeKnowledgeSelector
-          className="u-ml-auto"
-          onSelectTwakeKnowledge={setOpenedKnowledgePanel}
-          websearchEnabled={websearchEnabled}
-          onToggleWebsearch={handleToggleWebsearch}
-        />
+        <ComposerExtras disabled={!isThreadEmpty} />
       </div>
     </ComposerPrimitive.Root>
   )

--- a/packages/cozy-search/src/components/Conversations/ConversationListItem.jsx
+++ b/packages/cozy-search/src/components/Conversations/ConversationListItem.jsx
@@ -7,8 +7,8 @@ import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import { useCozyTheme } from 'cozy-ui-plus/dist/providers/CozyTheme'
 import { useI18n } from 'twake-i18n'
 
-import ConversationActions from './ConversationActions'
 import styles from './styles.styl'
+import { useChatComponents } from '../../contexts/ChatComponentsContext'
 import AssistantAvatar from '../Assistant/AssistantAvatar'
 import {
   formatConversationDate,
@@ -19,10 +19,12 @@ import {
 const ConversationListItem = ({
   conversation,
   selected,
-  onOpenConversation
+  onOpenConversation,
+  disableAction
 }) => {
   const { t, lang } = useI18n()
   const { type: theme } = useCozyTheme()
+  const { ConversationActions } = useChatComponents()
 
   return (
     <ListItem
@@ -37,10 +39,12 @@ const ConversationListItem = ({
       )}
       selected={selected}
     >
-      <ConversationActions
-        buttonClassName={styles['conversation-list-item-action']}
-        conversation={conversation}
-      />
+      {!disableAction && (
+        <ConversationActions
+          buttonClassName={styles['conversation-list-item-action']}
+          conversation={conversation}
+        />
+      )}
       <ListItemText
         className="u-m-0"
         primaryTypographyProps={{

--- a/packages/cozy-search/src/components/Conversations/ConversationListItemWider.jsx
+++ b/packages/cozy-search/src/components/Conversations/ConversationListItemWider.jsx
@@ -8,8 +8,8 @@ import Typography from 'cozy-ui/transpiled/react/Typography'
 import { useCozyTheme } from 'cozy-ui-plus/dist/providers/CozyTheme'
 import { useI18n } from 'twake-i18n'
 
-import ConversationActions from './ConversationActions'
 import styles from './styles.styl'
+import { useChatComponents } from '../../contexts/ChatComponentsContext'
 import AssistantAvatar from '../Assistant/AssistantAvatar'
 import {
   formatConversationDate,
@@ -26,6 +26,7 @@ const ConversationListItemWider = ({
 }) => {
   const { t, lang } = useI18n()
   const { type: theme } = useCozyTheme()
+  const { ConversationActions } = useChatComponents()
 
   return (
     <ListItem

--- a/packages/cozy-search/src/components/Conversations/CozyComposerExtras.jsx
+++ b/packages/cozy-search/src/components/Conversations/CozyComposerExtras.jsx
@@ -1,0 +1,35 @@
+import React, { useCallback } from 'react'
+
+import { useThread } from '@assistant-ui/react'
+import flag from 'cozy-flags'
+
+import AssistantSelection from '../Assistant/AssistantSelection'
+import { useAssistant } from '../AssistantProvider'
+import TwakeKnowledgeSelector from '../TwakeKnowledges/TwakeKnowledgeSelector'
+
+const CozyComposerExtras = ({ disabled }) => {
+  const isRunning = useThread(state => state.isRunning)
+  const { setOpenedKnowledgePanel, websearchEnabled, setWebsearchEnabled } =
+    useAssistant()
+
+  const handleToggleWebsearch = useCallback(() => {
+    if (isRunning) return
+    setWebsearchEnabled(prev => !prev)
+  }, [isRunning, setWebsearchEnabled])
+
+  return (
+    <>
+      {flag('cozy.assistant.create-assistant.enabled') && (
+        <AssistantSelection disabled={disabled} />
+      )}
+      <TwakeKnowledgeSelector
+        className="u-ml-auto"
+        onSelectTwakeKnowledge={setOpenedKnowledgePanel}
+        websearchEnabled={websearchEnabled}
+        onToggleWebsearch={handleToggleWebsearch}
+      />
+    </>
+  )
+}
+
+export default CozyComposerExtras

--- a/packages/cozy-search/src/components/Conversations/Sources/CozySourcesWithFilesQuery.jsx
+++ b/packages/cozy-search/src/components/Conversations/Sources/CozySourcesWithFilesQuery.jsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+import { useQuery, isQueryLoading } from 'cozy-client'
+
+import { Sources } from './Sources'
+import { EMAIL_DOCTYPE, buildFilesByIds } from '../../queries'
+
+const WEB_SOURCE_TYPE = 'web'
+
+const CozySourcesWithFilesQuery = ({ messageId, sources = [] }) => {
+  const fileIds = []
+  const emails = []
+  const urls = []
+  sources.forEach(source => {
+    if (source.sourceType === WEB_SOURCE_TYPE) urls.push(source)
+    else if (source.doctype === EMAIL_DOCTYPE) emails.push(source)
+    else fileIds.push(source.id)
+  })
+  const enabled = fileIds.length > 0
+  const filesByIds = buildFilesByIds(fileIds, enabled)
+  const { data: fetchedFiles, ...queryResult } = useQuery(
+    filesByIds.definition,
+    filesByIds.options
+  )
+  const isLoading = isQueryLoading(queryResult)
+  const files = fetchedFiles || []
+
+  if (
+    (isLoading && enabled) ||
+    (files.length === 0 && emails.length === 0 && urls.length === 0)
+  )
+    return null
+
+  return (
+    <Sources messageId={messageId} files={files} emails={emails} urls={urls} />
+  )
+}
+
+export default CozySourcesWithFilesQuery

--- a/packages/cozy-search/src/components/Conversations/Sources/Sources.jsx
+++ b/packages/cozy-search/src/components/Conversations/Sources/Sources.jsx
@@ -1,7 +1,6 @@
-import { Icon, MultiFiles, Right } from '@linagora/twake-icons'
 import React, { useState, useRef, useEffect } from 'react'
 
-import { useQuery, isQueryLoading } from 'cozy-client'
+import { Icon, MultiFiles, Right } from '@linagora/twake-icons'
 import Box from 'cozy-ui/transpiled/react/Box'
 import Chip from 'cozy-ui/transpiled/react/Chips'
 import Grow from 'cozy-ui/transpiled/react/Grow'
@@ -10,11 +9,8 @@ import { useI18n } from 'twake-i18n'
 import EmailSourceItem from './EmailSourceItem'
 import FileSourcesItem from './FileSourcesItem'
 import WebSourceItem from './WebSourceItem'
-import { EMAIL_DOCTYPE, buildFilesByIds } from '../../queries'
 
-const WEB_SOURCE_TYPE = 'web'
-
-const Sources = ({ messageId, files, emails, urls }) => {
+export const Sources = ({ messageId, files = [], emails = [], urls = [] }) => {
   const [showSources, setShowSources] = useState(false)
   const { t } = useI18n()
   const ref = useRef()
@@ -83,40 +79,3 @@ const Sources = ({ messageId, files, emails, urls }) => {
     </Box>
   )
 }
-
-const SourcesWithFilesQuery = ({ messageId, sources }) => {
-  const fileIds = []
-  const emails = []
-  const urls = []
-  let files
-  sources.map(source => {
-    if (source.sourceType === WEB_SOURCE_TYPE) {
-      urls.push(source)
-    } else if (source.doctype === EMAIL_DOCTYPE) {
-      emails.push(source)
-    } else {
-      fileIds.push(source.id)
-    }
-  })
-  const enabled = fileIds && fileIds.length > 0
-  const filesByIds = buildFilesByIds(fileIds, enabled)
-  const { data: fetchedFiles, ...queryResult } = useQuery(
-    filesByIds.definition,
-    filesByIds.options
-  )
-
-  const isLoading = isQueryLoading(queryResult)
-  files = fetchedFiles || []
-
-  if (
-    (isLoading && enabled) ||
-    (files.length === 0 && emails.length === 0 && urls.length === 0)
-  )
-    return null
-
-  return (
-    <Sources messageId={messageId} files={files} emails={emails} urls={urls} />
-  )
-}
-
-export default SourcesWithFilesQuery

--- a/packages/cozy-search/src/components/Messages/AssistantMessage.jsx
+++ b/packages/cozy-search/src/components/Messages/AssistantMessage.jsx
@@ -9,7 +9,7 @@ import { useI18n } from 'twake-i18n'
 
 import MarkdownText from './MarkdownText'
 import { TwakeAssistantIcon } from '../AssistantIcon/TwakeAssistantIcon'
-import Sources from '../Conversations/Sources/Sources'
+import { useChatComponents } from '../../contexts/ChatComponentsContext'
 
 const useIsErrorMessage = () => {
   return useMessage(s => s.metadata?.custom?.isError === true)
@@ -22,6 +22,7 @@ const AssistantMessage = () => {
   const isError = useIsErrorMessage()
   const messageId = useMessage(s => s.id)
   const sources = useMessage(s => s.metadata?.custom?.sources)
+  const { SourcesRenderer } = useChatComponents()
 
   return (
     <MessagePrimitive.Root className="u-mt-1-half">
@@ -48,7 +49,7 @@ const AssistantMessage = () => {
         />
       )}
       {sources?.length > 0 && (
-        <Sources messageId={messageId} sources={sources} />
+        <SourcesRenderer messageId={messageId} sources={sources} />
       )}
     </MessagePrimitive.Root>
   )

--- a/packages/cozy-search/src/components/Search/AssistantLink.jsx
+++ b/packages/cozy-search/src/components/Search/AssistantLink.jsx
@@ -1,6 +1,7 @@
 import { useNavigate, useLocation } from 'react-router-dom'
 
-import { isAssistantEnabled, makeConversationId } from '../helpers'
+import { isAssistantEnabled } from '../cozyHelpers'
+import { makeConversationId } from '../helpers'
 
 const AssistantLink = ({ children }) => {
   const navigate = useNavigate()

--- a/packages/cozy-search/src/components/Search/SearchBarDesktop.jsx
+++ b/packages/cozy-search/src/components/Search/SearchBarDesktop.jsx
@@ -9,7 +9,7 @@ import { AssistantButton } from './AssistantButton'
 import { useSearch } from './SearchProvider'
 import styles from './styles.styl'
 import ResultMenu from '../ResultMenu/ResultMenu'
-import { isAssistantEnabled } from '../helpers'
+import { isAssistantEnabled } from '../cozyHelpers'
 
 const SearchBarDesktop = ({
   value,

--- a/packages/cozy-search/src/components/Sidebar/index.jsx
+++ b/packages/cozy-search/src/components/Sidebar/index.jsx
@@ -1,9 +1,8 @@
-import { Icon, CrossSmall, Magnifier, Menu, Plus } from '@linagora/twake-icons'
 import cx from 'classnames'
 import React, { useState } from 'react'
 import { useParams } from 'react-router-dom'
 
-import flag from 'cozy-flags'
+import { Icon, CrossSmall, Magnifier, Menu, Plus } from '@linagora/twake-icons'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import Divider from 'cozy-ui/transpiled/react/Divider'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
@@ -13,8 +12,9 @@ import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'twake-i18n'
 
 import styles from './styles.styl'
+import { useChatComponents } from '../../contexts/ChatComponentsContext'
+import { useConversationStore } from '../../contexts/ConversationStoreContext'
 import useConversation from '../../hooks/useConversation'
-import useFetchConversations from '../../hooks/useFetchConversations'
 import { useAssistant } from '../AssistantProvider'
 import PrettyScrollbar from '../Containers/PrettyScrollbar'
 import ConversationList from '../Conversations/ConversationList'
@@ -27,8 +27,11 @@ const Sidebar = ({ className }) => {
     useAssistant()
   const { isMobile } = useBreakpoints()
   const [sidebarOpen, setSidebarOpen] = useState(!isMobile)
+  const { useSearchConversationEnabled } = useChatComponents()
+  const searchConversationEnabled = useSearchConversationEnabled()
 
-  const { conversations, hasMore, fetchMore } = useFetchConversations()
+  const { conversations, hasMore, fetchMore } =
+    useConversationStore().useConversations()
 
   // When the sidebar is closed on mobile, the toggle sits over the scrolling
   // conversation and must read as a distinct floating button, not blend into
@@ -80,18 +83,17 @@ const Sidebar = ({ className }) => {
             </IconButton>
           </div>
           <div>
-            {sidebarOpen &&
-              flag('cozy.assistant.search-conversation.enabled') && (
-                <IconButton
-                  size="medium"
-                  edge="end"
-                  className="u-bdrs-6"
-                  onClick={onToggleSearch}
-                  aria-label={t('assistant.sidebar.toggle_search')}
-                >
-                  <Icon icon={Magnifier} aria-hidden="true" />
-                </IconButton>
-              )}
+            {sidebarOpen && searchConversationEnabled && (
+              <IconButton
+                size="medium"
+                edge="end"
+                className="u-bdrs-6"
+                onClick={onToggleSearch}
+                aria-label={t('assistant.sidebar.toggle_search')}
+              >
+                <Icon icon={Magnifier} aria-hidden="true" />
+              </IconButton>
+            )}
             {sidebarOpen && isMobile && (
               <IconButton
                 size="medium"

--- a/packages/cozy-search/src/components/Views/AssistantDialog.jsx
+++ b/packages/cozy-search/src/components/Views/AssistantDialog.jsx
@@ -6,11 +6,17 @@ import { FixedDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import CozyTheme from 'cozy-ui-plus/dist/providers/CozyTheme'
 
-import AssistantProvider, { useAssistant } from '../AssistantProvider'
 import CreateAssistantDialog from './CreateAssistantDialog'
 import DeleteAssistantDialog from './DeleteAssistantDialog'
 import EditAssistantDialog from './EditAssistantDialog'
+import { ChatComponentsProvider } from '../../contexts/ChatComponentsContext'
+import CozyConversationStoreProvider from '../../contexts/cozy/CozyConversationStoreProvider'
+import { useCozySearchConversationEnabled } from '../../contexts/cozy/useCozySearchConversationEnabled'
 import AssistantContainer from '../Assistant/AssistantContainer'
+import AssistantProvider, { useAssistant } from '../AssistantProvider'
+import ConversationActions from '../Conversations/ConversationActions'
+import CozyComposerExtras from '../Conversations/CozyComposerExtras'
+import CozySourcesWithFilesQuery from '../Conversations/Sources/CozySourcesWithFilesQuery'
 import styles from '../styles.styl'
 
 const AssistantDialog = () => {
@@ -102,7 +108,18 @@ const AssistantDialogWithProviders = () => {
   return (
     <CozyTheme variant="normal">
       <AssistantProvider>
-        <AssistantDialog />
+        <ChatComponentsProvider
+          components={{
+            SourcesRenderer: CozySourcesWithFilesQuery,
+            ComposerExtras: CozyComposerExtras,
+            ConversationActions,
+            useSearchConversationEnabled: useCozySearchConversationEnabled
+          }}
+        >
+          <CozyConversationStoreProvider>
+            <AssistantDialog />
+          </CozyConversationStoreProvider>
+        </ChatComponentsProvider>
       </AssistantProvider>
     </CozyTheme>
   )

--- a/packages/cozy-search/src/components/Views/AssistantView.jsx
+++ b/packages/cozy-search/src/components/Views/AssistantView.jsx
@@ -4,11 +4,17 @@ import React from 'react'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import CozyTheme from 'cozy-ui-plus/dist/providers/CozyTheme'
 
-import AssistantProvider, { useAssistant } from '../AssistantProvider'
 import CreateAssistantDialog from './CreateAssistantDialog'
 import DeleteAssistantDialog from './DeleteAssistantDialog'
 import EditAssistantDialog from './EditAssistantDialog'
+import { ChatComponentsProvider } from '../../contexts/ChatComponentsContext'
+import CozyConversationStoreProvider from '../../contexts/cozy/CozyConversationStoreProvider'
+import { useCozySearchConversationEnabled } from '../../contexts/cozy/useCozySearchConversationEnabled'
 import AssistantContainer from '../Assistant/AssistantContainer'
+import AssistantProvider, { useAssistant } from '../AssistantProvider'
+import ConversationActions from '../Conversations/ConversationActions'
+import CozyComposerExtras from '../Conversations/CozyComposerExtras'
+import CozySourcesWithFilesQuery from '../Conversations/Sources/CozySourcesWithFilesQuery'
 import styles from '../styles.styl'
 
 const AssistantView = () => {
@@ -64,7 +70,18 @@ const AssistantViewWithProviders = () => {
   return (
     <CozyTheme variant="normal">
       <AssistantProvider>
-        <AssistantView />
+        <ChatComponentsProvider
+          components={{
+            SourcesRenderer: CozySourcesWithFilesQuery,
+            ComposerExtras: CozyComposerExtras,
+            ConversationActions,
+            useSearchConversationEnabled: useCozySearchConversationEnabled
+          }}
+        >
+          <CozyConversationStoreProvider>
+            <AssistantView />
+          </CozyConversationStoreProvider>
+        </ChatComponentsProvider>
       </AssistantProvider>
     </CozyTheme>
   )

--- a/packages/cozy-search/src/components/cozyHelpers.js
+++ b/packages/cozy-search/src/components/cozyHelpers.js
@@ -1,0 +1,5 @@
+import flag from 'cozy-flags'
+
+// Cozy-only helpers kept out of `helpers.js` so the presentational view layer
+// (which imports the date/name/description helpers) stays free of cozy-flags.
+export const isAssistantEnabled = () => flag('cozy.assistant.enabled')

--- a/packages/cozy-search/src/components/helpers.js
+++ b/packages/cozy-search/src/components/helpers.js
@@ -1,9 +1,5 @@
-import flag from 'cozy-flags'
-
 export const makeConversationId = () =>
   `${Date.now()}-${Math.floor(Math.random() * 90000) + 10000}`
-
-export const isAssistantEnabled = () => flag('cozy.assistant.enabled')
 
 /**
  * Sanitize chat content by removing special sources tags like

--- a/packages/cozy-search/src/contexts/ChatComponents.ts
+++ b/packages/cozy-search/src/contexts/ChatComponents.ts
@@ -1,0 +1,13 @@
+import type { ComponentType } from 'react'
+
+import type { ConversationSummary, StoredSource } from './ConversationStore'
+
+export interface ChatComponents {
+  SourcesRenderer: ComponentType<{ messageId: string; sources: StoredSource[] }>
+  ComposerExtras: ComponentType<{ disabled?: boolean }>
+  ConversationActions: ComponentType<{
+    buttonClassName?: string
+    conversation: ConversationSummary
+  }>
+  useSearchConversationEnabled: () => boolean
+}

--- a/packages/cozy-search/src/contexts/ChatComponentsContext.spec.tsx
+++ b/packages/cozy-search/src/contexts/ChatComponentsContext.spec.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+import {
+  ChatComponentsProvider,
+  useChatComponents
+} from './ChatComponentsContext'
+
+const Probe = (): JSX.Element => {
+  const { ComposerExtras } = useChatComponents()
+  return <ComposerExtras />
+}
+
+it('returns injected components', () => {
+  render(
+    <ChatComponentsProvider
+      components={{
+        SourcesRenderer: () => null,
+        ComposerExtras: () => <span>extras!</span>
+      }}
+    >
+      <Probe />
+    </ChatComponentsProvider>
+  )
+  expect(screen.getByText('extras!')).toBeTruthy()
+})
+
+it('falls back to no-op defaults without a provider', () => {
+  const { container } = render(<Probe />)
+  expect(container.innerHTML).toBe('')
+})

--- a/packages/cozy-search/src/contexts/ChatComponentsContext.tsx
+++ b/packages/cozy-search/src/contexts/ChatComponentsContext.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, ReactNode } from 'react'
+
+import type { ChatComponents } from './ChatComponents'
+
+// These defaults are intentional no-ops: every ChatComponents slot is an
+// OPTIONAL injection point, so rendering the views without a
+// ChatComponentsProvider yields no extras/sources/actions rather than a crash.
+// This differs deliberately from ConversationStore, which is REQUIRED data and
+// therefore throws when its provider is missing.
+const defaults: ChatComponents = {
+  SourcesRenderer: () => null,
+  ComposerExtras: () => null,
+  ConversationActions: () => null,
+  useSearchConversationEnabled: () => false
+}
+
+const ChatComponentsContext = createContext<ChatComponents>(defaults)
+
+export const ChatComponentsProvider = ({
+  components,
+  children
+}: {
+  components: Partial<ChatComponents>
+  children: ReactNode
+}): JSX.Element => (
+  <ChatComponentsContext.Provider value={{ ...defaults, ...components }}>
+    {children}
+  </ChatComponentsContext.Provider>
+)
+
+export const useChatComponents = (): ChatComponents =>
+  useContext(ChatComponentsContext)

--- a/packages/cozy-search/src/contexts/ConversationStore.ts
+++ b/packages/cozy-search/src/contexts/ConversationStore.ts
@@ -1,0 +1,48 @@
+export interface StoredSource {
+  id?: string
+  doctype?: string
+  sourceType?: string
+  url?: string
+  title?: string
+  snippet?: string
+}
+
+export interface StoredMessage {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+  sources?: StoredSource[]
+}
+
+export interface ConversationAssistant {
+  icon?: string
+  name?: string
+}
+
+export interface ConversationSummary {
+  _id: string
+  name?: string
+  messages?: StoredMessage[]
+  cozyMetadata?: { updatedAt?: string }
+  // Hydrated assistant, read directly by ConversationListItem to render its avatar.
+  assistant?: ConversationAssistant
+  relationships?: { assistant?: { data: { _id: string } } }
+}
+
+export interface UseConversationsResult {
+  conversations: ConversationSummary[]
+  hasMore: boolean
+  isLoading: boolean
+  fetchMore: () => void | Promise<void>
+}
+
+export interface ConversationStore {
+  useConversations: () => UseConversationsResult
+  useConversationMessages: (conversationId: string) => {
+    messages: StoredMessage[]
+    isLoading: boolean
+  }
+  createConversation: () => Promise<string>
+  deleteConversation: (conversationId: string) => Promise<void>
+  renameConversation: (conversationId: string, name: string) => Promise<void>
+}

--- a/packages/cozy-search/src/contexts/ConversationStoreContext.spec.tsx
+++ b/packages/cozy-search/src/contexts/ConversationStoreContext.spec.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+import {
+  ConversationStoreProvider,
+  useConversationStore
+} from './ConversationStoreContext'
+import type { ConversationStore } from './ConversationStore'
+
+const Probe = (): React.ReactElement => {
+  const store = useConversationStore()
+  return <div>{store.useConversations().conversations.length} convs</div>
+}
+
+const fakeStore: ConversationStore = {
+  useConversations: () => ({
+    conversations: [{ _id: 'a' }, { _id: 'b' }],
+    hasMore: false,
+    isLoading: false,
+    fetchMore: (): void => {}
+  }),
+  useConversationMessages: () => ({ messages: [], isLoading: false }),
+  createConversation: () => Promise.resolve('new'),
+  deleteConversation: () => Promise.resolve(),
+  renameConversation: () => Promise.resolve()
+}
+
+describe('ConversationStoreContext', () => {
+  it('exposes the injected store to consumers', () => {
+    render(
+      <ConversationStoreProvider store={fakeStore}>
+        <Probe />
+      </ConversationStoreProvider>
+    )
+    expect(screen.getByText('2 convs')).toBeTruthy()
+  })
+
+  it('throws when used without a provider', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => render(<Probe />)).toThrow(/ConversationStoreProvider/)
+    spy.mockRestore()
+  })
+})

--- a/packages/cozy-search/src/contexts/ConversationStoreContext.tsx
+++ b/packages/cozy-search/src/contexts/ConversationStoreContext.tsx
@@ -1,0 +1,27 @@
+import React, { createContext, useContext, ReactNode } from 'react'
+
+import type { ConversationStore } from './ConversationStore'
+
+const ConversationStoreContext = createContext<ConversationStore | null>(null)
+
+export const ConversationStoreProvider = ({
+  store,
+  children
+}: {
+  store: ConversationStore
+  children: ReactNode
+}): JSX.Element => (
+  <ConversationStoreContext.Provider value={store}>
+    {children}
+  </ConversationStoreContext.Provider>
+)
+
+export const useConversationStore = (): ConversationStore => {
+  const store = useContext(ConversationStoreContext)
+  if (!store) {
+    throw new Error(
+      'useConversationStore must be used within a ConversationStoreProvider'
+    )
+  }
+  return store
+}

--- a/packages/cozy-search/src/contexts/cozy/CozyConversationStore.spec.tsx
+++ b/packages/cozy-search/src/contexts/cozy/CozyConversationStore.spec.tsx
@@ -1,0 +1,123 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+
+const mockClient = {
+  query: jest
+    .fn()
+    .mockResolvedValue({ data: [], included: [], bookmark: null }),
+  stackClient: { fetchJSON: jest.fn() },
+  destroy: jest.fn(),
+  save: jest.fn()
+}
+
+jest.mock('cozy-client', () => ({
+  useClient: jest.fn(() => mockClient),
+  useQuery: jest.fn(() => ({ data: undefined, fetchStatus: 'loaded' })),
+  isQueryLoading: jest.fn(() => false),
+  Q: jest.fn(() => ({
+    getById: jest.fn(() => ({})),
+    where: jest.fn(() => ({
+      indexFields: jest.fn(() => ({
+        sortBy: jest.fn(() => ({
+          include: jest.fn(() => ({
+            offsetBookmark: jest.fn(() => ({
+              limitBy: jest.fn(() => ({}))
+            }))
+          }))
+        }))
+      }))
+    }))
+  })),
+  fetchPolicies: {
+    olderThan: jest.fn(() => ({}))
+  }
+}))
+jest.mock('cozy-realtime/dist/useRealtime', () => ({
+  __esModule: true,
+  default: (): void => {}
+}))
+jest.mock('../../hooks/useFetchConversations', () =>
+  jest.fn(() => ({
+    conversations: [],
+    hasMore: false,
+    isLoading: false,
+    fetchMore: jest.fn()
+  }))
+)
+
+import { useCozyConversationStore } from './CozyConversationStore'
+
+describe('CozyConversationStore', () => {
+  it('implements the ConversationStore surface', () => {
+    let store: ReturnType<typeof useCozyConversationStore> | undefined
+    const TestComponent = (): null => {
+      // eslint-disable-next-line react-hooks/globals -- test helper captures hook result outside component for assertion
+      store = useCozyConversationStore()
+      return null
+    }
+    render(<TestComponent />)
+
+    expect(typeof store!.useConversations).toBe('function')
+    expect(typeof store!.useConversationMessages).toBe('function')
+    expect(typeof store!.createConversation).toBe('function')
+    expect(typeof store!.deleteConversation).toBe('function')
+    expect(typeof store!.renameConversation).toBe('function')
+  })
+
+  it('creates a conversation id without touching the stack', async () => {
+    let store: ReturnType<typeof useCozyConversationStore> | undefined
+    const TestComponent = (): null => {
+      // eslint-disable-next-line react-hooks/globals -- test helper captures hook result outside component for assertion
+      store = useCozyConversationStore()
+      return null
+    }
+    render(<TestComponent />)
+
+    const id = await store!.createConversation()
+    expect(typeof id).toBe('string')
+    expect(id.length).toBeGreaterThan(0)
+    // The id is minted locally; no request must hit the stack on create.
+    expect(mockClient.stackClient.fetchJSON).not.toHaveBeenCalled()
+    expect(mockClient.query).not.toHaveBeenCalled()
+    expect(mockClient.save).not.toHaveBeenCalled()
+    expect(mockClient.destroy).not.toHaveBeenCalled()
+  })
+
+  it('destroys with the current _rev fetched from the stack', async () => {
+    let store: ReturnType<typeof useCozyConversationStore> | undefined
+    const TestComponent = (): null => {
+      // eslint-disable-next-line react-hooks/globals -- test helper captures hook result outside component for assertion
+      store = useCozyConversationStore()
+      return null
+    }
+    render(<TestComponent />)
+
+    mockClient.query.mockResolvedValueOnce({
+      data: { _id: 'conv-1', _rev: '2-abc' }
+    })
+    await store!.deleteConversation('conv-1')
+
+    expect(mockClient.destroy).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: 'conv-1', _rev: '2-abc' })
+    )
+  })
+
+  it('saves the renamed conversation with the current _rev', async () => {
+    let store: ReturnType<typeof useCozyConversationStore> | undefined
+    const TestComponent = (): null => {
+      // eslint-disable-next-line react-hooks/globals -- test helper captures hook result outside component for assertion
+      store = useCozyConversationStore()
+      return null
+    }
+    render(<TestComponent />)
+
+    mockClient.query.mockResolvedValueOnce({
+      data: { _id: 'conv-1', _rev: '2-abc', name: 'old' }
+    })
+    await store!.renameConversation('conv-1', 'new name')
+
+    expect(mockClient.save).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: 'conv-1', _rev: '2-abc', name: 'new name' })
+    )
+  })
+})

--- a/packages/cozy-search/src/contexts/cozy/CozyConversationStore.tsx
+++ b/packages/cozy-search/src/contexts/cozy/CozyConversationStore.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useMemo } from 'react'
+
+import { useClient, useQuery, isQueryLoading } from 'cozy-client'
+
+import { makeConversationId } from '../../components/helpers'
+import {
+  CHAT_CONVERSATIONS_DOCTYPE,
+  buildChatConversationQueryById
+} from '../../components/queries'
+import useFetchConversations from '../../hooks/useFetchConversations'
+import type { ConversationStore, StoredMessage } from '../ConversationStore'
+
+// Hoisted to module scope so their identities are stable across renders (they
+// capture nothing render-specific) and they don't need to appear in the store's
+// useMemo deps — which would otherwise rebuild the store object every render.
+const useConversations: ConversationStore['useConversations'] = () => {
+  const { conversations, hasMore, isLoading, fetchMore } =
+    useFetchConversations()
+  return { conversations, hasMore, isLoading, fetchMore }
+}
+
+const useConversationMessages: ConversationStore['useConversationMessages'] = (
+  conversationId: string
+) => {
+  const q = buildChatConversationQueryById(conversationId)
+  const res = useQuery(q.definition, q.options) as {
+    data?: { messages?: StoredMessage[] }
+  }
+  return {
+    messages: res.data?.messages ?? [],
+    isLoading: isQueryLoading(res)
+  }
+}
+
+// `createConversation` / `deleteConversation` / `renameConversation` fulfil the
+// ConversationStore contract for standalone consumers. The Cozy app itself
+// still mints ids via useConversation and mutates via ConversationActions, so
+// in-app these are reached mainly through the seam, not called directly here.
+export const useCozyConversationStore = (): ConversationStore => {
+  const client = useClient()
+
+  const createConversation = useCallback(
+    () => Promise.resolve(makeConversationId()),
+    []
+  )
+
+  // Existing-doc mutations need the current `_rev`, so we fetch the document
+  // first and spread it into destroy/save (as ConversationActions does in-app).
+  const fetchConversation = useCallback(
+    async (conversationId: string) => {
+      const q = buildChatConversationQueryById(conversationId)
+      const res = (await client?.query(q.definition)) as {
+        data?: { _id: string; _rev?: string } | null
+      }
+      return res?.data ?? null
+    },
+    [client]
+  )
+
+  const deleteConversation = useCallback(
+    async (conversationId: string) => {
+      if (!client) return
+      const conversation = await fetchConversation(conversationId)
+      if (!conversation) return
+      await client.destroy({
+        ...conversation,
+        _type: CHAT_CONVERSATIONS_DOCTYPE
+      })
+    },
+    [client, fetchConversation]
+  )
+
+  const renameConversation = useCallback(
+    async (conversationId: string, name: string) => {
+      if (!client) return
+      const conversation = await fetchConversation(conversationId)
+      if (!conversation) return
+      await client.save({
+        ...conversation,
+        _type: CHAT_CONVERSATIONS_DOCTYPE,
+        name
+      })
+    },
+    [client, fetchConversation]
+  )
+
+  return useMemo(
+    () => ({
+      useConversations,
+      useConversationMessages,
+      createConversation,
+      deleteConversation,
+      renameConversation
+    }),
+    [createConversation, deleteConversation, renameConversation]
+  )
+}

--- a/packages/cozy-search/src/contexts/cozy/CozyConversationStoreProvider.jsx
+++ b/packages/cozy-search/src/contexts/cozy/CozyConversationStoreProvider.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import { ConversationStoreProvider } from '../ConversationStoreContext'
+import { useCozyConversationStore } from './CozyConversationStore'
+
+const CozyConversationStoreProvider = ({ children }) => {
+  const store = useCozyConversationStore()
+  return (
+    <ConversationStoreProvider store={store}>
+      {children}
+    </ConversationStoreProvider>
+  )
+}
+
+export default CozyConversationStoreProvider

--- a/packages/cozy-search/src/contexts/cozy/useCozySearchConversationEnabled.spec.ts
+++ b/packages/cozy-search/src/contexts/cozy/useCozySearchConversationEnabled.spec.ts
@@ -1,0 +1,17 @@
+// The shared cozy-flags mock returns false for every flag, so the global test
+// setup only ever exercises the OFF path. Override it here to cover the ON path.
+jest.mock('cozy-flags', () => {
+  const flag = (name: string): boolean =>
+    name === 'cozy.assistant.search-conversation.enabled'
+  // mirror the real default-export shape consumed via `import flag from ...`
+  ;(flag as unknown as { default: unknown }).default = flag
+  return flag
+})
+
+import { useCozySearchConversationEnabled } from './useCozySearchConversationEnabled'
+
+describe('useCozySearchConversationEnabled', () => {
+  it('returns true when the cozy flag is enabled', () => {
+    expect(useCozySearchConversationEnabled()).toBe(true)
+  })
+})

--- a/packages/cozy-search/src/contexts/cozy/useCozySearchConversationEnabled.ts
+++ b/packages/cozy-search/src/contexts/cozy/useCozySearchConversationEnabled.ts
@@ -1,0 +1,4 @@
+import flag from 'cozy-flags'
+
+export const useCozySearchConversationEnabled = (): boolean =>
+  !!flag('cozy.assistant.search-conversation.enabled')

--- a/packages/cozy-search/src/contexts/viewLayerPurity.spec.ts
+++ b/packages/cozy-search/src/contexts/viewLayerPurity.spec.ts
@@ -1,0 +1,91 @@
+import fs from 'fs'
+import path from 'path'
+
+// The `ai-chat-ui.ts` entry is the contract consumed by standalone (non-Cozy)
+// apps: nothing it pulls in — TRANSITIVELY — may depend on the Cozy backend.
+// A shallow "does this one file import cozy-*" check is not enough, because a
+// pure-looking view can render a child that imports cozy-client. So we walk the
+// full static import graph starting from ai-chat-ui.ts and assert no reachable
+// module imports a forbidden package.
+const SRC = path.join(__dirname, '..')
+const ENTRY = path.join(SRC, 'ai-chat-ui.ts')
+
+const FORBIDDEN = [
+  'cozy-client',
+  'cozy-stack-client',
+  'cozy-realtime',
+  'cozy-flags',
+  'cozy-device-helper',
+  'cozy-dataproxy-lib'
+]
+
+const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx']
+
+// Resolve a relative import specifier to a real file on disk.
+const resolveLocal = (fromFile: string, spec: string): string | undefined => {
+  const base = path.resolve(path.dirname(fromFile), spec)
+  const candidates = [
+    base,
+    ...EXTENSIONS.map(ext => base + ext),
+    ...EXTENSIONS.map(ext => path.join(base, 'index' + ext))
+  ]
+  return candidates.find(c => fs.existsSync(c) && fs.statSync(c).isFile())
+}
+
+// Every module specifier referenced by `import ... from '...'`,
+// `export ... from '...'`, and side-effect `import '...'`.
+const specifiersOf = (src: string): string[] => {
+  const specs: string[] = []
+  const fromRe = /from\s*['"]([^'"]+)['"]/g
+  const bareRe = /(?:^|[\n;])\s*import\s+['"]([^'"]+)['"]/g
+  let m: RegExpExecArray | null
+  while ((m = fromRe.exec(src))) specs.push(m[1])
+  while ((m = bareRe.exec(src))) specs.push(m[1])
+  return specs
+}
+
+const isForbidden = (spec: string): string | undefined =>
+  FORBIDDEN.find(pkg => spec === pkg || spec.startsWith(`${pkg}/`))
+
+const findViolations = (
+  entry: string
+): { file: string; pkg: string; chain: string[] }[] => {
+  const seen = new Set<string>()
+  const violations: { file: string; pkg: string; chain: string[] }[] = []
+
+  const walk = (file: string, chain: string[]): void => {
+    if (seen.has(file)) return
+    seen.add(file)
+    const src = fs.readFileSync(file, 'utf8')
+    for (const spec of specifiersOf(src)) {
+      const pkg = isForbidden(spec)
+      if (pkg) {
+        violations.push({ file, pkg, chain: [...chain, file] })
+        continue
+      }
+      if (spec.startsWith('.')) {
+        const resolved = resolveLocal(file, spec)
+        // Only follow code modules; skip resolved assets like .styl / images.
+        if (resolved && EXTENSIONS.includes(path.extname(resolved))) {
+          walk(resolved, [...chain, file])
+        }
+      }
+    }
+  }
+
+  walk(entry, [])
+  return violations
+}
+
+describe('ai-chat-ui entry purity', () => {
+  it('ai-chat-ui.ts depends on no Cozy backend package (transitively)', () => {
+    const rel = (f: string): string => path.relative(SRC, f)
+    const report = findViolations(ENTRY)
+      .map(
+        v =>
+          `${rel(v.file)} imports "${v.pkg}"\n    via ${v.chain.map(rel).join(' → ')}`
+      )
+      .join('\n')
+    expect(report).toBe('')
+  })
+})

--- a/packages/cozy-search/src/index.ts
+++ b/packages/cozy-search/src/index.ts
@@ -14,3 +14,37 @@ export {
   createCozyRealtimeChatAdapter
 } from './components/adapters'
 export { default as AssistantView } from './components/Views/AssistantView'
+
+export { default as Sidebar } from './components/Sidebar'
+export { default as Conversation } from './components/Conversations/Conversation'
+export { default as AssistantMessage } from './components/Messages/AssistantMessage'
+export { default as UserMessage } from './components/Messages/UserMessage'
+export { Sources } from './components/Conversations/Sources/Sources'
+
+// Seams
+export {
+  ConversationStoreProvider,
+  useConversationStore
+} from './contexts/ConversationStoreContext'
+export type {
+  ConversationStore,
+  ConversationSummary,
+  StoredMessage,
+  StoredSource,
+  UseConversationsResult
+} from './contexts/ConversationStore'
+export {
+  ChatComponentsProvider,
+  useChatComponents
+} from './contexts/ChatComponentsContext'
+export type { ChatComponents } from './contexts/ChatComponents'
+
+// Cozy default implementations (for the existing Cozy app)
+export { default as CozyConversationStoreProvider } from './contexts/cozy/CozyConversationStoreProvider'
+export { useCozyConversationStore } from './contexts/cozy/CozyConversationStore'
+export { useCozySearchConversationEnabled } from './contexts/cozy/useCozySearchConversationEnabled'
+export { default as CozySourcesWithFilesQuery } from './components/Conversations/Sources/CozySourcesWithFilesQuery'
+export { default as CozyComposerExtras } from './components/Conversations/CozyComposerExtras'
+
+// i18n locales for foreign apps
+export { locales } from './locales'

--- a/packages/cozy-search/tests/jest.config.js
+++ b/packages/cozy-search/tests/jest.config.js
@@ -3,6 +3,7 @@
 const config = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/tests/jest.setup.ts'],
+  clearMocks: true,
   collectCoverage: false,
   collectCoverageFrom: ['./src/**/*.{ts,tsx}'],
   coverageDirectory: './tests/coverage',


### PR DESCRIPTION
The rationale for this big refactor is to be able to reuse the AI assistant UI from a non-twake app, typically openRAG. 
To achieve it, we export all the UI components and make sure no cozy dependency other than cozy-ui remains.
This way, any app can simply import relevant components (Conversation, Sidebar, etc), and deal with its own backend.

Eventually, we envision to have a dedicated assistant app served by openRAG and integrated in twake inside a shell app like it's done for mail, calendar, etc.

Note there is no breaking change, the AI assistant still work in twake app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public AI chat UI entry point for easier integration.
  * Expanded the search/chat experience with configurable composer extras, conversation actions, and sources rendering.
  * Added support for conversation storage and search-conversation enablement in the assistant experience.

* **Bug Fixes**
  * Improved handling of source details so message sources load more reliably.
  * Updated assistant-related checks and configuration lookups for more consistent behavior.

* **Tests**
  * Added coverage for the new chat component and conversation store integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->