### PR TITLE
Cozy-sharing: rework usage of avatar for hamonization

### DIFF
--- a/packages/cozy-sharing/src/DoctypeContact.js
+++ b/packages/cozy-sharing/src/DoctypeContact.js
@@ -1,29 +1,46 @@
-import { models } from 'cozy-client'
+import {
+  getInitials as clientGetInitials,
+  getDisplayName as clientGetDisplayName
+} from 'cozy-client/dist/models/contact'
 import { Contact as DoctypeContact } from 'cozy-doctypes'
-const ContactModel = models.contact
 
 const isContact = candidate => {
   return candidate._type === 'io.cozy.contacts'
 }
 export const getInitials = (contactOrRecipient, defaultValue = '') => {
   if (isContact(contactOrRecipient)) {
-    return ContactModel.getInitials(contactOrRecipient)
+    return clientGetInitials(contactOrRecipient)
   } else {
     // @todo Extract to RecipientModel ?
     const s =
       contactOrRecipient.public_name ||
+      contactOrRecipient.displayName ||
       contactOrRecipient.name ||
       contactOrRecipient.email
-    return (s && s[0].toUpperCase()) || defaultValue
+
+    if (!s) return defaultValue
+
+    const parts = s.split(' ').filter(Boolean)
+    if (parts.length === 0) return defaultValue
+    const firstLetter = parts[0][0]
+    const lastLetter = parts.length > 1 ? parts.at(-1)[0] : ''
+
+    return (firstLetter + lastLetter).toUpperCase()
   }
 }
 
 export const getDisplayName = (contact, defaultValue = '') => {
   if (isContact(contact)) {
-    return ContactModel.getDisplayName(contact)
+    return clientGetDisplayName(contact)
   } else {
     // @todo Extract to RecipientModel ?
-    return contact.public_name || contact.name || contact.email || defaultValue
+    return (
+      contact.public_name ||
+      contact.displayName ||
+      contact.name ||
+      contact.email ||
+      defaultValue
+    )
   }
 }
 

--- a/packages/cozy-sharing/src/components/Avatar/MemberAvatar.jsx
+++ b/packages/cozy-sharing/src/components/Avatar/MemberAvatar.jsx
@@ -1,10 +1,36 @@
 import React, { useState } from 'react'
 
 import { useClient } from 'cozy-client'
+import { getPrimaryCozy } from 'cozy-client/dist/models/contact'
 import Avatar from 'cozy-ui/transpiled/react/Avatar'
 
 import logger from '../../logger'
 import { getInitials } from '../../models'
+
+/**
+ * makeAvatarUrl derives the avatar image URL for the recipient.
+ * - If the recipient has an avatarPath (sharing context), it is
+ *   used directly with a base URI prefix (unless it is already
+ *   a full URL for a remote Cozy).
+ * - If the recipient has no avatarPath but has a cozy URL
+ *   (contact context), it points to that Cozy's public avatar.
+ * - The status is used as a cache-buster in the URL so the
+ *   browser refreshes the image when the sharing status changes.
+ *   For non-sharing recipients, 'contact' is the stable default.
+ */
+const makeAvatarUrl = (recipient, instanceUri) => {
+  const avatarPath = recipient.avatarPath
+  const cozyUrl = !avatarPath ? getPrimaryCozy(recipient) : null
+  if (!avatarPath && !cozyUrl) return null
+
+  const finalPath =
+    avatarPath ||
+    `${cozyUrl.replace(/\/$/, '')}/public/avatar?fallback=initials`
+  const status = recipient.status || 'contact'
+  const isFullPath = finalPath.startsWith('http')
+  const base = isFullPath ? '' : instanceUri
+  return `${base}${finalPath}${finalPath.includes('?') ? '&' : '?'}v=${status}`
+}
 
 const MemberAvatar = ({ recipient, ...rest }) => {
   const client = useClient()
@@ -23,22 +49,7 @@ const MemberAvatar = ({ recipient, ...rest }) => {
     return null
   }
 
-  /**
-   * avatarPath is always the same for a recipient, but image
-   * can be different since the stack generate it on the fly
-   * because they can be customized by the user.
-   * It can be "gray" during the first load depending of the
-   * status' sharing, but can become active (from the realtime)
-   * so we need a way to "refresh" the image. Passing the
-   * status in the url force the refresh of the image when the
-   * status changes
-   */
-  const image =
-    recipient.avatarPath && recipient.status
-      ? `${client.options.uri}${recipient.avatarPath}${
-          recipient.avatarPath.includes('?') ? '&' : '?'
-        }v=${recipient.status}`
-      : null
+  const image = makeAvatarUrl(recipient, client.options.uri)
 
   // The avatar can become unreachable (eg. the related sharing is revoked
   // while its members are still rendered), in which case the image request

--- a/packages/cozy-sharing/src/components/Avatar/MemberAvatar.spec.jsx
+++ b/packages/cozy-sharing/src/components/Avatar/MemberAvatar.spec.jsx
@@ -52,6 +52,42 @@ describe('MemberAvatar', () => {
     )
   })
 
