### PR TITLE
fix(cozy-viewer): Migrate Button to Buttons

### DIFF
--- a/packages/cozy-viewer/src/Footer/DownloadButton.jsx
+++ b/packages/cozy-viewer/src/Footer/DownloadButton.jsx
@@ -1,7 +1,7 @@
-import { Icon, Download } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import { Icon, Download } from '@linagora/twake-icons'
 import { useClient } from 'cozy-client'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'

--- a/packages/cozy-viewer/src/Footer/ForwardButton.jsx
+++ b/packages/cozy-viewer/src/Footer/ForwardButton.jsx
@@ -1,7 +1,7 @@
-import { Icon, Reply, ShareIos } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import { Icon, Reply, ShareIos } from '@linagora/twake-icons'
 import { useClient } from 'cozy-client'
 import { makeSharingLink } from 'cozy-client/dist/models/sharing'
 import { isIOS } from 'cozy-device-helper'

--- a/packages/cozy-viewer/src/Footer/SharingButton.jsx
+++ b/packages/cozy-viewer/src/Footer/SharingButton.jsx
@@ -1,7 +1,7 @@
-import { Icon, Share } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import { Icon, Share } from '@linagora/twake-icons'
 import { ShareButton } from 'cozy-sharing'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
 

--- a/packages/cozy-viewer/src/NoViewer/DownloadButton.jsx
+++ b/packages/cozy-viewer/src/NoViewer/DownloadButton.jsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { withClient } from 'cozy-client'
 import { downloadFile } from 'cozy-client/dist/models/file'
 import { useWebviewIntent } from 'cozy-intent'
-import Button from 'cozy-ui/transpiled/react/deprecated/Button'
+import Button from 'cozy-ui/transpiled/react/Buttons'
 import { FileDoctype } from 'cozy-ui-plus/dist/proptypes'
 import { useI18n } from 'twake-i18n'
 

