### PR TITLE
feat(cozy-ui-plus): Support forced themes 

### DIFF
--- a/packages/cozy-ui-plus/src/Intent/IntentDialogOpener/Readme.md
+++ b/packages/cozy-ui-plus/src/Intent/IntentDialogOpener/Readme.md
@@ -16,7 +16,7 @@ import DemoProvider from 'cozy-ui/docs/components/DemoProvider'
     fullWidth // extra props will be passed to the dialog
     maxWidth="md" // extra props will be passed to the dialog
     iframeProps={{ spinnerProps: { middle: true } }}
-    options={{ theme: 'dark' }}
+    options={{ theme: { type: 'dark' } }}
     waitForReadyToUse
     onComplete={res => alert('intent has completed ! ' + JSON.stringify(res))}
     onDismiss={() => alert('intent has been dismissed !')}
@@ -30,6 +30,6 @@ Set `waitForReadyToUse` to keep the intent hidden behind the loading spinner
 until its service sends the `readyToUse` signal. This option is disabled by
 default because older intent services do not send this signal.
 
-Set `options.theme` to `light` or `dark` to force that theme on the dialog,
-close button and loading surface as well as passing it to the intent service.
-With `auto`, an invalid value or no value, the dialog keeps the caller's theme.
+Set `options.theme.type` to `light` or `dark` to force that theme on the
+dialog, close button and loading surface as well as passing it to the intent
+service. Any other value or no value keeps the caller's theme.

--- a/packages/cozy-ui-plus/src/Intent/IntentDialogOpener/Readme.md
+++ b/packages/cozy-ui-plus/src/Intent/IntentDialogOpener/Readme.md
@@ -16,6 +16,7 @@ import DemoProvider from 'cozy-ui/docs/components/DemoProvider'
     fullWidth // extra props will be passed to the dialog
     maxWidth="md" // extra props will be passed to the dialog
     iframeProps={{ spinnerProps: { middle: true } }}
+    options={{ theme: 'dark' }}
     waitForReadyToUse
     onComplete={res => alert('intent has completed ! ' + JSON.stringify(res))}
     onDismiss={() => alert('intent has been dismissed !')}
@@ -28,3 +29,7 @@ import DemoProvider from 'cozy-ui/docs/components/DemoProvider'
 Set `waitForReadyToUse` to keep the intent hidden behind the loading spinner
 until its service sends the `readyToUse` signal. This option is disabled by
 default because older intent services do not send this signal.
+
+Set `options.theme` to `light` or `dark` to force that theme on the dialog,
+close button and loading surface as well as passing it to the intent service.
+With `auto`, an invalid value or no value, the dialog keeps the caller's theme.

--- a/packages/cozy-ui-plus/src/Intent/IntentDialogOpener/index.jsx
+++ b/packages/cozy-ui-plus/src/Intent/IntentDialogOpener/index.jsx
@@ -49,8 +49,9 @@ const IntentDialogOpener = props => {
   }
 
   const Tag = tag // React needs uppercase element names
