### PR TITLE
Introduce a readyToUse message in intent

### DIFF
--- a/packages/cozy-interapp/README.md
+++ b/packages/cozy-interapp/README.md
@@ -18,7 +18,11 @@ const intents = new Intents({ client })
 
 `intents.create(action, doctype [, data, permissions])` create an intent. It returns a modified Promise for the intent document, having a custom `start(element)` method. This method interacts with the DOM to append an iframe to the given HTML element. This iframe will provide an access to an app, which will serve a service page able to manage the intent action for the intent doctype. The `start(element)` method returns a promise for the result document provided by intent service.
 
-> **On Intent ready callback:** This `start` method also takes a second optional argument which is a callback function (`start(element, onReadyCallback)`). When provided, this function will be run when the intent iframe will be completely loaded (using the `onload` iframe listener). This callback could be useful to run a client code only when the intent iframe is ready and loaded.
+> **`start` options:** The `start` method takes an optional second argument, an options object: `start(element, options)`. Supported keys:
+>
+> - `onReady` — called when the intent iframe has finished loading (iframe `onload`). Useful for running client code once the iframe is ready.
+> - `onHideCross` / `onShowCross` — called when the service asks the client to hide/show the close button.
+> - `onReadyToUse` — called when the service signals it is **truly ready** (UI rendered and initial data loaded), via `service.notifyReadyToUse()`. Distinct from `onReady`, which only signals the iframe loaded. See `intents.createService()` below.
 
 An intent has to be created everytime an app need to perform an action over a doctype for wich it does not have permission. For example, the Cozy Drive app should create an intent to `pick` a `io.cozy.contacts` document. The cozy-stack will determines which app can offer a service to resolve the intent. It's this service's URL that will be passed to the iframe `src` property.
 
@@ -90,6 +94,8 @@ const app = await service.compose('INSTALL', 'io.cozy.apps', { slug: 'drive' })
 - `cancel()`: ends the intent process by passing a `null` value to the client. This method terminate the intent service the same way that `terminate()`.
 
 - `throw(error)`: throw an error to client and causes the intent promise rejection.
+
+- `notifyReadyToUse()`: tells the client the service UI is rendered and its initial data has loaded. A service may call this only once; a second call is a no-op with a warning. Throws if called after `terminate()`. The client receives it via the `onReadyToUse` option of `start()`.
 
 #### Example
 

--- a/packages/cozy-interapp/src/client.js
+++ b/packages/cozy-interapp/src/client.js
@@ -36,7 +36,7 @@ export function start(createIntent, intent, element, data, options = {}) {
       intent,
       element,
       service.href,
-      options.onReadyCallback
+      options.onReady
     )
 
     const serviceOrigin = extractOrigin(service.href)
