### PR TITLE
fix(dataproxy-lib): Remove hidden iframe border

### DIFF
--- a/packages/cozy-dataproxy-lib/src/dataproxy/DataProxyProvider.jsx
+++ b/packages/cozy-dataproxy-lib/src/dataproxy/DataProxyProvider.jsx
@@ -261,7 +261,8 @@ export const DataProxyProvider = React.memo(
               height={0}
               style={{
                 width: 0,
-                height: 0
+                height: 0,
+                border: 0
               }}
               sandbox="allow-same-origin allow-scripts"
               onError={() => {


### PR DESCRIPTION
The DataProxy iframe is rendered at zero width and height, but its default browser border remains visible. Set the iframe border to zero to remove the visual artifact while preserving the iframe and its communication with the DataProxy service.

<img width="209" height="139" alt="Capture d’écran du 2026-07-23 17-43-42" src="https://github.com/user-attachments/assets/3c565986-8ca7-459c-8205-d95dcf137799" />