-  const forcedTheme = ['light', 'dark'].includes(options?.theme)
-    ? options.theme
+  const themeType = options?.theme?.type
+  const forcedTheme = ['light', 'dark'].includes(themeType)
+    ? themeType
     : undefined
   const elements = [
     React.cloneElement(children, { key: 'opener', onClick: openModal })
@@ -101,7 +102,9 @@ IntentDialogOpener.propTypes = {
   action: PropTypes.string.isRequired,
   /** Options passed to the intent */
   options: PropTypes.shape({
-    theme: PropTypes.oneOf(['light', 'dark', 'auto'])
+    theme: PropTypes.shape({
+      type: PropTypes.oneOf(['light', 'dark'])
+    })
   }),
   /** Doctype on which you want to execute the action */
   doctype: PropTypes.string.isRequired,

--- a/packages/cozy-ui-plus/src/Intent/IntentDialogOpener/index.jsx
+++ b/packages/cozy-ui-plus/src/Intent/IntentDialogOpener/index.jsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 
 import { DialogCloseButton } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Dialog from 'cozy-ui/transpiled/react/Dialog'
+import CozyTheme from 'cozy-ui/transpiled/react/providers/CozyTheme'
 
 import IntentIframe, { iframeProps } from '../IntentIframe'
 
@@ -48,33 +49,37 @@ const IntentDialogOpener = props => {
   }
 
   const Tag = tag // React needs uppercase element names
+  const forcedTheme = ['light', 'dark'].includes(options?.theme)
+    ? options.theme
+    : undefined
   const elements = [
     React.cloneElement(children, { key: 'opener', onClick: openModal })
   ]
 
   if (modalOpened) {
     elements.push(
-      <Component
-        key="intent-modal"
-        open={modalOpened}
-        onClose={closable && handleDismiss}
-        {...componentProps}
-      >
-        {closable && showCloseButton && (
-          <DialogCloseButton onClick={handleDismiss} />
-        )}
-        <IntentIframe
-          action={action}
-          type={doctype}
-          data={options}
-          create={create}
-          onCancel={handleDismiss}
-          onTerminate={handleComplete}
-          onReadyToUse={onReadyToUse}
-          waitForReadyToUse={waitForReadyToUse}
-          iframeProps={iframeProps}
-        />
-      </Component>
+      <CozyTheme key="intent-modal" type={forcedTheme}>
+        <Component
+          open={modalOpened}
+          onClose={closable && handleDismiss}
+          {...componentProps}
+        >
+          {closable && showCloseButton && (
+            <DialogCloseButton onClick={handleDismiss} />
+          )}
+          <IntentIframe
+            action={action}
+            type={doctype}
+            data={options}
+            create={create}
+            onCancel={handleDismiss}
+            onTerminate={handleComplete}
+            onReadyToUse={onReadyToUse}
+            waitForReadyToUse={waitForReadyToUse}
+            iframeProps={iframeProps}
+          />
+        </Component>
+      </CozyTheme>
     )
   }
 
@@ -94,6 +99,10 @@ IntentDialogOpener.propTypes = {
   waitForReadyToUse: PropTypes.bool,
   /** Action you want to execute */
   action: PropTypes.string.isRequired,
+  /** Options passed to the intent */
+  options: PropTypes.shape({
+    theme: PropTypes.oneOf(['light', 'dark', 'auto'])
+  }),
   /** Doctype on which you want to execute the action */
   doctype: PropTypes.string.isRequired,
   /** Whether the dialog is closable by itself (not by the Intent) with a button or by clicking outside of it */

--- a/packages/cozy-ui-plus/src/Intent/IntentIframe/Readme.md
+++ b/packages/cozy-ui-plus/src/Intent/IntentIframe/Readme.md
@@ -14,7 +14,7 @@ import utils from '../../docs/utils'
 <IntentIframe
   action="PICK"
   create={utils.fakeIntentCreate}
-  data={{folder: '840af7e7be6c41bed3c5b76d03f66328', theme: 'dark'}}
+  data={{folder: '840af7e7be6c41bed3c5b76d03f66328', theme: { type: 'dark' }}}
   type="io.cozy.files"
   onCancel={() => alert('intent cancelled')}
   onError={(error) => alert('intent has failed with error: ' + error.message)}
@@ -27,9 +27,9 @@ Set `waitForReadyToUse` to keep the intent hidden behind the loading spinner
 until its service sends the `readyToUse` signal. This option is disabled by
 default because older intent services do not send this signal.
 
-Set `data.theme` to `light` or `dark` to force that theme on the loading
-surface and pass it to the intent service. With `auto`, an invalid value or no
-value, the loading surface keeps the caller's theme.
+Set `data.theme.type` to `light` or `dark` to force that theme on the
+loading surface and pass it to the intent service. Any other value or no value
+keeps the caller's theme.
 
 ### Within an application side controled Dialog
 

--- a/packages/cozy-ui-plus/src/Intent/IntentIframe/Readme.md
+++ b/packages/cozy-ui-plus/src/Intent/IntentIframe/Readme.md
@@ -14,7 +14,7 @@ import utils from '../../docs/utils'
 <IntentIframe
   action="PICK"
   create={utils.fakeIntentCreate}
-  data={{folder: '840af7e7be6c41bed3c5b76d03f66328'}}
+  data={{folder: '840af7e7be6c41bed3c5b76d03f66328', theme: 'dark'}}
   type="io.cozy.files"
   onCancel={() => alert('intent cancelled')}
   onError={(error) => alert('intent has failed with error: ' + error.message)}
@@ -26,6 +26,10 @@ import utils from '../../docs/utils'
 Set `waitForReadyToUse` to keep the intent hidden behind the loading spinner
 until its service sends the `readyToUse` signal. This option is disabled by
 default because older intent services do not send this signal.
+
+Set `data.theme` to `light` or `dark` to force that theme on the loading
+surface and pass it to the intent service. With `auto`, an invalid value or no
+value, the loading surface keeps the caller's theme.
 
 ### Within an application side controled Dialog
 

--- a/packages/cozy-ui-plus/src/Intent/IntentIframe/index.jsx
+++ b/packages/cozy-ui-plus/src/Intent/IntentIframe/index.jsx
@@ -84,9 +84,8 @@ class IntentIframe extends React.Component {
     const { error, frameLoaded, readyToUse } = this.state
     const loading =
       error === null && (!frameLoaded || (waitForReadyToUse && !readyToUse))
-    const forcedTheme = ['light', 'dark'].includes(data?.theme)
-      ? data.theme
-      : null
+    const themeType = data?.theme?.type
+    const forcedTheme = ['light', 'dark'].includes(themeType) ? themeType : null
     return (
       <CozyTheme
         type={forcedTheme}

--- a/packages/cozy-ui-plus/src/Intent/IntentIframe/index.jsx
+++ b/packages/cozy-ui-plus/src/Intent/IntentIframe/index.jsx
@@ -7,6 +7,7 @@ import React from 'react'
 import { withClient } from 'cozy-client'
 import { Intents } from 'cozy-interapp'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
+import CozyTheme from 'cozy-ui/transpiled/react/providers/CozyTheme'
 
 import styles from './styles.styl'
 
@@ -79,30 +80,38 @@ class IntentIframe extends React.Component {
   }
 
   render() {
-    const { iframeProps, waitForReadyToUse } = this.props
+    const { data, iframeProps, waitForReadyToUse } = this.props
     const { error, frameLoaded, readyToUse } = this.state
     const loading =
       error === null && (!frameLoaded || (waitForReadyToUse && !readyToUse))
-
+    const forcedTheme = ['light', 'dark'].includes(data?.theme)
+      ? data.theme
+      : null
     return (
-      <div
-        ref={intentViewer => (this.intentViewer = intentViewer)}
+      <CozyTheme
+        type={forcedTheme}
+        ignoreItself={false}
         className={styles.intentContainer}
-        aria-busy={loading}
-        data-iframe-loaded={frameLoaded}
-        data-waiting-for-ready-to-use={waitForReadyToUse && !readyToUse}
-        {...get(iframeProps, 'wrapperProps')}
       >
-        {loading && (
-          <div className={styles.intentContainer__loader}>
-            <Spinner size="xxlarge" {...get(iframeProps, 'spinnerProps')} />
-          </div>
-        )}
-        {error && (
-          <div className={styles.intentContainer__error}>{error.message}</div>
-        )}
-        {/* intent iframe will be appended here */}
-      </div>
+        <div
+          ref={intentViewer => (this.intentViewer = intentViewer)}
+          className={styles.intentContainer}
+          aria-busy={loading}
+          data-iframe-loaded={frameLoaded}
+          data-waiting-for-ready-to-use={waitForReadyToUse && !readyToUse}
+          {...get(iframeProps, 'wrapperProps')}
+        >
+          {loading && (
+            <div className={styles.intentContainer__loader}>
+              <Spinner size="xxlarge" {...get(iframeProps, 'spinnerProps')} />
+            </div>
+          )}
+          {error && (
+            <div className={styles.intentContainer__error}>{error.message}</div>
+          )}
+          {/* intent iframe will be appended here */}
+        </div>
+      </CozyTheme>
     )
   }
 }

--- a/packages/cozy-ui-plus/src/Intent/IntentIframe/index.spec.jsx
+++ b/packages/cozy-ui-plus/src/Intent/IntentIframe/index.spec.jsx
@@ -3,11 +3,25 @@ import React from 'react'
 
 import IntentIframe from './index'
 
+jest.mock('cozy-ui/transpiled/react/providers/CozyTheme', () => ({
+  __esModule: true,
+  default: ({ children, className, ignoreItself, type }) => (
+    <div
+      data-testid="intent-theme"
+      data-theme={type}
+      data-ignore-itself={ignoreItself}
+      className={className}
+    >
+      {children}
+    </div>
+  )
+}))
+
 jest.mock('cozy-ui/transpiled/react/Spinner', () => () => (
   <div data-testid="intent-spinner" />
 ))
 
-function setup({ startError = null, waitForReadyToUse = false } = {}) {
+function setup({ data, startError = null, waitForReadyToUse = false } = {}) {
   let startOptions
   const start = jest.fn((element, options) => {
     startOptions = options
@@ -24,6 +38,7 @@ function setup({ startError = null, waitForReadyToUse = false } = {}) {
       action="PICK"
       client={{}}
       create={create}
+      data={data}
       iframeProps={{ setIsLoading }}
       onCancel={jest.fn()}
       onError={onError}
@@ -51,6 +66,31 @@ describe('IntentIframe', () => {
   afterEach(() => {
     jest.restoreAllMocks()
   })
+
+  it.each(['light', 'dark'])(
+    'forces the %s theme on the iframe surface',
+    theme => {
+      const { getByTestId } = setup({ data: { theme } })
+
+      const intentTheme = getByTestId('intent-theme')
+
+      expect(intentTheme).toHaveAttribute('data-theme', theme)
+      expect(intentTheme).toHaveAttribute('data-ignore-itself', 'false')
+      expect(intentTheme.className).not.toBe('')
+    }
+  )
+
+  it.each([undefined, 'auto', 'sepia'])(
+    'preserves the caller theme for %s',
+    theme => {
+      const data = theme === undefined ? undefined : { theme }
+      const { getByTestId } = setup({ data })
+      const intentTheme = getByTestId('intent-theme')
+
+      expect(intentTheme).not.toHaveAttribute('data-theme')
+      expect(intentTheme.className).not.toBe('')
+    }
+  )
 
   it('keeps the iframe rendered behind the spinner until it is ready to use', () => {
     const {

--- a/packages/cozy-ui-plus/src/Intent/IntentIframe/index.spec.jsx
+++ b/packages/cozy-ui-plus/src/Intent/IntentIframe/index.spec.jsx
@@ -3,20 +3,6 @@ import React from 'react'
 
 import IntentIframe from './index'
 
-jest.mock('cozy-ui/transpiled/react/providers/CozyTheme', () => ({
-  __esModule: true,
-  default: ({ children, className, ignoreItself, type }) => (
-    <div
-      data-testid="intent-theme"
-      data-theme={type}
-      data-ignore-itself={ignoreItself}
-      className={className}
-    >
-      {children}
-    </div>
-  )
-}))
-
 jest.mock('cozy-ui/transpiled/react/Spinner', () => () => (
   <div data-testid="intent-spinner" />
 ))
@@ -66,31 +52,6 @@ describe('IntentIframe', () => {
   afterEach(() => {
     jest.restoreAllMocks()
   })
-
-  it.each(['light', 'dark'])(
-    'forces the %s theme on the iframe surface',
-    theme => {
-      const { getByTestId } = setup({ data: { theme: { type: theme } } })
-
-      const intentTheme = getByTestId('intent-theme')
-
-      expect(intentTheme).toHaveAttribute('data-theme', theme)
-      expect(intentTheme).toHaveAttribute('data-ignore-itself', 'false')
-      expect(intentTheme.className).not.toBe('')
-    }
-  )
-
-  it.each([undefined, 'auto', 'sepia'])(
-    'preserves the caller theme for %s',
-    theme => {
-      const data = theme === undefined ? undefined : { theme: { type: theme } }
-      const { getByTestId } = setup({ data })
-      const intentTheme = getByTestId('intent-theme')
-
-      expect(intentTheme).not.toHaveAttribute('data-theme')
-      expect(intentTheme.className).not.toBe('')
-    }
-  )
 
   it('keeps the iframe rendered behind the spinner until it is ready to use', () => {
     const {

--- a/packages/cozy-ui-plus/src/Intent/IntentIframe/index.spec.jsx
+++ b/packages/cozy-ui-plus/src/Intent/IntentIframe/index.spec.jsx
@@ -70,7 +70,7 @@ describe('IntentIframe', () => {
   it.each(['light', 'dark'])(
     'forces the %s theme on the iframe surface',
     theme => {
-      const { getByTestId } = setup({ data: { theme } })
+      const { getByTestId } = setup({ data: { theme: { type: theme } } })
 
       const intentTheme = getByTestId('intent-theme')
 
@@ -83,7 +83,7 @@ describe('IntentIframe', () => {
   it.each([undefined, 'auto', 'sepia'])(
     'preserves the caller theme for %s',
     theme => {
-      const data = theme === undefined ? undefined : { theme }
+      const data = theme === undefined ? undefined : { theme: { type: theme } }
       const { getByTestId } = setup({ data })
       const intentTheme = getByTestId('intent-theme')
 


### PR DESCRIPTION
Allow intent callers to request light or dark through intent data. This
keeps the host dialog, loading surface, and service iframe visually
consistent.

Keep auto, invalid, and omitted values on the caller theme. Give the
themed iframe wrapper explicit dimensions instead of relying on the
caller's u-dc utility, which could collapse the iframe to its intrinsic
300x150 size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added theme overrides for intent dialogs and embedded intent views.
  * Supports forcing light or dark themes for loading surfaces, dialogs, and close buttons.
  * Invalid, missing, or automatic theme values preserve the caller’s theme.

* **Documentation**
  * Updated usage examples and guidance for configuring intent themes.

* **Tests**
  * Extended intent view test setup to support theme configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->