### PR TITLE
feat(cozy-ui-plus): Wait for intent readiness signal

### DIFF
--- a/packages/cozy-ui-plus/src/Intent/IntentDialogOpener/Readme.md
+++ b/packages/cozy-ui-plus/src/Intent/IntentDialogOpener/Readme.md
@@ -16,6 +16,7 @@ import DemoProvider from 'cozy-ui/docs/components/DemoProvider'
     fullWidth // extra props will be passed to the dialog
     maxWidth="md" // extra props will be passed to the dialog
     iframeProps={{ spinnerProps: { middle: true } }}
+    waitForReadyToUse
     onComplete={res => alert('intent has completed ! ' + JSON.stringify(res))}
     onDismiss={() => alert('intent has been dismissed !')}
   >
@@ -23,3 +24,7 @@ import DemoProvider from 'cozy-ui/docs/components/DemoProvider'
   </IntentDialogOpener>
 </DemoProvider>
 ```
+
+Set `waitForReadyToUse` to keep the intent hidden behind the loading spinner
+until its service sends the `readyToUse` signal. This option is disabled by
+default because older intent services do not send this signal.

--- a/packages/cozy-ui-plus/src/Intent/IntentDialogOpener/index.jsx
+++ b/packages/cozy-ui-plus/src/Intent/IntentDialogOpener/index.jsx
@@ -23,6 +23,7 @@ const IntentDialogOpener = props => {
     onComplete,
     onDismiss,
     onReadyToUse,
+    waitForReadyToUse,
     iframeProps,
     Component,
     ...componentProps
@@ -70,6 +71,7 @@ const IntentDialogOpener = props => {
           onCancel={handleDismiss}
           onTerminate={handleComplete}
           onReadyToUse={onReadyToUse}
+          waitForReadyToUse={waitForReadyToUse}
           iframeProps={iframeProps}
         />
       </Component>
@@ -88,6 +90,8 @@ IntentDialogOpener.propTypes = {
   onDismiss: PropTypes.func,
   /** Called when the intent service signals it is ready to use */
   onReadyToUse: PropTypes.func,
+  /** Keep the loading state until the intent service signals it is ready to use */
+  waitForReadyToUse: PropTypes.bool,
   /** Action you want to execute */
   action: PropTypes.string.isRequired,
   /** Doctype on which you want to execute the action */
@@ -108,7 +112,8 @@ IntentDialogOpener.defaultProps = {
   tag: 'span',
   closable: true,
   Component: Dialog,
-  showCloseButton: true
+  showCloseButton: true,
+  waitForReadyToUse: false
 }
 
 export default IntentDialogOpener

--- a/packages/cozy-ui-plus/src/Intent/IntentDialogOpener/index.spec.jsx
+++ b/packages/cozy-ui-plus/src/Intent/IntentDialogOpener/index.spec.jsx
@@ -1,0 +1,44 @@
+import { fireEvent, render } from '@testing-library/react'
+import React from 'react'
+
+import IntentDialogOpener from './index'
+
+jest.mock('cozy-ui/transpiled/react/CozyDialogs', () => ({
+  DialogCloseButton: () => null
+}))
+
+jest.mock('cozy-ui/transpiled/react/Dialog', () => ({ children }) => (
+  <div>{children}</div>
+))
+
+jest.mock('../IntentIframe', () => ({
+  __esModule: true,
+  default: ({ waitForReadyToUse }) => (
+    <div
+      data-testid="intent-iframe"
+      data-wait-for-ready-to-use={waitForReadyToUse}
+    />
+  ),
+  iframeProps: require('prop-types').shape({})
+}))
+
+describe('IntentDialogOpener', () => {
+  it('forwards waitForReadyToUse to the intent iframe', () => {
+    const { getByRole, getByTestId } = render(
+      <IntentDialogOpener
+        action="PICK"
+        doctype="io.cozy.files"
+        waitForReadyToUse
+      >
+        <button type="button">Open</button>
+      </IntentDialogOpener>
+    )
+
+    fireEvent.click(getByRole('button', { name: 'Open' }))
+
+    expect(getByTestId('intent-iframe')).toHaveAttribute(
+      'data-wait-for-ready-to-use',
+      'true'
+    )
+  })
+})

--- a/packages/cozy-ui-plus/src/Intent/IntentIframe/Readme.md
+++ b/packages/cozy-ui-plus/src/Intent/IntentIframe/Readme.md
@@ -19,8 +19,13 @@ import utils from '../../docs/utils'
   onCancel={() => alert('intent cancelled')}
   onError={(error) => alert('intent has failed with error: ' + error.message)}
   onTerminate={doc => alert('intent has completed ! ' + JSON.stringify(doc))}
+  waitForReadyToUse
 />
 ```
