### PR TITLE
Add guideline to build an intent

### DIFF
--- a/packages/cozy-interapp/README.md
+++ b/packages/cozy-interapp/README.md
@@ -30,6 +30,17 @@ See [cozy-ui-plus](https://github.com/linagora/cozy-libs/tree/master/packages/co
 
 ## Guideline to build an intent
 
+### UI lifecycle
+
+The client app is responsible of the UI lifecycle of the intent, e.g.:
+- opening the intent
+- hiding the intent
+- closing the intent
+
+As the service app can not know how client application will display the service, we let the client:
+- choose how to display the intent: inside a modal, inside a bottomshet, inside a card, etc
+- choose how the user can close it (with a cross button, with a keyboard shortcut, etc) or hide it (with a minimize button, etc), etc
+
 ### Error handling
 
 The rule:

--- a/packages/cozy-interapp/README.md
+++ b/packages/cozy-interapp/README.md
@@ -28,6 +28,16 @@ const intents = new Intents({ client })
 
 See [cozy-ui-plus](https://github.com/linagora/cozy-libs/tree/master/packages/cozy-ui-plus/src/Intent) for ready for use React components using cozy-interapp.
 
+## Guideline to build an intent
+
+### Error handling
+
+The rule:
+- all business errors are managed inside the intent. e.g. with a File Picker: a user selects a file but when the user click on "Share" the file has been deleted => the File Picker manages itself the error. It displays an error message and let the user try again or select another file or close the File Picker if it does not make sense anymore, etc. There is not interest to forward this kind of errors to the client app because it will not know what to do with these business errors.
+- technical errors are forwarded to the client in an `error` message. The client app can decide what it does: try again, display an error message saying the service is unavailable, ...
+
+It is recommanded that the client app wait the `ready`message with a timeout >= 10 seconds in case the intent crash. In this case, it must consider this as a technical error.
+
 ## postMessage intent protocol overview
 
 ### Roles


### PR DESCRIPTION
Explaining how we should handle:
- UI lifecycle
- errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for building intents, including client-led UI lifecycle management and display, closing, and hiding behavior.
  * Clarified how to handle business and technical errors.
  * Documented the recommended `ready` message timeout and fallback behavior when it is not received.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->