### PR TITLE
fix(rsbuild-config-cozy-app): use a 16-char hash for immutable assets

### DIFF
--- a/config/rsbuild-config-cozy-app/getRsbuildConfig.js
+++ b/config/rsbuild-config-cozy-app/getRsbuildConfig.js
@@ -67,6 +67,13 @@ function getRsbuildConfig({
     },
     output: {
       cleanDistPath: true,
+      // cozy-stack serves an asset as immutable (max-age=1y) only when its
+      // filename fingerprint is at least 10 hex chars (statik's ExtractAssetID /
+      // isLongHexString). Rsbuild's default [contenthash:8] is 8 chars, so the
+      // stack does not recognize it and falls back to ETag revalidation, making
+      // every asset pay a 304 round-trip on each load. 16 chars crosses the
+      // threshold and lets the browser serve JS/CSS straight from disk cache.
+      filenameHash: 'contenthash:16',
       filename: {
         html: 'index.html'
       },


### PR DESCRIPTION
## Summary

- Set `output.filenameHash` to `contenthash:16` in the shared Rsbuild preset.
- cozy-stack only serves an asset with `Cache-Control: max-age=31536000, immutable` when its filename fingerprint is at least 10 hex chars (statik `ExtractAssetID` / `isLongHexString`).
- Rsbuild's default `[contenthash:8]` is 8 chars, below that threshold, so the stack falls back to `no-cache` + ETag and every JS/CSS asset takes a 304 revalidation round-trip on each load.
- Bumping the hash to 16 chars makes the stack recognize the fingerprint, so the browser serves assets from disk cache with no network request. The build-id query already busts caches across deploys, so immutable is safe.
- index.html is unaffected: `filenameHash` applies to js/css/wasm only, not HTML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved asset fingerprinting to support more reliable browser caching.
  * Reduced unnecessary cache revalidation when static assets remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->