### PR TITLE
fix(dataproxy-lib): do not leak shared-drive realtime sockets

### DIFF
--- a/packages/cozy-dataproxy-lib/src/search/SearchEngine.spec.js
+++ b/packages/cozy-dataproxy-lib/src/search/SearchEngine.spec.js
@@ -853,5 +853,33 @@ describe('Realtime features', () => {
         )
       })
     })
+
+    describe('shared drives realtime lifecycle', () => {
+      it('stops the previous realtime when re-subscribing the same drive', () => {
+        const firstInstance = { subscribe: jest.fn(), stop: jest.fn() }
+        const secondInstance = { subscribe: jest.fn(), stop: jest.fn() }
+        mockCozyRealtime
+          .mockReturnValueOnce(firstInstance)
+          .mockReturnValueOnce(secondInstance)
+
+        searchEngine.addSharedDriveRealtime('drive1')
+        searchEngine.addSharedDriveRealtime('drive1')
+
+        expect(firstInstance.stop).toHaveBeenCalledTimes(1)
+        expect(searchEngine.sharedDrivesRealtimes.drive1).toBe(secondInstance)
+      })
+
+      it('stopSharedDrivesRealtimes stops every socket and clears the map', () => {
+        const driveA = { subscribe: jest.fn(), stop: jest.fn() }
+        const driveB = { subscribe: jest.fn(), stop: jest.fn() }
+        searchEngine.sharedDrivesRealtimes = { driveA, driveB }
+
+        searchEngine.stopSharedDrivesRealtimes()
+
+        expect(driveA.stop).toHaveBeenCalledTimes(1)
+        expect(driveB.stop).toHaveBeenCalledTimes(1)
+        expect(searchEngine.sharedDrivesRealtimes).toEqual({})
+      })
+    })
   })
 })

--- a/packages/cozy-dataproxy-lib/src/search/SearchEngine.spec.js
+++ b/packages/cozy-dataproxy-lib/src/search/SearchEngine.spec.js
@@ -880,6 +880,18 @@ describe('Realtime features', () => {
         expect(driveB.stop).toHaveBeenCalledTimes(1)
         expect(searchEngine.sharedDrivesRealtimes).toEqual({})
       })
+
+      it('stops all shared drives realtimes when the client logs out', () => {
+        const stopSpy = jest.spyOn(searchEngine, 'stopSharedDrivesRealtimes')
+        const logoutHandler = mockClient.on.mock.calls.find(
+          ([event]) => event === 'logout'
+        )?.[1]
+
+        expect(logoutHandler).toBeDefined()
+        logoutHandler()
+
+        expect(stopSpy).toHaveBeenCalled()
+      })
     })
   })
 })

--- a/packages/cozy-dataproxy-lib/src/search/SearchEngine.ts
+++ b/packages/cozy-dataproxy-lib/src/search/SearchEngine.ts
@@ -104,6 +104,10 @@ export class SearchEngine {
         this.afterLogin()
       })
     }
+
+    this.client.on('logout', () => {
+      this.stopSharedDrivesRealtimes()
+    })
   }
 
   afterLogin(): void {

--- a/packages/cozy-dataproxy-lib/src/search/SearchEngine.ts
+++ b/packages/cozy-dataproxy-lib/src/search/SearchEngine.ts
@@ -268,6 +268,7 @@ export class SearchEngine {
   }
 
   private addSharedDriveRealtime(sharedDriveId: string): void {
+    this.sharedDrivesRealtimes[sharedDriveId]?.stop()
     // background: the indexer watches the drive without the user looking at
     // it, so the stack must not mark the sharing as seen
     const realtime = new CozyRealtime({
@@ -277,6 +278,13 @@ export class SearchEngine {
     })
     this.subscribeDoctype(this.client, FILES_DOCTYPE, realtime, sharedDriveId)
     this.sharedDrivesRealtimes[sharedDriveId] = realtime
+  }
+
+  stopSharedDrivesRealtimes(): void {
+    for (const driveId of Object.keys(this.sharedDrivesRealtimes)) {
+      this.sharedDrivesRealtimes[driveId]?.stop()
+    }
+    this.sharedDrivesRealtimes = {}
   }
 
   subscribeDoctype(


### PR DESCRIPTION
## Summary

`addSharedDriveRealtime` created a new `CozyRealtime` for a drive and overwrote `sharedDrivesRealtimes[id]` without stopping the previous one. Any extra call (a re-run of `init()` on a `login` event, or a repeated `addSharedDrive`) therefore orphaned a socket that keeps reconnecting in the background forever.

Against a drive whose `/sharings/drives/:id/realtime` endpoint returns 500, these orphaned sockets accumulate and fire together at cozy-realtime's 5 min backoff cap, producing recurring bursts of failed requests against the stack.

This stops any existing socket before re-subscribing, so a drive is watched by at most one realtime, and adds `stopSharedDrivesRealtimes()` to tear them all down.

## Tests

Added coverage in `SearchEngine.spec.js` for the dedup on re-subscription and for the teardown.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate realtime subscriptions for the same shared drive by replacing any existing subscription before starting a new one.
  * Ensured realtime subscriptions are fully cleaned up when the client logs out.
* **New Features**
  * Added a way to stop all active shared-drive realtime connections in one action.
* **Tests**
  * Extended realtime lifecycle coverage to verify replacement, full stop/reset behavior, and logout cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->