+  it('renders a full URL avatarPath without prefixing the local instance URI', () => {
+    const { container } = setup({
+      public_name: 'Jon Snow',
+      status: 'contact',
+      avatarPath: 'https://jonsnow.mycozy.cloud/public/avatar?fallback=initials'
+    })
+
+    expect(container.querySelector('img').getAttribute('src')).toBe(
+      'https://jonsnow.mycozy.cloud/public/avatar?fallback=initials&v=contact'
+    )
+  })
+
+  it('derives avatarPath from cozy URL when avatarPath is not set', () => {
+    const { container } = setup({
+      _type: 'io.cozy.contacts',
+      name: { givenName: 'Jon', familyName: 'Snow' },
+      cozy: [{ url: 'https://jonsnow.mycozy.cloud' }]
+    })
+
+    const img = container.querySelector('img')
+    expect(img).toBeTruthy()
+    expect(img.getAttribute('src')).toBe(
+      'https://jonsnow.mycozy.cloud/public/avatar?fallback=initials&v=contact'
+    )
+  })
+
+  it('renders initials when there is no avatarPath and no cozy URL', () => {
+    const { container, getByText } = setup({
+      _type: 'io.cozy.contacts',
+      name: { givenName: 'Jon', familyName: 'Snow' }
+    })
+
+    expect(container.querySelector('img')).toBeNull()
+    expect(getByText('JS')).toBeTruthy()
+  })
+
   it('renders the initials when there is no avatarPath', () => {
     const { container, getByText } = setup({
       public_name: 'Bob',

--- a/packages/cozy-sharing/src/components/ContactSuggestion.jsx
+++ b/packages/cozy-sharing/src/components/ContactSuggestion.jsx
@@ -1,47 +1,44 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import { models } from 'cozy-client'
-import Avatar from 'cozy-ui/transpiled/react/Avatar'
+import { getPrimaryCozy } from 'cozy-client/dist/models/contact'
 import ListItem from 'cozy-ui/transpiled/react/ListItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import { useI18n } from 'twake-i18n'
 
-import { Contact, Group, getDisplayName, getInitials } from '../models'
+import { Contact, Group, getDisplayName } from '../models'
 import { GroupAvatar } from './Avatar/GroupAvatar'
-
-const ContactModel = models.contact
+import { MemberAvatar } from './Avatar/MemberAvatar'
 
 export const ContactSuggestion = ({ contactOrGroup }) => {
   const { t } = useI18n()
-  let avatarText, name, details
-  const isContactGroup = contactOrGroup._type === Group.doctype
-  if (isContactGroup) {
-    name = contactOrGroup.name
-    avatarText = 'G'
-    details = t('Share.members.count', {
-      smart_count: contactOrGroup.members.length.toString()
-    })
-  } else {
-    name = getDisplayName(contactOrGroup)
-    avatarText = getInitials(contactOrGroup)
-    details = ContactModel.getPrimaryCozy(contactOrGroup)
+
+  if (contactOrGroup._type === Group.doctype) {
+    return (
+      <ListItem button>
+        <ListItemIcon>
+          <GroupAvatar size="m" />
+        </ListItemIcon>
+        <ListItemText
+          primary={contactOrGroup.name}
+          secondary={t('Share.members.count', {
+            smart_count: contactOrGroup.members.length.toString()
+          })}
+        />
+      </ListItem>
+    )
   }
+
+  const name = getDisplayName(contactOrGroup)
+  const cozyUrl = getPrimaryCozy(contactOrGroup)
 
   return (
     <ListItem button>
       <ListItemIcon>
-        {isContactGroup ? (
-          <GroupAvatar size="m" />
-        ) : (
-          <Avatar size="m">{avatarText}</Avatar>
-        )}
+        <MemberAvatar recipient={contactOrGroup} size="m" />
       </ListItemIcon>
-      <ListItemText
-        primary={name}
-        secondary={details && details !== '' ? details : '-'}
-      />
+      <ListItemText primary={name} secondary={cozyUrl || '-'} />
     </ListItem>
   )
 }

--- a/packages/cozy-sharing/src/index.jsx
+++ b/packages/cozy-sharing/src/index.jsx
@@ -9,6 +9,7 @@ export { SharingContext, withLocales }
 export { useSharingContext } from './hooks/useSharingContext'
 export { useFetchDocumentPath } from './hooks/useFetchDocumentPath'
 
+export { MemberAvatar } from './components/Avatar/MemberAvatar'
 export { SharedDocument } from './SharedDocument'
 export { SharedStatus } from './SharedStatus'
 export { SharedBadge } from './SharedBadge'


### PR DESCRIPTION
MemberAvatar is now responsible of getting avatar with initials (or custom avatar) from stack if possible, and return frontend built avatar with initials if not. We use it instead of Avatar directly in ContactSuggestion for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved contact and member avatars with smarter fallback initials and name display.
  * Added support for showing avatars from full image URLs or from a recipient’s Cozy URL when available.

* **Bug Fixes**
  * Avatar images now render more reliably, including cases where no explicit avatar path is set.
  * Search results and contact suggestions now show cleaner, more consistent member and group information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->