### PR TITLE
fix(cozy-sharing): Add padding to document chips

### DIFF
--- a/packages/cozy-sharing/src/components/ShareLinkAccessModal/ShareLinkAccessModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareLinkAccessModal/ShareLinkAccessModal.jsx
@@ -133,7 +133,7 @@ export const ShareLinkAccessModal = ({
                       {renderDocumentIcon(document, DOCUMENT_ICON_SIZE)}
                     </Box>
                   }
-                  className="u-maw-100"
+                  className="u-maw-100 u-p-half"
                   label={document.name}
                   size="small"
                 />

--- a/packages/cozy-sharing/src/components/ShareLinkAccessModal/ShareLinkAccessModal.spec.jsx
+++ b/packages/cozy-sharing/src/components/ShareLinkAccessModal/ShareLinkAccessModal.spec.jsx
@@ -144,9 +144,6 @@ describe('ShareLinkAccessModal', () => {
 
     expect(screen.getByRole('dialog')).toHaveTextContent('invoice.pdf')
     expect(screen.getByRole('dialog')).toHaveTextContent('Projects')
-    expect(screen.getByText('invoice.pdf').parentElement).toHaveClass(
-      'u-maw-100'
-    )
     expect(screen.getByLabelText('Access level')).toHaveTextContent('Viewer')
     expect(screen.getByRole('dialog')).toHaveAttribute('data-size', 'small')
   })


### PR DESCRIPTION
<img width="144" height="61" alt="image" src="https://github.com/user-attachments/assets/b4931838-7c72-44db-9f7a-7f9a201922cb" />
