### PR TITLE
feat: Display all entrypoints

### DIFF
--- a/packages/cozy-bar/src/components/AppsMenu/helper.js
+++ b/packages/cozy-bar/src/components/AppsMenu/helper.js
@@ -1,25 +1,14 @@
 import { models } from 'cozy-client'
 
 const {
-  applications: { selectEntrypoints, filterEntrypoints }
+  applications: { filterEntrypoints }
 } = models
 
-// We get only the entrypoints we want:
-// - Drive onlyoffice
 export const getEntrypoints = apps => {
-  const driveApp = apps.find(app => app.slug === 'drive') || {}
-
-  const driveEntrypoints = driveApp.entrypoints || []
-
-  const selectedEntrypoints = selectEntrypoints(driveEntrypoints, [
-    'new-file-type-text',
-    'new-file-type-sheet',
-    'new-file-type-slide'
-  ])
-  const filteredEntrypoints = filterEntrypoints(selectedEntrypoints)
-
-  return filteredEntrypoints.map(entrypoint => ({
-    ...entrypoint,
-    slug: driveApp.slug
-  }))
+  return (apps || []).flatMap(app =>
+    filterEntrypoints(app.entrypoints || []).map(entrypoint => ({
+      ...entrypoint,
+      slug: app.slug
+    }))
+  )
 }


### PR DESCRIPTION
No idea why I restricted previously entrypoints to a set of drive entrypoint because:
- currently we have only entrypoints in drive
- it removes the purpose of entrypoints if we need to update an app when we add an entrypoint

If one day we want to have entrypoint for only some part of the code, we need to extend the conditions attribute.

Related to https://github.com/linagora/cozy-home/pull/2370