### PR TITLE
feat(cozy-sharing): ShareAutosuggest can now be autofocus false

### DIFF
--- a/packages/cozy-sharing/src/components/ShareAutosuggest.jsx
+++ b/packages/cozy-sharing/src/components/ShareAutosuggest.jsx
@@ -23,6 +23,7 @@ const ShareAutosuggest = ({
   onRemove,
   enableCreateContact,
   placeholder,
+  autoFocus,
   endAdornment
 }) => {
   const [inputValue, setInputValue] = useState('')
@@ -201,7 +202,7 @@ const ShareAutosuggest = ({
         renderInputComponent={renderInput}
         highlightFirstSuggestion
         inputProps={{
-          autoFocus: true,
+          autoFocus,
           onFocus: onAutosuggestFocus,
           onChange: onAutosuggestChange,
           onPaste: onAutosuggestPaste,
@@ -217,6 +218,10 @@ const ShareAutosuggest = ({
   )
 }
 
+ShareAutosuggest.defaultProps = {
+  autoFocus: true
+}
+
 ShareAutosuggest.propTypes = {
   loading: PropTypes.bool,
   disabled: PropTypes.bool,
@@ -226,6 +231,7 @@ ShareAutosuggest.propTypes = {
   onRemove: PropTypes.func.isRequired,
   enableCreateContact: PropTypes.bool,
   placeholder: PropTypes.string,
+  autoFocus: PropTypes.bool,
   endAdornment: PropTypes.node
 }
 

--- a/packages/cozy-sharing/src/components/ShareByEmail.jsx
+++ b/packages/cozy-sharing/src/components/ShareByEmail.jsx
@@ -22,6 +22,7 @@ export const ShareByEmail = ({
   selectedOption,
   onSelectedOptionChange,
   enableCreateContact,
+  autoFocus,
   sharing
 }) => {
   const { t } = useI18n()
@@ -70,6 +71,7 @@ export const ShareByEmail = ({
           enableCreateContact={enableCreateContact}
           currentRecipients={currentRecipients}
           recipients={pendingRecipients}
+          autoFocus={autoFocus}
           endAdornment={
             <ShareTypeSelect
               value={selectedOption}
@@ -92,6 +94,7 @@ ShareByEmail.propTypes = {
   selectedOption: PropTypes.oneOf(['readWrite', 'readOnly']).isRequired,
   onSelectedOptionChange: PropTypes.func.isRequired,
   enableCreateContact: PropTypes.bool,
+  autoFocus: PropTypes.bool,
   sharing: PropTypes.object
 }
 

--- a/packages/cozy-sharing/src/components/ShareRecipientsInput.jsx
+++ b/packages/cozy-sharing/src/components/ShareRecipientsInput.jsx
@@ -30,6 +30,7 @@ const ShareRecipientsInput = ({
   onRemove,
   enableCreateContact,
   disabled,
+  autoFocus,
   endAdornment
 }) => {
   const reachableContactsQuery = buildReachableContactsQuery()
@@ -128,6 +129,7 @@ const ShareRecipientsInput = ({
       onRemove={onRemove}
       enableCreateContact={enableCreateContact}
       placeholder={placeholder}
+      autoFocus={autoFocus}
       endAdornment={endAdornment}
     />
   )
@@ -141,6 +143,7 @@ ShareRecipientsInput.propTypes = {
   onRemove: PropTypes.func.isRequired,
   enableCreateContact: PropTypes.bool,
   disabled: PropTypes.bool,
+  autoFocus: PropTypes.bool,
   endAdornment: PropTypes.node
 }
 

--- a/packages/cozy-sharing/src/components/SharedDrive/SharedDriveForm.jsx
+++ b/packages/cozy-sharing/src/components/SharedDrive/SharedDriveForm.jsx
@@ -16,6 +16,7 @@ const ShareByEmailSection = memo(function ShareByEmailSection({
   pendingRecipients,
   setPendingRecipients,
   selectedOption,
+  autoFocus,
   setSelectedOption
 }) {
   return (
@@ -25,6 +26,7 @@ const ShareByEmailSection = memo(function ShareByEmailSection({
       pendingRecipients={pendingRecipients}
       onPendingRecipientsChange={setPendingRecipients}
       selectedOption={selectedOption}
+      autoFocus={autoFocus}
       onSelectedOptionChange={setSelectedOption}
     />
   )
@@ -54,6 +56,7 @@ export const SharedDriveForm = withLocales(({ onSuccess, onCancel }) => {
           size="small"
           className="u-w-100 u-mt-1-half u-mb-1-half"
           value={sharedDriveName}
+          autoFocus
           onChange={handleSharedDriveNameChange}
         />
         <Typography variant="h6" className="u-mb-half">
@@ -63,6 +66,7 @@ export const SharedDriveForm = withLocales(({ onSuccess, onCancel }) => {
           pendingRecipients={pendingRecipients}
           setPendingRecipients={setPendingRecipients}
           selectedOption={selectedOption}
+          autoFocus={false}
           setSelectedOption={setSelectedOption}
         />
       </div>


### PR DESCRIPTION
Tree order : SharedDriveForm > ShareByEmail > ShareRecipientsInput > ShareAutosuggest

relative to https://github.com/linagora/cozy-libs/pull/3005 we finally need to disable autofocus for autosuggest in same cases :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sharing inputs now support configurable automatic focus, letting the first field focus by default while allowing other screens to disable it.
* **Bug Fixes**
  * Improved focus handling in sharing forms to prevent multiple fields from competing for initial focus.
  * Share-by-email and recipient inputs now behave more consistently when opening sharing dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->