### PR TITLE
feat: Rename shared drive to team drive

### DIFF
--- a/packages/cozy-sharing/locales/en.json
+++ b/packages/cozy-sharing/locales/en.json
@@ -448,19 +448,19 @@
   },
   "SharedDrive": {
     "sharedDriveModal": {
-      "title": "New shared drive",
-      "nameLabel": "Drive name",
+      "title": "New team drive",
+      "nameLabel": "Team drive name",
       "add": "Add",
       "cancel": "Cancel",
       "create": "Create",
       "save": "Save",
-      "successNotification": "Shared drive has been added",
-      "errorNotification": "Error during shared drive creation"
+      "successNotification": "Team drive has been added",
+      "errorNotification": "Error during team drive creation"
     },
     "editSharedDriveModal": {
-      "title": "Edit shared drive",
-      "successNotification": "Shared drive has been modified",
-      "errorNotification": "Error during shared drive modification"
+      "title": "Edit team drive",
+      "successNotification": "Team drive has been modified",
+      "errorNotification": "Error during team drive modification"
     }
   }
 }

--- a/packages/cozy-sharing/locales/fr.json
+++ b/packages/cozy-sharing/locales/fr.json
@@ -446,19 +446,19 @@
   },
   "SharedDrive": {
     "sharedDriveModal": {
-      "title": "Nouveau drive partagé",
-      "nameLabel": "Nom du drive partagé",
+      "title": "Nouveau drive d'équipe",
+      "nameLabel": "Nom du drive d'équipe",
       "add": "Ajouter",
       "cancel": "Annuler",
       "create": "Créer",
       "save": "Enregistrer",
-      "successNotification": "Le drive partagé a été ajouté",
-      "errorNotification": "Erreur lors de la création du drive partagé"
+      "successNotification": "Le drive d'équipe a été ajouté",
+      "errorNotification": "Erreur lors de la création du drive d'équipe"
     },
     "editSharedDriveModal": {
-      "title": "Modifier le drive partagé",
-      "successNotification": "Le drive partagé a été modifié",
-      "errorNotification": "Erreur lors de la modification du drive partagé"
+      "title": "Modifier le drive d'équipe",
+      "successNotification": "Le drive d'équipe a été modifié",
+      "errorNotification": "Erreur lors de la modification du drive d'équipe"
     }
   }
 }

--- a/packages/cozy-sharing/locales/ru.json
+++ b/packages/cozy-sharing/locales/ru.json
@@ -448,19 +448,19 @@
   },
   "SharedDrive": {
     "sharedDriveModal": {
-      "title": "Новый общий диск",
+      "title": "Новый командный диск",
       "nameLabel": "Имя диска",
       "add": "Добавить",
       "cancel": "Отмена",
       "create": "Создать",
       "save": "Сохранить",
-      "successNotification": "Общий диск добавлен",
-      "errorNotification": "Ошибка при создании общего диска"
+      "successNotification": "Командный диск добавлен",
+      "errorNotification": "Ошибка при создании командного диска"
     },
     "editSharedDriveModal": {
-      "title": "Редактировать общий диск",
-      "successNotification": "Общий диск был изменён",
-      "errorNotification": "Ошибка при модификации общего диска"
+      "title": "Редактировать командный диск",
+      "successNotification": "Командный диск был изменён",
+      "errorNotification": "Ошибка при модификации командного диска"
     }
   }
 }

--- a/packages/cozy-sharing/locales/vi.json
+++ b/packages/cozy-sharing/locales/vi.json
@@ -448,19 +448,19 @@
   },
   "SharedDrive": {
     "sharedDriveModal": {
-      "title": "Ổ đĩa được chia sẻ mới",
+      "title": "Ổ đĩa nhóm mới",
       "nameLabel": "Tên ổ đĩa",
       "add": "Thêm",
       "cancel": "Hủy",
       "create": "Tạo",
       "save": "Lưu",
-      "successNotification": "Ổ đĩa được chia sẻ đã được thêm",
-      "errorNotification": "Lỗi trong quá trình tạo ổ đĩa được chia sẻ"
+      "successNotification": "Ổ đĩa nhóm đã được thêm",
+      "errorNotification": "Lỗi trong quá trình tạo ổ đĩa nhóm"
     },
     "editSharedDriveModal": {
-      "title": "Sửa ổ đĩa được chia sẻ",
-      "successNotification": "Ổ đĩa được chia sẻ đã được sửa đổi",
-      "errorNotification": "Lỗi khi sửa đổi ổ đĩa được chia sẻ"
+      "title": "Sửa ổ đĩa nhóm",
+      "successNotification": "Ổ đĩa nhóm đã được sửa đổi",
+      "errorNotification": "Lỗi khi sửa đổi ổ đĩa nhóm"
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shared drive wording in English, French, Russian, and Vietnamese to use “team drive” / equivalent team-drive terminology.
  * Refreshed modal titles, field labels, and success/error messages so the wording is consistent across create and edit flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->