### PR TITLE
fix(sharing): Make shared-drive member modals consistent and correct

### DIFF
--- a/packages/cozy-sharing/README.md
+++ b/packages/cozy-sharing/README.md
@@ -177,6 +177,7 @@ Link and email sharing can coexist on the same resource. The recipient's permiss
 | Federated folder modal | Enabled by `drive.federated-shared-folder.enabled` flag | `ShareModal.jsx:39` |
 | Email sharing in federated folder | Disabled for files inside a federated shared folder (has `driveId` but is not the root) | `FederatedFolderModal.jsx:122-126` |
 | Link sharing in federated folder | Uses `getFederatedShareLink` which resolves the owner's instance URL | `FederatedFolderModal.jsx:108-110` |
+| Member view inside shared drive | Members see link management (gear + copy link) but no member perm management (cross/perm menu). Both root and subfolder modals are consistent. | `FederatedFolderModal.jsx:121-128`, `SharingDetailsModal.jsx:39-42` |
 
 ### Share management
 
@@ -252,3 +253,4 @@ Key decisions:
 - `EditableSharingModal` renders `ShareModal` (the dumb component), which decides `ShareDialogCozyToCozy` vs `ShareDialogOnlyByLink` based on flags and context.
 - `ShareDialogTwoStepsConfirmationContainer` wraps the cozy-to-cozy dialog when recipients need confirmation (untrusted contacts).
 - Federated mode: when `drive.federated-shared-folder.enabled` is true, `FederatedFolderModal` replaces the standard `EditableSharingModal`.
+- `WhoHasAccess` accepts an independent `canManageLink` prop to control link management (gear + perm dropdown) separately from `isReadOnly` which controls member management. This allows shared-drive members to see the link gear without the member cross/perm menu.

--- a/packages/cozy-sharing/README.md
+++ b/packages/cozy-sharing/README.md
@@ -174,17 +174,17 @@ Link and email sharing can coexist on the same resource. The recipient's permiss
 | Org shared drive | `isOrgSharedDrive` = `sharing.drive === true && sharing.org_drive === true` | `state.js:324` |
 | `canLeave` | `false` for org shared drives | `state.js:335` |
 | `canReshare` | `!org_drive && !read_only` for drives; `open_sharing && !read_only` for folders | `state.js:342` |
-| Federated folder modal | Enabled by `drive.federated-shared-folder.enabled` flag | `ShareModal.jsx:39` |
+| Federated folder modal | Enabled by `drive.federated-shared-folder.enabled` flag and `document.driveId` | `ShareModal.jsx:39` |
 | Email sharing in federated folder | Disabled for files inside a federated shared folder (has `driveId` but is not the root) | `FederatedFolderModal.jsx:122-126` |
 | Link sharing in federated folder | Uses `getFederatedShareLink` which resolves the owner's instance URL | `FederatedFolderModal.jsx:108-110` |
-| Member view inside shared drive | Members see link management (gear + copy link) but no member perm management (cross/perm menu). Both root and subfolder modals are consistent. | `FederatedFolderModal.jsx:121-128`, `SharingDetailsModal.jsx:39-42` |
+| Member view inside shared drive | Subfolder members see link management only (no member cross/perm). Root members with `canReshare` see full member management; read-only root members see link management only. | `FederatedFolderModal.jsx:118-133`, `SharingDetailsModal.jsx:38-39` |
 
 ### Share management
 
 | Condition | Rule | Source |
 |-----------|------|--------|
 | Editable modal | `isEditable = !byDocId[doc] \|\| isOwner(doc) \|\| canReshare(doc)` | `ShareModal.jsx:35-36` |
-| Non-editable view | `SharingDetailsModal` — read-only view of members, with revoke-self | `ShareModal.jsx:53-62` |
+| Non-editable view | `SharingDetailsModal` — read-only members (no cross/perm menu), with link management (gear + copy link) for shared drives | `ShareModal.jsx:53-62` |
 | Updating member type | `updateSharingMemberType` calls `setReadOnly` / `setReadWrite` on the stack | `SharingProvider.jsx:361-420` |
 | Revoke self | Available to all recipients | `SharingProvider.jsx:349-353` |
 | Revoke group | Available to owner/editor; removes all group members at once | `SharingProvider.jsx:336-347` |