+
+Set `waitForReadyToUse` to keep the intent hidden behind the loading spinner
+until its service sends the `readyToUse` signal. This option is disabled by
+default because older intent services do not send this signal.
 
 ### Within an application side controled Dialog
 

--- a/packages/cozy-ui-plus/src/Intent/IntentIframe/index.jsx
+++ b/packages/cozy-ui-plus/src/Intent/IntentIframe/index.jsx
@@ -18,7 +18,7 @@ const DEFAULT_DATA = {
 }
 
 class IntentIframe extends React.Component {
-  state = { loading: false }
+  state = { error: null, frameLoaded: false, readyToUse: false }
 
   componentDidMount() {
     const { action, data, type, onCancel, onError, onTerminate, client } =
@@ -36,7 +36,6 @@ class IntentIframe extends React.Component {
       create = intents.create
     }
 
-    this.setState({ loading: true })
     create(action, type, {
       ...DEFAULT_DATA,
       ...data
@@ -45,7 +44,7 @@ class IntentIframe extends React.Component {
         onReady: this.onFrameLoaded,
         onHideCross: this.props.onHideCross,
         onShowCross: this.props.onShowCross,
-        onReadyToUse: this.props.onReadyToUse
+        onReadyToUse: this.onReadyToUse
       })
       .then(result => {
         // eslint-disable-next-line promise/always-return
@@ -53,29 +52,51 @@ class IntentIframe extends React.Component {
       })
       .catch(error => {
         onError?.(error)
-        this.setState({ error: error, loading: false })
-        this.props.iframeProps?.setIsLoading?.(false)
+        this.setState({ error })
+        this.setIsLoading(false)
       })
   }
 
   onFrameLoaded = () => {
-    this.setState({ loading: false })
-    this.props.iframeProps?.setIsLoading?.(false)
+    this.setState({ frameLoaded: true }, () => {
+      if (!this.props.waitForReadyToUse || this.state.readyToUse) {
+        this.setIsLoading(false)
+      }
+    })
+  }
+
+  onReadyToUse = () => {
+    this.setState({ readyToUse: true }, () => {
+      if (this.props.waitForReadyToUse && this.state.frameLoaded) {
+        this.setIsLoading(false)
+      }
+    })
+    this.props.onReadyToUse?.()
+  }
+
+  setIsLoading = isLoading => {
+    this.props.iframeProps?.setIsLoading?.(isLoading)
   }
 
   render() {
-    const { iframeProps } = this.props
-    const { error, loading } = this.state
+    const { iframeProps, waitForReadyToUse } = this.props
+    const { error, frameLoaded, readyToUse } = this.state
+    const loading =
+      error === null && (!frameLoaded || (waitForReadyToUse && !readyToUse))
 
     return (
       <div
         ref={intentViewer => (this.intentViewer = intentViewer)}
         className={styles.intentContainer}
         aria-busy={loading}
+        data-iframe-loaded={frameLoaded}
+        data-waiting-for-ready-to-use={waitForReadyToUse && !readyToUse}
         {...get(iframeProps, 'wrapperProps')}
       >
         {loading && (
-          <Spinner size="xxlarge" {...get(iframeProps, 'spinnerProps')} />
+          <div className={styles.intentContainer__loader}>
+            <Spinner size="xxlarge" {...get(iframeProps, 'spinnerProps')} />
+          </div>
         )}
         {error && (
           <div className={styles.intentContainer__error}>{error.message}</div>
@@ -103,11 +124,13 @@ IntentIframe.propTypes = {
   iframeProps: iframeProps,
   onHideCross: PropTypes.func,
   onShowCross: PropTypes.func,
-  onReadyToUse: PropTypes.func
+  onReadyToUse: PropTypes.func,
+  waitForReadyToUse: PropTypes.bool
 }
 
 IntentIframe.defaultProps = {
-  data: {}
+  data: {},
+  waitForReadyToUse: false
 }
 
 export default withClient(IntentIframe)

--- a/packages/cozy-ui-plus/src/Intent/IntentIframe/index.spec.jsx
+++ b/packages/cozy-ui-plus/src/Intent/IntentIframe/index.spec.jsx
@@ -1,0 +1,121 @@
+import { act, render, waitFor } from '@testing-library/react'
+import React from 'react'
+
+import IntentIframe from './index'
+
+jest.mock('cozy-ui/transpiled/react/Spinner', () => () => (
+  <div data-testid="intent-spinner" />
+))
+
+function setup({ startError = null, waitForReadyToUse = false } = {}) {
+  let startOptions
+  const start = jest.fn((element, options) => {
+    startOptions = options
+    element.appendChild(document.createElement('iframe'))
+    return startError ? Promise.reject(startError) : new Promise(() => {})
+  })
+  const create = jest.fn(() => ({ start }))
+  const onError = jest.fn()
+  const onReadyToUse = jest.fn()
+  const setIsLoading = jest.fn()
+
+  const result = render(
+    <IntentIframe
+      action="PICK"
+      client={{}}
+      create={create}
+      iframeProps={{ setIsLoading }}
+      onCancel={jest.fn()}
+      onError={onError}
+      onReadyToUse={onReadyToUse}
+      onTerminate={jest.fn()}
+      type="io.cozy.files"
+      waitForReadyToUse={waitForReadyToUse}
+    />
+  )
+
+  return {
+    ...result,
+    getStartOptions: () => startOptions,
+    onError,
+    onReadyToUse,
+    setIsLoading
+  }
+}
+
+describe('IntentIframe', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('keeps the iframe rendered behind the spinner until it is ready to use', () => {
+    const {
+      container,
+      getStartOptions,
+      onReadyToUse,
+      queryByTestId,
+      setIsLoading
+    } = setup({ waitForReadyToUse: true })
+
+    act(() => getStartOptions().onReady())
+
+    expect(queryByTestId('intent-spinner')).toBeInTheDocument()
+    expect(container.querySelector('iframe')).toBeInTheDocument()
+    expect(
+      container.querySelector(
+        '[data-iframe-loaded="true"][data-waiting-for-ready-to-use="true"]'
+      )
+    ).toBeInTheDocument()
+    expect(setIsLoading).not.toHaveBeenCalled()
+
+    act(() => getStartOptions().onReadyToUse())
+
+    expect(queryByTestId('intent-spinner')).toBe(null)
+    expect(onReadyToUse).toHaveBeenCalledTimes(1)
+    expect(setIsLoading).toHaveBeenCalledWith(false)
+  })
+
+  it('waits for the iframe when readyToUse is received first', () => {
+    const { getStartOptions, queryByTestId, setIsLoading } = setup({
+      waitForReadyToUse: true
+    })
+
+    act(() => getStartOptions().onReadyToUse())
+
+    expect(queryByTestId('intent-spinner')).toBeInTheDocument()
+    expect(setIsLoading).not.toHaveBeenCalled()
+
+    act(() => getStartOptions().onReady())
+
+    expect(queryByTestId('intent-spinner')).toBe(null)
+    expect(setIsLoading).toHaveBeenCalledWith(false)
+  })
+
+  it('hides the spinner when the iframe loads by default', () => {
+    const { getStartOptions, queryByTestId, setIsLoading } = setup()
+
+    act(() => getStartOptions().onReady())
+    act(() => getStartOptions().onReadyToUse())
+
+    expect(queryByTestId('intent-spinner')).toBe(null)
+    expect(setIsLoading).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows intent errors instead of waiting for readyToUse', async () => {
+    const error = new Error('Intent failed')
+    const { container, onError, queryByTestId, setIsLoading } = setup({
+      startError: error,
+      waitForReadyToUse: true
+    })
+
+    await waitFor(() => expect(queryByTestId('intent-spinner')).toBe(null))
+
+    expect(container).toHaveTextContent('Intent failed')
+    expect(onError).toHaveBeenCalledWith(error)
+    expect(setIsLoading).toHaveBeenCalledWith(false)
+  })
+})

--- a/packages/cozy-ui-plus/src/Intent/IntentIframe/styles.styl
+++ b/packages/cozy-ui-plus/src/Intent/IntentIframe/styles.styl
@@ -11,10 +11,30 @@ iframe
     justify-content center
     align-items center
 
+.intentContainer
+    position relative
+
+.intentContainer__loader
+    display flex
+    justify-content center
+    align-items center
+
+.intentContainer[data-iframe-loaded=true] .intentContainer__loader
+    position absolute
+    z-index 1
+    top 0
+    right 0
+    bottom 0
+    left 0
+    background-color var(--paperBackgroundColor)
+
 /* Don't mess with the spinner centering until the iframe is fully loaded. */
-.intentContainer[aria-busy=true] iframe
+.intentContainer[data-iframe-loaded=false] iframe
     height 0
     width 0
+
+.intentContainer[data-waiting-for-ready-to-use=true] iframe
+    visibility hidden
 
 .intentContainer__error
     color var(--errorColor)


### PR DESCRIPTION
Allow consumers to keep the intent iframe hidden until its service emits the readyToUse signal. Preserve existing behavior by keeping this opt-in for services that do not provide the signal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional readiness mode for intent dialogs and iframes.
  - When enabled, intents remain hidden behind a loading indicator until both the iframe and intent service are ready.
  - Improved loading and error states, including clearer transitions when an intent fails to start.
  - Existing behavior remains unchanged by default for compatibility with older intent services.

- **Documentation**
  - Updated usage examples and guidance for the new readiness option.

- **Tests**
  - Added coverage for loading, readiness, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->