@@ -47,6 +47,10 @@ export function start(createIntent, intent, element, data, options = {}) {
 
       onReady: event => {
         event.source.postMessage(data, event.origin)
+      },
+
+      onReadyToUse: () => {
+        if (options.onReadyToUse) options.onReadyToUse()
       },
 
       onDone: event => {

--- a/packages/cozy-interapp/src/intents.js
+++ b/packages/cozy-interapp/src/intents.js
@@ -17,30 +17,20 @@ class Intents {
 
     const createPromise = this.request.post(action, type, data, permissions)
 
-    createPromise.start = (
-      element,
-      onReadyCallback,
-      onHideCross,
-      onShowCross
-    ) => {
-      const options = {
+    createPromise.start = (element, options = {}) => {
+      const opts = {
         filteredServices: data.filteredServices,
-        onReadyCallback: onReadyCallback,
-        onHideCross: onHideCross,
-        onShowCross: onShowCross
+        onReady: options.onReady,
+        onHideCross: options.onHideCross,
+        onShowCross: options.onShowCross,
+        onReadyToUse: options.onReadyToUse
       }
 
       delete data.filteredServices
 
       let intentManager
       const prom = createPromise.then(intent => {
-        intentManager = client.start(
-          this.create,
-          intent,
-          element,
-          data,
-          options
-        )
+        intentManager = client.start(this.create, intent, element, data, opts)
         return intentManager
       })
 

--- a/packages/cozy-interapp/src/intents.spec.js
+++ b/packages/cozy-interapp/src/intents.spec.js
@@ -210,6 +210,69 @@ describe('Interapp', () => {
         expect(element.querySelector('iframe')).toBe(null)
       })
 
+      describe('notifyReadyToUse', () => {
+        let service
+        beforeEach(async () => {
+          const freshIntent = {
+            id: 'readytouse-intent-id',
+            meta: { _rev: undefined },
+            attributes: {
+              action: 'PICK',
+              type: 'io.cozy.files',
+              permissions: ['GET'],
+              client: serviceOrigin,
+              services: [{ slug: 'files', href: serviceURL }]
+            }
+          }
+          api.respond('GET', '/intents/readytouse-intent-id', {
+            data: freshIntent
+          })
+          const freshIntents = new Intents({ client: cozyClient })
+          const servicePromise = freshIntents.createService(
+            freshIntent.id,
+            window
+          )
+          await sleep(1)
+          window.dispatchEvent(
+            Object.assign(new Event('message'), {
+              data: { id: 'fileId' },
+              origin: serviceOrigin,
+              source: window
+            })
+          )
+          service = await servicePromise
+        })
+
+        it('posts readyToUse message to parent', () => {
+          const postSpy = jest.spyOn(window, 'postMessage')
+          postSpy.mockClear()
+          service.notifyReadyToUse()
+          expect(postSpy).toHaveBeenCalledWith(
+            { type: `intent-${service.getIntent()._id}:readyToUse` },
+            service.getIntent().attributes.client
+          )
+          postSpy.mockRestore()
+        })
+
+        it('throws on second call', () => {
+          const postSpy = jest.spyOn(window, 'postMessage')
+          postSpy.mockClear()
+          service.notifyReadyToUse()
+          expect(() => service.notifyReadyToUse()).toThrow(
+            'Intent service is already ready to use'
+          )
+          expect(postSpy).toHaveBeenCalledTimes(1)
+          postSpy.mockRestore()
+        })
+
+        it('throws if called after terminate', () => {
+          service.terminate({})
+          expect(() => service.notifyReadyToUse()).toThrow(
+            'Intent service is terminated'
+          )
+        })
+      })
+
       it('handles composition', async () => {
         api.respond(
           'POST',

--- a/packages/cozy-interapp/src/intents.spec.js
+++ b/packages/cozy-interapp/src/intents.spec.js
@@ -113,7 +113,7 @@ describe('Interapp', () => {
         id: 'fileId'
       })
       intent = await promIntent
-      prom = promIntent.start(element)
+      prom = promIntent.start(element, {})
       await sleep(1)
       iframe = element.querySelector('iframe')
       iframe.postMessage = jest.fn()

--- a/packages/cozy-interapp/src/service.js
+++ b/packages/cozy-interapp/src/service.js
@@ -46,6 +46,7 @@ export const start = request => (intentIdArg, serviceWindowArg) => {
 
   return request.get(intentId).then(intent => {
     let terminated = false
+    let notifiedReadyToUse = false
 
     const sendMessage = message => {
       if (terminated)
@@ -137,7 +138,17 @@ export const start = request => (intentIdArg, serviceWindowArg) => {
         resizeClient: resizeClient,
         cancel: cancel,
         hideCross: hideCross,
-        showCross: showCross
+        showCross: showCross,
+        notifyReadyToUse: () => {
+          if (notifiedReadyToUse) {
+            throw new Error('Intent service is already ready to use')
+          }
+          if (terminated) {
+            throw new Error('Intent service is terminated')
+          }
+          notifiedReadyToUse = true
+          sendMessage({ type: `intent-${intent._id}:readyToUse` })
+        }
       }
     })
   })

--- a/packages/cozy-ui-plus/src/Intent/IntentDialogOpener/index.jsx
+++ b/packages/cozy-ui-plus/src/Intent/IntentDialogOpener/index.jsx
@@ -22,6 +22,7 @@ const IntentDialogOpener = props => {
     tag,
     onComplete,
     onDismiss,
+    onReadyToUse,
     iframeProps,
     Component,
     ...componentProps
@@ -68,6 +69,7 @@ const IntentDialogOpener = props => {
           create={create}
           onCancel={handleDismiss}
           onTerminate={handleComplete}
+          onReadyToUse={onReadyToUse}
           iframeProps={iframeProps}
         />
       </Component>
@@ -84,6 +86,8 @@ IntentDialogOpener.propTypes = {
   onComplete: PropTypes.func,
   /** What should happen when the intent has dismissed */
   onDismiss: PropTypes.func,
+  /** Called when the intent service signals it is ready to use */
+  onReadyToUse: PropTypes.func,
   /** Action you want to execute */
   action: PropTypes.string.isRequired,
   /** Doctype on which you want to execute the action */

--- a/packages/cozy-ui-plus/src/Intent/IntentIframe/index.jsx
+++ b/packages/cozy-ui-plus/src/Intent/IntentIframe/index.jsx
@@ -41,12 +41,12 @@ class IntentIframe extends React.Component {
       ...DEFAULT_DATA,
       ...data
     })
-      .start(
-        this.intentViewer,
-        this.onFrameLoaded,
-        this.props.onHideCross,
-        this.props.onShowCross
-      )
+      .start(this.intentViewer, {
+        onReady: this.onFrameLoaded,
+        onHideCross: this.props.onHideCross,
+        onShowCross: this.props.onShowCross,
+        onReadyToUse: this.props.onReadyToUse
+      })
       .then(result => {
         // eslint-disable-next-line promise/always-return
         result ? onTerminate && onTerminate(result) : onCancel()
@@ -102,7 +102,8 @@ IntentIframe.propTypes = {
   onTerminate: PropTypes.func.isRequired,
   iframeProps: iframeProps,
   onHideCross: PropTypes.func,
-  onShowCross: PropTypes.func
+  onShowCross: PropTypes.func,
+  onReadyToUse: PropTypes.func
 }
 
 IntentIframe.defaultProps = {


### PR DESCRIPTION
Use by the service to notify the client that it is ready to use by the user: UI rendered, query loaded, etc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “ready to use” lifecycle notification for intents.
  - Added an `onReadyToUse` callback for iframe and dialog integrations.
  - Updated intent startup options to support named readiness and cross-button callbacks.
  - Added a service method to signal when an intent is ready for use, with safeguards against repeated or late calls.
- **Documentation**
  - Updated integration documentation with the new startup options and readiness notification API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->