@@ -253,4 +253,4 @@ Key decisions:
 - `EditableSharingModal` renders `ShareModal` (the dumb component), which decides `ShareDialogCozyToCozy` vs `ShareDialogOnlyByLink` based on flags and context.
 - `ShareDialogTwoStepsConfirmationContainer` wraps the cozy-to-cozy dialog when recipients need confirmation (untrusted contacts).
 - Federated mode: when `drive.federated-shared-folder.enabled` is true, `FederatedFolderModal` replaces the standard `EditableSharingModal`.
-- `WhoHasAccess` accepts an independent `canManageLink` prop to control link management (gear + perm dropdown) separately from `isReadOnly` which controls member management. This allows shared-drive members to see the link gear without the member cross/perm menu.
+- `WhoHasAccess` accepts an independent `canManageLink` prop to control link management (gear + perm dropdown) separately from `canManageMembers` which controls member management. This allows shared-drive members to see the link gear without the member cross/perm menu.

--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
@@ -118,7 +118,10 @@ const FederatedFolderModalContent = ({
   const isInsideSharedDrive = Boolean(
     existingDocument?.driveId && !isSharedDriveRoot
   )
-  const isCurrentUserOwner = documentId ? isOwner(documentId) : false
+  const isCurrentUserOwner = existingDocument?.driveId
+    ? Boolean(sharedDriveSharing?.attributes?.owner)
+    : (documentId ? isOwner(documentId) : false)
+  const isMemberReadOnly = isInsideSharedDrive && !isCurrentUserOwner
   const hasParentRestriction = isInsideSharedDrive || hasSharedParentByPath
   const hasChildRestriction = Boolean(
     documentPath && hasSharedChild(documentPath)
@@ -322,6 +325,8 @@ const FederatedFolderModalContent = ({
             isOwner={isCurrentUserOwner}
             canManageSharing={canManageSharing}
             isSharedDrive
+            isReadOnly={isMemberReadOnly}
+            canManageLink={true}
             recipients={isSending ? frozenRecipients : existingRecipients}
             document={isSending ? frozenDoc : existingDocument}
             documentType="Files"

--- a/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
+++ b/packages/cozy-sharing/src/components/FederatedFolder/FederatedFolderModal.jsx
@@ -120,7 +120,9 @@ const FederatedFolderModalContent = ({
   )
   const isCurrentUserOwner = existingDocument?.driveId
     ? Boolean(sharedDriveSharing?.attributes?.owner)
-    : (documentId ? isOwner(documentId) : false)
+    : documentId
+      ? isOwner(documentId)
+      : false
   const isMemberReadOnly = isInsideSharedDrive && !isCurrentUserOwner
   const hasParentRestriction = isInsideSharedDrive || hasSharedParentByPath
   const hasChildRestriction = Boolean(
@@ -325,7 +327,7 @@ const FederatedFolderModalContent = ({
             isOwner={isCurrentUserOwner}
             canManageSharing={canManageSharing}
             isSharedDrive
-            isReadOnly={isMemberReadOnly}
+            canManageMembers={!isMemberReadOnly}
             canManageLink={true}
             recipients={isSending ? frozenRecipients : existingRecipients}
             document={isSending ? frozenDoc : existingDocument}

--- a/packages/cozy-sharing/src/components/Recipient/GroupRecipientPermissions.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/GroupRecipientPermissions.jsx
@@ -20,7 +20,7 @@ const GroupRecipientPermissions = ({
   name,
   color,
   isOwner,
-  isReadOnly,
+  canManageMembers = true,
   sharingId,
   groupIndex,
   read_only = false,
@@ -36,7 +36,7 @@ const GroupRecipientPermissions = ({
   const [revoking, setRevoking] = useState(false)
 
   const shouldShowMenu =
-    !isReadOnly && !revoking && (isOwner || isUserInsideMembers)
+    canManageMembers && !revoking && (isOwner || isUserInsideMembers)
 
   const toggleMenu = () => setMenuDisplayed(!isMenuDisplayed)
   const hideMenu = () => setMenuDisplayed(false)

--- a/packages/cozy-sharing/src/components/Recipient/MemberRecipientPermissions.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/MemberRecipientPermissions.jsx
@@ -12,7 +12,7 @@ import { PermissionTypeMenu } from './PermissionTypeMenu'
 const MemberRecipientPermissions = ({
   isOwner,
   canManageSharing = isOwner,
-  isReadOnly,
+  canManageMembers = true,
   status,
   instance,
   type,
@@ -31,7 +31,7 @@ const MemberRecipientPermissions = ({
     instance !== undefined && instance === client.options.uri
   const contactIsOwner = status === 'owner'
   const shouldShowMenu =
-    !isReadOnly &&
+    canManageMembers &&
     !revoking &&
     !contactIsOwner &&
     ((instanceMatchesClient && !isOwner) || canManageSharing)

--- a/packages/cozy-sharing/src/components/Recipient/RecipientList.jsx
+++ b/packages/cozy-sharing/src/components/Recipient/RecipientList.jsx
@@ -10,8 +10,8 @@ const RecipientList = ({
   recipientsToBeConfirmed,
   isOwner,
   canManageSharing,
+  canManageMembers,
   isSharedDrive,
-  isReadOnly,
   document,
   documentType,
   onRevoke,
@@ -35,7 +35,7 @@ const RecipientList = ({
         <GroupRecipient
           {...recipient}
           isOwner={isOwner}
-          isReadOnly={isReadOnly}
+          canManageMembers={canManageMembers}
           key={recipient.index}
           document={document}
           documentType={documentType}
@@ -52,8 +52,8 @@ const RecipientList = ({
         key={recipient.index}
         isOwner={isOwner}
         canManageSharing={canManageSharing}
+        canManageMembers={canManageMembers}
         isSharedDrive={isSharedDrive}
-        isReadOnly={isReadOnly}
         document={document}
         documentType={documentType}
         onRevoke={onRevoke}

--- a/packages/cozy-sharing/src/components/ShareModal/ShareModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal/ShareModal.jsx
@@ -23,8 +23,7 @@ export const ShareModal = withLocales(props => {
     canReshare,
     documentType,
     getRecipients,
-    revokeSelf,
-    allLoaded
+    revokeSelf
   } = useSharingContext()
 
   const handleRevokeSelf = async document => {
@@ -37,7 +36,7 @@ export const ShareModal = withLocales(props => {
 
   if (isEditable) {
     const isFederatedMode = flag('drive.federated-shared-folder.enabled')
-    if (isFederatedMode && allLoaded) {
+    if (isFederatedMode && document.driveId) {
       return (
         <FederatedFolderModal
           document={document}

--- a/packages/cozy-sharing/src/components/ShareModal/SharingDetailsModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal/SharingDetailsModal.jsx
@@ -1,10 +1,12 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import { FixedDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import { useI18n } from 'twake-i18n'
 
+import { useSharingContext } from '../../hooks/useSharingContext'
 import styles from '../../styles/share.styl'
+import ShareByLink from '../ShareByLink'
 import WhoHasAccess from '../WhoHasAccess'
 
 export const SharingDetailsModal = ({
@@ -16,9 +18,15 @@ export const SharingDetailsModal = ({
   onClose
 }) => {
   const { t } = useI18n()
+  const { getSharingLink, getFederatedShareLink } = useSharingContext()
+
+  const isSharedDrive = Boolean(document?.driveId)
+  const displayedLink = isSharedDrive
+    ? getFederatedShareLink(document)
+    : getSharingLink(document?._id)
 
   return (
-    <Dialog
+    <FixedDialog
       disableGutters
       open={true}
       onClose={onClose}
@@ -28,14 +36,27 @@ export const SharingDetailsModal = ({
         <div className={styles['share-modal-content']}>
           <WhoHasAccess
             isReadOnly
+            canManageLink={isSharedDrive}
+            isSharedDrive={isSharedDrive}
             recipients={recipients}
             document={document}
             documentType={documentType}
             onRevoke={onRevoke}
             onRevokeSelf={onRevokeSelf}
-            link="ok"
+            link={displayedLink}
           />
         </div>
+      }
+      actions={
+        isSharedDrive && (
+          <ShareByLink
+            link={displayedLink}
+            document={document}
+            documentType="Files"
+            showGenerateLinkButton={true}
+            autoOpenShareRestriction={false}
+          />
+        )
       }
     />
   )

--- a/packages/cozy-sharing/src/components/ShareModal/SharingDetailsModal.jsx
+++ b/packages/cozy-sharing/src/components/ShareModal/SharingDetailsModal.jsx
@@ -35,7 +35,7 @@ export const SharingDetailsModal = ({
       content={
         <div className={styles['share-modal-content']}>
           <WhoHasAccess
-            isReadOnly
+            canManageMembers={false}
             canManageLink={isSharedDrive}
             isSharedDrive={isSharedDrive}
             recipients={recipients}

--- a/packages/cozy-sharing/src/components/WhoHasAccess.jsx
+++ b/packages/cozy-sharing/src/components/WhoHasAccess.jsx
@@ -32,6 +32,7 @@ const WhoHasAccess = ({
   canManageSharing = isOwner,
   isSharedDrive = false,
   isReadOnly = false,
+  canManageLink = !isReadOnly,
   showOwner = true,
   recipients,
   recipientsToBeConfirmed = [],
@@ -58,7 +59,7 @@ const WhoHasAccess = ({
       <List>
         {link && (
           <LinkRecipient
-            isReadOnly={isReadOnly}
+            isReadOnly={!canManageLink}
             document={document}
             documentType={documentType}
             onRevoke={onRevoke}
@@ -97,6 +98,7 @@ const WhoHasAccess = ({
 WhoHasAccess.propTypes = {
   isOwner: PropTypes.bool,
   canManageSharing: PropTypes.bool,
+  canManageLink: PropTypes.bool,
   showOwner: PropTypes.bool,
   recipients: PropTypes.array.isRequired,
   recipientsToBeConfirmed: PropTypes.arrayOf(

--- a/packages/cozy-sharing/src/components/WhoHasAccess.jsx
+++ b/packages/cozy-sharing/src/components/WhoHasAccess.jsx
@@ -32,7 +32,8 @@ const WhoHasAccess = ({
   canManageSharing = isOwner,
   isSharedDrive = false,
   isReadOnly = false,
-  canManageLink = !isReadOnly,
+  canManageMembers = !isReadOnly,
+  canManageLink = canManageMembers,
   showOwner = true,
   recipients,
   recipientsToBeConfirmed = [],
@@ -81,8 +82,8 @@ const WhoHasAccess = ({
           recipientsToBeConfirmed={recipientsToBeConfirmed}
           isOwner={isOwner}
           canManageSharing={canManageSharing}
+          canManageMembers={canManageMembers}
           isSharedDrive={isSharedDrive}
-          isReadOnly={isReadOnly}
           document={document}
           documentType={documentType}
           onRevoke={onRevoke}
@@ -98,6 +99,7 @@ const WhoHasAccess = ({
 WhoHasAccess.propTypes = {
   isOwner: PropTypes.bool,
   canManageSharing: PropTypes.bool,
+  canManageMembers: PropTypes.bool,
   canManageLink: PropTypes.bool,
   showOwner: PropTypes.bool,
   recipients: PropTypes.array.isRequired,


### PR DESCRIPTION
The root folder and subfolder sharing modals were inconsistent for shared-drive
members. The subfolder modal showed cross/perm menus that should not be visible
to non-owner members, while the root modal lacked a copy-link button and link
management entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved shared-drive sharing controls: members can manage sharing links while member permissions remain protected.
  - Added consistent access-management behavior for shared-drive roots and subfolders.
  - Sharing dialogs now display the correct link and provide link actions where applicable.

- **Bug Fixes**
  - Corrected ownership and read-only handling for shared-drive members.
  - Prevented unauthorized member-management actions from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->