### PR TITLE
Read inline intent doc if it exists

### DIFF
--- a/packages/cozy-interapp/src/request.js
+++ b/packages/cozy-interapp/src/request.js
@@ -3,11 +3,17 @@ class Request {
     this.stackClient = cozyClient.stackClient
   }
 
-  get(id) {
+  get(id, { tryDOM = false } = {}) {
+    if (tryDOM) {
+      const intentFromDOM = this.fromDOM()
+      if (intentFromDOM && intentFromDOM.id === id) {
+        return Promise.resolve(intentFromDOM)
+      }
+    }
+
     return this.stackClient.fetchJSON('GET', `/intents/${id}`).then(resp => {
-      const data = resp.data
-      if (!data._id) data._id = data.id
-      return data
+      const intent = resp.data
+      return normalizeIntent(intent)
     })
   }
 
@@ -26,6 +32,21 @@ class Request {
       })
       .then(resp => resp.data)
   }
+
+  fromDOM() {
+    if (typeof document !== 'undefined') {
+      const node = document.getElementById('cozy-intent')
+      if (node) {
+        const intent = JSON.parse(node.textContent)
+        return normalizeIntent(intent)
+      }
+    }
+  }
+}
+
+const normalizeIntent = intent => {
+  if (!intent._id) intent._id = intent.id
+  return intent
 }
 
 export default Request

--- a/packages/cozy-interapp/src/request.spec.js
+++ b/packages/cozy-interapp/src/request.spec.js
@@ -12,17 +12,107 @@ describe('[Interapp] Request', () => {
     request = new Request(cozyClient)
   })
 
-  it('should initialise with cozyFetchJSON function', () => {
+  it('should initialise with stackClient', () => {
     expect(request.stackClient).toEqual(cozyClient.stackClient)
   })
 
-  it('should get an intent', () => {
-    request.get()
-    expect(cozyClient.stackClient.fetchJSON).toHaveBeenCalledTimes(1)
+  describe('get', () => {
+    it('should fetch intent by id', async () => {
+      cozyClient.stackClient.fetchJSON.mockReturnValue(
+        Promise.resolve({
+          data: { id: 'intent-1', attributes: { action: 'PICK' } }
+        })
+      )
+
+      const intent = await request.get('intent-1')
+      expect(cozyClient.stackClient.fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        '/intents/intent-1'
+      )
+      expect(intent._id).toBe('intent-1')
+      expect(intent.attributes.action).toBe('PICK')
+    })
+
+    it('should not override existing _id', async () => {
+      cozyClient.stackClient.fetchJSON.mockReturnValue(
+        Promise.resolve({
+          data: { _id: 'custom-id', id: 'intent-1' }
+        })
+      )
+
+      const intent = await request.get('intent-1')
+      expect(intent._id).toBe('custom-id')
+    })
+
+    it('should return intent from DOM when tryDOM is true and element exists', async () => {
+      const node = document.createElement('div')
+      node.id = 'cozy-intent'
+      node.textContent = JSON.stringify({
+        id: 'dom-intent',
+        attributes: { action: 'VIEW' }
+      })
+      document.body.appendChild(node)
+
+      const intent = await request.get('dom-intent', { tryDOM: true })
+      expect(intent._id).toBe('dom-intent')
+      expect(intent.attributes.action).toBe('VIEW')
+      expect(cozyClient.stackClient.fetchJSON).not.toHaveBeenCalled()
+      document.body.removeChild(node)
+    })
+
+    it('should fall back to API when tryDOM is true but DOM element is missing', async () => {
+      cozyClient.stackClient.fetchJSON.mockReturnValue(
+        Promise.resolve({
+          data: { id: 'api-intent', attributes: { action: 'PICK' } }
+        })
+      )
+
+      const intent = await request.get('api-intent', { tryDOM: true })
+      expect(intent.id).toBe('api-intent')
+      expect(cozyClient.stackClient.fetchJSON).toHaveBeenCalledWith(
+        'GET',
+        '/intents/api-intent'
+      )
+    })
+
+    it('should use default tryDOM=false when no options passed', async () => {
+      cozyClient.stackClient.fetchJSON.mockReturnValue(
+        Promise.resolve({ data: { id: 'default' } })
+      )
+
+      await request.get('default')
+      expect(cozyClient.stackClient.fetchJSON).toHaveBeenCalled()
+    })
   })
 
-  it('should post an intent', () => {
-    request.post()
-    expect(cozyClient.stackClient.fetchJSON).toHaveBeenCalledTimes(1)
+  describe('fromDOM', () => {
+    it('should return undefined when element does not exist', () => {
+      const result = request.fromDOM()
+      expect(result).toBeUndefined()
+    })
+
+    it('should parse and normalize intent from DOM element', () => {
+      const node = document.createElement('div')
+      node.id = 'cozy-intent'
+      node.textContent = JSON.stringify({
+        id: 'dom-intent',
+        attributes: { action: 'SHARE' }
+      })
+      document.body.appendChild(node)
+
+      const result = request.fromDOM()
+      expect(result._id).toBe('dom-intent')
+      expect(result.attributes.action).toBe('SHARE')
+      document.body.removeChild(node)
+    })
+  })
+
+  describe('error handling', () => {
+    it('should propagate fetchJSON rejection', async () => {
+      const error = new Error('Network error')
+      cozyClient.stackClient.fetchJSON.mockReturnValue(Promise.reject(error))
+
+      await expect(request.get('fail')).rejects.toThrow('Network error')
+    })
   })
 })

--- a/packages/cozy-interapp/src/service.js
+++ b/packages/cozy-interapp/src/service.js
@@ -44,7 +44,7 @@ export const start = request => (intentIdArg, serviceWindowArg) => {
   if (!intentId)
     return Promise.reject(new Error('Cannot retrieve intent from URL'))
 
-  return request.get(intentId).then(intent => {
+  return request.get(intentId, { tryDOM: true }).then(intent => {
     let terminated = false
     let notifiedReadyToUse = false
 


### PR DESCRIPTION
See https://github.com/linagora/cozy-stack/pull/4853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled loading intent data embedded in the page when available, with automatic fallback to fetching from the API when not.
  * Updated startup behavior to prefer embedded intent data.
* **Bug Fixes**
  * Improved compatibility when intents use either `id` or `_id`, ensuring the correct identifier is always available.
* **Tests**
  * Added Jest coverage for embedded intent loading behavior and API fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->