### PR TITLE
fix(cozy-viewer): Ensure ShortcutViewer button renders as anchor

### DIFF
--- a/packages/cozy-viewer/src/ViewersByFile/ShortcutViewer.jsx
+++ b/packages/cozy-viewer/src/ViewersByFile/ShortcutViewer.jsx
@@ -21,6 +21,7 @@ const ShortcutViewer = ({ t, file }) => {
       file={file}
       renderFallbackExtraContent={() => (
         <Button
+          component="a"
           label={`${t('Viewer.goto', { url: get(url, 'origin', '') })}`}
           startIcon={<Openwith />}
           href={`${get(url, 'origin', '')}`}

--- a/packages/cozy-viewer/src/ViewersByFile/__snapshots__/ShortcutViewer.spec.jsx.snap
+++ b/packages/cozy-viewer/src/ViewersByFile/__snapshots__/ShortcutViewer.spec.jsx.snap
@@ -33,12 +33,13 @@ exports[`Shortcutviewer renders the component 1`] = `
     <p
       class="viewer-filename"
     />
-    <button
+    <a
+      aria-disabled="false"
       class="MuiButtonBase-root MuiButton-root MuiButton-contained customColor-primary customSize-default MuiButton-containedPrimary MuiButton-disableElevation"
       href=""
+      role="button"
       tabindex="0"
       target="_blank"
-      type="button"
     >
       <span
         class="MuiButton-label"
@@ -60,7 +61,7 @@ exports[`Shortcutviewer renders the component 1`] = `
       <span
         class="MuiTouchRipple-root"
       />
-    </button>
+    </a>
   </div>
 </div>
 `;


### PR DESCRIPTION
Without component="a", MuiButton renders <button> when href is empty, unlike the deprecated ButtonLink which always rendered <a>. Add component="a" to keep the link semantics.