### PR TITLE
feat(cozy-sharing): Hide email for org instance owner

### DIFF
--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
@@ -40,7 +40,8 @@ jest.mock('../../hooks/useSharingContext', () => ({
     getSharedParentPath: jest.fn().mockReturnValue(null),
     getSharingById: mockGetSharingById,
     hasSharedChild: mockHasSharedChild,
-    hasSharedParent: mockHasSharedParent
+    hasSharedParent: mockHasSharedParent,
+    isOrgSharedDrive: jest.fn(() => false)
   })
 }))
 

--- a/packages/cozy-sharing/src/components/Recipient/MemberRecipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/MemberRecipient.jsx
@@ -32,6 +32,7 @@ const MemberRecipient = props => {
     recipientConfirmationData,
     verifyRecipient,
     fadeIn,
+    isOrgSharedDrive,
     ...rest
   } = props
 
@@ -68,6 +69,7 @@ const MemberRecipient = props => {
               instance={instance}
               email={rest.email}
               name={rest.name || rest.public_name}
+              isOrgSharedDrive={isOrgSharedDrive}
             />
           }
         />
@@ -82,7 +84,8 @@ MemberRecipient.propTypes = {
   isOwner: PropTypes.bool,
   status: PropTypes.string,
   recipientConfirmationData: PropTypes.object,
-  verifyRecipient: PropTypes.func
+  verifyRecipient: PropTypes.func,
+  isOrgSharedDrive: PropTypes.bool
 }
 
 export default MemberRecipient

--- a/packages/cozy-sharing/src/components/Recipient/MemberRecipientStatus.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/MemberRecipientStatus.jsx
@@ -10,6 +10,7 @@ const MemberRecipientStatus = ({
   instance,
   email,
   name,
+  isOrgSharedDrive,
   typographyProps
 }) => {
   const { t } = useI18n()
@@ -22,7 +23,13 @@ const MemberRecipientStatus = ({
     // (getDisplayName falls back to email when the recipient has no name).
     // Keep the instance visible when there is no email at all, so the user
     // can still tell the recipient lives on a different Cozy instance.
-    text = isMe || name || !email ? email || instance : ''
+    // For org shared drive owners, hide the email and instance entirely.
+    text =
+      status === 'owner' && isOrgSharedDrive
+        ? ''
+        : isMe || name || !email
+          ? email || instance
+          : ''
   } else if (isSendingEmail) {
     text = t('Share.status.mail-not-sent')
   } else {
@@ -45,6 +52,7 @@ MemberRecipientStatus.propTypes = {
   instance: PropTypes.string,
   email: PropTypes.string,
   name: PropTypes.string,
+  isOrgSharedDrive: PropTypes.bool,
   typographyProps: PropTypes.object
 }
 

--- a/packages/cozy-sharing/src/components/Recipient/MemberRecipientStatus.spec.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/MemberRecipientStatus.spec.jsx
@@ -63,6 +63,19 @@ describe('MemberRecipientStatus component', () => {
     expect(getByText('owner@example.com')).toBeTruthy()
   })
 
+  it('should hide email and instance when status is owner and isOrgSharedDrive is true', () => {
+    const { queryByText } = setup({
+      status: 'owner',
+      isMe: false,
+      email: 'org@example.com',
+      instance: 'foo.mycozy.cloud',
+      name: 'Org Owner',
+      isOrgSharedDrive: true
+    })
+    expect(queryByText('org@example.com')).toBe(null)
+    expect(queryByText('foo.mycozy.cloud')).toBe(null)
+  })
+
   it('should show "Sending invitation mail..." when status is mail-not-sent and not isMe', () => {
     const { getByText } = setup({
       status: 'mail-not-sent',

--- a/packages/cozy-sharing/src/components/Recipient/OwnerRecipient.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/OwnerRecipient.jsx
@@ -4,20 +4,26 @@ import React from 'react'
 import MemberRecipient from './MemberRecipient'
 import OwnerRecipientDefault from './OwnerRecipientDefault'
 
-const OwnerRecipient = ({ recipients }) => {
+const OwnerRecipient = ({ recipients, isOrgSharedDrive }) => {
   const ownerRecipient = recipients.find(
     recipient => recipient.status === 'owner'
   )
 
   if (ownerRecipient) {
-    return <MemberRecipient {...ownerRecipient} />
+    return (
+      <MemberRecipient
+        {...ownerRecipient}
+        isOrgSharedDrive={isOrgSharedDrive}
+      />
+    )
   }
 
   return <OwnerRecipientDefault />
 }
 
 OwnerRecipient.propTypes = {
-  recipients: PropTypes.array.isRequired
+  recipients: PropTypes.array.isRequired,
+  isOrgSharedDrive: PropTypes.bool
 }
 
 export default OwnerRecipient

--- a/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogCozyToCozy.spec.jsx
@@ -17,7 +17,8 @@ jest.mock('cozy-client', () => ({
 jest.mock('../hooks/useSharingContext', () => ({
   useSharingContext: () => ({
     getSharingLink: jest.fn(() => null),
-    updateSharingMemberType: jest.fn()
+    updateSharingMemberType: jest.fn(),
+    isOrgSharedDrive: jest.fn(() => false)
   })
 }))
 

--- a/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareDialogOnlyByLink.spec.jsx
@@ -14,7 +14,8 @@ jest.mock('../hooks/useSharingContext', () => ({
     getDocumentPermissions: () => [],
     getSharingLink: () => mockSharingLink,
     revokeSharingLink: jest.fn(),
-    updateDocumentPermissions: jest.fn()
+    updateDocumentPermissions: jest.fn(),
+    isOrgSharedDrive: jest.fn(() => false)
   })
 }))
 

--- a/packages/cozy-sharing/src/components/WhoHasAccess.jsx
+++ b/packages/cozy-sharing/src/components/WhoHasAccess.jsx
@@ -8,6 +8,7 @@ import LinkRecipient from './Recipient/LinkRecipient'
 import OwnerRecipient from './Recipient/OwnerRecipient'
 import { RecipientList } from './Recipient/RecipientList'
 import { usePrevious } from '../helpers/hooks'
+import { useSharingContext } from '../hooks/useSharingContext'
 
 /**
  * Displays a warning if some contacts are waiting for confirmation of their sharing
@@ -46,6 +47,8 @@ const WhoHasAccess = ({
 }) => {
   const previousLink = usePrevious(link)
   const linkHasBeenJustCreated = link && previousLink === null
+  const { isOrgSharedDrive } = useSharingContext()
+  const isOrgDrive = isOrgSharedDrive(document?._id)
 
   return (
     <div className={className}>
@@ -65,7 +68,12 @@ const WhoHasAccess = ({
           />
         )}
 
-        {showOwner && <OwnerRecipient recipients={recipients} />}
+        {showOwner && (
+          <OwnerRecipient
+            recipients={recipients}
+            isOrgSharedDrive={isOrgDrive}
+          />
+        )}
 
         <RecipientList
           recipients={recipients}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved recipient display for shared drives, hiding owner details where appropriate in org shared drive contexts.
  * Updated sharing dialogs and recipient views to handle shared-drive-specific behavior consistently.

* **Bug Fixes**
  * Fixed tests by aligning mocked sharing context values with the current component expectations.
  * Added coverage for owner recipient display when shared-drive visibility rules apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->