### PR TITLE
fix(cozy-search): Fix custom provider icon and select new assistant

### DIFF
--- a/packages/cozy-search/src/components/CreateAssistantSteps/providers.json
+++ b/packages/cozy-search/src/components/CreateAssistantSteps/providers.json
@@ -48,7 +48,7 @@
     "id": "custom",
     "name": "assistant_create.steps.provider_selection.custom.name",
     "description": "assistant_create.steps.provider_selection.custom.description",
-    "icon": "PlusSmallIcon",
+    "icon": "PlusSmall",
     "external": true
   }
 ]

--- a/packages/cozy-search/src/components/Views/CreateAssistantDialog.jsx
+++ b/packages/cozy-search/src/components/Views/CreateAssistantDialog.jsx
@@ -16,6 +16,7 @@ import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n, useExtendI18n } from 'twake-i18n'
 
 import { locales } from '../../locales'
+import { useAssistant } from '../AssistantProvider'
 import AssistantDialogContent from '../CreateAssistantSteps/AssistantDialogContent'
 import { getSelectedProviderById } from '../CreateAssistantSteps/helpers'
 import styles from '../CreateAssistantSteps/styles.styl'
@@ -32,6 +33,7 @@ const CreateAssistantDialog = ({ open, onClose }) => {
   const client = useClient()
   const { showAlert } = useAlert()
   const { isMobile } = useBreakpoints()
+  const { setSelectedAssistantId } = useAssistant()
 
   const {
     step,
@@ -61,7 +63,7 @@ const CreateAssistantDialog = ({ open, onClose }) => {
   }
 
   const onSubmit = async () => {
-    await createAssistant(client, {
+    const savedAssistant = await createAssistant(client, {
       name: formData.name,
       prompt: formData.description,
       icon: formData.icon,
@@ -70,6 +72,9 @@ const CreateAssistantDialog = ({ open, onClose }) => {
       baseUrl: formData.baseUrl,
       providerId: selectedProvider.id
     })
+    if (savedAssistant?._id) {
+      setSelectedAssistantId(savedAssistant._id)
+    }
     showAlert({ message: t('assistant_create.success'), severity: 'success' })
   }
 


### PR DESCRIPTION
- providers.json: the custom provider referenced the icon key "PlusSmallIcon", but the ICONS map was renamed to "PlusSmall" during the twake-icons migration (8cd4f7186), so the lookup returned undefined and the "+" icon disappeared. Align the JSON to the map key.
- CreateAssistantDialog: select the newly created assistant via setSelectedAssistantId so the chat chip switches to it on create.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Creating a new assistant now automatically selects it after a successful save, making it immediately ready to use.

* **Bug Fixes**
  * Updated the provider icon used in the assistant creation flow so it displays correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->