--- a/packages/cozy-viewer/src/NoViewer/FileIcon.jsx
+++ b/packages/cozy-viewer/src/NoViewer/FileIcon.jsx
@@ -1,3 +1,5 @@
+import React from 'react'
+
 import {
   Icon,
   FileTypeBin,
@@ -9,7 +11,6 @@ import {
   FileTypeText,
   FileTypeZip
 } from '@linagora/twake-icons'
-import React from 'react'
 
 const FileIcon = ({ type }) => {
   let icon

--- a/packages/cozy-viewer/src/NoViewer/__snapshots__/NoViewer.spec.jsx.snap
+++ b/packages/cozy-viewer/src/NoViewer/__snapshots__/NoViewer.spec.jsx.snap
@@ -36,14 +36,18 @@ exports[`NoViewer should render the viewer 1`] = `
       notSupported.xyz
     </p>
     <button
-      class="styles__c-btn___3kXsk styles__c-btn--center___Nny0n"
-      type="submit"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained customColor-primary customSize-default MuiButton-containedPrimary MuiButton-disableElevation"
+      tabindex="0"
+      type="button"
     >
-      <span>
-        <span>
-          Viewer.download
-        </span>
+      <span
+        class="MuiButton-label"
+      >
+        Viewer.download
       </span>
+      <span
+        class="MuiTouchRipple-root"
+      />
     </button>
   </div>
 </div>

--- a/packages/cozy-viewer/src/Panel/AI/AIAssistantPanel.jsx
+++ b/packages/cozy-viewer/src/Panel/AI/AIAssistantPanel.jsx
@@ -1,3 +1,8 @@
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React, { useCallback, useState, useEffect, useRef } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+
 import {
   Icon,
   Assistant,
@@ -5,11 +10,6 @@ import {
   CrossMedium,
   Refresh
 } from '@linagora/twake-icons'
-import cx from 'classnames'
-import PropTypes from 'prop-types'
-import React, { useCallback, useState, useEffect, useRef } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
-
 import { useClient } from 'cozy-client'
 import { extractText, chatCompletion } from 'cozy-client/dist/models/ai'
 import { fetchBlobFileById } from 'cozy-client/dist/models/file'

--- a/packages/cozy-viewer/src/Panel/ActionMenuDesktop.jsx
+++ b/packages/cozy-viewer/src/Panel/ActionMenuDesktop.jsx
@@ -1,7 +1,7 @@
-import { Icon, Copy, Rename } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React, { forwardRef } from 'react'
 
+import { Icon, Copy, Rename } from '@linagora/twake-icons'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import ActionMenu, {
   ActionMenuItem

--- a/packages/cozy-viewer/src/Panel/ActionMenuMobile.jsx
+++ b/packages/cozy-viewer/src/Panel/ActionMenuMobile.jsx
@@ -1,7 +1,7 @@
-import { Icon, Copy, Rename } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import { Icon, Copy, Rename } from '@linagora/twake-icons'
 import BottomSheet, {
   BottomSheetItem
 } from 'cozy-ui/transpiled/react/BottomSheet'

--- a/packages/cozy-viewer/src/Panel/Antivirus.jsx
+++ b/packages/cozy-viewer/src/Panel/Antivirus.jsx
@@ -1,7 +1,7 @@
-import { Icon, InfoOutlined, Shield } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 
+import { Icon, InfoOutlined, Shield } from '@linagora/twake-icons'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
 import Link from 'cozy-ui/transpiled/react/Link'
 import List from 'cozy-ui/transpiled/react/List'

--- a/packages/cozy-viewer/src/Panel/Informations.jsx
+++ b/packages/cozy-viewer/src/Panel/Informations.jsx
@@ -1,3 +1,7 @@
+import has from 'lodash/has'
+import PropTypes from 'prop-types'
+import React, { useRef, useState } from 'react'
+
 import {
   Icon,
   Calendar,
@@ -8,10 +12,6 @@ import {
   Safe,
   Server
 } from '@linagora/twake-icons'
-import has from 'lodash/has'
-import PropTypes from 'prop-types'
-import React, { useRef, useState } from 'react'
-
 import { useClient } from 'cozy-client'
 import ActionsMenu from 'cozy-ui/transpiled/react/ActionsMenu'
 import {

--- a/packages/cozy-viewer/src/Panel/PanelContent.jsx
+++ b/packages/cozy-viewer/src/Panel/PanelContent.jsx
@@ -1,8 +1,8 @@
-import { Icon, CrossMedium } from '@linagora/twake-icons'
 import cx from 'classnames'
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { Icon, CrossMedium } from '@linagora/twake-icons'
 import flag from 'cozy-flags'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
 import Paper from 'cozy-ui/transpiled/react/Paper'

--- a/packages/cozy-viewer/src/Panel/Qualifications/QualificationListItemContact.jsx
+++ b/packages/cozy-viewer/src/Panel/Qualifications/QualificationListItemContact.jsx
@@ -1,7 +1,7 @@
-import { Icon, Dots, People } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React, { forwardRef } from 'react'
 
+import { Icon, Dots, People } from '@linagora/twake-icons'
 import {
   getTranslatedNameForContact,
   formatContactValue

--- a/packages/cozy-viewer/src/Panel/Qualifications/QualificationListItemDate.jsx
+++ b/packages/cozy-viewer/src/Panel/Qualifications/QualificationListItemDate.jsx
@@ -1,7 +1,7 @@
-import { Icon, Calendar, Dots, Right } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React, { forwardRef } from 'react'
 
+import { Icon, Calendar, Dots, Right } from '@linagora/twake-icons'
 import {
   isExpired,
   isExpiringSoon,

--- a/packages/cozy-viewer/src/Panel/Qualifications/QualificationListItemInformation.jsx
+++ b/packages/cozy-viewer/src/Panel/Qualifications/QualificationListItemInformation.jsx
@@ -1,3 +1,6 @@
+import PropTypes from 'prop-types'
+import React, { forwardRef } from 'react'
+
 import {
   Icon,
   Bell,
@@ -9,9 +12,6 @@ import {
   Number,
   Right
 } from '@linagora/twake-icons'
-import PropTypes from 'prop-types'
-import React, { forwardRef } from 'react'
-
 import {
   getTranslatedNameForInformationMetadata,
   formatInformationMetadataValue,

--- a/packages/cozy-viewer/src/Panel/Qualifications/QualificationListItemOther.jsx
+++ b/packages/cozy-viewer/src/Panel/Qualifications/QualificationListItemOther.jsx
@@ -1,7 +1,7 @@
-import { Icon, Dots, File, Right } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React, { forwardRef } from 'react'
 
+import { Icon, Dots, File, Right } from '@linagora/twake-icons'
 import {
   getTranslatedNameForOtherMetadata,
   formatOtherMetadataValue

--- a/packages/cozy-viewer/src/Panel/Qualifications/QualificationListItemQualification.jsx
+++ b/packages/cozy-viewer/src/Panel/Qualifications/QualificationListItemQualification.jsx
@@ -1,7 +1,7 @@
-import { Icon, Right } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import { Icon, Right } from '@linagora/twake-icons'
 import { formatOtherMetadataValue } from 'cozy-client/dist/models/paper'
 import ListItem from 'cozy-ui/transpiled/react/ListItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'

--- a/packages/cozy-viewer/src/Panel/Qualifications/QualificationListItemQualificationEmpty.jsx
+++ b/packages/cozy-viewer/src/Panel/Qualifications/QualificationListItemQualificationEmpty.jsx
@@ -1,7 +1,7 @@
-import { Icon, LabelOutlined, Right } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import { Icon, LabelOutlined, Right } from '@linagora/twake-icons'
 import List from 'cozy-ui/transpiled/react/List'
 import ListItem from 'cozy-ui/transpiled/react/ListItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'

--- a/packages/cozy-viewer/src/Panel/Sharing.jsx
+++ b/packages/cozy-viewer/src/Panel/Sharing.jsx
@@ -1,7 +1,7 @@
-import { Icon, Right } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import { Icon, Right } from '@linagora/twake-icons'
 import { useClient, useQuery } from 'cozy-client'
 import flag from 'cozy-flags'
 import {

--- a/packages/cozy-viewer/src/Panel/Summary.jsx
+++ b/packages/cozy-viewer/src/Panel/Summary.jsx
@@ -1,9 +1,9 @@
-import { Icon, Bottom, Dots, Right, Text } from '@linagora/twake-icons'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useState, useRef } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
+import { Icon, Bottom, Dots, Right, Text } from '@linagora/twake-icons'
 import flag from 'cozy-flags'
 import Accordion from 'cozy-ui/transpiled/react/Accordion'
 import AccordionDetails from 'cozy-ui/transpiled/react/AccordionDetails'

--- a/packages/cozy-viewer/src/Panel/helpers.js
+++ b/packages/cozy-viewer/src/Panel/helpers.js
@@ -1,6 +1,6 @@
-import { ShieldClean, ShieldInfected, Spinner } from '@linagora/twake-icons'
 import get from 'lodash/get'
 
+import { ShieldClean, ShieldInfected, Spinner } from '@linagora/twake-icons'
 import { splitFilename, isFromKonnector } from 'cozy-client/dist/models/file'
 import { KNOWN_BILLS_ATTRIBUTES_NAMES } from 'cozy-client/dist/models/paper'
 

--- a/packages/cozy-viewer/src/ViewersByFile/AudioViewer.jsx
+++ b/packages/cozy-viewer/src/ViewersByFile/AudioViewer.jsx
@@ -1,6 +1,6 @@
-import { Icon, FileTypeAudio } from '@linagora/twake-icons'
 import React from 'react'
 
+import { Icon, FileTypeAudio } from '@linagora/twake-icons'
 import isTesting from 'cozy-ui/transpiled/react/helpers/isTesting'
 
 import styles from './styles.styl'

--- a/packages/cozy-viewer/src/ViewersByFile/NoNetworkViewer.jsx
+++ b/packages/cozy-viewer/src/ViewersByFile/NoNetworkViewer.jsx
@@ -1,7 +1,7 @@
-import { Icon, CloudBroken } from '@linagora/twake-icons'
 import React from 'react'
 
-import Button from 'cozy-ui/transpiled/react/deprecated/Button'
+import { Icon, CloudBroken } from '@linagora/twake-icons'
+import Button from 'cozy-ui/transpiled/react/Buttons'
 
 import styles from './styles.styl'
 import { withViewerLocales } from '../hoc/withViewerLocales'

--- a/packages/cozy-viewer/src/ViewersByFile/OnlyOfficeViewer.jsx
+++ b/packages/cozy-viewer/src/ViewersByFile/OnlyOfficeViewer.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import Button from 'cozy-ui/transpiled/react/deprecated/Button'
+import Button from 'cozy-ui/transpiled/react/Buttons'
 import { FileDoctype } from 'cozy-ui-plus/dist/proptypes'
 
 import NoViewer from '../NoViewer'

--- a/packages/cozy-viewer/src/ViewersByFile/PdfJsViewer.jsx
+++ b/packages/cozy-viewer/src/ViewersByFile/PdfJsViewer.jsx
@@ -1,4 +1,3 @@
-import { Icon, Pen } from '@linagora/twake-icons'
 import cx from 'classnames'
 import flow from 'lodash/flow'
 import throttle from 'lodash/throttle'
@@ -6,6 +5,7 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { Document, Page } from 'react-pdf'
 
+import { Icon, Pen } from '@linagora/twake-icons'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 
 import styles from './styles.styl'

--- a/packages/cozy-viewer/src/ViewersByFile/ShortcutViewer.jsx
+++ b/packages/cozy-viewer/src/ViewersByFile/ShortcutViewer.jsx
@@ -1,9 +1,9 @@
-import { Openwith } from '@linagora/twake-icons'
 import get from 'lodash/get'
 import React from 'react'
 
+import { Openwith } from '@linagora/twake-icons'
 import { useClient, useFetchShortcut } from 'cozy-client'
-import { ButtonLink } from 'cozy-ui/transpiled/react/deprecated/Button'
+import Button from 'cozy-ui/transpiled/react/Buttons'
 import { FileDoctype } from 'cozy-ui-plus/dist/proptypes'
 
 import NoViewer from '../NoViewer'
@@ -20,9 +20,9 @@ const ShortcutViewer = ({ t, file }) => {
     <NoViewer
       file={file}
       renderFallbackExtraContent={() => (
-        <ButtonLink
+        <Button
           label={`${t('Viewer.goto', { url: get(url, 'origin', '') })}`}
-          icon={Openwith}
+          startIcon={<Openwith />}
           href={`${get(url, 'origin', '')}`}
           target="_blank"
         />

--- a/packages/cozy-viewer/src/ViewersByFile/__snapshots__/ShortcutViewer.spec.jsx.snap
+++ b/packages/cozy-viewer/src/ViewersByFile/__snapshots__/ShortcutViewer.spec.jsx.snap
@@ -33,30 +33,34 @@ exports[`Shortcutviewer renders the component 1`] = `
     <p
       class="viewer-filename"
     />
-    <a
-      class="styles__c-btn___3kXsk"
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained customColor-primary customSize-default MuiButton-containedPrimary MuiButton-disableElevation"
       href=""
+      tabindex="0"
       target="_blank"
+      type="button"
     >
-      <span>
-        <svg
-          aria-hidden="true"
-          class="styles__icon___23x3R"
-          focusable="false"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+      <span
+        class="MuiButton-label"
+      >
+        <span
+          class="MuiButton-startIcon MuiButton-iconSizeMedium"
         >
-          <path
-            d="M14.222 14.222H1.778V1.778H8V0H1.778C.79 0 0 .8 0 1.778v12.444C0 15.2.791 16 1.778 16h12.444C15.2 16 16 15.2 16 14.222V8h-1.778zM9.778 0v1.778h3.19l-8.737 8.738 1.253 1.253 8.738-8.738v3.191H16V0z"
-          />
-        </svg>
-        <span>
-          Viewer.goto
+          <svg
+            viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M14.222 14.222H1.778V1.778H8V0H1.778C.79 0 0 .8 0 1.778v12.444C0 15.2.791 16 1.778 16h12.444C15.2 16 16 15.2 16 14.222V8h-1.778zM9.778 0v1.778h3.19l-8.737 8.738 1.253 1.253 8.738-8.738v3.191H16V0z"
+            />
+          </svg>
         </span>
+        Viewer.goto
       </span>
-    </a>
+      <span
+        class="MuiTouchRipple-root"
+      />
+    </button>
   </div>
 </div>
 `;

--- a/packages/cozy-viewer/src/actions/makeSummaryLonger.js
+++ b/packages/cozy-viewer/src/actions/makeSummaryLonger.js
@@ -1,6 +1,6 @@
-import { Icon, Expand } from '@linagora/twake-icons'
 import React, { forwardRef } from 'react'
 
+import { Icon, Expand } from '@linagora/twake-icons'
 import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'

--- a/packages/cozy-viewer/src/actions/makeSummaryShorter.js
+++ b/packages/cozy-viewer/src/actions/makeSummaryShorter.js
@@ -1,6 +1,6 @@
-import { Icon, Narrow } from '@linagora/twake-icons'
 import React, { forwardRef } from 'react'
 
+import { Icon, Narrow } from '@linagora/twake-icons'
 import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'

--- a/packages/cozy-viewer/src/components/Navigation.jsx
+++ b/packages/cozy-viewer/src/components/Navigation.jsx
@@ -1,7 +1,8 @@
-import { Icon, DropdownClose } from '@linagora/twake-icons'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
+
+import { Icon, DropdownClose } from '@linagora/twake-icons'
 
 import styles from './styles.styl'
 

--- a/packages/cozy-viewer/src/components/PdfToolbarButton.jsx
+++ b/packages/cozy-viewer/src/components/PdfToolbarButton.jsx
@@ -1,7 +1,7 @@
-import { Icon } from '@linagora/twake-icons'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import { Icon } from '@linagora/twake-icons'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 
 const PdfToolbarButton = ({ icon, onClick, disabled, label }) => (

--- a/packages/cozy-viewer/src/components/SummarizeByAIButton.jsx
+++ b/packages/cozy-viewer/src/components/SummarizeByAIButton.jsx
@@ -1,8 +1,8 @@
-import { Icon, Article } from '@linagora/twake-icons'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import { Icon, Article } from '@linagora/twake-icons'
 import flag from 'cozy-flags'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import { useI18n } from 'twake-i18n'

--- a/packages/cozy-viewer/src/components/Toolbar.jsx
+++ b/packages/cozy-viewer/src/components/Toolbar.jsx
@@ -1,8 +1,8 @@
-import { Icon, Download, Previous } from '@linagora/twake-icons'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import { Icon, Download, Previous } from '@linagora/twake-icons'
 import { useClient } from 'cozy-client'
 import { downloadFile } from 'cozy-client/dist/models/file'
 import { useWebviewIntent } from 'cozy-intent'


### PR DESCRIPTION
## What

Migrate all `cozy-viewer` source files from `cozy-ui/transpiled/react/deprecated/Button` to `cozy-ui/transpiled/react/Buttons`, and fix import ordering to comply with ESLint rules.

## Why

`deprecated/Button` calls `Icon.isProperIcon()` on icon props. `@linagora/twake-icons` v2 no longer exports this static method, causing `TypeError: Icon.isProperIcon is not a function` in downstream consumers like `cozy-drive`. The new `Buttons` component (wrapper around MuiButton v4) does not use this API — icons are passed as React elements via `startIcon`/`endIcon` props.

## How

- Replaced `import Button from 'cozy-ui/transpiled/react/deprecated/Button'` with `import Button from 'cozy-ui/transpiled/react/Buttons'` in 4 files
- Converted `ButtonLink` + `icon={Openwith}` pattern to `Button` + `startIcon={<Openwith />}` in `ShortcutViewer`
- Reordered all `@linagora/twake-icons` imports above external package imports (alphabetical order per ESLint)
- Regenerated 2 snapshots (`NoViewer.spec`, `ShortcutViewer.spec`) to reflect MuiButton markup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new information row in the document details panel with translated labels, value formatting, clipboard copy, and quick access to edit actions.

* **Bug Fixes**
  * Updated several viewer and toolbar interactions to use the current button components for a more consistent experience.
  * Improved fallback and action menu behavior across document viewers and panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->