### PR TITLE
fix(cozy-sharing): Style of shared only by link banner wasn't correct

### DIFF
--- a/packages/cozy-sharing/src/styles/share.styl
+++ b/packages/cozy-sharing/src/styles/share.styl
@@ -38,11 +38,10 @@
 .share-byemail-onlybylink
     background var(--defaultBackgroundColor)
     padding 1rem 2rem
-    margin -1.5rem -2rem 1rem
+    margin -0.1rem -2rem 1rem
 
     +small-screen()
         padding 1rem
-        margin -1.5rem -1rem 1rem
 
 .share-modal-content
     @extend $form


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the responsive layout of the email-sharing section.
  * Adjusted spacing and positioning for a more consistent appearance across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->