### PR TITLE
Fix changelogs and deps

### DIFF
--- a/packages/cozy-devtools/package.json
+++ b/packages/cozy-devtools/package.json
@@ -26,7 +26,7 @@
     "cozy-flags": "^4.9.1",
     "cozy-intent": "^2.31.1",
     "cozy-pouch-link": "^60.28.0",
-    "cozy-ui": "^140.1.0",
+    "cozy-ui": "^139.0.2",
     "jest": "30.3.0",
     "jest-environment-jsdom": "30.3.0",
     "react": "^16.12.0",
@@ -44,7 +44,7 @@
     "cozy-flags": ">=4.9.1",
     "cozy-intent": ">=2.31.1",
     "cozy-pouch-link": ">=60.28.0",
-    "cozy-ui": ">=140.1.0",
+    "cozy-ui": ">=139.0.2",
     "react": ">=16.12.0",
     "react-dom": ">=16.12.0"
   }

--- a/packages/cozy-sharing/CHANGELOG.md
+++ b/packages/cozy-sharing/CHANGELOG.md
@@ -29,13 +29,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### BREAKING CHANGES
 
-- You need:
-  "@linagora/twake-icons": ">=2.6.6"
-  "cozy-client": ">=60.28.0"
-  "cozy-flags": ">=4.9.1"
-  "cozy-intent": ">=2.31.1"
-  "cozy-pouch-link": ">=60.28.0"
-  "cozy-ui": ">=140.1.0
+- You must have `"cozy-client": ">=60.28.0"`
 
 # [35.0.0](https://github.com/cozy/cozy-libs/compare/cozy-sharing@34.1.2...cozy-sharing@35.0.0) (2026-06-25)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17328,7 +17328,7 @@ __metadata:
     cozy-flags: "npm:^4.9.1"
     cozy-intent: "npm:^2.31.1"
     cozy-pouch-link: "npm:^60.28.0"
-    cozy-ui: "npm:^140.1.0"
+    cozy-ui: "npm:^139.0.2"
     date-fns: "npm:2.29.3"
     jest: "npm:30.3.0"
     jest-environment-jsdom: "npm:30.3.0"
@@ -17343,7 +17343,7 @@ __metadata:
     cozy-flags: ">=4.9.1"
     cozy-intent: ">=2.31.1"
     cozy-pouch-link: ">=60.28.0"
-    cozy-ui: ">=140.1.0"
+    cozy-ui: ">=139.0.2"
     react: ">=16.12.0"
     react-dom: ">=16.12.0"
   languageName: unknown
@@ -18307,47 +18307,6 @@ __metadata:
   bin:
     rsg-screenshots: scripts/screenshots.js
   checksum: 10c0/4583ef011291ce6b867a36263725035a3da911750c752f9960debbbbad94448d714da5d3bb1b59df9077bf4bcd6bfcfdb92ee8d1cdc21714e8a02d6ec875bd72
-  languageName: node
-  linkType: hard
-
-"cozy-ui@npm:^140.1.0":
-  version: 140.1.0
-  resolution: "cozy-ui@npm:140.1.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.3.4"
-    "@date-io/date-fns": "npm:1"
-    "@material-ui/core": "npm:4.12.3"
-    "@material-ui/lab": "npm:^4.0.0-alpha.61"
-    "@material-ui/pickers": "npm:3.3.11"
-    "@popperjs/core": "npm:^2.4.4"
-    classnames: "npm:^2.2.5"
-    date-fns: "npm:2.30.0"
-    hammerjs: "npm:^2.0.8"
-    intersection-observer: "npm:0.11.0"
-    mui-bottom-sheet: "git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9"
-    node-polyglot: "npm:^2.5.0"
-    normalize.css: "npm:^8.0.0"
-    patch-package: "npm:^8.0.0"
-    pdf-lib: "npm:1.17.1"
-    react-markdown: "npm:^4.0.8"
-    react-popper: "npm:^2.2.3"
-    react-remove-scroll: "npm:^2.4.0"
-    react-select: "npm:^4.3.0"
-    react-swipeable-views: "npm:^0.13.3"
-    react-virtuoso: "npm:^4.13.0"
-    rooks: "npm:7.14.1"
-  peerDependencies:
-    "@linagora/twake-icons": ">=2.6.2"
-    cozy-device-helper: ">=2.0.0"
-    cozy-intent: ">=2.29.1"
-    react: ^16 || ^17 || ^18
-    react-dnd: ^16.0.1
-    react-dnd-html5-backend: ^16.0.1
-    react-dom: ^16 || ^17 || ^18
-    twake-i18n: ">=0.3.0"
-  bin:
-    rsg-screenshots: scripts/screenshots.js
-  checksum: 10c0/e6e8b07a89d59af1492f9f30ba79ea6f71820f6d375b9065b9436a34e28b81a655efa8d6ae3e70349c571479f0fe94e83c8effdef406f6ec874e866d69b49e00
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We previously upgraded cozy-ui to 140+ in cozy-devtools. It was a mistake, no need to deal with that yet. In fact, at this stage, no libs does. To ease the migration, we downgrade here to avoid forcing the apply of the 140.0.0 BC

For the changelogs, it was a "bug" because we did a BC on devtools and add a sharing file in the same commit.