### PR TITLE
fix(cozy-sharing): Restore federated recipient management

### DIFF
--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
@@ -35,6 +35,7 @@ const FederatedFolderModalContent = ({
   const client = useClient()
   const { t } = useI18n()
   const {
+    canReshare,
     share,
     getSharingById,
     getSharingLink,
@@ -224,6 +225,8 @@ const FederatedFolderModalContent = ({
     ? getFederatedShareLink(existingDocument)
     : getSharingLink(existingDocument?._id)
   const isCurrentUserOwner = documentId ? isOwner(documentId) : false
+  const canManageSharing =
+    isCurrentUserOwner || (documentId ? canReshare(documentId) : false)
 
   const handleRevokeSelf = async document => {
     await revokeSelf(document)
@@ -323,6 +326,7 @@ const FederatedFolderModalContent = ({
           </div>
           <WhoHasAccess
             isOwner={isCurrentUserOwner}
+            canManageSharing={canManageSharing}
             isSharedDrive
             recipients={isSending ? frozenRecipients : existingRecipients}
             document={isSending ? frozenDoc : existingDocument}

--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.spec.jsx
@@ -13,6 +13,7 @@ const mockShareByLink = jest.fn()
 const mockRevoke = jest.fn()
 const mockRevokeSelf = jest.fn()
 const mockIsOwner = jest.fn()
+const mockCanReshare = jest.fn()
 const mockGetSharingLink = jest.fn()
 const mockGetFederatedShareLink = jest.fn()
 const mockGetRecipients = jest.fn().mockReturnValue([])
@@ -31,6 +32,7 @@ jest.mock('../../hooks/useSharingContext', () => ({
     revoke: mockRevoke,
     revokeSelf: mockRevokeSelf,
     isOwner: mockIsOwner,
+    canReshare: mockCanReshare,
     getSharingLink: mockGetSharingLink,
     getFederatedShareLink: mockGetFederatedShareLink,
     getDocumentPermissions: mockGetDocumentPermissions,
@@ -109,6 +111,7 @@ describe('FederatedFolderModal', () => {
     mockRevoke.mockResolvedValue()
     mockRevokeSelf.mockResolvedValue()
     mockIsOwner.mockReturnValue(false)
+    mockCanReshare.mockReturnValue(false)
     mockGetDocumentPermissions.mockReturnValue([])
     mockFetchSharedDriveSharingLinks.mockResolvedValue([])
     mockGetSharingLink.mockReturnValue('https://example.com/share/abc123')
@@ -470,6 +473,31 @@ describe('FederatedFolderModal', () => {
         expect(mockRevokeSelf).toHaveBeenCalledWith(mockDocument)
         expect(mockRevoke).not.toHaveBeenCalled()
         expect(onRevokeSuccess).toHaveBeenCalledWith(mockDocument)
+      })
+    })
+
+    it('should allow a write recipient to revoke another recipient', async () => {
+      const otherRecipient = {
+        instance: 'https://other.mycozy.cloud',
+        memberIndex: 2,
+        sharingId: 'sharing-id',
+        type: 'two-way'
+      }
+      mockCanReshare.mockReturnValue(true)
+      mockGetRecipients.mockReturnValue([otherRecipient])
+
+      const { findByLabelText } = setup()
+
+      fireEvent.click(await findByLabelText('Remove from sharing'))
+
+      await waitFor(() => {
+        expect(mockCanReshare).toHaveBeenCalledWith(mockDocument._id)
+        expect(mockRevoke).toHaveBeenCalledWith(
+          mockDocument,
+          otherRecipient.sharingId,
+          otherRecipient.memberIndex
+        )
+        expect(mockRevokeSelf).not.toHaveBeenCalled()
       })
     })
   })


### PR DESCRIPTION
## What changed

- derive federated sharing management rights from ownership or `canReshare`
- pass those rights to `WhoHasAccess`
- add a regression test for a write recipient revoking another recipient

## Why

Commit `25e62c241` (`fix(sharing): Call self revoke for federated
recipients`) corrected ownership detection and routed a recipient removing
themselves through `revokeSelf`.

Before that change, `FederatedFolderModal` passed the boolean `isOwner` prop
without a value, which accidentally exposed management controls to every
user. The change introduced the explicit `canManageSharing` path in the
recipient components, but the federated modal did not pass its `canReshare`
result into that path.

As a result, a non-owner recipient with write/reshare permission could still
remove themselves, but the permission and revoke controls for other
recipients were hidden. This regression was first released in
`cozy-sharing@34.1.2`.

The modal now passes `isOwner || canReshare` as `canManageSharing`. Removing
the current recipient continues to use `revokeSelf`, while managing another
recipient uses the regular `revoke` flow.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Users with permission to reshare a federated document can now manage its sharing access, including revoking access for other recipients.

- **Bug Fixes**
  - Corrected sharing controls so eligible write recipients can revoke another recipient’s access instead of being limited to revoking their own access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->