### PR TITLE
feat: Allow to use cozy-interapp without a client from cozy-client

### DIFF
--- a/packages/cozy-interapp/README.md
+++ b/packages/cozy-interapp/README.md
@@ -14,9 +14,12 @@ See [cozy-drive](https://github.com/linagora/twake-drive/blob/master/docs/file-p
 yarn add cozy-interapp
 ```
 
-`cozy-interapp` does not depend on React. It needs a `cozy-client` instance to talk to the stack.
+`cozy-interapp` does not depend on React. It needs a way to talk to the
+stack: either a `cozy-client` instance or a `fetch` function managing authentication.
 
 ### Initialization
+
+With `cozy-client`:
 
 ```js
 import CozyClient from 'cozy-client'
@@ -24,6 +27,27 @@ import Intents from 'cozy-interapp'
 
 const client = new CozyClient({ uri, token })
 const intents = new Intents({ client })
+```
+
+Without `cozy-client`, pass a `fetch` function with the following signature:
+
+```js
+import Intents from 'cozy-interapp'
+
+const fetchJSON = async (method, path, body) => {
+  const res = await fetch(`${WORKSPACE_URL}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${TOKEN}`
+    },
+    body: body ? JSON.stringify(body) : undefined
+  })
+  if (!res.ok) throw new Error(await res.text())
+  return res.json()
+}
+
+const intents = new Intents({ fetch: fetchJSON })
 ```
 
 See [cozy-ui-plus](https://github.com/linagora/cozy-libs/tree/master/packages/cozy-ui-plus/src/Intent) for ready for use React components using cozy-interapp.

--- a/packages/cozy-interapp/src/intents.js
+++ b/packages/cozy-interapp/src/intents.js
@@ -4,8 +4,18 @@ import Request from './request'
 import * as service from './service'
 
 class Intents {
-  constructor({ client } = {}) {
-    this.request = new Request(client)
+  constructor({ client, fetch } = {}) {
+    const fetchJSON =
+      fetch ||
+      (client &&
+        client.stackClient &&
+        client.stackClient.fetchJSON.bind(client.stackClient))
+    if (!fetchJSON) {
+      throw new Error(
+        'Intents: "fetch" function or "client" (with stackClient.fetchJSON) is required'
+      )
+    }
+    this.request = new Request(fetchJSON)
     this.create = this.create.bind(this)
   }
 

--- a/packages/cozy-interapp/src/intents.spec.js
+++ b/packages/cozy-interapp/src/intents.spec.js
@@ -47,8 +47,8 @@ describe('Interapp', () => {
     cozyClient.stackClient.fetchJSON.mockImplementation(api.fetch)
   })
 
-  it('should initialise with cozy client', () => {
-    expect(intents.request.stackClient).toEqual(cozyClient.stackClient)
+  it('should initialise with fetchJSON from client', () => {
+    expect(typeof intents.request.fetchJSON).toBe('function')
   })
 
   describe('creation', () => {

--- a/packages/cozy-interapp/src/request.js
+++ b/packages/cozy-interapp/src/request.js
@@ -1,6 +1,6 @@
 class Request {
-  constructor(cozyClient) {
-    this.stackClient = cozyClient.stackClient
+  constructor(fetchJSON) {
+    this.fetchJSON = fetchJSON
   }
 
   get(id, { tryDOM = false } = {}) {
@@ -11,26 +11,24 @@ class Request {
       }
     }
 
-    return this.stackClient.fetchJSON('GET', `/intents/${id}`).then(resp => {
+    return this.fetchJSON('GET', `/intents/${id}`).then(resp => {
       const intent = resp.data
       return normalizeIntent(intent)
     })
   }
 
   post(action, type, data, permissions) {
-    return this.stackClient
-      .fetchJSON('POST', '/intents', {
-        data: {
-          type: 'io.cozy.intents',
-          attributes: {
-            action: action,
-            type: type,
-            data: data,
-            permissions: permissions
-          }
+    return this.fetchJSON('POST', '/intents', {
+      data: {
+        type: 'io.cozy.intents',
+        attributes: {
+          action: action,
+          type: type,
+          data: data,
+          permissions: permissions
         }
-      })
-      .then(resp => resp.data)
+      }
+    }).then(resp => resp.data)
   }
 
   fromDOM() {

--- a/packages/cozy-interapp/src/request.spec.js
+++ b/packages/cozy-interapp/src/request.spec.js
@@ -9,11 +9,11 @@ describe('[Interapp] Request', () => {
         fetchJSON: jest.fn().mockReturnValue(Promise.resolve({ data: [] }))
       }
     }
-    request = new Request(cozyClient)
+    request = new Request(cozyClient.stackClient.fetchJSON)
   })
 
-  it('should initialise with stackClient', () => {
-    expect(request.stackClient).toEqual(cozyClient.stackClient)
+  it('should initialise with fetchJSON', () => {
+    expect(request.fetchJSON).toBe(cozyClient.stackClient.fetchJSON)
   })
 
   describe('get', () => {


### PR DESCRIPTION
App can now pass to `new Intents` a fetch method built for the platform like this

```js
const fetchJSON = async (method, path, body) => {
  const res = await fetch(`${stackUrl}${path}`, {
    method,
    headers: {
      'Content-Type': 'application/json',
      Authorization: `Bearer ${token}`
    },
    body: body ? JSON.stringify(body) : undefined
  })
  if (!res.ok) throw new Error(await res.text())
  return res.json()
}

const intents = new Intents({ fetch: fetchJSON })
```

Related to https://github.com/linagora/twake-calendar-frontend/pull/1203 and https://github.com/linagora/twake-calendar-frontend/pull/1203#issuecomment-5100935811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for initializing inter-app communication with a custom authenticated `fetch` function.
  * Existing initialization through a `cozy-client` instance remains supported.
  * Requests can now retrieve and send data through either supported communication method.

* **Documentation**
  * Updated initialization guidance with the custom `fetch` option, function signature, and usage example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->