### PR TITLE
fix(cozy-realtime): give up reconnecting background sockets after a cap

### DIFF
--- a/packages/cozy-realtime/src/CozyRealtime.js
+++ b/packages/cozy-realtime/src/CozyRealtime.js
@@ -6,7 +6,8 @@ import {
   raiseErrorAfterAttempts,
   timeBeforeSuccessful,
   baseWaitAfterFirstFailure,
-  maxWaitBetweenRetries
+  maxWaitBetweenRetries,
+  maxBackgroundConnectionAttempts
 } from './config'
 import defaultLogger from './logger'
 import {
@@ -36,10 +37,14 @@ class CozyRealtime {
    * @param {object} [options.logger] A custom logger
    * @param {string} [options.sharedDriveId] - The ID of the shared drive to connect to
    * @param {boolean} [options.background] - Whether the shared drive connection is made by a background service rather than the user viewing the drive, so the stack does not mark the sharing as seen
+   * @param {number} [options.maxReconnectionAttempts] - Give up reconnecting after this many failed attempts (defaults to unlimited, or a finite cap for background connections)
    */
   constructor(options) {
     this.sharedDriveId = options.sharedDriveId
     this.background = options.background
+    this.maxReconnectionAttempts =
+      options.maxReconnectionAttempts ??
+      (this.background ? maxBackgroundConnectionAttempts : null)
     this.client = getCozyClientFromOptions(options)
     this.createWebSocket = options.createWebSocket || createWebSocket
     this.logger = options.logger || defaultLogger
@@ -126,6 +131,16 @@ class CozyRealtime {
    * Throws the previous socket and connect a new one
    */
   async reconnect({ immediate = false } = {}) {
+    if (
+      this.maxReconnectionAttempts !== null &&
+      this.retryManager.retries > this.maxReconnectionAttempts
+    ) {
+      this.logger.warn(
+        `giving up reconnecting after ${this.retryManager.retries} failed attempts`
+      )
+      this.stop()
+      return
+    }
     if (this.hasWebSocket()) {
       this.revokeWebSocket()
     }

--- a/packages/cozy-realtime/src/CozyRealtime.spec.js
+++ b/packages/cozy-realtime/src/CozyRealtime.spec.js
@@ -776,4 +776,37 @@ describe('CozyRealtime', () => {
       })
     })
   })
+
+  describe('background reconnection give-up', () => {
+    it('stops a background realtime after too many failed attempts instead of reconnecting forever', () => {
+      const realtime = createRealtime({
+        background: true,
+        sharedDriveId: 'drive1'
+      })
+      const stopSpy = jest.spyOn(realtime, 'stop')
+      const connectSpy = jest
+        .spyOn(realtime, 'connect')
+        .mockImplementation(() => {})
+      realtime.retryManager.retries = 999
+
+      realtime.reconnect()
+
+      expect(stopSpy).toHaveBeenCalled()
+      expect(connectSpy).not.toHaveBeenCalled()
+    })
+
+    it('keeps reconnecting a foreground realtime regardless of the attempt count', () => {
+      const realtime = createRealtime()
+      const stopSpy = jest.spyOn(realtime, 'stop')
+      const connectSpy = jest
+        .spyOn(realtime, 'connect')
+        .mockImplementation(() => {})
+      realtime.retryManager.retries = 999
+
+      realtime.reconnect()
+
+      expect(stopSpy).not.toHaveBeenCalled()
+      expect(connectSpy).toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/cozy-realtime/src/config.js
+++ b/packages/cozy-realtime/src/config.js
@@ -43,6 +43,14 @@ export const timeBeforeSuccessful = 1.2 * sec
 export const raiseErrorAfterAttempts = 8
 
 /**
+ * Give up reconnecting a background connection after this many failed attempts
+ *
+ * @type {number}
+ * @private
+ */
+export const maxBackgroundConnectionAttempts = 10
+
+/**
  * If one subscribe multiple times to the exact same event with the exact
  * same handler, should we call the handler multiple times for each event?
  * eventWhat to do if someone ask multiple times for the same subscription?


### PR DESCRIPTION
## Summary

A failed WebSocket handshake surfaces as `onerror`/`onclose` without the HTTP status, so a background connection whose endpoint keeps returning 500 (for example a shared drive's `/sharings/drives/:id/realtime`) was reconnected forever, bounded only by the 5 min backoff cap.

This adds a `maxReconnectionAttempts` option, defaulting to unlimited for foreground connections and to `maxBackgroundConnectionAttempts` for background ones. Once the cap is exceeded, `reconnect()` stops the socket instead of scheduling another attempt, so the user-facing socket keeps its resilience while a doomed background indexer connection gives up.

## Tests

Added coverage in `CozyRealtime.spec.js` for the background give-up and for foreground connections still reconnecting past the cap.
